### PR TITLE
Cleanup of base.Reader

### DIFF
--- a/package/MDAnalysis/coordinates/CRD.py
+++ b/package/MDAnalysis/coordinates/CRD.py
@@ -25,7 +25,6 @@ Read and write coordinates in CHARMM CARD coordinate format (suffix
 
 import numpy
 
-import MDAnalysis
 import MDAnalysis.core.util as util
 from . import base
 from MDAnalysis import FormatError
@@ -36,7 +35,6 @@ class CRDReader(base.SingleFrameReader):
     """
     format = 'CRD'
     units = {'time': None, 'length': 'Angstrom'}
-    _Timestep = base.Timestep
 
     def _read_first_frame(self):
         # EXT:

--- a/package/MDAnalysis/coordinates/DCD.py
+++ b/package/MDAnalysis/coordinates/DCD.py
@@ -352,13 +352,10 @@ class DCDWriter(base.Writer):
 
     def close(self):
         """Close trajectory and flush buffers."""
-        self._finish_dcd_write()
-        self.dcdfile.close()
-        self.dcdfile = None
-
-    def __del__(self):
         if hasattr(self, 'dcdfile') and not self.dcdfile is None:
-            self.close()
+            self._finish_dcd_write()
+            self.dcdfile.close()
+            self.dcdfile = None
 
 
 class DCDReader(base.Reader):
@@ -405,6 +402,7 @@ class DCDReader(base.Reader):
     """
     format = 'DCD'
     units = {'time': 'AKMA', 'length': 'Angstrom'}
+    _Timestep = Timestep
 
     def __init__(self, dcdfilename, **kwargs):
         self.filename = self.dcdfilename = dcdfilename  # dcdfilename is legacy
@@ -424,7 +422,7 @@ class DCDReader(base.Reader):
         self.periodic = False
 
         self._read_dcd_header()
-        self.ts = Timestep(self.numatoms)
+        self.ts = self._Timestep(self.numatoms)
         # Read in the first timestep
         self._read_next_timestep()
 
@@ -536,7 +534,7 @@ class DCDReader(base.Reader):
                                      sizedata, lowerb, upperb, start, stop, skip)
 
     def close(self):
-        if not self.dcdfile is None:
+        if self.dcdfile is not None:
             self._finish_dcd_read()
             self.dcdfile.close()
             self.dcdfile = None

--- a/package/MDAnalysis/coordinates/DCD.py
+++ b/package/MDAnalysis/coordinates/DCD.py
@@ -69,9 +69,9 @@ Classes
 import os
 import errno
 import numpy
+import struct
 
-import base
-
+from . import base
 import MDAnalysis.core
 import MDAnalysis.core.units
 from MDAnalysis import NoDataError
@@ -288,8 +288,6 @@ class DCDWriter(base.Writer):
         #    struct.unpack("LLiiiiidiPPiiii",self._dcd_C_str)
         # seems to do the job on Mac OS X 10.6.4 ... but I have no idea why,
         # given that the C code seems to define them as normal integers
