### PR TITLE
Added SingleFrameReader

### DIFF
--- a/package/MDAnalysis/coordinates/CRD.py
+++ b/package/MDAnalysis/coordinates/CRD.py
@@ -23,42 +23,22 @@ Read and write coordinates in CHARMM CARD coordinate format (suffix
 
 """
 
+import numpy
+
 import MDAnalysis
 import MDAnalysis.core.util as util
-import base
+from . import base
 from MDAnalysis import FormatError
-import numpy
-import base
 
 
-class Timestep(base.Timestep):
-    @property
-    def dimensions(self):
-        """unitcell dimensions (*A*, *B*, *C*, *alpha*, *beta*, *gamma*)
-
-        CRD files do not contain unitcell information but in order to
-        allow interoperability (and give the use a chance to set the
-        simulation box themselves for e.g. writing out to different
-        formats) we add an empty unit cell, i.e. when reading a CRD
-        file this will only contain zeros.
-
-        lengths *a*, *b*, *c* are in the MDAnalysis length unit (Å), and
-        angles are in degrees.
-        """
-        return self._unitcell
-
-    @dimensions.setter
-    def dimensions(self, box):
-        self._unitcell[:] = box
-
-class CRDReader(base.Reader):
+class CRDReader(base.SingleFrameReader):
     """CRD reader that implements the standard and extended CRD coordinate formats
     """
     format = 'CRD'
     units = {'time': None, 'length': 'Angstrom'}
-    _Timestep = Timestep
+    _Timestep = base.Timestep
 
-    def __init__(self, crdfilename, convert_units=None, **kwargs):
+    def _read_first_frame(self):
         # EXT:
         #      (i10,2x,a)  natoms,'EXT'
         #      (2I10,2X,A8,2X,A8,3F20.10,2X,A8,2X,A8,F20.10)
@@ -67,15 +47,8 @@ class CRDReader(base.Reader):
         #      (i5) natoms
         #      (2I5,1X,A4,1X,A4,3F10.5,1X,A4,1X,A4,F10.5)
         #      iatom,ires,resn,typr,x,y,z,segid,orig_resid,wmain
-
-        self.crdfilename = crdfilename
-        self.filename = self.crdfilename
-        if convert_units is None:
-            # Note: not used at the moment in CRDReader/Writer
-            convert_units = MDAnalysis.core.flags['convert_lengths']
-        self.convert_units = convert_units  # convert length and time to base units
         coords_list = []
-        with util.openany(crdfilename, 'r') as crdfile:
+        with util.openany(self.filename, 'r') as crdfile:
             extended = False
             natoms = 0
             for linenum, line in enumerate(crdfile):
@@ -97,12 +70,7 @@ class CRDReader(base.Reader):
                     raise FormatError("Check CRD format at line %d: %s" % (linenum, line.rstrip()))
 
         self.numatoms = len(coords_list)
-        self.numframes = 1
-        self.fixed = 0  # parse wmain field for fixed atoms?
-        self.skip = 1
-        self.periodic = False
-        self.delta = 0
-        self.skip_timestep = 1
+
         self.ts = self._Timestep(numpy.array(coords_list))
         self.ts.frame = 1  # 1-based frame number
         # if self.convert_units:
@@ -124,19 +92,6 @@ class CRDReader(base.Reader):
 
         """
         return CRDWriter(filename, **kwargs)
-
-    def __iter__(self):
-        yield self.ts  # Just a single frame
-        raise StopIteration
-
-    def _read_frame(self, frame):
-        if frame != 0:
-            raise IndexError("CRD only contains a single frame at frame index 0")
-        return self.ts
-
-    def _read_next_timestep(self):
-        # CRD files only contain a single frame
-        raise IOError
 
 
 class CRDWriter(base.Writer):

--- a/package/MDAnalysis/coordinates/PQR.py
+++ b/package/MDAnalysis/coordinates/PQR.py
@@ -87,12 +87,12 @@ import numpy
 
 import MDAnalysis.core
 import MDAnalysis.core.util as util
-import base
+from . import base
 from base import Timestep
 import pdb.extensions
 
 
-class PQRReader(base.Reader):
+class PQRReader(base.SingleFrameReader):
     """Read a PQR_ file into MDAnalysis.
 
     The :mod:`~MDAnalysis.topology.PQRParser` takes charges from the
@@ -101,29 +101,20 @@ class PQRReader(base.Reader):
     accessible through the :meth:`get_radii` method of the reader, the
     :meth:`MDAnalysis.core.AtomGroup.AtomGroup.radii` method and the
     :attr:`MDAnalysis.core.AtomGroup.Atom.radius` attribute.
+
+    .. _PQR:
+        http://www.poissonboltzmann.org/file-formats/biomolecular-structurw/pqr
     """
     format = 'PQR'
     units = {'time': None, 'length': 'Angstrom'}
     _Timestep = Timestep
 
-    def __init__(self, filename, convert_units=None, **kwargs):
-        """Read coordinates from *filename*.
-
-        *filename* can be a gzipped or bzip2ed compressed PQR_ file.
-
-        .. _PQR:
-           http://www.poissonboltzmann.org/file-formats/biomolecular-structurw/pqr
-        """
-        self.filename = filename
-        if convert_units is None:
-            convert_units = MDAnalysis.core.flags['convert_lengths']
-        self.convert_units = convert_units  # convert length and time to base units
-
+    def _read_first_frame(self):
         coords = []
         atoms = []
         unitcell = numpy.zeros(6, dtype=numpy.float32)
         segID = ''  # use empty string (not in PQR), PQRParsers sets it to SYSTEM
-        with util.openany(filename, 'r') as pqrfile:
+        with util.openany(self.filename, 'r') as pqrfile:
             for line in pqrfile:
                 if line[:6] in ('ATOM  ', 'HETATM'):
                     fields = line.split()
@@ -143,12 +134,7 @@ class PQRReader(base.Reader):
         if self.convert_units:
             self.convert_pos_from_native(self.ts._pos)  # in-place !
             self.convert_pos_from_native(self.ts._unitcell[:3])  # in-place ! (only lengths)
-        self.numframes = 1
-        self.fixed = 0
-        self.skip = 1
-        self.periodic = False
-        self.delta = 0
-        self.skip_timestep = 1
+
         # hack for PQRParser:
         self._atoms = numpy.rec.fromrecords(atoms, names="serial,name,resName,chainID,resSeq,charge,radius,segID")
 
@@ -170,19 +156,6 @@ class PQRReader(base.Reader):
         :Returns: :class:`PQRWriter`
         """
         return PQRWriter(filename, **kwargs)
-
-    def __iter__(self):
-        yield self.ts  # Just a single frame
-        raise StopIteration
-
-    def _read_frame(self, frame):
-        if frame != 0:
-            raise IndexError("PQR only contains a single frame at frame index 0")
-        return self.ts
-
-    def _read_next_timestep(self):
-        # PQR file only contains a single frame
-        raise IOError
 
 
 class PQRWriter(base.Writer):

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -984,3 +984,53 @@ class Writer(IObase):
         return numpy.all(criteria["min"] < x) and numpy.all(x <= criteria["max"])
 
         # def write_next_timestep(self, ts=None)
+
+class SingleFrameReader(Reader):
+    """Base class for Readers that only have one frame.
+
+    .. versionadded:: 0.10.0
+    """
+    _err = "{} only contains a single frame"
+
+    def __init__(self, filename, convert_units=None, **kwargs):
+        self.filename = filename
+        if convert_units is None:
+            convert_units = MDAnalysis.core.flags['convert_lengths']
+        self.convert_units = convert_units
+
+        self.numframes = 1
+        self.fixed = 0
+        self.skip = 1
+        self.periodic = False
+        self.delta = 0
+        self.skip_timestep = 1
+
+        self._read_first_frame()
+
+    def _read_first_frame(self):
+        # Override this in subclasses to create and fill a Timestep
+        pass
+
+    def next(self):
+        raise IOError(self._err.format(self.__class__.__name__))
+
+    def __iter__(self):
+        yield self.ts
+        raise StopIteration
+
+    def _read_frame(self, frame):
+        if frame != 0:
+            raise IndexError(self._err.format(self.__class__.__name__))
+
+        return self.ts
+
+    def read_next_timestep(self):
+        raise IOError(self._err.format(self.__class__.__name__))
+                             
+    def close(self):
+        # all single frame readers should use context managers to access
+        # self.filename
+        pass
+
+    def __del__(self):
+        self.close()

--- a/testsuite/MDAnalysisTests/test_coordinates.py
+++ b/testsuite/MDAnalysisTests/test_coordinates.py
@@ -18,6 +18,7 @@ import MDAnalysis
 import MDAnalysis as mda
 import MDAnalysis.coordinates
 import MDAnalysis.coordinates.core
+from MDAnalysis.coordinates.base import Timestep, SingleFrameReader
 
 import numpy as np
 import cPickle
@@ -3094,7 +3095,7 @@ class _TestLammpsData_Coords(TestCase):
 
     def test_seek_2(self):
         ts = self.u.trajectory[0]
-        assert_equal(type(ts), MDAnalysis.coordinates.LAMMPS.DATATimestep)
+        assert_equal(type(ts), MDAnalysis.coordinates.base.Timestep)
 
     def test_iter(self):
         # Check that iterating works, but only gives a single frame
@@ -3172,25 +3173,9 @@ class _LAMMPSTimestep(_DCDTimestep):  # LAMMPS Timestep is a subclass of DCD Tim
     name = "LAMMPS"
 
 
-class _LAMMPSDataTimestep(_BaseTimestep):
-    Timestep = MDAnalysis.coordinates.LAMMPS.DATATimestep
-    name = "LAMMPSData"
-    has_box = True
-    set_box = True
-    unitcell = np.array([10., 11., 12., 90., 90., 90.])
-
-
 class _PDBTimestep(_BaseTimestep):
     Timestep = MDAnalysis.coordinates.PDB.Timestep
     name = "PDB"
-    has_box = True
-    set_box = True
-    unitcell = np.array([10., 11., 12., 90., 90., 90.])
-
-
-class _PDBQTTimestep(_BaseTimestep):
-    Timestep = MDAnalysis.coordinates.PDBQT.Timestep
-    name = "PDBQT"
     has_box = True
     set_box = True
     unitcell = np.array([10., 11., 12., 90., 90., 90.])
@@ -3416,15 +3401,7 @@ class TestLAMMPSTimestep(_TestTimestep, _LAMMPSTimestep):
     pass
 
 
-class TestLAMMPSDataTimestep(_TestTimestep, _LAMMPSDataTimestep):
-    pass
-
-
 class TestPDBTimestep(_TestTimestep, _PDBTimestep):
-    pass
-
-
-class TestPDBQTTimestep(_TestTimestep, _PDBQTTimestep):
     pass
 
 
@@ -3442,3 +3419,93 @@ class TestXTCTimestep(_TestTimestep, _XTCTimestep):
 
 class TestTRRTimestep(_TestTimestep, _TRRTimestep):
     pass
+
+
+class AmazingReader(SingleFrameReader):
+    format = 'Amazing'
+    # have to hack this in to get the base class to "work"
+    def _read_first_frame(self):
+        self.numatoms = 10
+        self.ts = Timestep(self.numatoms)
+        self.ts.frame = 1
+
+class TestSingleFrameReader(TestCase):
+    def setUp(self):
+        self.numatoms = 10
+        self.r = AmazingReader
+        self.sfr = AmazingReader('test.txt')
+        self.ts = self.sfr.ts
+
+    def tearDown(self):
+        del self.r
+        del self.sfr
+        del self.ts
+        del self.numatoms
+
+    def test_required_attributes(self):
+        """Test that SFReader has the required attributes"""
+        for attr in ['filename', 'numatoms', 'numframes', 'fixed', 'skip',
+                     'skip_timestep', 'delta', 'periodic', 'ts',
+                     'units', 'format']:
+            assert_equal(hasattr(self.sfr, attr), True, "Missing attr: {}".format(attr))
+        
+    def test_iter(self):
+        l = [ts for ts in self.sfr]
+
+        assert_equal(len(l), 1)
+
+    def test_close(self):
+        sfr = self.r('text.txt')
+
+        ret = sfr.close()
+        # Check that method works?
+        assert_equal(ret, None)
+
+    def test_next(self):
+        assert_raises(IOError, self.sfr.next)
+
+    def test_rewind(self):
+        ret = self.sfr.rewind()
+
+        assert_equal(ret, None)
+        assert_equal(self.sfr.ts.frame, 1)
+
+    def test_context(self):
+        with self.r('text.txt') as sfr:
+            l = sfr.ts.frame
+
+        assert_equal(l, 1)
+
+    def test_len(self):
+        l = len(self.sfr)
+
+        assert_equal(l, 1)
+
+    # Getitem tests
+    # only 0 & -1 should work
+    # others should get IndexError
+    def _check_get_results(self, l):
+        assert_equal(len(l), 1)
+        assert_equal(self.ts in l, True)
+
+    def test_getitem(self):
+        fr = [self.sfr[0]]
+
+        self._check_get_results(fr)
+
+    def test_getitem_2(self):
+        fr = [self.sfr[-1]]
+
+        self._check_get_results(fr)
+
+    def test_getitem_IE(self):
+        assert_raises(IndexError, self.sfr.__getitem__, 1)
+
+    def test_getitem_IE_2(self):
+        assert_raises(IndexError, self.sfr.__getitem__, -2)
+
+    # Slicing should still work!
+    def test_slice_1(self):
+        l = list(self.sfr[::])
+
+        self._check_get_results(l)


### PR DESCRIPTION
Acts as base class for Readers which only have a single frame
Should help reduce amount of boilerplate that Readers have to have.

All single frame readers now just have to define how to read their format, and all functionality, eg iter, getitem is handled by the parent class.

Removed some Timesteps which are now obsolete because base.Timestep
handles dimensions
* CRD.Timestep
* LAMMPS.DATATimestep
* PDBQT.Timestep

Added tests for coordinates.base.SingleFrameReader which ensure that
the new reader strictly follows the API (and therefore all subclasses
do)

Tests all pass, so can be merged once reviewed.