### PR TITLE
Changed Residue and Segment to managed properties

### DIFF
--- a/testsuite/MDAnalysisTests/test_selections.py
+++ b/testsuite/MDAnalysisTests/test_selections.py
@@ -33,13 +33,13 @@ class TestSelectionsCHARMM(TestCase):
     def test_segid(self):
         sel = self.universe.selectAtoms('segid 4AKE')
         assert_equal(sel.numberOfAtoms(), 3341, "failed to select segment 4AKE")
-        assert_equal(sel._atoms, self.universe.s4AKE._atoms,
+        assert_equal(list(sel.atoms), list(self.universe.s4AKE.atoms),
                      "selected segment 4AKE is not the same as auto-generated segment s4AKE")
 
     def test_protein(self):
         sel = self.universe.selectAtoms('protein')
         assert_equal(sel.numberOfAtoms(), 3341, "failed to select protein")
-        assert_equal(sel._atoms, self.universe.s4AKE._atoms,
+        assert_equal(list(sel.atoms), list(self.universe.s4AKE.atoms),
                      "selected protein is not the same as auto-generated protein segment s4AKE")
 
     def test_backbone(self):
@@ -87,7 +87,7 @@ class TestSelectionsCHARMM(TestCase):
         sel = self.universe.selectAtoms('resname LEU')
         assert_equal(sel.numberOfAtoms(), 304, "Failed to find all 'resname LEU' atoms.")
         assert_equal(sel.numberOfResidues(), 16, "Failed to find all 'resname LEU' residues.")
-        assert_equal(sel._atoms, self.universe.s4AKE.LEU._atoms,
+        assert_equal(list(sel.atoms), list(self.universe.s4AKE.LEU.atoms),
                      "selected 'resname LEU' atoms are not the same as auto-generated s4AKE.LEU")
 
     def test_name(self):


### PR DESCRIPTION
Will resolve #202

Major changes:
Atom.residue is now a managed property
Atom.segment now just points to Atom.residue.segment
Setting Atom.residue will now:
- remove the Atom from it's original Residue
- add it into the new Residue
- clear the Segment's caches if the Atom has moved between segments
Residue.segment is also now a managed property

AtomGroup._atoms removed (previously gave access to private list)
AtomGroup.__atoms moved to _atoms

ResidueGroup and SegmentGroup now no longer populate .atoms on creation.
Instead this is done lazily and cached.
This means:
- AtomGroup just has list of Atoms
- ResidueGroup just has list of Residues
- SegmentGroup just has list of Segments
And other things are created on demand. 

eg
AtomGroup has list of atoms and creates .residues lazily
ResidueGroup has list of residues and creates .atoms lazily.

Other small changes:
Atom.__universe changed to Atom._universe