-        import struct
-
         desc = [
             'file_desc', 'header_size', 'natoms', 'nsets', 'setsread', 'istart',
             'nsavc', 'delta', 'nfixed', 'freeind_ptr', 'fixedcoords_ptr',
@@ -460,8 +458,6 @@ class DCDReader(base.Reader):
         #    struct.unpack("LLiiiiidiPPiiii",self._dcd_C_str)
         # seems to do the job on Mac OS X 10.6.4 ... but I have no idea why,
         # given that the C code seems to define them as normal integers
-        import struct
-
         desc = [
             'file_desc', 'header_size', 'natoms', 'nsets', 'setsread', 'istart',
             'nsavc', 'delta', 'nfixed', 'freeind_ptr', 'fixedcoords_ptr', 'reverse',
@@ -488,31 +484,11 @@ class DCDReader(base.Reader):
         ts.frame = self._read_next_frame(ts._x, ts._y, ts._z, ts._unitcell, self.skip)
         return ts
 
-    def __getitem__(self, frame):
-        if (numpy.dtype(type(frame)) != numpy.dtype(int)) and (type(frame) != slice):
-            raise TypeError
-        if (numpy.dtype(type(frame)) == numpy.dtype(int)):
-            if (frame < 0):
-                # Interpret similar to a sequence
-                frame = len(self) + frame
-            if (frame < 0) or (frame >= len(self)):
-                raise IndexError
-            self._jump_to_frame(frame)  # XXX required!!
-            ts = self.ts
-            ts.frame = self._read_next_frame(ts._x, ts._y, ts._z, ts._unitcell, 1)  # XXX required!!
-            return ts
-        elif type(frame) == slice:  # if frame is a slice object
-            if not (((type(frame.start) == int) or (frame.start is None)) and
-               ((type(frame.stop) == int) or (frame.stop is None)) and
-               ((type(frame.step) == int) or (frame.step is None))):
-                raise TypeError("Slice indices are not integers")
-
-            def iterDCD(start=frame.start, stop=frame.stop, step=frame.step):
-                start, stop, step = self._check_slice_indices(start, stop, step)
-                for i in xrange(start, stop, step):
-                    yield self[i]
-
-            return iterDCD()
+    def _read_frame(self, frame):
+        self._jump_to_frame(frame)
+        ts = self.ts
+        ts.frame = self._read_next_frame(ts._x, ts._y, ts._z, ts._unitcell, 1)  # XXX required!!
+        return ts
 
     def timeseries(self, asel, start=0, stop=-1, skip=1, format='afc'):
         """Return a subset of coordinate data for an AtomGroup
@@ -556,12 +532,14 @@ class DCDReader(base.Reader):
         sizedata = timeseries._getDataSize()
         atomcounts = timeseries._getAtomCounts()
         auxdata = timeseries._getAuxData()
-        return self._read_timecorrel(atomlist, atomcounts, format, auxdata, sizedata, lowerb, upperb, start, stop, skip)
+        return self._read_timecorrel(atomlist, atomcounts, format, auxdata,
+                                     sizedata, lowerb, upperb, start, stop, skip)
 
     def close(self):
-        self._finish_dcd_read()
-        self.dcdfile.close()
-        self.dcdfile = None
+        if not self.dcdfile is None:
+            self._finish_dcd_read()
+            self.dcdfile.close()
+            self.dcdfile = None
 
     def Writer(self, filename, **kwargs):
         """Returns a DCDWriter for *filename* with the same parameters as this DCD.
@@ -604,10 +582,6 @@ class DCDReader(base.Reader):
         kwargs.setdefault('remarks', self.remarks)
         # dt keyword is simply passed through if provided
         return DCDWriter(filename, numatoms, **kwargs)
-
-    def __del__(self):
-        if not self.dcdfile is None:
-            self.close()
 
 # Add the c functions to their respective classes so they act as class methods
 import _dcdmodule

--- a/package/MDAnalysis/coordinates/DMS.py
+++ b/package/MDAnalysis/coordinates/DMS.py
@@ -26,16 +26,10 @@ coordinate files (as used by the Desmond_ MD package).
 .. _DMS: http://www.deshawresearch.com/Desmond_Users_Guide-0.7.pdf
 """
 
-import os
-import errno
-import warnings
-from copy import deepcopy
 import numpy
 import sqlite3
 
-import MDAnalysis
 from . import base
-import MDAnalysis.core.util as util
 from MDAnalysis.coordinates.core import triclinic_box, triclinic_vectors
 
 

--- a/package/MDAnalysis/coordinates/GMS.py
+++ b/package/MDAnalysis/coordinates/GMS.py
@@ -27,12 +27,13 @@ There appears to be no rigid format definition so it is likely users
 will need to tweak this Class.
 """
 
-import MDAnalysis.core.util as util
-import os, errno, re
+import os
+import errno
+import re
 import numpy
 
-import base
-from base import Timestep
+from . import base
+import MDAnalysis.core.util as util
 
 
 class GMSReader(base.Reader):
@@ -72,7 +73,7 @@ class GMSReader(base.Reader):
         self._numframes = None
         self._runtyp = None
 
-        self.ts = Timestep(0) # need for properties initial calculations
+        self.ts = self._Timestep(0) # need for properties initial calculations
         self.fixed = 0
         self.skip = 1
         self.periodic = False
@@ -83,7 +84,7 @@ class GMSReader(base.Reader):
             raise AttributeError('Wrong RUNTYP= '+self.runtyp)
         self.skip_timestep = 1
 
-        self.ts = Timestep(self.numatoms)
+        self.ts = self._Timestep(self.numatoms)
         # update numframes property
         self.numframes
 

--- a/package/MDAnalysis/coordinates/GMS.py
+++ b/package/MDAnalysis/coordinates/GMS.py
@@ -103,7 +103,6 @@ class GMSReader(base.Reader):
         else:
             return self._runtyp
 
-
     def _determine_runtyp(self):
         self._reopen()
         counter = 0
@@ -115,8 +114,6 @@ class GMSReader(base.Reader):
 
         self.close()
         raise EOFError
-
-
 
     @property
     def numatoms(self):
@@ -143,7 +140,6 @@ class GMSReader(base.Reader):
         self.close()
         raise EOFError
 
-
     @property
     def numframes(self):
         if not self._numframes is None:   # return cached value
@@ -169,7 +165,6 @@ class GMSReader(base.Reader):
 
         self.close()
         return int(counter)
-
 
     def __iter__(self):
         self.ts.frame = 0  # start at 0 so that the first frame becomes 1
@@ -242,7 +237,6 @@ class GMSReader(base.Reader):
 
         raise EOFError
 
-
     def rewind(self):
         """reposition on first frame"""
         self._reopen()
@@ -277,6 +271,4 @@ class GMSReader(base.Reader):
         self.outfile.close()
         self.outfile = None
 
-    def __del__(self):
-        self.close()
 

--- a/package/MDAnalysis/coordinates/GRO.py
+++ b/package/MDAnalysis/coordinates/GRO.py
@@ -26,10 +26,7 @@ Classes to read and write Gromacs_ GRO_ coordinate files; see the notes on the
 .. _GRO format: http://chembytes.wikidot.com/g-grofile
 """
 
-import os
-import errno
 import warnings
-from copy import deepcopy
 import numpy
 
 import MDAnalysis

--- a/package/MDAnalysis/coordinates/INPCRD.py
+++ b/package/MDAnalysis/coordinates/INPCRD.py
@@ -23,14 +23,13 @@ Read and write coordinates in Amber_ coordinate/restart file (suffix
 
 .. _Amber: http://ambermd.org/formats.html#restart
 """
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from . import base
 
 class INPReader(base.SingleFrameReader):
     format = 'INPCRD'
     units = {'length': 'Angstrom'}
-    _Timestep = base.Timestep
 
     def _read_first_frame(self):
         # Read header

--- a/package/MDAnalysis/coordinates/LAMMPS.py
+++ b/package/MDAnalysis/coordinates/LAMMPS.py
@@ -69,14 +69,9 @@ Classes
 """
 
 from . import DCD
-from MDAnalysis.core import units
-from MDAnalysis.topology.LAMMPSParser import DATAParser
-import MDAnalysis.core
+from ..core import units
+from ..topology.LAMMPSParser import DATAParser
 from . import base
-
-
-class Timestep(DCD.Timestep):
-    """LAMMPS trajectory time step"""
 
 
 class DCDWriter(DCD.DCDWriter):
@@ -126,8 +121,7 @@ class DCDReader(DCD.DCDReader):
 
 
 class DATAReader(base.SingleFrameReader):
-    """
-    Reads a single frame of coordinate information from a LAMMPS DATA file.
+    """Reads a single frame of coordinate information from a LAMMPS DATA file.
 
     .. versionadded:: 0.9.0
     """
@@ -141,7 +135,7 @@ class DATAReader(base.SingleFrameReader):
         super(DATAReader, self).__init__(filename, **kwargs)
 
     def _read_first_frame(self):
-        self.ts = base.Timestep(self.numatoms)
+        self.ts = self._Timestep(self.numatoms)
         with DATAParser(self.filename) as p:
             p.read_DATA_timestep(self.ts)
 

--- a/package/MDAnalysis/coordinates/MOL2.py
+++ b/package/MDAnalysis/coordinates/MOL2.py
@@ -40,15 +40,13 @@ To open a mol2, remove all hydrogens and save as a new file, use the following::
 import numpy as np
 
 from . import base
-from MDAnalysis.topology.core import guess_atom_element
 from .. import core
-import MDAnalysis.core.util as util
+from ..core import util
 
 
 class MOL2Reader(base.Reader):
     format = 'MOL2'
     units = {'time': None, 'length': 'Angstrom'}
-    _Timestep = base.Timestep
 
     def __init__(self, filename, convert_units=None, **kwargs):
         """Read coordinates from *filename*.
@@ -273,8 +271,6 @@ class MOL2Writer(base.Writer):
 
     def close(self):
         self.file.close()
-
-    __del__ = close
 
     def encode_block(self, obj):
         traj = obj.universe.trajectory

--- a/package/MDAnalysis/coordinates/MOL2.py
+++ b/package/MDAnalysis/coordinates/MOL2.py
@@ -39,39 +39,16 @@ To open a mol2, remove all hydrogens and save as a new file, use the following::
 
 import numpy as np
 
-import base
-from MDAnalysis.core.AtomGroup import Universe, AtomGroup
+from . import base
 from MDAnalysis.topology.core import guess_atom_element
 from .. import core
 import MDAnalysis.core.util as util
 
 
-class Timestep(base.Timestep):
-    @property
-    def dimensions(self):
-        """unitcell dimensions (`A, B, C, alpha, beta, gamma`)
-
-        MOL2 does not contain unitcell information but for
-        compatibility, an empty unitcell is provided.
-
-        - `A, B, C` are the lengths of the primitive cell vectors `e1, e2, e3`
-        - `alpha` = angle(`e1, e2`)
-        - `beta` = angle(`e1, e3`)
-        - `gamma` = angle(`e2, e3`)
-
-        """
-        # Layout of unitcell is [A,B,C,90,90,90] with the primitive cell vectors
-        return self._unitcell
-
-    @dimensions.setter
-    def dimensions(self, box):
-        self._unitcell = box
-
-
 class MOL2Reader(base.Reader):
     format = 'MOL2'
     units = {'time': None, 'length': 'Angstrom'}
-    _Timestep = Timestep
+    _Timestep = base.Timestep
 
     def __init__(self, filename, convert_units=None, **kwargs):
         """Read coordinates from *filename*.
@@ -120,10 +97,6 @@ class MOL2Reader(base.Reader):
         self.periodic = False
         self.delta = 0
         self.skip_timestep = 1
-
-    def next(self):
-        """Read the next time step."""
-        return self._read_next_timestep()
 
     def __iter__(self):
         for i in xrange(0, self.numframes):

--- a/package/MDAnalysis/coordinates/PDB.py
+++ b/package/MDAnalysis/coordinates/PDB.py
@@ -245,7 +245,6 @@ class PDBReader(base.SingleFrameReader):
     """
     format = 'PDB'
     units = {'time': None, 'length': 'Angstrom'}
-    _Timestep = base.Timestep
 
     def _read_first_frame(self):
         pdb_id = "0UNK"
@@ -434,7 +433,6 @@ class PrimitivePDBReader(base.Reader):
     """
     format = 'PDB'
     units = {'time': None, 'length': 'Angstrom'}
-    _Timestep = base.Timestep
 
     def __init__(self, filename, convert_units=None, **kwargs):
         """Read coordinates from *filename*.
@@ -521,7 +519,7 @@ class PrimitivePDBReader(base.Reader):
                     else:
                         assert self.format == "PDB"
                         resSeq = _c(23, 26, int)
-                        insertCode = _c(27, 27, str)  # not used
+                        # insertCode = _c(27, 27, str)  # not used
                     x, y, z = _c(31, 38), _c(39, 46), _c(47, 54)
                     occupancy = _c(55, 60)
                     tempFactor = _c(61, 66)
@@ -600,11 +598,6 @@ class PrimitivePDBReader(base.Reader):
         """
         kwargs.setdefault('multiframe', self.numframes > 1)
         return PrimitivePDBWriter(filename, **kwargs)
-
-    def close(self):
-        pass
-
-    __del__ = close
 
     def __iter__(self):
         for i in xrange(0, self.numframes):
@@ -828,8 +821,6 @@ class PrimitivePDBWriter(base.Writer):
                 logger.warn("END record has already been written before the final closing of the file")
             self.pdbfile.close()
         self.pdbfile = None
-
-    __del__ = close
 
     def _write_pdb_title(self):
         if self.multiframe:

--- a/package/MDAnalysis/coordinates/PDBQT.py
+++ b/package/MDAnalysis/coordinates/PDBQT.py
@@ -36,10 +36,8 @@ import errno
 import numpy
 import warnings
 
-import MDAnalysis.core
 import MDAnalysis.core.util as util
 from . import base
-from MDAnalysis.topology.core import guess_atom_element
 
 # PDBQTReader and Writer classes will subclass PrimitiveReader/Writer from PDB module
 #from MDAnalysis.coordinates.PDB import PrimitivePDBReader
@@ -140,7 +138,6 @@ class PDBQTReader(base.SingleFrameReader):
     """
     format = 'PDBQT'
     units = {'time': None, 'length': 'Angstrom'}
-    _Timestep = base.Timestep
 
     def _read_first_frame(self):
         # Ugly inner method: moved outside of for-loop below
@@ -378,5 +375,3 @@ class PDBQTWriter(base.Writer):
         partialCharge = float(partialCharge)  # Already pre-formatted when passed to this method
         self.pdb.write(self.fmt['ATOM'] % vars())
 
-    def __del__(self):
-        self.close()

--- a/package/MDAnalysis/coordinates/PQR.py
+++ b/package/MDAnalysis/coordinates/PQR.py
@@ -88,8 +88,6 @@ import numpy
 import MDAnalysis.core
 import MDAnalysis.core.util as util
 from . import base
-from base import Timestep
-import pdb.extensions
 
 
 class PQRReader(base.SingleFrameReader):
@@ -107,7 +105,6 @@ class PQRReader(base.SingleFrameReader):
     """
     format = 'PQR'
     units = {'time': None, 'length': 'Angstrom'}
-    _Timestep = Timestep
 
     def _read_first_frame(self):
         coords = []

--- a/package/MDAnalysis/coordinates/TRR.py
+++ b/package/MDAnalysis/coordinates/TRR.py
@@ -124,4 +124,4 @@ Module reference
    :inherited-members:
 """
 
-from xdrfile.TRR import TRRReader, TRRWriter, Timestep
+from .xdrfile.TRR import TRRReader, TRRWriter, Timestep

--- a/package/MDAnalysis/coordinates/TRZ.py
+++ b/package/MDAnalysis/coordinates/TRZ.py
@@ -72,13 +72,15 @@ Reads coordinates, velocities and more (see attributes of the
    :members:
 """
 
+from sys import maxint
+import numpy
 import os
 import errno
+
 import base
 from base import Timestep
 import MDAnalysis.core
 import MDAnalysis.core.util as util
-import numpy
 from MDAnalysis.coordinates.core import triclinic_box
 
 
@@ -211,14 +213,14 @@ class TRZReader(base.Reader):
         self.filename = trzfilename
         self.trzfile = util.anyopen(self.filename, 'rb')
 
-        self.__numatoms = numatoms
+        self._numatoms = numatoms
         self.fixed = False
         self.periodic = True
         self.skip = 1
-        self.__numframes = None
-        self.__delta = None
-        self.__dt = None
-        self.__skip_timestep = None
+        self._numframes = None
+        self._delta = None
+        self._dt = None
+        self._skip_timestep = None
 
         self._read_trz_header()
         self.ts = Timestep(self.numatoms, has_force=self.has_force)
@@ -325,19 +327,19 @@ class TRZReader(base.Reader):
     @property
     def numatoms(self):
         """Number of atoms in a frame"""
-        return self.__numatoms
+        return self._numatoms
 
     @property
     def numframes(self):
         """Total number of frames in a trajectory"""
-        if not self.__numframes is None:
-            return self.__numframes
+        if not self._numframes is None:
+            return self._numframes
         try:
-            self.__numframes = self._read_trz_numframes(self.trzfile)
+            self._numframes = self._read_trz_numframes(self.trzfile)
         except IOError:
             return 0
         else:
-            return self.__numframes
+            return self._numframes
 
     def _read_trz_numframes(self, trzfile):
         """Uses size of file and dtype information to determine how many frames exist
@@ -362,42 +364,42 @@ class TRZReader(base.Reader):
         stitched together)
         Returns 0 in case of IOError
         """
-        if not self.__dt is None:
-            return self.__dt
+        if not self._dt is None:
+            return self._dt
         try:
             t0 = self.ts.time
             self.next()
             t1 = self.ts.time
-            self.__dt = t1 - t0
+            self._dt = t1 - t0
         except IOError:
             return 0
         finally:
             self.rewind()
-        return self.__dt
+        return self._dt
 
     @property
     def delta(self):
         """MD integration timestep"""
-        if not self.__delta is None:
-            return self.__delta
-        self.__delta = self.dt / self.skip_timestep
-        return self.__delta
+        if not self._delta is None:
+            return self._delta
+        self._delta = self.dt / self.skip_timestep
+        return self._delta
 
     @property
     def skip_timestep(self):
         """Timesteps between trajectory frames"""
-        if not self.__skip_timestep is None:
-            return self.__skip_timestep
+        if not self._skip_timestep is None:
+            return self._skip_timestep
         try:
             t0 = self.ts.step
             self.next()
             t1 = self.ts.step
-            self.__skip_timestep = t1 - t0
+            self._skip_timestep = t1 - t0
         except IOError:
             return 0
         finally:
             self.rewind()
-        return self.__skip_timestep
+        return self._skip_timestep
 
     def __iter__(self):
         self._reopen()
@@ -418,8 +420,6 @@ class TRZReader(base.Reader):
         return self.ts
 
     def _seek(self, nframes):
-        from sys import maxint
-
         """Move *nframes* in the trajectory
 
         Note that this doens't read the trajectory (ts remains unchanged)
@@ -483,9 +483,6 @@ class TRZReader(base.Reader):
         if self.trzfile is not None:
             self.trzfile.close()
             self.trzfile = None
-
-    def __del__(self):
-        self.close()
 
 
 class TRZWriter(base.Writer):

--- a/package/MDAnalysis/coordinates/TRZ.py
+++ b/package/MDAnalysis/coordinates/TRZ.py
@@ -77,8 +77,7 @@ import numpy
 import os
 import errno
 
-import base
-from base import Timestep
+from . import base
 import MDAnalysis.core
 import MDAnalysis.core.util as util
 from MDAnalysis.coordinates.core import triclinic_box

--- a/package/MDAnalysis/coordinates/XTC.py
+++ b/package/MDAnalysis/coordinates/XTC.py
@@ -72,4 +72,4 @@ Module reference
 
 """
 
-from xdrfile.XTC import XTCReader, XTCWriter, Timestep
+from .xdrfile.XTC import XTCReader, XTCWriter, Timestep

--- a/package/MDAnalysis/coordinates/XYZ.py
+++ b/package/MDAnalysis/coordinates/XYZ.py
@@ -72,9 +72,9 @@ import errno
 import numpy
 import itertools
 
-import base
 import MDAnalysis
-import MDAnalysis.core
+from . import base
+from ..core import flags
 import MDAnalysis.core.util as util
 from MDAnalysis import NoDataError
 
@@ -115,7 +115,7 @@ class XYZWriter(base.Writer):
         self.filename = args[0]
         # convert length and time to base units on the fly?
         convert_units = kwargs.pop('convert_units', None)
-        self.convert_units = convert_units if convert_units is not None else MDAnalysis.core.flags['convert_lengths']
+        self.convert_units = convert_units if convert_units is not None else flags['convert_lengths']
         self.atomnames = self._get_atomnames(kwargs.pop('atoms', "X"))
         self.remark = kwargs.pop('remark',
                                  "Written by {0} (release {1})".format(self.__class__.__name__, MDAnalysis.__version__))

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -533,7 +533,7 @@ class Reader(IObase):
         raise NotImplementedError("BUG: Override _read_next_timestep() in the trajectory reader!")
 
     def __del__(self):
-        pass
+        self.close()
 
     def __iter__(self):
         raise NotImplementedError("BUG: Override __iter__() in the trajectory reader (%s)!" % type(self))
@@ -559,69 +559,77 @@ class Reader(IObase):
                 raise IndexError("Index %d exceeds length of trajectory (%d)." % (frame, len(self)))
             return self._read_frame(frame)  # REPLACE WITH APPROPRIATE IMPLEMENTATION
         elif type(frame) == slice:  # if frame is a slice object
-            if not (((type(frame.start) == int) or (frame.start is None)) and
-               ((type(frame.stop) == int) or (frame.stop is None)) and
-               ((type(frame.step) == int) or (frame.step is None))):
-                raise TypeError("Slice indices are not integers")
-            return self._sliced_iter(frame)
+            start, stop, step = self._check_slice_indices(frame.start, frame.stop, frame.step)
+            if start == 0 and stop == len(self) and step == 1:
+                return self.__iter__()
+            else:            
+                return self._sliced_iter(start, stop, step)
 
     def _read_frame(self, frame):
         """Move to *frame* and fill timestep with data."""
-        raise TypeError("Reader does not support direct frame indexing.""")
+        raise NotImplementedError("{} does not support direct frame indexing."
+                                  "".format(self.__class__.__name__))
         # Example implementation in the DCDReader:
         #self._jump_to_frame(frame)
         #ts = self.ts
         #ts.frame = self._read_next_frame(ts._x, ts._y, ts._z, ts._unitcell, 1) # XXX required!!
         #return ts
 
-    def _sliced_iter(self, frames):
+    def _sliced_iter(self, start, stop, step):
         """Generator for slicing a trajectory.
 
-        *frames* must be a :class:`slice` object or behave like one.
+        *start* *stop* and *step* are 3 integers describing the slice.
+        Error checking is not done past this point.
 
-        If *frames* corresponds to the whole trajectory then the
-        standard iterator is used; this should work for any trajectory
-        reader. A :exc:`TypeError` is raised if random access to
+        A :exc:`NotImplementedError` is raised if random access to
         frames is not implemented.
         """
         # override with an appropriate implementation e.g. using self[i] might
         # be much slower than skipping steps in a next() loop
-        start, stop, step = self._check_slice_indices(frames.start, frames.stop, frames.step)
-        if start == 0 and stop == len(self) and step == 1:
-            # standard iterator (always implemented)
-            _iter = self.__iter__
-        else:
-            # real slicing
+        def _iter(start=start, stop=stop, step=step):
             try:
-                # Test if the iterator will work: need to do this here so that code can
-                # immediately know if slicing works, even before running through the iterator.
-                self[0]  # should raise TypeError if it cannot do random access
-            except TypeError:
-                raise TypeError("Reader does not support slicing.")
-
-            def _iter(start=start, stop=stop, step=step):
                 for i in xrange(start, stop, step):
                     yield self[i]
+            except NotImplementedError:  # if _read_frame not implemented
+                raise NotImplementedError("{} does not support slicing."
+                                          "".format(self.__class__.__name__))
         return _iter()
 
     def _check_slice_indices(self, start, stop, step):
-        if start is None:
-            start = 0
-        if stop is None:
-            stop = len(self)
-        if step is None:
-            step = 1
-        if (start < 0):
-            start += len(self)
-        if (stop < 0):
-            stop += len(self)
-        elif (stop > len(self)):
-            stop = len(self)
+        """Unpack the slice object and do checks
+
+        Return the start stop and step indices
+        """
+        if not (((type(start) == int) or (start is None)) and
+                ((type(stop) == int) or (stop is None)) and
+                ((type(step) == int) or (step is None))):
+            raise TypeError("Slice indices are not integers")
+        if step == 0:
+            raise ValueError("Step size is zero")
+
+        n = len(self)
+        step = step or 1
+
+        if start:
+            if start < 0:
+                start += n
+        else:
+            start = 0 if step > 0 else n - 1
+
+        if stop:
+            if stop < 0:
+                stop += n
+            elif stop > n:
+                stop = n
+        else:
+            stop = n if step > 0 else -1
+        
         if step > 0 and stop <= start:
             raise IndexError("Stop frame is lower than start frame")
-        if ((start < 0) or (start >= len(self)) or (stop < 0) or (stop > len(self))):
+        if ((start < 0) or (start >= n) or (stop > n)):
             raise IndexError("Frame start/stop outside of the range of the trajectory.")
-        return (start, stop, step)
+
+        return start, stop, step
 
     def __repr__(self):
         return "< %s %r with %d frames of %d atoms (%d fixed) >" % \

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -567,8 +567,8 @@ class Reader(IObase):
 
     def _read_frame(self, frame):
         """Move to *frame* and fill timestep with data."""
-        raise NotImplementedError("{} does not support direct frame indexing."
-                                  "".format(self.__class__.__name__))
+        raise TypeError("{} does not support direct frame indexing."
+                        "".format(self.__class__.__name__))
         # Example implementation in the DCDReader:
         #self._jump_to_frame(frame)
         #ts = self.ts
@@ -590,9 +590,9 @@ class Reader(IObase):
             try:
                 for i in xrange(start, stop, step):
                     yield self[i]
-            except NotImplementedError:  # if _read_frame not implemented
-                raise NotImplementedError("{} does not support slicing."
-                                          "".format(self.__class__.__name__))
+            except TypeError:  # if _read_frame not implemented
+                raise TypeError("{} does not support slicing."
+                                "".format(self.__class__.__name__))
         return _iter()
 
     def _check_slice_indices(self, start, stop, step):

--- a/package/MDAnalysis/coordinates/xdrfile/TRR.py
+++ b/package/MDAnalysis/coordinates/xdrfile/TRR.py
@@ -368,8 +368,6 @@ class TRRReader(core.TrjReader):
         self._numframes, self._offsets = libxdrfile2.read_trr_numframes(filename)
         self._store_offsets()
 
-        return
-
     def _read_next_timestep(self, ts=None):
         if ts is None:
             ts = self.ts
@@ -404,7 +402,7 @@ class TRRReader(core.TrjReader):
                           self.filename)
         elif not ts.status == libxdrfile2.exdrOK:
             raise IOError(errno.EBADF, "Problem with %s file, status %s" %
-                                       (self.format, statno.errorcode[ts.status]), self.filename)
+                                       (self.format, statno.ERRORCODE[ts.status]), self.filename)
 
         if self.convert_units:
             # TRRs have the annoying possibility of frames without coordinates/velocities/forces...

