### PR TITLE
Bugfix to ProgressMeter.

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -23,6 +23,7 @@ The rules for this file:
     Lifetimes, Water Orientational Relaxation, Angular Distribution, Mean Square 
     Displacement and Survival Probability. Documentation and test are included.
   * RMSF class added to rms analysis module
+  * ProgressMeter now outputs every *interval* number of ``update`` calls
 
   Changes
   * Timestep can now only init using an integer argument (which

--- a/package/MDAnalysis/core/log.py
+++ b/package/MDAnalysis/core/log.py
@@ -224,6 +224,7 @@ class ProgressMeter(object):
         self.numsteps = numsteps
         self.interval = int(interval)
         self.offset = int(offset)
+        self.numouts = -1
         self.quiet = quiet
         if format is None:
             format = "Step %(step)5d/%(numsteps)d [%(percentage)5.1f%%]\r"
@@ -247,6 +248,8 @@ class ProgressMeter(object):
         self.percentage = 100. * self.step / self.numsteps
         for k, v in kwargs.items():
             setattr(self, k, v)
+
+        self.numouts += 1
 
     def echo(self, step, **kwargs):
         """Print the state to stderr, but only every *interval* steps.
@@ -273,7 +276,7 @@ class ProgressMeter(object):
         if self.step == self.numsteps:
             if self.last_newline:
                 format = self.format[:-1] + self.last_newline
-        elif self.step % self.interval == 0:
+        elif self.numouts % self.interval == 0:
             pass
         else:
             return


### PR DESCRIPTION
ProgressMeter would only output progress if the frame number coincided
with the given *interval*; when doing frame steps other than 1, this
often meant seeing no output at all. The behavior has been modified to
output only every *interval* number of calls to
:meth:`ProgressMeter.update`.