### PR TITLE
Closes Issue #310

### DIFF
--- a/package/MDAnalysis/analysis/helanal.py
+++ b/package/MDAnalysis/analysis/helanal.py
@@ -281,7 +281,7 @@ def helanal_trajectory(universe, selection="name CA", start=None, end=None, begi
     trajectory = universe.trajectory
 
     if finish is not None:
-        if trajectory.time > finish:  # you'd be starting with a finish time (in ps) that has already passed or not
+        if trajectory.ts.time > finish:  # you'd be starting with a finish time (in ps) that has already passed or not
         # available
             raise FinishTimeException(
                 'The input finish time ({finish} ps) precedes the current trajectory time of {traj_time} ps.'.format(

--- a/package/MDAnalysis/coordinates/CRD.py
+++ b/package/MDAnalysis/coordinates/CRD.py
@@ -34,6 +34,7 @@ class CRDReader(base.SingleFrameReader):
 
     .. versionchanged:: 0.11.0
        Now returns a ValueError instead of FormatError
+       Frames now 0-based instead of 1-based
     """
     format = 'CRD'
     units = {'time': None, 'length': 'Angstrom'}
@@ -73,7 +74,7 @@ class CRDReader(base.SingleFrameReader):
         self.numatoms = len(coords_list)
 
         self.ts = self._Timestep.from_coordinates(np.array(coords_list))
-        self.ts.frame = 1  # 1-based frame number
+        self.ts.frame = 0  # 0-based frame number
         # if self.convert_units:
         #    self.convert_pos_from_native(self.ts._pos)             # in-place !
 
@@ -100,6 +101,9 @@ class CRDWriter(base.Writer):
 
     It automatically writes the CHARMM EXT extended format if there
     are more than 99,999 atoms.
+
+    .. versionchanged:: 0.11.0
+       Frames now 0-based instead of 1-based
     """
     format = 'CRD'
     units = {'time': None, 'length': 'Angstrom'}
@@ -137,7 +141,7 @@ class CRDWriter(base.Writer):
             try:
                 frame = u.trajectory.ts.frame
             except AttributeError:
-                frame = 1  # should catch cases when we are analyzing a single PDB (?)
+                frame = 0  # should catch cases when we are analyzing a single PDB (?)
 
         atoms = selection.atoms  # make sure to use atoms (Issue 46)
         coor = atoms.coordinates()  # can write from selection == Universe (Issue 49)

--- a/package/MDAnalysis/coordinates/DCD.py
+++ b/package/MDAnalysis/coordinates/DCD.py
@@ -19,7 +19,7 @@
 ============================================================
 
 Classes to read and write DCD binary trajectories, the format used by
-CHARMM, NAMD but also LAMMPS. Trajectories can be read regardless of
+CHARMM, NAMD, and also LAMMPS. Trajectories can be read regardless of
 system-endianness as this is auto-detected.
 
 Generally, DCD trajectories produced by any code can be read (with the
@@ -385,6 +385,9 @@ class DCDReader(base.Reader):
 
     .. _Issue 187: https://github.com/MDAnalysis/mdanalysis/issues/187
 
+    .. versionchanged:: 0.11.0
+       Frames now 0-based instead of 1-based
+
     """
     format = 'DCD'
     units = {'time': 'AKMA', 'length': 'Angstrom'}
@@ -455,12 +458,16 @@ class DCDReader(base.Reader):
         if ts is None:
             ts = self.ts
         ts.frame = self._read_next_frame(ts._x, ts._y, ts._z, ts._unitcell, self.skip)
+        # dcd.c gives 1 based, we want 0 based
+        ts.frame -= 1
         return ts
 
     def _read_frame(self, frame):
         self._jump_to_frame(frame)
         ts = self.ts
         ts.frame = self._read_next_frame(ts._x, ts._y, ts._z, ts._unitcell, 1)
+        # dcd.c gives 1 basead, we want 0 based
+        ts.frame -= 1
         return ts
 
     def timeseries(self, asel, start=0, stop=-1, skip=1, format='afc'):

--- a/package/MDAnalysis/coordinates/DMS.py
+++ b/package/MDAnalysis/coordinates/DMS.py
@@ -57,6 +57,9 @@ class Timestep(base.Timestep):
 class DMSReader(base.SingleFrameReader):
     """
     Reads both coordinates and velocities.
+
+    .. versionchanged:: 0.11.0
+       Frames now 0-based instead of 1-based
     """
     format = 'DMS'
     units = {'time': None, 'length': 'A', 'velocity': 'A/ps'}
@@ -109,7 +112,7 @@ class DMSReader(base.SingleFrameReader):
 
         self.ts = self._Timestep.from_coordinates(
             np.array(coords_list, dtype=np.float32), velocities=velocities)
-        self.ts.frame = 1  # 1-based frame number
+        self.ts.frame = 0  # 0-based frame number
 
         self.ts._unitcell = unitcell
         if self.convert_units:

--- a/package/MDAnalysis/coordinates/GMS.py
+++ b/package/MDAnalysis/coordinates/GMS.py
@@ -51,6 +51,9 @@ class GMSReader(base.Reader):
     .. Note: this can read both compressed (foo.out) and compressed
           (foo.out.bz2 or foo.out.gz) files; uncompression is handled
           on the fly
+
+    .. versionchanged:: 0.11.0
+       Frames now 0-based instead of 1-based
     """
 
     format = "GMS"
@@ -247,7 +250,7 @@ class GMSReader(base.Reader):
         # reset ts
         ts = self.ts
         ts.status = 1
-        ts.frame = 0
+        ts.frame = -1 
         ts.step = 0
         ts.time = 0
         return self.outfile

--- a/package/MDAnalysis/coordinates/GRO.py
+++ b/package/MDAnalysis/coordinates/GRO.py
@@ -79,7 +79,11 @@ class Timestep(base.Timestep):
 
 
 class GROReader(base.SingleFrameReader):
-    '''Now reads in velocities as well, if available.'''
+    """Reader for the Gromacs GRO structure format.
+    
+    .. versionchanged:: 0.11.0
+       Frames now 0-based instead of 1-based
+    """
     format = 'GRO'
     units = {'time': None, 'length': 'nm', 'velocity': 'nm/ps'}
     _Timestep = Timestep
@@ -121,7 +125,7 @@ class GROReader(base.SingleFrameReader):
             np.array(coords_list),
             velocities=np.array(velocities_list, dtype=np.float32) if velocities_list else None)
 
-        self.ts.frame = 1  # 1-based frame number
+        self.ts.frame = 0  # 0-based frame number
 
         if len(unitcell) == 3:
             # special case: a b c --> (a 0 0) (b 0 0) (c 0 0)
@@ -138,6 +142,7 @@ class GROReader(base.SingleFrameReader):
             if self.ts.has_velocities:
                 # converts nm/ps to A/ps units
                 self.convert_velocities_from_native(self.ts._velocities)
+
     def Writer(self, filename, **kwargs):
         """Returns a CRDWriter for *filename*.
 
@@ -158,6 +163,9 @@ class GROWriter(base.Writer):
 
        The precision is hard coded to three decimal places and
        velocities are not written (yet).
+
+    .. versionchanged:: 0.11.0
+       Frames now 0-based instead of 1-based
     """
 
     format = 'GRO'
@@ -219,7 +227,7 @@ class GROWriter(base.Writer):
             try:
                 frame = u.trajectory.ts.frame
             except AttributeError:
-                frame = 1  # should catch cases when we are analyzing a single GRO (?)
+                frame = 0  # should catch cases when we are analyzing a single GRO (?)
 
         atoms = selection.atoms  # make sure to use atoms (Issue 46)
         coordinates = atoms.coordinates()  # can write from selection == Universe (Issue 49)

--- a/package/MDAnalysis/coordinates/LAMMPS.py
+++ b/package/MDAnalysis/coordinates/LAMMPS.py
@@ -121,6 +121,8 @@ class DATAReader(base.SingleFrameReader):
     """Reads a single frame of coordinate information from a LAMMPS DATA file.
 
     .. versionadded:: 0.9.0
+    .. versionchanged:: 0.11.0
+       Frames now 0-based instead of 1-based
     """
     format = 'DATA'
     units = {'time': None, 'length': 'Angstrom'}
@@ -135,6 +137,6 @@ class DATAReader(base.SingleFrameReader):
         with DATAParser(self.filename) as p:
             self.ts = p.read_DATA_timestep(self.numatoms, self._Timestep)
 
-        self.ts.frame = 1
+        self.ts.frame = 0
         if self.convert_units:
             self.convert_pos_from_native(self.ts._pos)  # in-place !

--- a/package/MDAnalysis/coordinates/PDBQT.py
+++ b/package/MDAnalysis/coordinates/PDBQT.py
@@ -134,7 +134,8 @@ class PDBQTReader(base.SingleFrameReader):
          TORSDOF 3
          123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789. (column reference)
 
-
+    .. versionchanged:: 0.11.0
+       Frames now 0-based instead of 1-based
     """
     format = 'PDBQT'
     units = {'time': None, 'length': 'Angstrom'}
@@ -174,7 +175,7 @@ class PDBQTReader(base.SingleFrameReader):
         self.numatoms = len(coords)
         self.ts = self._Timestep.from_coordinates(np.array(coords, dtype=np.float32))
         self.ts._unitcell[:] = unitcell
-        self.ts.frame = 1  # 1-based frame number
+        self.ts.frame = 0  # 0-based frame number
         if self.convert_units:
             self.convert_pos_from_native(self.ts._pos)  # in-place !
             self.convert_pos_from_native(self.ts._unitcell[:3])  # in-place ! (only lengths)
@@ -284,6 +285,9 @@ class PDBQTWriter(base.Writer):
            The first letter of the
            :attr:`~MDAnalysis.core.AtomGroup.Atom.segid` is used as the PDB
            chainID.
+
+        .. versionchanged:: 0.11.0
+           Frames now 0-based instead of 1-based
         """
         u = selection.universe
         if frame is not None:
@@ -292,7 +296,7 @@ class PDBQTWriter(base.Writer):
             try:
                 frame = u.trajectory.ts.frame
             except AttributeError:
-                frame = 1  # should catch cases when we are analyzing a single PDB (?)
+                frame = 0  # should catch cases when we are analyzing a single PDB (?)
 
         self.TITLE("FRAME " + str(frame) + " FROM " + str(u.trajectory.filename))
         self.CRYST1(self.convert_dimensions_to_unitcell(u.trajectory.ts))

--- a/package/MDAnalysis/coordinates/PQR.py
+++ b/package/MDAnalysis/coordinates/PQR.py
@@ -102,6 +102,9 @@ class PQRReader(base.SingleFrameReader):
 
     .. _PQR:
         http://www.poissonboltzmann.org/file-formats/biomolecular-structurw/pqr
+
+    .. versionchanged:: 0.11.0
+       Frames now 0-based instead of 1-based
     """
     format = 'PQR'
     units = {'time': None, 'length': 'Angstrom'}
@@ -127,7 +130,7 @@ class PQRReader(base.SingleFrameReader):
         self.numatoms = len(coords)
         self.ts = self._Timestep.from_coordinates(np.array(coords, dtype=np.float32))
         self.ts._unitcell[:] = unitcell
-        self.ts.frame = 1  # 1-based frame number
+        self.ts.frame = 0  # 0-based frame number
         if self.convert_units:
             self.convert_pos_from_native(self.ts._pos)  # in-place !
             self.convert_pos_from_native(self.ts._unitcell[:3])  # in-place ! (only lengths)
@@ -212,6 +215,9 @@ class PQRWriter(base.Writer):
          :Keywords:
              *frame*
                 optionally move to frame number *frame*
+
+        .. versionchanged:: 0.11.0
+           Frames now 0-based instead of 1-based
         """
         # write() method that complies with the Trajectory API
         u = selection.universe
@@ -221,7 +227,7 @@ class PQRWriter(base.Writer):
             try:
                 frame = u.trajectory.ts.frame
             except AttributeError:
-                frame = 1  # should catch cases when we are analyzing a single frame(?)
+                frame = 0  # should catch cases when we are analyzing a single frame(?)
 
         atoms = selection.atoms  # make sure to use atoms (Issue 46)
         coordinates = atoms.coordinates()  # can write from selection == Universe (Issue 49)

--- a/package/MDAnalysis/coordinates/TRJ.py
+++ b/package/MDAnalysis/coordinates/TRJ.py
@@ -183,6 +183,9 @@ class TRJReader(base.Reader):
     trajectory.
 
     .. _AMBER TRJ format: http://ambermd.org/formats.html#trajectory
+
+    .. versionchanged:: 0.11.0
+       Frames now 0-based instead of 1-based
     """
     format = 'TRJ'
     units = {'time': 'ps', 'length': 'Angstrom'}
@@ -349,7 +352,7 @@ class TRJReader(base.Reader):
         # reset ts
         ts = self.ts
         ts.status = 1
-        ts.frame = 0
+        ts.frame = -1 
         ts.step = 0
         ts.time = 0
         return self.trjfile
@@ -401,6 +404,8 @@ class NCDFReader(base.Reader):
     .. versionadded: 0.7.6
     .. versionchanged:: 0.10.0
        Added ability to read Forces
+    .. versionchanged:: 0.11.0
+       Frame labels now 0-based instead of 1-based
     """
 
     format = 'NCDF'
@@ -520,7 +525,7 @@ class NCDFReader(base.Reader):
                 self.convert_forces_from_native(ts._forces, inplace=True)
             if self.periodic:
                 self.convert_pos_from_native(ts._unitcell[:3])  # in-place ! (only lengths)
-        ts.frame = frame + 1  # frame labels are 1-based
+        ts.frame = frame # frame labels are 0-based
         self._current_frame = frame
         return ts
 

--- a/package/MDAnalysis/coordinates/xdrfile/core.py
+++ b/package/MDAnalysis/coordinates/xdrfile/core.py
@@ -55,6 +55,9 @@ for the XTC and TRR format.
    stale. The offsets are automatically regenerated if they are stale or
    missing.
 
+.. versionchanged:: 0.11.0
+   Frames now 0-based instead of 1-based
+
 .. autoclass:: Timestep
    :members:
 .. autoclass:: TrjReader
@@ -628,7 +631,7 @@ class TrjReader(base.Reader):
         try:
             self.__getitem__(-1)
             # ensure we return to the frame we started with
-            self.__getitem__(frame - 1)
+            self.__getitem__(frame)
         except (IndexError, IOError):
             warnings.warn("Could not access last frame with loaded offsets;"
                           " will rebuild offsets instead.")
@@ -651,7 +654,7 @@ class TrjReader(base.Reader):
         # reset ts
         ts = self.ts
         ts.status = libxdrfile2.exdrOK
-        ts.frame = 0
+        ts.frame = -1 
         ts.step = 0
         ts.time = 0
         # additional data for XTC
@@ -701,7 +704,7 @@ class TrjReader(base.Reader):
         return self._Writer(filename, numatoms, **kwargs)
 
     def __iter__(self):
-        self.ts.frame = 0  # start at 0 so that the first frame becomes 1
+        self.ts.frame = -1  # start at -1 so that the first frame becomes 0
         self._reopen()
         while True:
             try:
@@ -725,14 +728,11 @@ class TrjReader(base.Reader):
     def _read_frame(self, frame):
         """ Fast, index-based, random frame access
 
-        :TODO: Should we treat frame as 0-based or 1-based??  Right
-               now: 0-based (which is inconsistent) but analogous to
-               DCDReader
         """
         if self._offsets is None:
             self._read_trj_numframes(self.filename)
         self._seek(self._offsets[frame])
-        self.ts.frame = frame  # frame gets +1'd in _read_next_timestep   
+        self.ts.frame = frame - 1 # frame gets +1'd in _read_next_timestep   
         self._read_next_timestep()
         return self.ts
 

--- a/testsuite/MDAnalysisTests/test_analysis.py
+++ b/testsuite/MDAnalysisTests/test_analysis.py
@@ -503,6 +503,7 @@ class Test_Helanal(TestCase):
         """Check for sustained resolution of Issue 188."""
         u = self.universe
         sel = self.selection
+        u.trajectory[1]
 
         assert_raises(FinishTimeException, MDAnalysis.analysis.helanal.helanal_trajectory,
                       u, selection=sel, finish=5)

--- a/testsuite/MDAnalysisTests/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/test_atomgroup.py
@@ -1241,7 +1241,7 @@ class TestAtomGroupVelocities(TestCase):
         assert_(numpy.any(numpy.abs(v) > 1e-6), "velocities should be non-zero")
 
     def test_vel_src(self):
-        assert_equal(self.universe.trajectory.ts._vel_source, 1)
+        assert_equal(self.universe.trajectory.ts._vel_source, 0)
         
     @dec.slow
     def test_velocities(self):

--- a/testsuite/MDAnalysisTests/test_coordinates.py
+++ b/testsuite/MDAnalysisTests/test_coordinates.py
@@ -146,7 +146,7 @@ class TestXYZReader(TestCase, Ref2r9r):
 
     def test_full_slice(self):
         trj_iter = self.universe.trajectory[:]
-        frames = [ts.frame - 1 for ts in trj_iter]
+        frames = [ts.frame for ts in trj_iter]
         assert_equal(frames, np.arange(self.universe.trajectory.numframes))
 
     def test_slice_raises_TypeError(self):
@@ -173,6 +173,19 @@ class TestXYZReaderAsTopology(object):
                         [2.0, 2.0, 2.0]],
                        dtype=np.float32)
         assert_array_almost_equal(self.u.atoms.positions, ref)
+
+    def test_rewind(self):
+        self.universe.trajectory.rewind()
+        assert_equal(self.universe.trajectory.ts.frame, 0, "rewinding to frame 0")
+
+    def test_next(self):
+        self.universe.trajectory.rewind()
+        self.universe.trajectory.next()
+        assert_equal(self.universe.trajectory.ts.frame, 1, "loading frame 1")
+
+    def test_dt(self):
+        assert_almost_equal(self.universe.trajectory.dt, 1.0, 4,
+                            err_msg="wrong timestep dt")
 
 class TestCompressedXYZReader(TestCase, Ref2r9r):
     def setUp(self):
@@ -204,7 +217,7 @@ class TestCompressedXYZReader(TestCase, Ref2r9r):
 
     def test_full_slice(self):
         trj_iter = self.universe.trajectory[:]
-        frames = [ts.frame - 1 for ts in trj_iter]
+        frames = [ts.frame for ts in trj_iter]
         assert_equal(frames, np.arange(self.universe.trajectory.numframes))
 
     def test_slice_raises_TypeError(self):
@@ -212,6 +225,19 @@ class TestCompressedXYZReader(TestCase, Ref2r9r):
             return list(self.universe.trajectory[::2])
 
         assert_raises(TypeError, trj_iter)
+
+    def test_rewind(self):
+        self.universe.trajectory.rewind()
+        assert_equal(self.universe.trajectory.ts.frame, 0, "rewinding to frame 0")
+
+    def test_next(self):
+        self.universe.trajectory.rewind()
+        self.universe.trajectory.next()
+        assert_equal(self.universe.trajectory.ts.frame, 1, "loading frame 1")
+
+    def test_dt(self):
+        assert_almost_equal(self.universe.trajectory.dt, 1.0, 4,
+                            err_msg="wrong timestep dt")
 
 
 class TestXYZWriter(TestCase, Ref2r9r):
@@ -354,9 +380,9 @@ class _TRJReaderTest(TestCase):
         assert_almost_equal(total, self.ref_sum_centre_of_geometry, self.prec,
                             err_msg="sum of centers of geometry over the trajectory do not match")
 
-    def test_initial_frame_is_1(self):
-        assert_equal(self.universe.trajectory.ts.frame, 1,
-                     "initial frame is not 1 but {0}".format(self.universe.trajectory.ts.frame))
+    def test_initial_frame_is_0(self):
+        assert_equal(self.universe.trajectory.ts.frame, 0,
+                     "initial frame is not 0 but {0}".format(self.universe.trajectory.ts.frame))
 
     def test_starts_with_first_frame(self):
         """Test that coordinate arrays are filled as soon as the trajectory has been opened."""
@@ -367,15 +393,15 @@ class _TRJReaderTest(TestCase):
         trj = self.universe.trajectory
         trj.next()
         trj.next()  # for readers that do not support indexing
-        assert_equal(trj.ts.frame, 3, "failed to forward to frame 3 (frameindex 2)")
+        assert_equal(trj.ts.frame, 2, "failed to forward to frame 2 (frameindex 2)")
         trj.rewind()
-        assert_equal(trj.ts.frame, 1, "failed to rewind to first frame")
+        assert_equal(trj.ts.frame, 0, "failed to rewind to first frame")
         assert_(np.any(self.universe.atoms.coordinates() > 0),
                 "Reader does not populate coordinates() after rewinding.")
 
     def test_full_slice(self):
         trj_iter = self.universe.trajectory[:]
-        frames = [ts.frame - 1 for ts in trj_iter]
+        frames = [ts.frame for ts in trj_iter]
         assert_equal(frames, np.arange(self.universe.trajectory.numframes))
 
 
@@ -415,7 +441,7 @@ class TestNCDFReader(_TRJReaderTest, RefVGV):
         self.prec = 3
 
     def test_slice_iteration(self):
-        frames = [ts.frame - 1 for ts in self.universe.trajectory[4:-2:4]]
+        frames = [ts.frame for ts in self.universe.trajectory[4:-2:4]]
         assert_equal(frames,
                      np.arange(self.universe.trajectory.numframes)[4:-2:4],
                      err_msg="slicing did not produce the expected frames")
@@ -605,8 +631,7 @@ class TestINPCRDReader(TestCase):
         self._check_ts(u.trajectory.ts)
 
     def test_universe_restrt(self):
-        u = MDAnalysis.Universe(XYZ_five, INPCRD, format='RESTRT')
-
+        u = MDAnalysis.Universe(XYZ_five, INPCRD, format='RESTRT') 
         self._check_ts(u.trajectory.ts)
 
 
@@ -710,12 +735,12 @@ class _SingleFrameReader(TestCase, RefAdKSmall):
         assert_equal(self.universe.trajectory.time, 0.0, "wrong time of the frame")
 
     def test_frame(self):
-        assert_equal(self.universe.trajectory.frame, 1,
-                     "wrong frame number (1-based, should be 1 for single frame readers)")
+        assert_equal(self.universe.trajectory.frame, 0,
+                     "wrong frame number (0-based, should be 0 for single frame readers)")
 
     def test_frame_index_0(self):
         self.universe.trajectory[0]
-        assert_equal(self.universe.trajectory.ts.frame, 1, "frame number for frame index 0 should be 1")
+        assert_equal(self.universe.trajectory.ts.frame, 0, "frame number for frame index 0 should be 0")
 
     def test_frame_index_1_raises_IndexError(self):
         def go_to_2(traj=self.universe.trajectory):
@@ -742,12 +767,12 @@ class _SingleFrameReader(TestCase, RefAdKSmall):
 
     def test_full_slice(self):
         trj_iter = self.universe.trajectory[:]
-        frames = [ts.frame - 1 for ts in trj_iter]
+        frames = [ts.frame for ts in trj_iter]
         assert_equal(frames, np.arange(self.universe.trajectory.numframes))
 
     def test_last_slice(self):
         trj_iter = self.universe.trajectory[-1:]  # should be same as above: only 1 frame!
-        frames = [ts.frame - 1 for ts in trj_iter]
+        frames = [ts.frame for ts in trj_iter]
         assert_equal(frames, np.arange(self.universe.trajectory.numframes))
 
 
@@ -943,12 +968,23 @@ class TestGMSReader(TestCase):
         z2 = np.sqrt(sum(pp**2))
         return z1-z2
 
+    def test_rewind(self):
+        self.u_aso.trajectory.rewind()
+        assert_equal(self.u_aso.trajectory.ts.frame, 0, "rewinding to frame 0")
+
+    def test_next(self):
+        self.u_aso.trajectory.rewind()
+        self.u_aso.trajectory.next()
+        assert_equal(self.u_aso.trajectory.ts.frame, 1, "loading frame 1")
+
+    def test_dt(self):
+        assert_almost_equal(self.u_aso.trajectory.dt, 1.0, 4,
+                            err_msg="wrong timestep dt")
+
     def tearDown(self):
         del self.u_aso
         del self.u_so
         del self.u_ass
-
-
 
 
 class TestMultiPDBReader(TestCase):
@@ -981,9 +1017,9 @@ class TestMultiPDBReader(TestCase):
     def test_rewind(self):
         u = self.multiverse
         u.trajectory[11]
-        assert_equal(u.trajectory.ts.frame, 12, "Failed to forward to 12th frame (frame index 11)")
+        assert_equal(u.trajectory.ts.frame, 11, "Failed to forward to 11th frame (frame index 11)")
         u.trajectory.rewind()
-        assert_equal(u.trajectory.ts.frame, 1, "Failed to rewind to first frame (frame index 0)")
+        assert_equal(u.trajectory.ts.frame, 0, "Failed to rewind to 0th frame (frame index 0)")
 
     @attr('slow')
     def test_iteration(self):
@@ -1004,7 +1040,7 @@ class TestMultiPDBReader(TestCase):
         u = self.multiverse
         frames = []
         for ts in u.trajectory[4:-2:4]:
-            frames.append(ts.frame - 1)
+            frames.append(ts.frame)
         assert_equal(np.array(frames),
                      np.arange(u.trajectory.numframes)[4:-2:4],
                      err_msg="slicing did not produce the expected frames")
@@ -1295,7 +1331,7 @@ class TestGROReader(TestCase, RefAdK):
         assert_equal(self.universe.trajectory.time, 0.0, "wrong time of the frame")
 
     def test_frame(self):
-        assert_equal(self.universe.trajectory.frame, 1, "wrong frame number (should be 1 for 1-based ts.frame)")
+        assert_equal(self.universe.trajectory.frame, 0, "wrong frame number (should be 0 for 0-based ts.frame)")
 
     def test_dt(self):
         """testing that accessing universe.trajectory.dt raises a KeyError for single frame readers"""
@@ -1330,7 +1366,7 @@ class TestGROReader(TestCase, RefAdK):
 
     def test_full_slice(self):
         trj_iter = self.universe.trajectory[:]
-        frames = [ts.frame - 1 for ts in trj_iter]
+        frames = [ts.frame for ts in trj_iter]
         assert_equal(frames, np.arange(self.universe.trajectory.numframes))
 
 
@@ -1359,6 +1395,25 @@ class TestDMSReader(TestCase):
         coords_0 = np.array([-11.0530004501343, 26.6800003051758, 12.7419996261597, ], dtype=np.float32)
         assert_array_equal(self.universe.atoms[0].pos, coords_0)
 
+    def test_numframes(self):
+        assert_equal(self.universe.trajectory.numframes, 1, "wrong number of frames in pdb")
+
+    def test_time(self):
+        assert_equal(self.universe.trajectory.time, 0.0, "wrong time of the frame")
+
+    def test_frame(self):
+        assert_equal(self.universe.trajectory.frame, 0,
+                     "wrong frame number (0-based, should be 0 for single frame readers)")
+
+    def test_frame_index_0(self):
+        self.universe.trajectory[0]
+        assert_equal(self.universe.trajectory.ts.frame, 0, "frame number for frame index 0 should be 0")
+
+    def test_frame_index_1_raises_IndexError(self):
+        def go_to_2(traj=self.universe.trajectory):
+            traj[1]
+
+        assert_raises(IndexError, go_to_2)
 
 class TestGROReaderNoConversion(TestCase, RefAdK):
     def setUp(self):
@@ -1505,7 +1560,7 @@ class TestPDBReaderBig(TestCase, RefAdK):
 
     @dec.slow
     def test_frame(self):
-        assert_equal(self.universe.trajectory.frame, 1, "wrong frame number")
+        assert_equal(self.universe.trajectory.frame, 0, "wrong frame number")
 
     @dec.slow
     def test_dt(self):
@@ -1572,34 +1627,34 @@ class TestDCDReaderClass(TestCase):
         except:
             raise AssertionError("with_statement not working for DCDReader")
         assert_equal(N, 98, err_msg="with_statement: DCDReader reads wrong number of frames")
-        assert_array_equal(frames, np.arange(1, N + 1), err_msg="with_statement: DCDReader does not read all frames")
+        assert_array_equal(frames, np.arange(0, N), err_msg="with_statement: DCDReader does not read all frames")
 
 
 class TestDCDReader(_TestDCD):
     def test_rewind_dcd(self):
         self.dcd.rewind()
-        assert_equal(self.ts.frame, 1, "rewinding to frame 1")
+        assert_equal(self.ts.frame, 0, "rewinding to frame 0")
 
     def test_next_dcd(self):
         self.dcd.rewind()
         self.dcd.next()
-        assert_equal(self.ts.frame, 2, "loading frame 2")
+        assert_equal(self.ts.frame, 1, "loading frame 1")
 
     def test_jump_dcd(self):
-        self.dcd[15]  # index is 0-based but frames are 1-based
-        assert_equal(self.ts.frame, 16, "jumping to frame 16")
+        self.dcd[15]  # index is 0-based and frames are 0-based
+        assert_equal(self.ts.frame, 15, "jumping to frame 15")
 
     def test_jump_lastframe_dcd(self):
         self.dcd[-1]
-        assert_equal(self.ts.frame, 98, "indexing last frame with dcd[-1]")
+        assert_equal(self.ts.frame, 97, "indexing last frame with dcd[-1]")
 
     def test_slice_dcd(self):
         frames = [ts.frame for ts in self.dcd[5:17:3]]
-        assert_equal(frames, [6, 9, 12, 15], "slicing dcd [5:17:3]")
+        assert_equal(frames, [5, 8, 11, 14], "slicing dcd [5:17:3]")
 
     def test_reverse_dcd(self):
         frames = [ts.frame for ts in self.dcd[20:5:-1]]
-        assert_equal(frames, range(21, 6, -1), "reversing dcd [20:5:-1]")
+        assert_equal(frames, range(20, 5, -1), "reversing dcd [20:5:-1]")
 
     def test_numatoms(self):
         assert_equal(self.universe.trajectory.numatoms, 3341, "wrong number of atoms")
@@ -1619,12 +1674,12 @@ class TestDCDReader(_TestDCD):
                             err_msg="wrong total length of AdK trajectory")
 
     def test_frame(self):
