### PR TITLE
Tests can now detect memleaks on a test-by-test basis (closes #323)

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -16,6 +16,7 @@ The rules for this file:
   * 0.11.0
 
   Enhancements
+  * Tests can now detect memleaks on a per-test basis (Issue #323)
   * AtomGroups can now be pickled/unpickled (Issue #293)
   * Universes can have a __del__ method (not actually added) without
     leaking (Issue #297)

--- a/testsuite/MDAnalysisTests/__init__.py
+++ b/testsuite/MDAnalysisTests/__init__.py
@@ -87,6 +87,11 @@ Writing test cases
 The unittests use the :mod:`unittest` module together with nose_. See the
 examples in the ``MDAnalysisTests`` directory.
 
+Memory leak detection can be enabled for a class of tests by having it inherit
+:class:`MemleakTest` instead of :class:`TestCase` or just :class:`object`.
+This approach makes use of a `@classmethod` :meth:`setUpClass` in the
+:class:`MemleakTest` class, which should not be overridden in a test class.
+
 The `SciPy testing guidelines`_ are a good howto for writing test cases,
 especially as we are directly using this framework (imported from numpy).
 
@@ -104,7 +109,7 @@ especially as we are directly using this framework (imported from numpy).
 __version__ = "0.11.0-dev"  # keep in sync with RELEASE in setup.py
 
 try:
-    from numpy.testing import Tester, assert_equal
+    from numpy.testing import Tester, assert_equal, TestCase
 
     test = Tester().test
 except ImportError:
@@ -191,3 +196,37 @@ def executable_not_found_runtime(*args):
     """
     return lambda: executable_not_found(*args)
 
+class MemleakTest(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.leakedobjs = set()
+        try:
+            cls._tearDown = cls.tearDown
+        except AttributeError:
+            pass
+
+        def tearDown(self):
+            import gc
+            try:
+                self._tearDown()
+            except AttributeError:
+                pass
+            gc.collect()
+            # We have to keep track of previously seen leaks, otherwise
+            # we report them multiple times per test class.
+            latest_leaks = [ obj for obj in gc.garbage if obj not in self.leakedobjs ]
+            self.leakedobjs.update(gc.garbage)
+            if self._testMethodName == "test_that_memleaks":
+                # This one is actually supposed to leak
+                assert_(latest_leaks, "Failed to detect a memleak")
+                # Let's clean it up:
+                # this should resolve the circular reference and clear the uncollectable list
+                gc.garbage[0].s = None
+                gc.garbage[:] = []
+                gc.collect()
+                latest_leaks = [ obj for obj in gc.garbage if obj not in self.leakedobjs or obj in latest_leaks ]
+                assert_(not latest_leaks, "Failed to clean the memleak we created for testing purposes")
+            else:
+                assert_(not latest_leaks, "Memleak: GC failed to collect the following: {}".format(latest_leaks))
+
+        cls.tearDown = tearDown

--- a/testsuite/MDAnalysisTests/test_persistence.py
+++ b/testsuite/MDAnalysisTests/test_persistence.py
@@ -21,12 +21,11 @@ from MDAnalysis.core.AtomGroup import AtomGroup
 
 import numpy
 from numpy.testing import *
-from . import assert_
+from . import assert_, MemleakTest
 
 import cPickle
 
-class TestAtomGroupPickle(TestCase):
-
+class TestAtomGroupPickle(MemleakTest):
     def setUp(self):
         """Set up hopefully unique universes."""
         # _n marks named universes/atomgroups/pickled strings
@@ -107,4 +106,17 @@ def test_pickle_unpickle_empty():
     pickle_str = cPickle.dumps(ag, protocol=cPickle.HIGHEST_PROTOCOL)
     newag = cPickle.loads(pickle_str)
     assert_equal(len(newag), 0)
+
+class TestMemleak(MemleakTest):
+    def test_that_memleaks(self):
+        """Test that memleaks (Issue 323)"""
+        #This is a small leak that won't break anything
+        # just to check that MemleakTest is working fine.
+        # We actually clean up after ourselves there.
+        class A():
+            def __init__(self):
+                self.s = self
+            def __del__(self):
+                pass
+        a = A()
 

--- a/testsuite/MDAnalysisTests/test_persistence.py
+++ b/testsuite/MDAnalysisTests/test_persistence.py
@@ -118,5 +118,5 @@ class TestMemleak(MemleakTest):
                 self.s = self
             def __del__(self):
                 pass
-        a = A()
+        self.a = A()
 


### PR DESCRIPTION
Here it is. Let me know what you think.
I exemplified the use in `test_persistence.py` and included there the positive case where a leak *does* occur (testing the tester... is this getting too meta?).
The job now is to extend the use to all test classes we think should be tested for memleaks (all of them?)

One caveat:
I'm using a `@classmethod setUpClass` to hack the wrapping of `tearDown`. We don't use `setUpClass` anywhere else on the tests, but future test classes must also not override it (I added a note in the docs).