### PR TITLE
Cleaned up Reader classes

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -33,6 +33,8 @@ The rules for this file:
   * Removed FormatError, now replaced by ValueError
   * distances.contact_matrix(): changed keyword 'suppress_progmet' to
     'quiet'
+  * base.Reader now defines __iter__
+  * __iter__ removed from many Readers (now use base.Reader implementation)
 
   Fixes
   * analysis.hbonds.HydrogenBondAnalysis performs a sanity check for

--- a/package/MDAnalysis/coordinates/DCD.py
+++ b/package/MDAnalysis/coordinates/DCD.py
@@ -462,19 +462,8 @@ class DCDReader(base.Reader):
             'charmm', 'first', 'with_unitcell']
         return dict(zip(desc, struct.unpack("LLiiiiidiPPiiii", self._dcd_C_str)))
 
-    def __iter__(self):
-        # Reset the trajectory file, read from the start
-        # usage is "from ts in dcd:" where dcd does not have indexes
+    def _reopen(self):
         self._reset_dcd_read()
-
-        def iterDCD():
-            for i in xrange(0, self.numframes, self.skip):  # FIXME: skip is not working!!!
-                try:
-                    yield self._read_next_timestep()
-                except IOError:
-                    raise StopIteration
-
-        return iterDCD()
 
     def _read_next_timestep(self, ts=None):
         if ts is None:

--- a/package/MDAnalysis/coordinates/DLPoly.py
+++ b/package/MDAnalysis/coordinates/DLPoly.py
@@ -260,15 +260,6 @@ class HistoryReader(base.Reader):
 
         return numframes
 
-    def __iter__(self):
-        self._reopen()
-        while True:
-            try:
-                yield self._read_next_timestep()
-            except IOError:
-                self.rewind()
-                raise StopIteration
-
     def rewind(self):
         self._reopen()
         self.next()

--- a/package/MDAnalysis/coordinates/GMS.py
+++ b/package/MDAnalysis/coordinates/GMS.py
@@ -165,16 +165,6 @@ class GMSReader(base.Reader):
         self.close()
         return int(counter)
 
-    def __iter__(self):
-        self.ts.frame = 0  # start at 0 so that the first frame becomes 1
-        self._reopen()
-        while True:
-            try:
-                yield self._read_next_timestep()
-            except EOFError:
-                self.close()
-                raise StopIteration
-
     def _read_next_timestep(self, ts=None):
         # check that the timestep object exists
         if ts is None:

--- a/package/MDAnalysis/coordinates/MOL2.py
+++ b/package/MDAnalysis/coordinates/MOL2.py
@@ -96,13 +96,6 @@ class MOL2Reader(base.Reader):
         self.delta = 0
         self.skip_timestep = 1
 
-    def __iter__(self):
-        for i in xrange(0, self.numframes):
-            try:
-                yield self._read_frame(i)
-            except IOError:
-                raise StopIteration
-
     def parse_block(self, block):
         sections = {}
         cursor = None

--- a/package/MDAnalysis/coordinates/PDB.py
+++ b/package/MDAnalysis/coordinates/PDB.py
@@ -551,12 +551,13 @@ class PrimitivePDBReader(base.Reader):
         kwargs.setdefault('multiframe', self.numframes > 1)
         return PrimitivePDBWriter(filename, **kwargs)
 
-    def __iter__(self):
-        for i in xrange(0, self.numframes):
-            try:
-                yield self._read_frame(i)
-            except IOError:
-                raise StopIteration
+    def rewind(self):
+        self._read_frame(0)
+
+    def _reopen(self):
+        # Pretend the current TS is 0 (in 1 based) so "next" is the
+        # first frame
+        self.ts.frame = 0
 
     def _read_next_timestep(self, ts=None):
         if ts is None:
@@ -571,8 +572,6 @@ class PrimitivePDBReader(base.Reader):
         return self._read_frame(frame)
 
     def _read_frame(self, frame):
-        if numpy.dtype(type(frame)) != numpy.dtype(int):
-            raise TypeError("frame must be a integer")
         # Assume _read_frame is passed a 0-based frame number. Convert this to
         # 1-based.
         frame += 1

--- a/package/MDAnalysis/coordinates/TRZ.py
+++ b/package/MDAnalysis/coordinates/TRZ.py
@@ -341,15 +341,6 @@ class TRZReader(base.Reader):
             self.rewind()
         return self._skip_timestep
 
-    def __iter__(self):
-        self._reopen()
-        while True:
-            try:
-                yield self._read_next_timestep()
-            except IOError:
-                self.rewind()
-                raise StopIteration
-
     # can use base.Reader __getitem__ implementation
     def _read_frame(self, frame):
         """Move to *frame* and fill timestep with data."""

--- a/package/MDAnalysis/coordinates/XYZ.py
+++ b/package/MDAnalysis/coordinates/XYZ.py
@@ -315,16 +315,6 @@ class XYZReader(base.Reader):
         numframes = int(counter / linesPerFrame)
         return numframes
 
-    def __iter__(self):
-        self.ts.frame = 0  # start at 0 so that the first frame becomes 1
-        self._reopen()
-        while True:
-            try:
-                yield self._read_next_timestep()
-            except EOFError:
-                self.close()
-                raise StopIteration
-
     def _read_next_timestep(self, ts=None):
         # check that the timestep object exists
         if ts is None:

--- a/package/MDAnalysis/coordinates/xdrfile/core.py
+++ b/package/MDAnalysis/coordinates/xdrfile/core.py
@@ -718,11 +718,6 @@ class TrjReader(base.Reader):
             else:
                 yield ts
 
-    def rewind(self):
-        """Position at beginning of trajectory"""
-        self._reopen()
-        self.next()  # read first frame
-
     def _reopen(self):
         self.close()
         self.open_trajectory()
@@ -744,19 +739,6 @@ class TrjReader(base.Reader):
     # Renamed this once upon a time.
     _goto_frame = _read_frame
 
-    def _sliced_iter(self, start, stop, step):
-        def _iter(start=start, stop=stop, step=step):
-            if step == 1:
-                rng = xrange(start + 1, stop, step)
-                yield self._read_frame(start)
-                for framenr in rng:
-                    yield self._read_frame(framenr)
-            else:
-                rng = xrange(start, stop, step)
-                for framenr in rng:
-                    yield self._read_frame(framenr)
-        return _iter()
-        
     def timeseries(self, asel, start=0, stop=-1, skip=1, format='afc'):
         raise NotImplementedError("timeseries not available for Gromacs trajectories")
 


### PR DESCRIPTION
In preparation for many Reader improvements ( #239 #314 ), did a clean up of how `Reader.__iter__` works

Removed custom `__iter__` from all but `coordinates.xdrfile.core` (XTC & TRR formats)

Removed many custom `_sliced_iter` implementations, can use `base` version

`base.Reader` now has `__iter__` method

`base.Reader.rewind` now doesn't require seeking access, instead
`_reopen`s and calls `next`