--- a/package/MDAnalysis/coordinates/xdrfile/TRR.py
+++ b/package/MDAnalysis/coordinates/xdrfile/TRR.py
@@ -47,9 +47,11 @@ Classes
 """
 
 import numpy
+import errno
 
-import core
-import libxdrfile2
+from . import statno
+from . import core
+from . import libxdrfile2
 from MDAnalysis import NoDataError
 
 
@@ -353,3 +355,66 @@ class TRRReader(core.TrjReader):
     _Timestep = Timestep
     _Writer = TRRWriter
     units = {'time': 'ps', 'length': 'nm', 'velocity': 'nm/ps', 'force': 'kJ/(mol*nm)'}
+
+    def _allocate_sub(self, DIM):
+        self._pos_buf = numpy.zeros((self._trr_numatoms, DIM), dtype=numpy.float32, order='C')
+        self._velocities_buf = numpy.zeros((self._trr_numatoms, DIM), dtype=numpy.float32, order='C')
+        self._forces_buf = numpy.zeros((self._trr_numatoms, DIM), dtype=numpy.float32, order='C')
+    
+    def _read_trj_natoms(self, filename):
+        return libxdrfile2.read_trr_natoms(filename)
+    
+    def _read_trj_numframes(self, filename):
+        self._numframes, self._offsets = libxdrfile2.read_trr_numframes(filename)
+        self._store_offsets()
+
+        return
+
+    def _read_next_timestep(self, ts=None):
+        if ts is None:
+            ts = self.ts
+        elif not hasattr(ts, '_tpos'):  # If a foreign Timestep is passed as the receptacle of the data
+            ts = Timestep(ts)  # we must make sure the access-checking stuff gets set up.
+
+        if self.xdrfile is None:
+            self.open_trajectory()
+
+        if self._sub is None:
+            ts.status, ts.step, ts.time, ts.lmbda,\
+                ts.has_x, ts.has_v, ts.has_f = libxdrfile2.read_trr(self.xdrfile,
+                                                                    ts._unitcell,
+                                                                    ts._tpos,
+                                                                    ts._tvelocities,
+                                                                    ts._tforces)
+        else:
+            ts.status, ts.step, ts.time, ts.lmbda,\
+                ts.has_x, ts.has_v, ts.has_f = libxdrfile2.read_trr(self.xdrfile,
+                                                                    ts._unitcell,
+                                                                    self._pos_buf,
+                                                                    self._velocities_buf,
+                                                                    self._forces_buf)
+            ts._tpos[:] = self._pos_buf[self._sub]
+            ts._tvelocities[:] = self._velocities_buf[self._sub]
+            ts._tforces[:] = self._forces_buf[self._sub]
+
+        if (ts.status == libxdrfile2.exdrENDOFFILE) or \
+           (ts.status == libxdrfile2.exdrINT):
+            # seems that trr files can get a exdrINT when reaching EOF (??)
+            raise IOError(errno.EIO, "End of file reached for %s file" % self.format,
+                          self.filename)
+        elif not ts.status == libxdrfile2.exdrOK:
+            raise IOError(errno.EBADF, "Problem with %s file, status %s" %
+                                       (self.format, statno.errorcode[ts.status]), self.filename)
+
+        if self.convert_units:
+            # TRRs have the annoying possibility of frames without coordinates/velocities/forces...
+            if ts.has_x:
+                self.convert_pos_from_native(ts._pos)  # in-place !
+            self.convert_pos_from_native(ts._unitcell)  # in-place ! (note: trr contain unit vecs!)
+            ts.time = self.convert_time_from_native(ts.time)  # in-place does not work with scalars
+            if ts.has_v:
+                self.convert_velocities_from_native(ts._velocities)  # in-place
+            if ts.has_f:
+                self.convert_forces_from_native(ts._forces)  # in-place
+        ts.frame += 1
+        return ts        

--- a/package/MDAnalysis/coordinates/xdrfile/XTC.py
+++ b/package/MDAnalysis/coordinates/xdrfile/XTC.py
@@ -82,8 +82,6 @@ class XTCReader(core.TrjReader):
         self._numframes, self._offsets = libxdrfile2.read_xtc_numframes(filename)
         self._store_offsets()
 
-        return
-
     def _read_next_timestep(self, ts=None):
         if ts is None:
             ts = self.ts
@@ -102,7 +100,7 @@ class XTCReader(core.TrjReader):
                           self.filename)
         elif not ts.status == libxdrfile2.exdrOK:
             raise IOError(errno.EBADF, "Problem with %s file, status %s" %
-                                       (self.format, statno.errorcode[ts.status]), self.filename)
+                                       (self.format, statno.ERRORCODE[ts.status]), self.filename)
 
         if self.convert_units:
             self.convert_pos_from_native(ts._pos)  # in-place !

--- a/package/MDAnalysis/coordinates/xdrfile/__init__.py
+++ b/package/MDAnalysis/coordinates/xdrfile/__init__.py
@@ -26,5 +26,5 @@ dimensions) are made available as numpy_ arrays.
 
 __all__ = ['XTC', 'TRR']
 
-import XTC
-import TRR
+from . import XTC
+from . import TRR

--- a/package/MDAnalysis/coordinates/xdrfile/statno.py
+++ b/package/MDAnalysis/coordinates/xdrfile/statno.py
@@ -31,7 +31,7 @@ symbol names.
 
 """
 