-        self.dcd[15]  # index is 0-based but frames are 1-based
-        assert_equal(self.universe.trajectory.frame, 16, "wrong frame number")
+        self.dcd[15]  # index is 0-based and frames are 0-based
+        assert_equal(self.universe.trajectory.frame, 15, "wrong frame number")
 
     def test_time(self):
-        self.dcd[15]  # index is 0-based but frames are 1-based
-        assert_almost_equal(self.universe.trajectory.time, 16.0, 5,
+        self.dcd[15]  # index is 0-based and frames are 0-based
+        assert_almost_equal(self.universe.trajectory.time, 15.0, 5,
                             err_msg="wrong time of frame")
 
     def test_volume(self):
@@ -2017,7 +2072,7 @@ class TestChainReader(TestCase):
     def test_next_trajectory(self):
         self.trajectory.rewind()
         self.trajectory.next()
-        assert_equal(self.trajectory.ts.frame, 2, "loading frame 2")
+        assert_equal(self.trajectory.ts.frame, 1, "loading frame 2")
 
     def test_numatoms(self):
         assert_equal(self.universe.trajectory.numatoms, 3341, "wrong number of atoms")
@@ -2028,27 +2083,27 @@ class TestChainReader(TestCase):
     def test_iteration(self):
         for ts in self.trajectory:
             pass  # just forward to last frame
-        assert_equal(self.trajectory.numframes, ts.frame,
+        assert_equal(self.trajectory.numframes - 1, ts.frame,
                      "iteration yielded wrong number of frames (%d), should be %d"
                      % (ts.frame, self.trajectory.numframes))
 
     def test_jump_lastframe_trajectory(self):
         self.trajectory[-1]
         print self.trajectory.ts, self.trajectory.ts.frame
-        assert_equal(self.trajectory.ts.frame, self.trajectory.numframes, "indexing last frame with trajectory[-1]")
+        assert_equal(self.trajectory.ts.frame + 1, self.trajectory.numframes, "indexing last frame with trajectory[-1]")
 
     def test_slice_trajectory(self):
         frames = [ts.frame for ts in self.trajectory[5:17:3]]
-        assert_equal(frames, [6, 9, 12, 15], "slicing dcd [5:17:3]")
+        assert_equal(frames, [5, 8, 11, 14], "slicing dcd [5:17:3]")
 
     def test_full_slice(self):
         trj_iter = self.universe.trajectory[:]
-        frames = [ts.frame - 1 for ts in trj_iter]
+        frames = [ts.frame for ts in trj_iter]
         assert_equal(frames, np.arange(self.universe.trajectory.numframes))
 
     def test_frame_numbering(self):
-        self.trajectory[98]  # index is 0-based but frames are 1-based
-        assert_equal(self.universe.trajectory.frame, 99, "wrong frame number")
+        self.trajectory[98]  # index is 0-based and frames are 0-based
+        assert_equal(self.universe.trajectory.frame, 98, "wrong frame number")
 
     def test_frame(self):
         self.trajectory[0]
@@ -2171,33 +2226,33 @@ class _GromacsReader(TestCase):
     @dec.slow
     def test_rewind_xdrtrj(self):
         self.trajectory.rewind()
-        assert_equal(self.ts.frame, 1, "rewinding to frame 1")
+        assert_equal(self.ts.frame, 0, "rewinding to frame 1")
 
     @dec.slow
     def test_next_xdrtrj(self):
         self.trajectory.rewind()
         self.trajectory.next()
-        assert_equal(self.ts.frame, 2, "loading frame 2")
+        assert_equal(self.ts.frame, 1, "loading frame 1")
 
     @dec.slow
     def test_jump_xdrtrj(self):
-        self.trajectory[4]  # index is 0-based but frames are 1-based
-        assert_equal(self.ts.frame, 5, "jumping to frame 5")
+        self.trajectory[4]  # index is 0-based and frames are 0-based
+        assert_equal(self.ts.frame, 4, "jumping to frame 4")
 
     @dec.slow
     def test_jump_lastframe_xdrtrj(self):
         self.trajectory[-1]
-        assert_equal(self.ts.frame, 10, "indexing last frame with trajectory[-1]")
+        assert_equal(self.ts.frame, 9, "indexing last frame with trajectory[-1]")
 
     @dec.slow
     def test_slice_xdrtrj(self):
         frames = [ts.frame for ts in self.trajectory[2:9:3]]
-        assert_equal(frames, [3, 6, 9], "slicing xdrtrj [2:9:3]")
+        assert_equal(frames, [2, 5, 8], "slicing xdrtrj [2:9:3]")
 
     @dec.slow
     def test_reverse_xdrtrj(self):
         frames = [ts.frame for ts in self.trajectory[::-1]]
-        assert_equal(frames, range(10, 0, -1), "slicing xdrtrj [::-1]")
+        assert_equal(frames, range(9, -1, -1), "slicing xdrtrj [::-1]")
 
     @dec.slow
     def test_coordinates(self):
@@ -2209,7 +2264,7 @@ class _GromacsReader(TestCase):
         T.rewind()
         T.next()
         T.next()
-        assert_equal(self.ts.frame, 3, "failed to step to frame 3")
+        assert_equal(self.ts.frame, 2, "failed to step to frame 3")
         ca = U.selectAtoms('name CA and resid 122')
         # low precision match (2 decimals in A, 3 in nm) because the above are the trr coords
         assert_array_almost_equal(ca.coordinates(), ca_Angstrom, 2,
@@ -2246,13 +2301,13 @@ class _GromacsReader(TestCase):
 
     @dec.slow
     def test_frame(self):
-        self.trajectory[4]  # index is 0-based but frames are 1-based
-        assert_equal(self.universe.trajectory.frame, 5, "wrong frame number")
+        self.trajectory[4]  # index is 0-based and frames are 0-based
+        assert_equal(self.universe.trajectory.frame, 4, "wrong frame number")
 
     @dec.slow
     def test_time(self):
-        self.trajectory[4]  # index is 0-based but frames are 1-based
-        assert_almost_equal(self.universe.trajectory.time, 500.0, 5,
+        self.trajectory[4]
+        assert_almost_equal(self.universe.trajectory.time, 400.0, 5,
                             err_msg="wrong time of frame")
 
     @dec.slow
@@ -2303,7 +2358,7 @@ class TestXTCReaderClass(TestCase):
         except:
             raise AssertionError("with_statement not working for XTCReader")
         assert_equal(N, 10, err_msg="with_statement: XTCReader reads wrong number of frames")
-        assert_array_equal(frames, np.arange(1, N + 1), err_msg="with_statement: XTCReader does not read all frames")
+        assert_array_equal(frames, np.arange(0, N), err_msg="with_statement: XTCReader does not read all frames")
 
 
 class TestTRRReader(_GromacsReader):
@@ -2324,7 +2379,7 @@ class TestTRRReader(_GromacsReader):
         # velocities in the MDA base unit A/ps (needed for True)
         v_base = v_native * 10.0
         self.universe.trajectory.rewind()
-        assert_equal(self.ts.frame, 1, "failed to read frame 1")
+        assert_equal(self.ts.frame, 0, "failed to read frame 1")
 
         assert_array_almost_equal(self.universe.trajectory.ts._velocities[[47675, 47676]], v_base, self.prec,
                                   err_msg="ts._velocities for indices 47675,47676 do not match known values")
@@ -2562,7 +2617,7 @@ class _XDRNoConversion(TestCase):
         T.rewind()
         T.next()
         T.next()
-        assert_equal(self.ts.frame, 3, "failed to step to frame 3")
+        assert_equal(self.ts.frame, 2, "failed to step to frame 3")
         ca = U.selectAtoms('name CA and resid 122')
         # low precision match because we also look at the trr: only 3 decimals in nm in xtc!
         assert_array_almost_equal(ca.coordinates(), ca_nm, 3,
@@ -2837,30 +2892,33 @@ class TestTRZReader(TestCase, RefTRZ):
         assert_equal(len(U.atoms), self.ref_numatoms, "load Universe from PSF and TRZ")
 
     def test_next_trz(self):
-        self.trz.rewind()
+        assert_equal(self.ts.frame, 0, "starts at first frame")
         self.trz.next()
-        assert_equal(self.ts.frame, 2, "loading frame 2")
+        assert_equal(self.ts.frame, 1, "next returns frame index 1")
 
     def test_rewind_trz(self):
+        # move to different frame and rewind to get first frame back
+        self.trz[2]
         self.trz.rewind()
-        assert_equal(self.ts.frame, 1, "rewinding to frame 1")
+        assert_equal(self.ts.frame, 0, "rewinding to frame 1")
 
     def test_numframes(self):
         assert_equal(self.universe.trajectory.numframes, self.ref_numframes, "wrong number of frames in trz")
 
     def test_seeking(self):
-        self.trz.rewind()
-
         self.universe.trajectory[3]
+        assert_equal(self.ts.frame, 3, "loading frame 3")
 
-        orig = self.universe.atoms[0:3].positions
+        orig = self.universe.atoms[0:3].positions.copy()
 
         self.universe.trajectory[4]
+        assert_equal(self.ts.frame, 4, "loading frame 4")
         self.universe.trajectory[3]
 
         assert_almost_equal(self.universe.atoms[0:3].positions, orig, self.prec)
 
         self.universe.trajectory[0]
+        assert_equal(self.ts.frame, 0, "loading frame 0")
         self.universe.trajectory[3]
 
         assert_almost_equal(self.universe.atoms[0:3].positions, orig, self.prec)
@@ -2889,7 +2947,6 @@ class TestTRZReader(TestCase, RefTRZ):
         assert_almost_equal(self.trz.delta, newref, self.prec, "couldn't inject to delta")
 
     def test_time(self):
-        self.trz.rewind()
         assert_almost_equal(self.trz.time, self.ref_time, self.prec, "wrong time value in trz")
 
     def test_get_writer(self):

--- a/testsuite/MDAnalysisTests/test_coordinates.py
+++ b/testsuite/MDAnalysisTests/test_coordinates.py
@@ -162,26 +162,21 @@ class TestXYZReader(TestCase, Ref2r9r):
 class TestXYZReaderAsTopology(object):
     """Test that an XYZ file can act as its own topology"""
     def setUp(self):
-        self.u = mda.Universe(XYZ_mini)
+        self.universe = mda.Universe(XYZ_mini)
 
     def tearDown(self):
-        del self.u
+        del self.universe
 
     def test_coords(self):
         ref = np.array([[0.0, 0.0, 0.0],
                         [1.0, 1.0, 1.0],
                         [2.0, 2.0, 2.0]],
                        dtype=np.float32)
-        assert_array_almost_equal(self.u.atoms.positions, ref)
+        assert_array_almost_equal(self.universe.atoms.positions, ref)
 
     def test_rewind(self):
         self.universe.trajectory.rewind()
         assert_equal(self.universe.trajectory.ts.frame, 0, "rewinding to frame 0")
-
-    def test_next(self):
-        self.universe.trajectory.rewind()
-        self.universe.trajectory.next()
-        assert_equal(self.universe.trajectory.ts.frame, 1, "loading frame 1")
 
     def test_dt(self):
         assert_almost_equal(self.universe.trajectory.dt, 1.0, 4,

--- a/testsuite/MDAnalysisTests/test_mol2.py
+++ b/testsuite/MDAnalysisTests/test_mol2.py
@@ -68,3 +68,43 @@ class TestMol2(TestCase):
         #    u = Universe(mol2_broken_molecule)
         #self.assertEqual("The mol2 block (BrokenMolecule.mol2:0) has no atoms" in context.exception.message,
         # True)
+
+class TestMol2_traj(TestCase):
+    def setUp(self):
+        self.universe = Universe(mol2_molecules)
+        self.traj = self.universe.trajectory
+        self.ts = self.universe.coord
+
+    def tearDown(self):
+        del self.universe
+        del self.traj
+        del self.ts
+
+    def test_rewind_traj(self):
+        self.traj.rewind()
+        assert_equal(self.ts.frame, 0, "rewinding to frame 0")
+
+    def test_next_traj(self):
+        self.traj.rewind()
+        self.traj.next()
+        assert_equal(self.ts.frame, 1, "loading frame 1")
+
+    def test_jump_traj(self):
+        self.traj[15]  # index is 0-based and frames are 0-based
+        assert_equal(self.ts.frame, 15, "jumping to frame 15")
+
+    def test_jump_lastframe_traj(self):
+        self.traj[-1]
+        assert_equal(self.ts.frame, 199, "indexing last frame with traj[-1]")
+
+    def test_slice_traj(self):
+        frames = [ts.frame for ts in self.traj[5:17:3]]
+        assert_equal(frames, [5, 8, 11, 14], "slicing traj [5:17:3]")
+
+    def test_reverse_traj(self):
+        frames = [ts.frame for ts in self.traj[20:5:-1]]
+        assert_equal(frames, range(20, 5, -1), "reversing traj [20:5:-1]")
+
+    def test_numframes(self):
+        assert_equal(self.universe.trajectory.numframes, 200, "wrong number of frames in traj")
+

--- a/testsuite/MDAnalysisTests/test_pdbqt.py
+++ b/testsuite/MDAnalysisTests/test_pdbqt.py
@@ -76,3 +76,13 @@ class TestPDBQT(TestCase):
         assert_equal(uA.atoms._atoms, self.universe.A.atoms._atoms,
                      "Writing and reading of chain A does not recover same atoms")
         del uA
+
+    def test_numframes(self):
+        assert_equal(self.universe.trajectory.numframes, 1, "wrong number of frames in pdb")
+
+    def test_time(self):
+        assert_equal(self.universe.trajectory.time, 0.0, "wrong time of the frame")
+
+    def test_frame(self):
+        assert_equal(self.universe.trajectory.frame, 0,
+                     "wrong frame number (0-based, should be 0 for single frame readers)")


### PR DESCRIPTION
*Special thanks to @richardjgowers for lots of work on troublesome
Readers.*

Went through each Reader class; changed frame to 0-based.

Fixed tests relating to 0 based frame numbering

Added 0 based frames to DCD

Modified tests for DCDs.

Added 0-based frame tests to DMS, GMS test classes.

Added new tests for MOL2 reader checking frame indexing.

Finished tests for XYZ reader frames indices.

Fixed TRZ Reader frame numbering. TRZReader now reports Time from
Timestep not based on dt * frame.

Fixed MOL2 reader 0-based numbering. Now reuses Timesteps (like other
Readers) Now has _reopen method which "rewinds" the frame
numbering

The helanal analysis could use a redesign, but in the meantime fixed to
ensure that it works as expected regarding trajectory times.

Fixed test_reader_api tests to work with 0-based frames.

Updated Reader API checks for 0 based operation

Fixed XYZReader not rewinding properly on checking numframes

Added final .. versionchanged directives to classes, module docs

Fixed 2.6 XYZReader