### PR TITLE
Lightweight serialization of AtomGroups by reutilization of built Universes

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -30,7 +30,6 @@ The rules for this file:
   * ProgressMeter now outputs every *interval* number of ``update`` calls
 
   Changes
-  * Tests now cover memory leaks, but can only be run in serial (Issue #312).
   * A ProtoReader class intermediate between IObase and Reader was added so
     specific Readers can be subclassed without __del__ (the ChainReader and
     SingleFrameReader), thus preventing memleaks (Issue #312).

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -10,11 +10,15 @@ The rules for this file:
     use tabs but use spaces for formatting
 
 ------------------------------------------------------------------------------
-??/??/15  tyler.je.reddy, richardjgowers, alejob, orbeckst, dotsdl
+??/??/15  tyler.je.reddy, richardjgowers, alejob, orbeckst, dotsdl,
+        manuel.nuno.melo
 
   * 0.11.0
 
   Enhancements
+  * AtomGroups can now be pickled/unpickled (Issue #293)
+  * Universes can have a __del__ method (not actually added) without
+    leaking (Issue #297)
   * Added reading of DL_Poly format CONFIG and HISTORY files (Issue #298)
     These can both act as both Topology and Coordinate information
   * Timestep objects now have __eq__ method
@@ -26,6 +30,13 @@ The rules for this file:
   * ProgressMeter now outputs every *interval* number of ``update`` calls
 
   Changes
+  * Tests now cover memory leaks, but can only be run in serial (Issue #312).
+  * A ProtoReader class intermediate between IObase and Reader was added so
+    specific Readers can be subclassed without __del__ (the ChainReader and
+    SingleFrameReader), thus preventing memleaks (Issue #312).
+  * Atoms (and all container classes thereof) are now bound to Universes
+    only via weakrefs. If Universes are not explicitly kept in scope Atoms
+    will become orphaned.
   * Timestep can now only init using an integer argument (which
     represents the number of atoms)
   * Added from_timestep and from_coordinates construction methods
@@ -40,6 +51,7 @@ The rules for this file:
   * __iter__ removed from many Readers (now use base.Reader implementation)
 
   Fixes
+  * ChainReaders no longer leak (Issue #312)
   * analysis.hbonds.HydrogenBondAnalysis performs a sanity check for
     static selections (Issue #296)
   * Fixed TRZWriter failing when passed a non TRZTimestep (Issue #302)

--- a/package/MDAnalysis/__init__.py
+++ b/package/MDAnalysis/__init__.py
@@ -159,7 +159,6 @@ __all__ = ['Timeseries', 'Universe', 'asUniverse', 'Writer', 'collection']
 
 import logging
 
-
 # see the advice on logging and libraries in
 # http://docs.python.org/library/logging.html?#configuring-logging-for-a-library
 class NullHandler(logging.Handler):
@@ -246,3 +245,6 @@ from core.AtomGroup import Universe, asUniverse, Merge
 from coordinates.core import writer as Writer
 
 collection = Timeseries.TimeseriesCollection()
+import weakref
+_anchor_universes = weakref.WeakSet()
+del weakref

--- a/package/MDAnalysis/__init__.py
+++ b/package/MDAnalysis/__init__.py
@@ -247,4 +247,5 @@ from coordinates.core import writer as Writer
 collection = Timeseries.TimeseriesCollection()
 import weakref
 _anchor_universes = weakref.WeakSet()
+_named_anchor_universes = weakref.WeakSet()
 del weakref

--- a/package/MDAnalysis/coordinates/__init__.py
+++ b/package/MDAnalysis/coordinates/__init__.py
@@ -367,8 +367,6 @@ The following methods must be implemented in a Reader class.
 
  ``close()``
      close the file and cease I/O
- ``__del__()``
-     ensure that the trajectory is closed
  ``next()``
      advance to next time step or raise :exc:`IOError` when moving
      past the last frame
@@ -379,6 +377,12 @@ The following methods must be implemented in a Reader class.
  ``__exit__()``
      exit method of a `Context Manager`_, should call ``close()``.
 
+.. Note::
+   a ``__del__()`` method should also be present to ensure that the
+   trajectory is properly closed. However, certain types of Reader can ignore
+   this requirement. These include the :class:`SingleFrameReader` (file reading
+   is done within a context manager and needs no closing by hand) and the :class:`ChainReader`
+   (it is a colllection of Readers, each already with its own ``__del__`` method).
 
 **Optional methods**
 

--- a/package/MDAnalysis/coordinates/__init__.py
+++ b/package/MDAnalysis/coordinates/__init__.py
@@ -382,7 +382,7 @@ The following methods must be implemented in a Reader class.
    trajectory is properly closed. However, certain types of Reader can ignore
    this requirement. These include the :class:`SingleFrameReader` (file reading
    is done within a context manager and needs no closing by hand) and the :class:`ChainReader`
-   (it is a colllection of Readers, each already with its own ``__del__`` method).
+   (it is a collection of Readers, each already with its own ``__del__`` method).
 
 **Optional methods**
 

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -605,9 +605,15 @@ class IObase(object):
 class ProtoReader(IObase):
     """Base class for Readers, without a :meth:`__del__` method.
 
+    Extends :class:`IObase` with most attributes and methods of a generic Reader,
+    with the exception of a :meth:`__del__` method. It should be used as base for Readers
+    that do not need :meth:`__del__`, especially since having even an empty :meth:`__del__`
+    might lead to memory leaks.
+
     See the :ref:`Trajectory API` definition in
     :mod:`MDAnalysis.coordinates.__init__` for the required attributes and methods.
     .. versionadded:: 0.11.0
+    .. SeeAlso:: :class:`Reader`
     """
     #: The appropriate Timestep class, e.g.
     #: :class:`MDAnalysis.coordinates.xdrfile.XTC.Timestep` for XTC.
@@ -800,11 +806,18 @@ class ProtoReader(IObase):
                (self.__class__.__name__, self.filename, self.numframes, self.numatoms, self.fixed)
 
 class Reader(ProtoReader):
-    """Base class for trajectory readers. Complements :class:`ProtoReader` with a 
-    :meth:`__del__` method.
+    """Base class for trajectory readers that extends :class:`ProtoReader` with a :meth:`__del__` method.
+
+    New Readers should subclass :class:`Reader` and properly implement a :meth:`close`
+    method, to ensure proper release of resources (mainly file handles). Readers that
+    are inherently safe in this regard should subclass :class:`ProtoReader` instead.
 
     See the :ref:`Trajectory API` definition in
     :mod:`MDAnalysis.coordinates.__init__` for the required attributes and methods.
+    .. SeeAlso:: :class:`ProtoReader`
+    .. versionchanged:: 0.11.0
+       Most of the base Reader class definitions were offloaded to :class:`ProtoReader`
+       so as to allow the subclassing of Readers without a :meth:`__del__` method.
     """
     def __del__(self):
         self.close()

--- a/package/MDAnalysis/core/AtomGroup.py
+++ b/package/MDAnalysis/core/AtomGroup.py
@@ -407,6 +407,7 @@ from collections import defaultdict
 import copy
 import logging
 import os.path
+import weakref
 
 # Local imports
 import MDAnalysis
@@ -433,9 +434,16 @@ class Atom(object):
     are included (and thus it is not possible to add attributes "on
     the fly"; they have to be included in the class definition).
 
+    An :class:`Atom` is bound to a particular :class:`Universe`, but
+    via a weak reference only. This means that the :class:`Atom`, and
+    any :class:`AtomGroup` it is in, are only relevant while the
+    originating :class:`Universe` is in scope.
+
     .. versionchanged 0.9.0
        Added fragment managed property.
        Changed bonds angles torsions impropers to be a managed property
+    .. versionchanged 0.11.0
+       Changed references to :class:`Universe` to be weak.
     """
 
     __slots__ = (
@@ -462,7 +470,12 @@ class Atom(object):
         self.radius = radius
         self.bfactor = bfactor
         self.serial = serial
-        self._universe = universe
+        # Beware: Atoms hold only weakrefs to the universe, enforced
+        #  throught the Atom.universe setter.
+        if universe is None:
+            self._universe = None
+        else:
+            self.universe = universe
 
     def __repr__(self):
         return ("<Atom {idx}: {name} of type {t} of resname {rname}, "
@@ -587,15 +600,17 @@ class Atom(object):
     @property
     def universe(self):
         """a pointer back to the Universe"""
-        if not self._universe is None:
-            return self._universe
+        # Beware: Atoms hold only weakrefs to the universe. We call them to get hard references.
+        if self._universe is not None and self._universe() is not None:
+            return self._universe()
         else:
             raise AttributeError(
                 "Atom {0} is not assigned to a Universe".format(self.number))
 
     @universe.setter
     def universe(self, universe):
-        self._universe = universe
+        # Beware: Atoms hold only weakrefs to the universe
+        self._universe = weakref.ref(universe)
 
     @property
     def bonded_atoms(self):
@@ -671,6 +686,10 @@ class AtomGroup(object):
     from a selection. It is build from any list-like collection of
     :class:`Atom` instances. It is also possible to create an empty AtomGroup
     from an empty list.
+
+    AtomGroup instances are bound to a :class:`Universe`, but only through the
+    weak reference :class:`Atom` has. The connection is lost as soon as the
+    :class:`Universe` goes out of scope.
 
     An AtomGroup can be indexed and sliced like a list::
 
@@ -881,7 +900,7 @@ class AtomGroup(object):
         """The universe to which the atoms belong (read-only)."""
         try:
             return self._atoms[0].universe
-        except AttributeError:
+        except (AttributeError, IndexError):
             return None
 
     def __len__(self):
@@ -972,10 +991,26 @@ class AtomGroup(object):
             natoms=len(self))
 
     def __getstate__(self):
-        raise NotImplementedError
+        if self.universe is None:
+            return None, None, None, None
+        try: # We want to get the ChainReader case, where the trajectory has multiple filenames
+            fname = self.universe.trajectory.filenames
+        except AttributeError:
+            fname = self.universe.trajectory.filename
+        return self.indices(), len(self.universe.atoms), self.universe.filename, fname
 
     def __setstate__(self, state):
-        raise NotImplementedError
+        indices, universe_natoms = state[:2]
+        if indices is None:
+            self.__init__([])
+            return
+        if numpy.max(indices) >= universe_natoms:
+            raise ValueError("Trying to unpickle an inconsistent AtomGroup")
+        for test_universe in MDAnalysis._anchor_universes:
+            if test_universe._matches_unpickling(*state[1:]):
+                self.__init__(test_universe.atoms[indices]._atoms)
+                return
+        raise RuntimeError("Couldn't find suitable Universe to unpickle AtomGroup onto. (needed a universe with %d atoms, topology name: %s, and trajectory name: %s" % state[1:])
 
     def numberOfAtoms(self):
         """Total number of atoms in the group"""
@@ -3264,6 +3299,10 @@ class Universe(object):
           *vdwradii*
               For use with *guess_bonds*. Supply a dict giving a vdwradii for each atom type
               which are used in guessing bonds.
+          *is_anchor*
+              When unpickling instances of :class:`MDAnalysis.core.AtomGroup.AtomGroup`
+              existing Universes are searched for one where to anchor those atoms. Set
+              to ``False`` to prevent this Universe from being considered. [``True``]
 
 
         This routine tries to do the right thing:
@@ -3291,7 +3330,11 @@ class Universe(object):
            Added ``'guess_bonds'`` keyword to cause topology to be guessed on
            Universe creation.
            Deprecated ``'bonds'`` keyword, use ``'guess_bonds'`` instead.
+        .. versionchanged:: 0.11.0
+           Added the *is_anchor* keyword for finer behavior control when unpickling
+           instances of :class:`MDAnalysis.core.AtomGroup.AtomGroup`.
         """
+
         from ..topology.core import get_parser_for, guess_format
         from ..topology.base import TopologyReader
 
@@ -3373,6 +3416,10 @@ class Universe(object):
         if kwargs.get('guess_bonds', False):
             self.atoms.guess_bonds(vdwradii=kwargs.get('vdwradii',None))
 
+        # For control of AtomGroup unpickling
+        if kwargs.get('is_anchor', True):
+            self.make_anchor()
+
     def _clear_caches(self, *args):
         """Clear cache for all *args*.
 
@@ -3431,7 +3478,6 @@ class Universe(object):
         # create memory problems?
         self.segments = self.atoms.segments
         self.residues = self.atoms.residues
-        self.universe = self  # for Writer.write(universe), see Issue 49
 
     def _init_top(self, cat, Top):
         """Initiate a generic form of topology.
@@ -3581,6 +3627,13 @@ class Universe(object):
         frags = tuple([AtomGroup(list(a.ats)) for a in set(f.values())])
 
         return frags
+
+    @property
+    def universe(self):
+        # for Writer.write(universe), see Issue 49
+        # Encapsulation in an accessor prevents the Universe from having to keep a reference to itself,
+        #  which might be undesirable if it has a __del__ method. It is also cleaner than a weakref.
+        return self
 
     @property
     @cached('fragments')
@@ -4096,10 +4149,37 @@ class Universe(object):
         del self.__trajectory  # guarantees that files are closed (?)
         self.__trajectory = value
 
+    def make_anchor(self):
+        """Add this Universe to the list where anchors are searched for when unpickling
+        :class:`MDAnalysis.core.AtomGroup.AtomGroup` instances. Silently proceeds if it
+        is already on the list."""
+        MDAnalysis._anchor_universes.add(self)
+
+    def remove_anchor(self):
+        """Remove this Universe from the list where anchors are searched for when unpickling
+        :class:`MDAnalysis.core.AtomGroup.AtomGroup` instances. Silently proceeds if it
+        is already not on the list."""
+        MDAnalysis._anchor_universes.discard(self)
+
+    @property
+    def is_anchor(self):
+        """Whether this Universe will be checked for anchoring when unpickling
+        :class:`MDAnalysis.core.AtomGroup.AtomGroup` instances"""
+        return self in MDAnalysis._anchor_universes
+
+    def _matches_unpickling(self, natoms, fname, trajname):
+        try:
+            return len(self.atoms)==natoms and self.filename==fname and self.trajectory.filenames==trajname 
+        except AttributeError: # Only ChainReaders have filenames (plural)
+            return len(self.atoms)==natoms and self.filename==fname and self.trajectory.filename==trajname 
+
     # NOTE: DO NOT ADD A __del__() method: it somehow keeps the Universe
     #       alive during unit tests and the unit tests run out of memory!
     #### def __del__(self): <------ do not add this! [orbeckst]
-
+    # This can be overriden, but bear in mind that for that to work objects under
+    # Universe that hold backreferences to it can only do so using weakrefs. (Issue #297) 
+    #def __del__(self):
+    #    pass
 
 def asUniverse(*args, **kwargs):
     """Return a universe from the input arguments.

--- a/testsuite/MDAnalysisTests/__init__.py
+++ b/testsuite/MDAnalysisTests/__init__.py
@@ -112,6 +112,25 @@ except ImportError:
                       """(For example, try "easy_install 'numpy>=1.3'").""")
 
 try:
+    from numpy.testing import assert_
+except ImportError:
+    # missing in numpy 1.2 but needed here:
+    # copied code from numpy.testing 1.5
+    def assert_(val, msg=''):
+        """
+        Assert that works in release mode.
+
+        The Python built-in ``assert`` does not work when executing code in
+        optimized mode (the ``-O`` flag) - no byte-code is generated for it.
+
+        For documentation on usage, refer to the Python documentation.
+
+        (Code taken from numpy.testing 1.4)
+        """
+        if not val:
+            raise AssertionError(msg)
+
+try:
     import nose
 except ImportError:
     raise ImportError("""nose is required to run the test suite. Please install it first. """
@@ -171,9 +190,4 @@ def executable_not_found_runtime(*args):
       ...
     """
     return lambda: executable_not_found(*args)
-
-def teardown_package():
-    import gc
-    gc.collect()
-    assert_equal(len(gc.garbage), 0, "Garbage collector can't collect the following: %r" % gc.garbage)
 

--- a/testsuite/MDAnalysisTests/__init__.py
+++ b/testsuite/MDAnalysisTests/__init__.py
@@ -104,7 +104,7 @@ especially as we are directly using this framework (imported from numpy).
 __version__ = "0.11.0-dev"  # keep in sync with RELEASE in setup.py
 
 try:
-    from numpy.testing import Tester
+    from numpy.testing import Tester, assert_equal
 
     test = Tester().test
 except ImportError:
@@ -114,7 +114,7 @@ except ImportError:
 try:
     import nose
 except ImportError:
-    raise ImportError("""nose is requires to run the test suite. Please install it first. """
+    raise ImportError("""nose is required to run the test suite. Please install it first. """
                       """(For example, try "easy_install nose").""")
 
 try:
@@ -171,3 +171,9 @@ def executable_not_found_runtime(*args):
       ...
     """
     return lambda: executable_not_found(*args)
+
+def teardown_package():
+    import gc
+    gc.collect()
+    assert_equal(len(gc.garbage), 0, "Garbage collector can't collect the following: %r" % gc.garbage)
+

--- a/testsuite/MDAnalysisTests/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/test_atomgroup.py
@@ -771,17 +771,6 @@ class TestAtomGroup(TestCase):
         assert_equal(u.atoms.segids(), ["CORE", "NMP", "CORE", "LID", "CORE"],
                      err_msg="failed to change segids = {0}".format(u.atoms.segids()))
 
-    def test_pickle_raises_NotImplementedError(self):
-        import cPickle
-        ag = self.universe.selectAtoms("bynum 12:42 and name H*")
-        assert_raises(NotImplementedError, cPickle.dumps, ag, protocol=cPickle.HIGHEST_PROTOCOL)
-
-    def test_unpickle_raises_NotImplementedError(self):
-        ag = self.universe.atoms[:3]
-        def ag_setstate(ag):
-            return ag.__setstate__('a')
-        assert_raises(NotImplementedError, ag_setstate, ag)
-
     def test_wronglen_set(self):
         """Give the setter function a list of wrong length"""
         assert_raises(ValueError, self.ag.set_mass, [0.1, 0.2])
@@ -1287,10 +1276,9 @@ class TestAtomGroupTimestep(TestCase):
 
 
 def test_empty_AtomGroup():
-    """Test that a empty AtomGroup can be constructed (Issue 12)"""
+    """Test that an empty AtomGroup can be constructed (Issue 12)"""
     ag = MDAnalysis.core.AtomGroup.AtomGroup([])
     assert_equal(len(ag), 0)
-
 
 class _WriteAtoms(TestCase):
     """Set up the standard AdK system in implicit solvent."""
@@ -1486,7 +1474,6 @@ class TestUniverse(TestCase):
         box = numpy.array([10, 11, 12, 90, 90, 90])
         u.dimensions = numpy.array([10, 11, 12, 90, 90, 90])
         assert_allclose(u.dimensions, box)
-
 
 class TestPBCFlag(TestCase):
     def setUp(self):

--- a/testsuite/MDAnalysisTests/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/test_atomgroup.py
@@ -25,6 +25,7 @@ from MDAnalysis import NoDataError
 
 import numpy
 from numpy.testing import *
+from . import assert_
 from numpy import array, float32, rad2deg
 from nose.plugins.attrib import attr
 
@@ -33,24 +34,6 @@ import tempfile
 import itertools
 
 from MDAnalysisTests import knownfailure
-
-try:
-    from numpy.testing import assert_
-except ImportError:
-    # missing in numpy 1.2 but needed here:
-    # copied code from numpy.testing 1.5
-    def assert_(val, msg=''):
-        """
-        Assert that works in release mode.
-
-        The Python built-in ``assert`` does not work when executing code in
-        optimized mode (the ``-O`` flag) - no byte-code is generated for it.
-
-        For documentation on usage, refer to the Python documentation.
-
-        """
-        if not val:
-            raise AssertionError(msg)
 
 
 class TestAtom(TestCase):

--- a/testsuite/MDAnalysisTests/test_libxdrfile2.py
+++ b/testsuite/MDAnalysisTests/test_libxdrfile2.py
@@ -20,25 +20,7 @@ from MDAnalysis.tests.datafiles import XTC, TRR
 import MDAnalysis.coordinates.xdrfile.libxdrfile2 as xdr
 
 # FIXES: test_xdropen: error because assert_ not found in numpy < 1.3
-# maybe move this into separate module together with
-# from numpy.testing import * ?
-try:
-    from numpy.testing import assert_
-except ImportError:
-    def assert_(val, msg=''):
-        """
-        Assert that works in release mode.
-
-        The Python built-in ``assert`` does not work when executing code in
-        optimized mode (the ``-O`` flag) - no byte-code is generated for it.
-
-        For documentation on usage, refer to the Python documentation.
-
-        (Code taken from numpy.testing 1.4)
-        """
-        if not val:
-            raise AssertionError(msg)
-
+from . import assert_
 
 class TestLib(TestCase):
     def test_constants(self):

--- a/testsuite/MDAnalysisTests/test_modelling.py
+++ b/testsuite/MDAnalysisTests/test_modelling.py
@@ -25,30 +25,13 @@ from MDAnalysis import NoDataError
 
 import numpy
 from numpy.testing import *
+from . import assert_
 from numpy import array, float32, rad2deg
 from nose.plugins.attrib import attr
 
 import os
 import tempfile
 import itertools
-
-try:
-    from numpy.testing import assert_
-except ImportError:
-    # missing in numpy 1.2 but needed here:
-    # copied code from numpy.testing 1.5
-    def assert_(val, msg=''):
-        """
-        Assert that works in release mode.
-
-        The Python built-in ``assert`` does not work when executing code in
-        optimized mode (the ``-O`` flag) - no byte-code is generated for it.
-
-        For documentation on usage, refer to the Python documentation.
-
-        """
-        if not val:
-            raise AssertionError(msg)
 
 from MDAnalysis import Universe, Merge
 from MDAnalysis.analysis.align import alignto

--- a/testsuite/MDAnalysisTests/test_persistence.py
+++ b/testsuite/MDAnalysisTests/test_persistence.py
@@ -21,53 +21,90 @@ from MDAnalysis.core.AtomGroup import AtomGroup
 
 import numpy
 from numpy.testing import *
+from . import assert_
 
-import gc
 import cPickle
 
 class TestAtomGroupPickle(TestCase):
 
     def setUp(self):
-        """Set up a hopefully unique universe."""
+        """Set up hopefully unique universes."""
+        # _n marks named universes/atomgroups/pickled strings
         self.universe = MDAnalysis.Universe(PDB_small, PDB_small, PDB_small)
+        self.universe_n = MDAnalysis.Universe(PDB_small, PDB_small, PDB_small, is_anchor=False, anchor_name="test1")
         self.ag = self.universe.atoms[:20]  # prototypical AtomGroup
+        self.ag_n = self.universe_n.atoms[:10]
+        self.pickle_str = cPickle.dumps(self.ag, protocol=cPickle.HIGHEST_PROTOCOL)
+        self.pickle_str_n = cPickle.dumps(self.ag_n, protocol=cPickle.HIGHEST_PROTOCOL)
 
     def tearDown(self):
         del self.universe
+        del self.universe_n
         del self.ag
+        del self.ag_n
 
-    def test_pickle_unpickle(self):
-        """Test that an AtomGroup can be pickled/unpickled (Issue 293)"""
-        pickle_str = cPickle.dumps(self.ag, protocol=cPickle.HIGHEST_PROTOCOL)
-        newag = cPickle.loads(pickle_str)
+    def test_unpickle(self):
+        """Test that an AtomGroup can be unpickled (Issue 293)"""
+        newag = cPickle.loads(self.pickle_str)
         # Can unpickle
         assert_array_equal(self.ag.indices(), newag.indices())
+        assert_(newag.universe is self.universe, "Unpickled AtomGroup on wrong Universe.")
+
+    def test_unpickle_named(self):
+        """Test that an AtomGroup can be unpickled (Issue 293)"""
+        newag = cPickle.loads(self.pickle_str_n)
+        # Can unpickle
+        assert_array_equal(self.ag_n.indices(), newag.indices())
+        assert_(newag.universe is self.universe_n, "Unpickled AtomGroup on wrong Universe.")
+
+    def test_unpickle_noanchor(self):
         # Shouldn't unpickle if the universe is removed from the anchors
         self.universe.remove_anchor()
         # In the complex (parallel) testing environment there's the risk of other compatible Universes being available
         #  for anchoring even after this one is expressly removed.
-        assert_raises(RuntimeError, cPickle.loads, pickle_str)
+        assert_raises(RuntimeError, cPickle.loads, self.pickle_str)
           # If this fails to raise an exception either:"
           #  1-the anchoring Universe failed to remove_anchor or"
           #  2-another Universe with the same characteristics was created for testing and is being used as anchor."
-        # Now it goes back into the anchor list again
+
+    def test_unpickle_reanchor(self):
+        # universe is removed from the anchors
+        self.universe.remove_anchor()
+        # now it goes back into the anchor list again
         self.universe.make_anchor()
-        newag2 = cPickle.loads(pickle_str)
-        assert_array_equal(self.ag.indices(), newag2.indices())
+        newag = cPickle.loads(self.pickle_str)
+        assert_array_equal(self.ag.indices(), newag.indices())
+        assert_(newag.universe is self.universe, "Unpickled AtomGroup on wrong Universe.")
+
+    def test_unpickle_reanchor_other(self):
+        # universe is removed from the anchors
+        self.universe.remove_anchor()
+        # and universe_n goes into the anchor list
+        self.universe_n.make_anchor()
+        newag = cPickle.loads(self.pickle_str)
+        assert_array_equal(self.ag.indices(), newag.indices())
+        assert_(newag.universe is self.universe_n, "Unpickled AtomGroup on wrong Universe.")
+
+    def test_unpickle_wrongname(self):
+        # we change the universe's anchor_name
+        self.universe_n.anchor_name = "test2"
+        # shouldn't unpickle if no name matches, even if there's a compatible
+        #  universe in the unnamed anchor list.
+        assert_raises(RuntimeError, cPickle.loads, self.pickle_str_n)
+
+    def test_unpickle_rename(self):
+        # we change universe_n's anchor_name
+        self.universe_n.anchor_name = "test2"
+        # and make universe a named anchor
+        self.universe.anchor_name = "test1"
+        newag = cPickle.loads(self.pickle_str_n)
+        assert_array_equal(self.ag_n.indices(), newag.indices())
+        assert_(newag.universe is self.universe, "Unpickled AtomGroup on wrong Universe.")
 
 def test_pickle_unpickle_empty():
     """Test that an empty AtomGroup can be pickled/unpickled (Issue 293)"""
-    import gc
     ag = AtomGroup([])
     pickle_str = cPickle.dumps(ag, protocol=cPickle.HIGHEST_PROTOCOL)
     newag = cPickle.loads(pickle_str)
     assert_equal(len(newag), 0)
 
-#def test_memleak(self):
-#    u1 = MDAnalysis.Universe(PSF, DCD)
-#    u2 = MDAnalysis.Universe(PSF, DCD, DCD)
-#    del u1
-#    del u2
-#    gc.collect()
-#    assert_equal(len(gc.garbage), 0, "Garbage collector can't collect the following: %r" % gc.garbage)
-#

--- a/testsuite/MDAnalysisTests/test_persistence.py
+++ b/testsuite/MDAnalysisTests/test_persistence.py
@@ -1,0 +1,73 @@
+# -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 fileencoding=utf-8
+#
+# MDAnalysis --- http://www.MDAnalysis.org
+# Copyright (c) 2006-2015 Naveen Michaud-Agrawal, Elizabeth J. Denning, Oliver Beckstein
+# and contributors (see AUTHORS for the full list)
+#
+# Released under the GNU Public Licence, v2 or any higher version
+#
+# Please cite your use of MDAnalysis in published work:
+#
+# N. Michaud-Agrawal, E. J. Denning, T. B. Woolf, and O. Beckstein.
+# MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
+# J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
+#
+
+import MDAnalysis
+from MDAnalysis.tests.datafiles import PSF, DCD, PDB_small
+import MDAnalysis.core.AtomGroup
+from MDAnalysis.core.AtomGroup import AtomGroup
+
+import numpy
+from numpy.testing import *
+
+import gc
+import cPickle
+
+class TestAtomGroupPickle(TestCase):
+
+    def setUp(self):
+        """Set up a hopefully unique universe."""
+        self.universe = MDAnalysis.Universe(PDB_small, PDB_small, PDB_small)
+        self.ag = self.universe.atoms[:20]  # prototypical AtomGroup
+
+    def tearDown(self):
+        del self.universe
+        del self.ag
+
+    def test_pickle_unpickle(self):
+        """Test that an AtomGroup can be pickled/unpickled (Issue 293)"""
+        pickle_str = cPickle.dumps(self.ag, protocol=cPickle.HIGHEST_PROTOCOL)
+        newag = cPickle.loads(pickle_str)
+        # Can unpickle
+        assert_array_equal(self.ag.indices(), newag.indices())
+        # Shouldn't unpickle if the universe is removed from the anchors
+        self.universe.remove_anchor()
+        # In the complex (parallel) testing environment there's the risk of other compatible Universes being available
+        #  for anchoring even after this one is expressly removed.
+        assert_raises(RuntimeError, cPickle.loads, pickle_str)
+          # If this fails to raise an exception either:"
+          #  1-the anchoring Universe failed to remove_anchor or"
+          #  2-another Universe with the same characteristics was created for testing and is being used as anchor."
+        # Now it goes back into the anchor list again
+        self.universe.make_anchor()
+        newag2 = cPickle.loads(pickle_str)
+        assert_array_equal(self.ag.indices(), newag2.indices())
+
+def test_pickle_unpickle_empty():
+    """Test that an empty AtomGroup can be pickled/unpickled (Issue 293)"""
+    import gc
+    ag = AtomGroup([])
+    pickle_str = cPickle.dumps(ag, protocol=cPickle.HIGHEST_PROTOCOL)
+    newag = cPickle.loads(pickle_str)
+    assert_equal(len(newag), 0)
+
+#def test_memleak(self):
+#    u1 = MDAnalysis.Universe(PSF, DCD)
+#    u2 = MDAnalysis.Universe(PSF, DCD, DCD)
+#    del u1
+#    del u2
+#    gc.collect()
+#    assert_equal(len(gc.garbage), 0, "Garbage collector can't collect the following: %r" % gc.garbage)
+#


### PR DESCRIPTION
AtomGroups can now be pickled/unpickled (closes #293)
A weakref system was implemented so that Universes can have a __del__
method without memleaking (closes #297)
ChainReaders no longer leak (and also no longer have a __del__  method)
(closes #312)
Tests now specifically look for uncollectable objects at the end. Breaks
parallelization, though.

These issues/enhancements all got interdependent at one point, hence the common commit.
I found a way to include memory leak checks at `teardown_package`, in `MDAnalysisTests.__init__.py`, but the inclusion of this function apparently keeps nose from parallelizing (n processes/threads are still started, but they run in only one core).
Ignored the 59 known (Issue #319) test errors related to DL_Poly.