-import libxdrfile2
+from . import libxdrfile2
 
 #: List of all error symbols ``exdr*`` extracted from :mod:`libxdrfile2`.
 errorsymbols = [k for k in libxdrfile2.__dict__.keys() if k[:4] == 'exdr']

--- a/package/MDAnalysis/coordinates/xdrfile/statno.py
+++ b/package/MDAnalysis/coordinates/xdrfile/statno.py
@@ -26,17 +26,17 @@ in ``xdrfile.h``).
 The dictionary :data:`xdrfile.errno.errorcode` maps numeric codes to
 symbol names.
 
-.. data:: errorcode
-.. data:: errorsymbols
+.. data:: ERRORCODE
+.. data:: ERRORSYMBOLS
 
 """
 
 from . import libxdrfile2
 
 #: List of all error symbols ``exdr*`` extracted from :mod:`libxdrfile2`.
-errorsymbols = [k for k in libxdrfile2.__dict__.keys() if k[:4] == 'exdr']
+ERRORSYMBOLS = [k for k in libxdrfile2.__dict__.keys() if k[:4] == 'exdr']
 
 #: Dictionary that maps error codes to symbol names.
-errorcode = dict(((libxdrfile2.__dict__[k], k) for k in errorsymbols))
+ERRORCODE = dict(((libxdrfile2.__dict__[k], k) for k in ERRORSYMBOLS))
 
-globals().update(dict((errorcode[n], n) for n in errorcode))
+globals().update(dict((ERRORCODE[n], n) for n in ERRORCODE))

--- a/testsuite/MDAnalysisTests/test_coordinates.py
+++ b/testsuite/MDAnalysisTests/test_coordinates.py
@@ -18,7 +18,7 @@ import MDAnalysis
 import MDAnalysis as mda
 import MDAnalysis.coordinates
 import MDAnalysis.coordinates.core
-from MDAnalysis.coordinates.base import Timestep, SingleFrameReader
+from MDAnalysis.coordinates.base import Timestep
 
 import numpy as np
 import cPickle
@@ -147,11 +147,11 @@ class TestXYZReader(TestCase, Ref2r9r):
         frames = [ts.frame - 1 for ts in trj_iter]
         assert_equal(frames, np.arange(self.universe.trajectory.numframes))
 
-    def test_slice_raises_TypeError(self):
+    def test_slice_raises_NotImplemented(self):
         def trj_iter():
-            return self.universe.trajectory[::2]
+            return list(self.universe.trajectory[::2])
 
-        assert_raises(TypeError, trj_iter)
+        assert_raises(NotImplementedError, trj_iter)
 
         # for whenever full slicing is implemented ...
         #frames = [ts.frame-1 for ts in trj_iter()]
@@ -191,11 +191,11 @@ class TestCompressedXYZReader(TestCase, Ref2r9r):
         frames = [ts.frame - 1 for ts in trj_iter]
         assert_equal(frames, np.arange(self.universe.trajectory.numframes))
 
-    def test_slice_raises_TypeError(self):
+    def test_slice_raises_NotImplemented(self):
         def trj_iter():
-            return self.universe.trajectory[::2]
+            return list(self.universe.trajectory[::2])
 
-        assert_raises(TypeError, trj_iter)
+        assert_raises(NotImplementedError, trj_iter)
 
 
 class TestXYZWriter(TestCase, Ref2r9r):
@@ -368,23 +368,17 @@ class TestTRJReader(_TRJReaderTest, RefACHE):
         self.universe = mda.Universe(PRM, TRJ)
         self.prec = 3
 
-    def test_slice_raises_TypeError(self):
+    def test_slice_raises_NotImplemented(self):
         def trj_iter():
-            return self.universe.trajectory[::2]
+            return list(self.universe.trajectory[::2])
 
-        assert_raises(TypeError, trj_iter)
+        assert_raises(NotImplementedError, trj_iter)
 
 
 class TestBzippedTRJReader(TestTRJReader):
     def setUp(self):
         self.universe = mda.Universe(PRM, TRJ_bz2)
         self.prec = 3
-
-    def test_slice_raises_TypeError(self):
-        def trj_iter():
-            return self.universe.trajectory[::2]
-
-        assert_raises(TypeError, trj_iter)
 
 
 class TestBzippedTRJReaderPBC(_TRJReaderTest, RefCappedAla):
@@ -394,9 +388,9 @@ class TestBzippedTRJReaderPBC(_TRJReaderTest, RefCappedAla):
 
     def test_slice_raises_TypeError(self):
         def trj_iter():
-            return self.universe.trajectory[::2]
+            return list(self.universe.trajectory[::2])
 
-        assert_raises(TypeError, trj_iter)
+        assert_raises(NotImplementedError, trj_iter)
 
 
 class TestNCDFReader(_TRJReaderTest, RefVGV):
@@ -2359,36 +2353,36 @@ class _GromacsReader_offsets(TestCase):
 
     @dec.slow
     def test_offsets(self):
-        if self.trajectory._TrjReader__offsets is None:
+        if self.trajectory._offsets is None:
             self.trajectory.numframes
-        assert_array_almost_equal(self.trajectory._TrjReader__offsets, self.ref_offsets,
+        assert_array_almost_equal(self.trajectory._offsets, self.ref_offsets,
                                   err_msg="wrong frame offsets")
 
         # Saving
         self.trajectory.save_offsets(self.outfile_offsets)
         with open(self.outfile_offsets, 'rb') as f:
             saved_offsets = cPickle.load(f)
-        assert_array_almost_equal(self.trajectory._TrjReader__offsets, saved_offsets['offsets'],
+        assert_array_almost_equal(self.trajectory._offsets, saved_offsets['offsets'],
                                   err_msg="error saving frame offsets")
         assert_array_almost_equal(self.ref_offsets, saved_offsets['offsets'],
                                   err_msg="saved frame offsets don't match the known ones")
 
         # Loading
         self.trajectory.load_offsets(self.outfile_offsets)
-        assert_array_almost_equal(self.trajectory._TrjReader__offsets, self.ref_offsets,
+        assert_array_almost_equal(self.trajectory._offsets, self.ref_offsets,
                                   err_msg="error loading frame offsets")
 
     @dec.slow
     def test_persistent_offsets_new(self):
         # check that offsets will be newly generated and not loaded from stored
         # offsets
-        assert_equal(self.trajectory._TrjReader__offsets, None)
+        assert_equal(self.trajectory._offsets, None)
 
     @dec.slow
     def test_persistent_offsets_stored(self):
         # build offsets
         self.trajectory.numframes
-        assert_equal((self.trajectory._TrjReader__offsets is None), False)
+        assert_equal((self.trajectory._offsets is None), False)
     
         # check that stored offsets present
         assert_equal(os.path.exists(self.trajectory._offset_filename()), True)
@@ -2422,7 +2416,7 @@ class _GromacsReader_offsets(TestCase):
 
         # check that stored offsets are loaded for new universe
         u = mda.Universe(self.top, self.traj)
-        assert_equal((u.trajectory._TrjReader__offsets is not None), True)
+        assert_equal((u.trajectory._offsets is not None), True)
 
     @dec.slow
     def test_persistent_offsets_ctime_mismatch(self):
@@ -2440,7 +2434,7 @@ class _GromacsReader_offsets(TestCase):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")  # Drop the warnings silently
             u = mda.Universe(self.top, self.traj)
-            assert_equal((u.trajectory._TrjReader__offsets is None), True)
+            assert_equal((u.trajectory._offsets is None), True)
         
     @dec.slow
     def test_persistent_offsets_size_mismatch(self):
@@ -2456,7 +2450,7 @@ class _GromacsReader_offsets(TestCase):
             cPickle.dump(saved_offsets, f)
 
         u = mda.Universe(self.top, self.traj)
-        assert_equal((u.trajectory._TrjReader__offsets is None), True)
+        assert_equal((u.trajectory._offsets is None), True)
         
     @dec.slow
     def test_persistent_offsets_last_frame_wrong(self):
@@ -2474,7 +2468,7 @@ class _GromacsReader_offsets(TestCase):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")  # Drop the warnings silently
             u = mda.Universe(self.top, self.traj)
-            assert_equal((u.trajectory._TrjReader__offsets is None), True)
+            assert_equal((u.trajectory._offsets is None), True)
 
     @dec.slow
     def test_persistent_offsets_readonly(self):
@@ -2500,7 +2494,7 @@ class _GromacsReader_offsets(TestCase):
         # check that the *refresh_offsets* keyword ensures stored offsets
         # aren't retrieved
         u = mda.Universe(self.top, self.traj, refresh_offsets=True)
-        assert_equal((u.trajectory._TrjReader__offsets is None), True)
+        assert_equal((u.trajectory._offsets is None), True)
 
     @dec.slow
     def test_persistent_offsets_refreshFalse(self):
@@ -2509,7 +2503,7 @@ class _GromacsReader_offsets(TestCase):
 
         # check that the *refresh_offsets* keyword as False grabs offsets
         u = mda.Universe(self.top, self.traj, refresh_offsets=False)
-        assert_equal((u.trajectory._TrjReader__offsets is None), False)
+        assert_equal((u.trajectory._offsets is None), False)
 
 
 class TestXTCReader_offsets(_GromacsReader_offsets):
@@ -3205,14 +3199,6 @@ class _LAMMPSTimestep(_DCDTimestep):  # LAMMPS Timestep is a subclass of DCD Tim
     name = "LAMMPS"
 
 
-class _PDBTimestep(_BaseTimestep):
-    Timestep = MDAnalysis.coordinates.PDB.Timestep
-    name = "PDB"
-    has_box = True
-    set_box = True
-    unitcell = np.array([10., 11., 12., 90., 90., 90.])
-
-
 class _TRJTimestep(_BaseTimestep):
     Timestep = MDAnalysis.coordinates.TRJ.Timestep
     name = "TRJ"
@@ -3433,10 +3419,6 @@ class TestLAMMPSTimestep(_TestTimestep, _LAMMPSTimestep):
     pass
 
 
-class TestPDBTimestep(_TestTimestep, _PDBTimestep):
-    pass
-
-
 class TestTRJTimestep(_TestTimestep, _TRJTimestep):
     pass
 
@@ -3451,93 +3433,3 @@ class TestXTCTimestep(_TestTimestep, _XTCTimestep):
 
 class TestTRRTimestep(_TestTimestep, _TRRTimestep):
     pass
-
-
-class AmazingReader(SingleFrameReader):
-    format = 'Amazing'
-    # have to hack this in to get the base class to "work"
-    def _read_first_frame(self):
-        self.numatoms = 10
-        self.ts = Timestep(self.numatoms)
-        self.ts.frame = 1
-
-class TestSingleFrameReader(TestCase):
-    def setUp(self):
-        self.numatoms = 10
-        self.r = AmazingReader
-        self.sfr = AmazingReader('test.txt')
-        self.ts = self.sfr.ts
-
-    def tearDown(self):
-        del self.r
-        del self.sfr
-        del self.ts
-        del self.numatoms
-
-    def test_required_attributes(self):
-        """Test that SFReader has the required attributes"""
-        for attr in ['filename', 'numatoms', 'numframes', 'fixed', 'skip',
-                     'skip_timestep', 'delta', 'periodic', 'ts',
-                     'units', 'format']:
-            assert_equal(hasattr(self.sfr, attr), True, "Missing attr: {}".format(attr))
-        
-    def test_iter(self):
-        l = [ts for ts in self.sfr]
-
-        assert_equal(len(l), 1)
-
-    def test_close(self):
-        sfr = self.r('text.txt')
-
-        ret = sfr.close()
-        # Check that method works?
-        assert_equal(ret, None)
-
-    def test_next(self):
-        assert_raises(IOError, self.sfr.next)
-
-    def test_rewind(self):
-        ret = self.sfr.rewind()
-
-        assert_equal(ret, None)
-        assert_equal(self.sfr.ts.frame, 1)
-
-    def test_context(self):
-        with self.r('text.txt') as sfr:
-            l = sfr.ts.frame
-
-        assert_equal(l, 1)
-
-    def test_len(self):
-        l = len(self.sfr)
-
-        assert_equal(l, 1)
-
-    # Getitem tests
-    # only 0 & -1 should work
-    # others should get IndexError
-    def _check_get_results(self, l):
-        assert_equal(len(l), 1)
-        assert_equal(self.ts in l, True)
-
-    def test_getitem(self):
-        fr = [self.sfr[0]]
-
-        self._check_get_results(fr)
-
-    def test_getitem_2(self):
-        fr = [self.sfr[-1]]
-
-        self._check_get_results(fr)
-
-    def test_getitem_IE(self):
-        assert_raises(IndexError, self.sfr.__getitem__, 1)
-
-    def test_getitem_IE_2(self):
-        assert_raises(IndexError, self.sfr.__getitem__, -2)
-
-    # Slicing should still work!
-    def test_slice_1(self):
-        l = list(self.sfr[::])
-
-        self._check_get_results(l)

--- a/testsuite/MDAnalysisTests/test_coordinates.py
+++ b/testsuite/MDAnalysisTests/test_coordinates.py
@@ -147,11 +147,11 @@ class TestXYZReader(TestCase, Ref2r9r):
         frames = [ts.frame - 1 for ts in trj_iter]
         assert_equal(frames, np.arange(self.universe.trajectory.numframes))
 
-    def test_slice_raises_NotImplemented(self):
+    def test_slice_raises_TypeError(self):
         def trj_iter():
             return list(self.universe.trajectory[::2])
 
-        assert_raises(NotImplementedError, trj_iter)
+        assert_raises(TypeError, trj_iter)
 
         # for whenever full slicing is implemented ...
         #frames = [ts.frame-1 for ts in trj_iter()]
@@ -191,11 +191,11 @@ class TestCompressedXYZReader(TestCase, Ref2r9r):
         frames = [ts.frame - 1 for ts in trj_iter]
         assert_equal(frames, np.arange(self.universe.trajectory.numframes))
 
-    def test_slice_raises_NotImplemented(self):
+    def test_slice_raises_TypeError(self):
         def trj_iter():
             return list(self.universe.trajectory[::2])
 
-        assert_raises(NotImplementedError, trj_iter)
+        assert_raises(TypeError, trj_iter)
 
 
 class TestXYZWriter(TestCase, Ref2r9r):
@@ -368,11 +368,11 @@ class TestTRJReader(_TRJReaderTest, RefACHE):
         self.universe = mda.Universe(PRM, TRJ)
         self.prec = 3
 
-    def test_slice_raises_NotImplemented(self):
+    def test_slice_raises_TypeError(self):
         def trj_iter():
             return list(self.universe.trajectory[::2])
 
-        assert_raises(NotImplementedError, trj_iter)
+        assert_raises(TypeError, trj_iter)
 
 
 class TestBzippedTRJReader(TestTRJReader):
@@ -390,7 +390,7 @@ class TestBzippedTRJReaderPBC(_TRJReaderTest, RefCappedAla):
         def trj_iter():
             return list(self.universe.trajectory[::2])
 
-        assert_raises(NotImplementedError, trj_iter)
+        assert_raises(TypeError, trj_iter)
 
 
 class TestNCDFReader(_TRJReaderTest, RefVGV):
@@ -3194,11 +3194,6 @@ class _GROTimestep(_BaseTimestep):
         ])
 
 
-class _LAMMPSTimestep(_DCDTimestep):  # LAMMPS Timestep is a subclass of DCD Timestep
-    Timestep = MDAnalysis.coordinates.LAMMPS.Timestep
-    name = "LAMMPS"
-
-
 class _TRJTimestep(_BaseTimestep):
     Timestep = MDAnalysis.coordinates.TRJ.Timestep
     name = "TRJ"
@@ -3413,10 +3408,6 @@ class TestGROTimestep(_TestTimestep, _GROTimestep):
         assert_array_almost_equal(self.ts._unitcell, ref, decimal=2)
 
         self.ts._unitcell = old
-
-
-class TestLAMMPSTimestep(_TestTimestep, _LAMMPSTimestep):
-    pass
 
 
 class TestTRJTimestep(_TestTimestep, _TRJTimestep):

--- a/testsuite/MDAnalysisTests/test_reader_api.py
+++ b/testsuite/MDAnalysisTests/test_reader_api.py
@@ -1,0 +1,221 @@
+# -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 fileencoding=utf-8
+#
+# MDAnalysis --- http://www.MDAnalysis.org
+# Copyright (c) 2006-2015 Naveen Michaud-Agrawal, Elizabeth J. Denning, Oliver Beckstein
+# and contributors (see AUTHORS for the full list)
+#
+# Released under the GNU Public Licence, v2 or any higher version
+#
+# Please cite your use of MDAnalysis in published work:
+#
+# N. Michaud-Agrawal, E. J. Denning, T. B. Woolf, and O. Beckstein.
+# MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
+# J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
+#
+
+from MDAnalysis.coordinates.base import Timestep, SingleFrameReader, Reader
+
+from numpy.testing import *
+
+"""
+Isolate the API definitions of Readers independent of implementations
+"""
+
+class AmazingMultiFrameReader(Reader):
+    format = 'AmazingMulti'
+
+    def __init__(self, filename, **kwargs):
+        self.filename = filename
+        self.numframes = 10
+        self.numatoms = 10
+        self.skip = 1
+        self.fixed = 0
+        self.periodic = True
+        self.delta = 1.0
+        self.skip_timestep = 1
+        # ts isn't a real timestep, but just an integer
+        # whose value represents the frame number (1 based)
+        self.ts = Timestep(self.numatoms)
+        self._read_next_timestep()
+
+    def __iter__(self):
+        self._reopen()
+        while True:
+            try:
+                yield self._read_next_timestep()
+            except IOError:
+                break
+
+    def _read_next_timestep(self):
+        self.ts.frame += 1
+        if self.ts.frame > self.numframes:
+            raise IOError
+        else:
+            return self.ts
+        
+    def _read_frame(self, frame):
+        self.ts.frame = frame + 1
+
+        return self.ts
+
+    def _reopen(self):
+        self.ts.frame = 0
+
+
+class AmazingReader(SingleFrameReader):
+    format = 'Amazing'
+    # have to hack this in to get the base class to "work"
+    def _read_first_frame(self):
+        self.numatoms = 10
+        self.ts = Timestep(self.numatoms)
+        self.ts.frame = 1
+
+
+class _TestReader(TestCase):
+    """Basic API for readers"""
+    def setUp(self):
+        self.reader = self.readerclass('test.txt')
+        self.ts = self.reader.ts
+    
+    def test_required_attributes(self):
+        """Test that Reader has the required attributes"""
+        for attr in ['filename', 'numatoms', 'numframes', 'fixed', 'skip',
+                     'skip_timestep', 'delta', 'periodic', 'ts',
+                     'units', 'format']:
+            assert_equal(hasattr(self.reader, attr), True, "Missing attr: {}".format(attr))
+        
+    def test_iter(self):
+        l = [ts for ts in self.reader]
+
+        assert_equal(len(l), self.numframes)
+
+    def test_close(self):
+        sfr = self.readerclass('text.txt')
+
+        ret = sfr.close()
+        # Check that method works?
+        assert_equal(ret, None)
+
+    def test_rewind(self):
+        ret = self.reader.rewind()
+
+        assert_equal(ret, None)
+        assert_equal(self.reader.ts.frame, 1)
+
+    def test_context(self):
+        with self.readerclass('text.txt') as sfr:
+            l = sfr.ts.frame
+
+        assert_equal(l, 1)
+
+    def test_len(self):
+        l = len(self.reader)
+
+        assert_equal(l, self.numframes)
+
+
+class _Multi(object):
+    numframes = 10
+    numatoms = 10
+    readerclass = AmazingMultiFrameReader
+    reference = [i+1 for i in range(10)]
+    
+class TestMultiFrameReader(_Multi, _TestReader):
+    def _check_slice(self, sl):
+        """Compare the slice applied to trajectory, to slice of list"""
+        res = [ts.frame for ts in self.reader[sl]]
+        ref = self.reference[sl]
+
+        assert_equal(res, ref)
+    
+    def test_slice_1(self):
+        sl = slice(0, 10, 1)
+        self._check_slice(sl)
+
+    def test_slice_2(self):
+        sl = slice(0, 10, 2)
+        self._check_slice(sl)
+
+    def test_slice_3(self):
+        """Upper bound below traj length"""
+        sl = slice(0, 5, 2)
+        self._check_slice(sl)
+
+    def test_slice_4(self):
+        """Upper bound above traj length"""
+        sl = slice(0, 20, 2)
+        self._check_slice(sl)
+
+    def test_slice_5(self):
+        """Reverse order"""
+        sl = slice(0, 10, -1)
+        self._check_slice(sl)
+
+    def test_slice_IE_1(self):
+        """Stop less than start"""
+        def sl():
+            return list(self.reader[5:1:1])
+        assert_raises(IndexError, sl)
+
+    def test_slice_IE_2(self):
+        """Outside of range of trajectory"""
+        def sl():
+            return list(self.reader[100:])
+        assert_raises(IndexError, sl)
+
+    def test_slice_IE_3(self):
+        def sl():
+            return list(self.reader[-100:])
+        assert_raises(IndexError, sl)
+
+    def test_slice_VE_1(self):
+        def sl():
+            return list(self.reader[::0])
+        assert_raises(ValueError, sl)
+
+    def test_slice_TE_1(self):
+        def sl():
+            return list(self.reader[1.2:2.5:0.1])
+        assert_raises(TypeError, sl)
+
+class _Single(TestCase):
+    numframes = 1
+    numatoms = 10
+    readerclass = AmazingReader
+
+class TestSingleFrameReader(_Single, _TestReader):
+    def test_next(self):
+        assert_raises(IOError, self.reader.next)
+
+    # Getitem tests
+    # only 0 & -1 should work
+    # others should get IndexError
+    def _check_get_results(self, l):
+        assert_equal(len(l), 1)
+        assert_equal(self.ts in l, True)
+
+    def test_getitem(self):
+        fr = [self.reader[0]]
+
+        self._check_get_results(fr)
+
+    def test_getitem_2(self):
+        fr = [self.reader[-1]]
+
+        self._check_get_results(fr)
+
+    def test_getitem_IE(self):
+        assert_raises(IndexError, self.reader.__getitem__, 1)
+
+    def test_getitem_IE_2(self):
+        assert_raises(IndexError, self.reader.__getitem__, -2)
+
+    # Slicing should still work!
+    def test_slice_1(self):
+        l = list(self.reader[::])
+        self._check_get_results(l)
+
+    def test_slice_2(self):
+        l = list(self.reader[::-1])
+        self._check_get_results(l)


### PR DESCRIPTION
Removed lots of duplicate code

Removed obsolete Timestep classes

Changed PDBReader to subclass SingleFrameReader

Cleaned up multiframe Readers

Moved Reader API tests into own file.

Reworked TRR and XTC Readers.  coordinates.xdrfile.core.Reader can now be properly subclassed.

All tests pass, so can merge once reviewed.