### PR TITLE
Cleaned up MemleakTest and expanded its use in the tests

### DIFF
--- a/testsuite/MDAnalysisTests/__init__.py
+++ b/testsuite/MDAnalysisTests/__init__.py
@@ -89,8 +89,6 @@ examples in the ``MDAnalysisTests`` directory.
 
 Memory leak detection can be enabled for a class of tests by having it inherit
 :class:`MemleakTest` instead of :class:`TestCase` or just :class:`object`.
-This approach makes use of a `@classmethod` :meth:`setUpClass` in the
-:class:`MemleakTest` class, which should not be overridden in a test class.
 
 The `SciPy testing guidelines`_ are a good howto for writing test cases,
 especially as we are directly using this framework (imported from numpy).
@@ -180,10 +178,22 @@ def executable_not_found_runtime(*args):
 import gc
 
 class MemleakTest(TestCase):
+"""Class that provides memory leak detection to tests.
+
+Memory leak detection can be activated for a class of tests by having it
+subclass :class:`MemleakTest`.
+
+This approach makes use of a `@classmethod` :meth:`setUpClass`. New test
+classes must not override this method.
+
+All objects created during a test (including :meth:`setUp` and :meth`tearDown`)
+will be monitored for leaks, except if their name begins with an underscore.
+Therefore, refrain from using such private names in new tests.
+"""
     @classmethod
     def setUpClass(cls):
-        cls.leakedobjs = set()
-        cls.initobjs = set()
+        cls._initobjs = set()
+        cls._leakedobjs = set()
         if hasattr(cls, "setUp"):
             cls._mlt_setUp = cls.setUp
         if hasattr(cls, "tearDown"):
@@ -193,7 +203,7 @@ class MemleakTest(TestCase):
         #  the ones we just assigned to the private _mlt_ variables.
         def setUp(self):
             # We just record what attributes we have before setup
-            self.initobjs.update(self.__dict__.keys())
+            self._initobjs.update(self.__dict__.keys())
             if hasattr(self, '_mlt_setUp'):
                 self._mlt_setUp()
 
@@ -202,22 +212,22 @@ class MemleakTest(TestCase):
                 self._mlt_tearDown()
             # We now specifically delete all remaining attributes that
             #  tearDown didn't take care of (we leave private ones be).
-            for obj in set(self.__dict__.keys()).difference(self.initobjs):
+            for obj in set(self.__dict__.keys()).difference(self._initobjs):
                 if not obj.startswith("_"): delattr(self, obj)
             gc.collect()
             # We have to keep track of previously seen leaks, otherwise
             # we report them multiple times per test class.
-            latest_leaks = [ obj for obj in gc.garbage if obj not in self.leakedobjs ]
-            self.leakedobjs.update(gc.garbage)
+            latest_leaks = [ obj for obj in gc.garbage if obj not in self._leakedobjs ]
+            self._leakedobjs.update(gc.garbage)
             if self._testMethodName == "test_that_memleaks":
                 # This one is actually supposed to leak
                 assert_(latest_leaks, "Failed to detect a memleak")
                 # Let's clean it up:
                 # this should resolve the circular reference and clear the uncollectable list
-                gc.garbage[0].s = None
+                gc.garbage[0].self_ref = None
                 gc.garbage[:] = []
                 gc.collect()
-                latest_leaks = [ obj for obj in gc.garbage if obj not in self.leakedobjs or obj in latest_leaks ]
+                latest_leaks = [ obj for obj in gc.garbage if obj not in self._leakedobjs or obj in latest_leaks ]
                 assert_(not latest_leaks, "Failed to clean the memleak we created for testing purposes")
             else:
                 assert_(not latest_leaks, "Memleak: GC failed to collect the following: {}".format(latest_leaks))

--- a/testsuite/MDAnalysisTests/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/test_atomgroup.py
@@ -22,6 +22,7 @@ from MDAnalysis.tests.datafiles import PSF, DCD, PDB_small, GRO, TRR, \
 import MDAnalysis.core.AtomGroup
 from MDAnalysis.core.AtomGroup import Atom, AtomGroup, asUniverse
 from MDAnalysis import NoDataError
+from MDAnalysisTests import MemleakTest
 
 import numpy
 from numpy.testing import *
@@ -35,7 +36,7 @@ import itertools
 from MDAnalysisTests import knownfailure
 
 
-class TestAtom(TestCase):
+class TestAtom(MemleakTest):
     """Tests of Atom."""
 
     def setUp(self):
@@ -118,7 +119,7 @@ class TestAtom(TestCase):
         assert_equal(ref, list(at.bonded_atoms))
 
 
-class TestAtomNoForceNoVel(TestCase):
+class TestAtomNoForceNoVel(MemleakTest):
     def setUp(self):
         self.u = MDAnalysis.Universe(XYZ_mini)
         self.a = self.u.atoms[0]
@@ -139,7 +140,7 @@ class TestAtomNoForceNoVel(TestCase):
         assert_raises(NoDataError, setattr, self.a, 'force', [1.0, 1.0, 1.0])
 
 
-class TestAtomGroup(TestCase):
+class TestAtomGroup(MemleakTest):
     """Tests of AtomGroup; selections are tested separately."""
     # all tests are done with the AdK system (PSF and DCD)
     # sequence: http://www.uniprot.org/uniprot/P69441.fasta
@@ -794,7 +795,7 @@ class TestAtomGroup(TestCase):
             self.universe.atoms.NO_SUCH_ATOM
         assert_raises(AttributeError, access_nonexistent_instantselector)
 
-class TestAtomGroupNoTop(TestCase):
+class TestAtomGroupNoTop(MemleakTest):
     def setUp(self):
         self.u = MDAnalysis.Universe(PSF_notop, DCD)
         self.ag = self.u.atoms[:10]
@@ -885,7 +886,7 @@ class TestAtomGroupNoTop(TestCase):
         assert_allclose(u.atoms.dimensions, box)
 
 
-class TestUniverseSetTopology(TestCase):
+class TestUniverseSetTopology(MemleakTest):
     """Tests setting of bonds/angles/torsions/impropers from Universe."""
 
     def setUp(self):
@@ -984,7 +985,7 @@ class TestUniverseSetTopology(TestCase):
         assert_equal('improperDict' in self.u._cache, False)
 
 
-class TestResidue(TestCase):
+class TestResidue(MemleakTest):
     def setUp(self):
         self.universe = MDAnalysis.Universe(PSF, DCD)
         self.res = self.universe.residues[100]
@@ -1013,7 +1014,7 @@ class TestResidue(TestCase):
         assert_equal(atoms.names(), ["N", "CA", "C", "O"])
 
 
-class TestResidueGroup(TestCase):
+class TestResidueGroup(MemleakTest):
     def setUp(self):
         """Set up the standard AdK system in implicit solvent."""
         self.universe = MDAnalysis.Universe(PSF, DCD)
@@ -1149,7 +1150,7 @@ class TestResidueGroup(TestCase):
                      err_msg="failed to set_mass H* atoms in resid 12:42 to {0}".format(mass))
 
 
-class TestSegment(TestCase):
+class TestSegment(MemleakTest):
     def setUp(self):
         self.universe = MDAnalysis.Universe(PSF, DCD)
         self.universe.residues[:100].set_segid("A")  # make up some segments
@@ -1187,7 +1188,7 @@ class TestSegment(TestCase):
             assert_equal(val, new)
 
 
-class TestSegmentGroup(TestCase):
+class TestSegmentGroup(MemleakTest):
     def setUp(self):
         """Set up the standard AdK system in implicit solvent."""
         self.universe = MDAnalysis.Universe(PSF, DCD)
@@ -1251,7 +1252,7 @@ class TestSegmentGroup(TestCase):
         assert_raises(ValueError, self.g.set_resid, [1, 2, 3, 4])
 
 
-class TestAtomGroupVelocities(TestCase):
+class TestAtomGroupVelocities(MemleakTest):
     """Tests of velocity-related functions in AtomGroup"""
 
     def setUp(self):
@@ -1286,7 +1287,7 @@ class TestAtomGroupVelocities(TestCase):
                             err_msg="messages were not set to new value")
 
 
-class TestAtomGroupTimestep(TestCase):
+class TestAtomGroupTimestep(MemleakTest):
     """Tests the AtomGroup.ts attribute (partial timestep)"""
 
     def setUp(self):
@@ -1315,7 +1316,7 @@ def test_empty_AtomGroup():
     ag = MDAnalysis.core.AtomGroup.AtomGroup([])
     assert_equal(len(ag), 0)
 
-class _WriteAtoms(TestCase):
+class _WriteAtoms(MemleakTest):
     """Set up the standard AdK system in implicit solvent."""
     ext = None  # override to test various output writers
     precision = 3
@@ -1440,7 +1441,7 @@ def test_instantselection_termini():
     del universe
 
 
-class TestUniverse(TestCase):
+class TestUniverse(MemleakTest):
     def test_load(self):
         # Universe(top, trj)
         u = MDAnalysis.Universe(PSF, PDB_small)
@@ -1510,7 +1511,7 @@ class TestUniverse(TestCase):
         u.dimensions = numpy.array([10, 11, 12, 90, 90, 90])
         assert_allclose(u.dimensions, box)
 
-class TestPBCFlag(TestCase):
+class TestPBCFlag(MemleakTest):
     def setUp(self):
         self.prec = 3
         self.universe = MDAnalysis.Universe(TRZ_psf, TRZ)
@@ -1619,7 +1620,7 @@ class TestPBCFlag(TestCase):
         MDAnalysis.core.flags['use_pbc'] = False
 
 
-class TestAsUniverse(TestCase):
+class TestAsUniverse(MemleakTest):
     def setUp(self):
         self.u = MDAnalysis.Universe(PSF_notop, DCD)
 
@@ -1641,7 +1642,7 @@ class TestAsUniverse(TestCase):
         assert_equal(set(returnval.atoms), set(self.u.atoms))
 
 
-class TestFragments(TestCase):
+class TestFragments(MemleakTest):
     def setUp(self):
         self.u = MDAnalysis.Universe(PSF, DCD)
         # To create a fragment with only one atom in, remove a bond
@@ -1694,7 +1695,7 @@ class TestFragments(TestCase):
         assert_equal(len(ag.fragments), 1)
 
 
-class TestUniverseCache(TestCase):
+class TestUniverseCache(MemleakTest):
     def setUp(self):
         self.u = MDAnalysis.Universe()  # not using atoms so just blank universe
         self.fill = [1, 2, 3]
@@ -1748,7 +1749,7 @@ class TestUniverseCache(TestCase):
         assert_equal(self.u._cache, dict())
 
 
-class TestUnorderedResidues(TestCase):
+class TestUnorderedResidues(MemleakTest):
     """
     This pdb file has resids that are non sequential
 
@@ -1765,7 +1766,7 @@ class TestUnorderedResidues(TestCase):
     def test_build_residues(self):
         assert_equal(len(self.u.residues), 35)
 
-class TestCustomReaders(TestCase):
+class TestCustomReaders(MemleakTest):
     """
     Can pass a reader as kwarg on Universe creation
     """
@@ -1785,7 +1786,7 @@ class TestCustomReaders(TestCase):
                                 topology_format=MDAnalysis.topology.PSFParser.PSFParser)
         assert_equal(len(u.atoms), 8184)
 
-class TestWrap(TestCase):
+class TestWrap(MemleakTest):
     def setUp(self):
         self.u = MDAnalysis.Universe(TRZ_psf, TRZ)
         self.ag = self.u.atoms[:100]
@@ -1848,7 +1849,7 @@ class TestWrap(TestCase):
         assert_equal(self._in_box(cen), True)
 
 
-class TestGuessBonds(TestCase):
+class TestGuessBonds(MemleakTest):
     """Test the AtomGroup methed guess_bonds
 
     This needs to be done both from Universe creation (via kwarg) and AtomGroup

--- a/testsuite/MDAnalysisTests/test_coordinates.py
+++ b/testsuite/MDAnalysisTests/test_coordinates.py
@@ -25,7 +25,6 @@ import numpy as np
 import cPickle
 from numpy.testing import *
 from nose.plugins.attrib import attr
-import warnings
 
 from MDAnalysisTests.datafiles import (
     PSF, DCD, DCD_empty, PDB_small, XPDB_small, PDB_closed, PDB_multiframe,
@@ -38,10 +37,9 @@ from MDAnalysisTests.datafiles import (
     DLP_CONFIG, DLP_CONFIG_order, DLP_CONFIG_minimal,
     DLP_HISTORY, DLP_HISTORY_order, DLP_HISTORY_minimal)
 
-from MDAnalysisTests import knownfailure
+from MDAnalysisTests import knownfailure, MemleakTest
 
 import os
-import shutil
 import errno
 import tempfile
 import itertools
@@ -116,7 +114,7 @@ class Ref2r9r(object):
     ref_numframes = 10
 
 
-class TestXYZReader(TestCase, Ref2r9r):
+class TestXYZReader(MemleakTest, Ref2r9r):
     def setUp(self):
         self.universe = mda.Universe(XYZ_psf, XYZ)
         self.prec = 3  # 4 decimals in xyz file
@@ -182,7 +180,7 @@ class TestXYZReaderAsTopology(object):
         assert_almost_equal(self.universe.trajectory.dt, 1.0, 4,
                             err_msg="wrong timestep dt")
 
-class TestCompressedXYZReader(TestCase, Ref2r9r):
+class TestCompressedXYZReader(MemleakTest, Ref2r9r):
     def setUp(self):
         self.universe = mda.Universe(XYZ_psf, XYZ_bz2)
         self.prec = 3  # 4 decimals in xyz file
@@ -235,7 +233,7 @@ class TestCompressedXYZReader(TestCase, Ref2r9r):
                             err_msg="wrong timestep dt")
 
 
-class TestXYZWriter(TestCase, Ref2r9r):
+class TestXYZWriter(MemleakTest, Ref2r9r):
     def setUp(self):
         self.universe = mda.Universe(XYZ_psf, XYZ_bz2)
         self.prec = 3  # 4 decimals in xyz file
@@ -347,7 +345,7 @@ class RefVGV(object):
     ref_periodic = True
 
 
-class _TRJReaderTest(TestCase):
+class _TRJReaderTest(MemleakTest):
     # use as a base class (override setUp()) and mixin a reference
     def tearDown(self):
         del self.universe
@@ -446,7 +444,7 @@ class TestNCDFReader(_TRJReaderTest, RefVGV):
         assert_equal(data.Conventions, 'AMBER')
         assert_equal(data.ConventionVersion, '1.0')
 
-class TestNCDFReader2(TestCase):
+class TestNCDFReader2(MemleakTest):
     """NCDF Trajectory with positions and forces.
 
     Contributed by Albert Solernou
@@ -502,7 +500,7 @@ class TestNCDFReader2(TestCase):
         assert_almost_equal(ref, self.u.trajectory[1].time, self.prec)
 
 
-class TestNCDFWriter(TestCase, RefVGV):
+class TestNCDFWriter(MemleakTest, RefVGV):
     def setUp(self):
         self.universe = mda.Universe(PRMncdf, NCDF)
         self.prec = 6
@@ -600,7 +598,7 @@ class TestNCDFWriter(TestCase, RefVGV):
                                       err_msg="unitcells are not identical")
 
 
-class TestINPCRDReader(TestCase):
+class TestINPCRDReader(MemleakTest):
     """Test reading Amber restart coordinate files"""
     def _check_ts(self, ts):
         # Check a ts has the right values in
@@ -630,7 +628,7 @@ class TestINPCRDReader(TestCase):
         self._check_ts(u.trajectory.ts)
 
 
-class TestNCDFWriterVelsForces(TestCase):
+class TestNCDFWriterVelsForces(MemleakTest):
     """Test writing NCDF trajectories with a mixture of options"""
     def setUp(self):
         fd, self.outfile = tempfile.mkstemp(suffix='.ncdf')
@@ -700,7 +698,7 @@ class TestNCDFWriterVelsForces(TestCase):
         self._write_ts(True, True, True)
 
 
-class _SingleFrameReader(TestCase, RefAdKSmall):
+class _SingleFrameReader(MemleakTest, RefAdKSmall):
     # see TestPDBReader how to set up!
 
     def tearDown(self):
@@ -848,7 +846,7 @@ class TestPSF_PrimitivePDBReader(TestPrimitivePDBReader):
                             "Primitive PDB reader failed to get unitcell dimensions from CRYST1")
 
 
-class TestPrimitivePDBWriter(TestCase):
+class TestPrimitivePDBWriter(MemleakTest):
     def setUp(self):
         self.universe = mda.Universe(PSF, PDB_small, permissive=True)
         self.universe2 = mda.Universe(PSF, DCD, permissive=True)
@@ -913,7 +911,7 @@ class TestPrimitivePDBWriter(TestCase):
         del u
 
 
-class TestGMSReader(TestCase):
+class TestGMSReader(MemleakTest):
     ''' Test cases for GAMESS output log-files '''
 
     def setUp(self):
@@ -982,7 +980,7 @@ class TestGMSReader(TestCase):
         del self.u_ass
 
 
-class TestMultiPDBReader(TestCase):
+class TestMultiPDBReader(MemleakTest):
     def setUp(self):
         self.multiverse = mda.Universe(PDB_multiframe, permissive=True, guess_bonds=True)
         self.multiverse.build_topology()
@@ -1139,7 +1137,7 @@ class TestMultiPDBReader(TestCase):
                      len(u._topology['bonds']), len(desired)))
 
 
-class TestMultiPDBWriter(TestCase):
+class TestMultiPDBWriter(MemleakTest):
     def setUp(self):
         self.universe = mda.Universe(PSF, PDB_small, permissive=True)
         self.multiverse = mda.Universe(PDB_multiframe, permissive=True)
@@ -1243,7 +1241,7 @@ class TestPQRReader(_SingleFrameReader):
                             "Charges for N atoms in Pro residues do not match.")
 
 
-class TestPQRWriter(TestCase, RefAdKSmall):
+class TestPQRWriter(MemleakTest, RefAdKSmall):
     def setUp(self):
         self.universe = mda.Universe(PQR)
         self.prec = 3
@@ -1296,7 +1294,7 @@ class TestPQRWriter(TestCase, RefAdKSmall):
                             "Total charge (in CHARMM) does not match expected value.")
 
 
-class TestGROReader(TestCase, RefAdK):
+class TestGROReader(MemleakTest, RefAdK):
     def setUp(self):
         self.universe = mda.Universe(GRO)
         self.ts = self.universe.trajectory.ts
@@ -1365,7 +1363,7 @@ class TestGROReader(TestCase, RefAdK):
         assert_equal(frames, np.arange(self.universe.trajectory.numframes))
 
 
-class TestDMSReader(TestCase):
+class TestDMSReader(MemleakTest):
     def setUp(self):
         self.universe = mda.Universe(DMS)
         self.ts = self.universe.trajectory.ts
@@ -1410,7 +1408,7 @@ class TestDMSReader(TestCase):
 
         assert_raises(IndexError, go_to_2)
 
-class TestGROReaderNoConversion(TestCase, RefAdK):
+class TestGROReaderNoConversion(MemleakTest, RefAdK):
     def setUp(self):
         self.universe = mda.Universe(GRO, convert_units=False)
         self.ts = self.universe.trajectory.ts
@@ -1456,7 +1454,7 @@ class TestGROReaderNoConversion(TestCase, RefAdK):
                             err_msg="wrong volume for unitcell (rhombic dodecahedron)")
 
 
-class TestGROWriter(TestCase):
+class TestGROWriter(MemleakTest):
     def setUp(self):
         self.universe = mda.Universe(GRO)
         self.prec = 2  # 3 decimals in file in nm but MDAnalysis is in A
@@ -1521,7 +1519,7 @@ class TestGROWriter(TestCase):
         del u
 
 
-class TestPDBReaderBig(TestCase, RefAdK):
+class TestPDBReaderBig(MemleakTest, RefAdK):
     def setUp(self):
         self.universe = mda.Universe(PDB)
         self.prec = 6
@@ -1599,7 +1597,7 @@ def TestDCD_Issue32():
     assert_raises(IOError, mda.Universe, PSF, DCD_empty)
 
 
-class _TestDCD(TestCase):
+class _TestDCD(MemleakTest):
     def setUp(self):
         self.universe = mda.Universe(PSF, DCD)
         self.dcd = self.universe.trajectory
@@ -1611,7 +1609,7 @@ class _TestDCD(TestCase):
         del self.ts
 
 
-class TestDCDReaderClass(TestCase):
+class TestDCDReaderClass(MemleakTest):
     def test_with_statement(self):
         from MDAnalysis.coordinates.DCD import DCDReader
 
@@ -1682,7 +1680,7 @@ class TestDCDReader(_TestDCD):
                             err_msg="wrong volume for unitcell (no unitcell in DCD so this should be 0)")
 
 
-class TestDCDWriter(TestCase):
+class TestDCDWriter(MemleakTest):
     def setUp(self):
         self.universe = mda.Universe(PSF, DCD)
         ext = ".dcd"
@@ -1768,7 +1766,7 @@ class TestDCDWriter(TestCase):
                             err_msg="with_statement: coordinates do not match")
 
 
-class TestDCDWriter_Issue59(TestCase):
+class TestDCDWriter_Issue59(MemleakTest):
     def setUp(self):
         """Generate input xtc."""
         self.u = MDAnalysis.Universe(PSF, DCD)
@@ -1854,7 +1852,7 @@ class RefNAMDtriclinicDCD(object):
             [1., 38.426594, 38.393101, 44.759800, 90.000000, 90.000000, 60.028915],
             ])
 
-class _TestDCDReader_TriclinicUnitcell(TestCase):
+class _TestDCDReader_TriclinicUnitcell(MemleakTest):
     def setUp(self):
         self.u = MDAnalysis.Universe(self.topology, self.trajectory)
         fd, self.dcd = tempfile.mkstemp(suffix='.dcd')
@@ -1892,7 +1890,7 @@ class TestDCDReader_NAMD_Unitcell(_TestDCDReader_TriclinicUnitcell, RefNAMDtricl
     pass
 
 
-class TestNCDF2DCD(TestCase):
+class TestNCDF2DCD(MemleakTest):
     def setUp(self):
         self.u = MDAnalysis.Universe(PRMncdf, NCDF)
         # create the DCD
@@ -2048,7 +2046,7 @@ def compute_correl_references():
     return results
 
 
-class TestChainReader(TestCase):
+class TestChainReader(MemleakTest):
     def setUp(self):
         self.universe = mda.Universe(PSF, [DCD, CRD, DCD, CRD, DCD, CRD, CRD])
         self.trajectory = self.universe.trajectory
@@ -2129,7 +2127,7 @@ class TestChainReader(TestCase):
                                 err_msg="Coordinates disagree at frame %d" % ts_orig.frame)
 
 
-class TestChainReaderFormats(TestCase):
+class TestChainReaderFormats(MemleakTest):
     """Test of ChainReader with explicit formats (Issue 76)."""
 
     @attr('issue')
@@ -2148,7 +2146,7 @@ class TestChainReaderFormats(TestCase):
         assert_equal(universe.trajectory.numframes, 2)
 
 
-class TestTRRReader_Sub(TestCase):
+class TestTRRReader_Sub(MemleakTest):
     def setUp(self):
         """
         grab values from selected atoms from full solvated traj,
@@ -2184,13 +2182,11 @@ class TestTRRReader_Sub(TestCase):
                                   err_msg="positions differ")
 
 
-class _GromacsReader(TestCase):
+class _GromacsReader(MemleakTest):
     # This base class assumes same lengths and dt for XTC and TRR test cases!
     filename = None
     ref_unitcell = np.array([80.017, 80.017, 80.017, 60., 60., 90.], dtype=np.float32)
     ref_volume = 362270.0  # computed with Gromacs: 362.26999999999998 nm**3 * 1000 A**3/nm**3
-    ref_offsets = None
-    ref_offset_file = None
 
     def setUp(self):
         # loading from GRO is 4x faster than the PDB reader
@@ -2202,13 +2198,10 @@ class _GromacsReader(TestCase):
         ext = os.path.splitext(self.filename)[1]
         fd, self.outfile = tempfile.mkstemp(suffix=ext)
         os.close(fd)
-        fd, self.outfile_offsets = tempfile.mkstemp(suffix='.npy')
-        os.close(fd)
 
     def tearDown(self):
         try:
             os.unlink(self.outfile)
-            os.unlink(self.outfile_offsets)
         except:
             pass
         del self.universe
@@ -2342,7 +2335,7 @@ class TestXTCReader(_GromacsReader):
     filename = XTC
 
 
-class TestXTCReaderClass(TestCase):
+class TestXTCReaderClass(MemleakTest):
     def test_with_statement(self):
         from MDAnalysis.coordinates.XTC import XTCReader
 
@@ -2386,213 +2379,7 @@ class TestTRRReader(_GromacsReader):
             assert_array_almost_equal(self.universe.atoms[index].velocity, v_known, self.prec,
                                       err_msg="atom[%d].velocity does not match known values" % index)
 
-
-class _GromacsReader_offsets(TestCase):
-    # This base class assumes same lengths and dt for XTC and TRR test cases!
-    filename = None
-    ref_unitcell = np.array([80.017, 80.017, 80.017, 60., 60., 90.], dtype=np.float32)
-    ref_volume = 362270.0  # computed with Gromacs: 362.26999999999998 nm**3 * 1000 A**3/nm**3
-    ref_offsets = None
-
-    def setUp(self):
-        # since offsets are automatically generated in the same directory
-        # as the trajectory, we do everything from a temporary directory
-
-        self.tmpdir = tempfile.mkdtemp()
-        # loading from GRO is 4x faster than the PDB reader
-        shutil.copy(GRO, self.tmpdir)
-        shutil.copy(self.filename, self.tmpdir)
-
-        self.top = os.path.join(self.tmpdir, os.path.basename(GRO))
-        self.traj = os.path.join(self.tmpdir, os.path.basename(self.filename))
-
-        self.universe = mda.Universe(self.top, self.traj, convert_units=True)
-        self.trajectory = self.universe.trajectory
-        self.prec = 3
-        self.ts = self.universe.coord
-        
-        # dummy output file
-        ext = os.path.splitext(self.filename)[1]
-        fd, self.outfile = tempfile.mkstemp(suffix=ext)
-        os.close(fd)
-        fd, self.outfile_offsets = tempfile.mkstemp(suffix='.pkl')
-        os.close(fd)
-
-    def tearDown(self):
-        try:
-            os.unlink(self.outfile)
-            os.unlink(self.outfile_offsets)
-            shutil.rmtree(self.tmpdir)
-        except:
-            pass
-        del self.universe
-
-    @dec.slow
-    def test_offsets(self):
-        if self.trajectory._offsets is None:
-            self.trajectory.numframes
-        assert_array_almost_equal(self.trajectory._offsets, self.ref_offsets,
-                                  err_msg="wrong frame offsets")
-
-        # Saving
-        self.trajectory.save_offsets(self.outfile_offsets)
-        with open(self.outfile_offsets, 'rb') as f:
-            saved_offsets = cPickle.load(f)
-        assert_array_almost_equal(self.trajectory._offsets, saved_offsets['offsets'],
-                                  err_msg="error saving frame offsets")
-        assert_array_almost_equal(self.ref_offsets, saved_offsets['offsets'],
-                                  err_msg="saved frame offsets don't match the known ones")
-
-        # Loading
-        self.trajectory.load_offsets(self.outfile_offsets)
-        assert_array_almost_equal(self.trajectory._offsets, self.ref_offsets,
-                                  err_msg="error loading frame offsets")
-
-    @dec.slow
-    def test_persistent_offsets_new(self):
-        # check that offsets will be newly generated and not loaded from stored
-        # offsets
-        assert_equal(self.trajectory._offsets, None)
-
-    @dec.slow
-    def test_persistent_offsets_stored(self):
-        # build offsets
-        self.trajectory.numframes
-        assert_equal((self.trajectory._offsets is None), False)
-    
-        # check that stored offsets present
-        assert_equal(os.path.exists(self.trajectory._offset_filename()), True)
-
-    @dec.slow
-    def test_persistent_offsets_ctime_match(self):
-        # build offsets
-        self.trajectory.numframes
-
-        with open(self.trajectory._offset_filename(), 'rb') as f:
-            saved_offsets = cPickle.load(f)
-
-        # check that stored offsets ctime matches that of trajectory file
-        assert_equal(saved_offsets['ctime'], os.path.getctime(self.traj))
-    
-    @dec.slow
-    def test_persistent_offsets_size_match(self):
-        # build offsets
-        self.trajectory.numframes
-
-        with open(self.trajectory._offset_filename(), 'rb') as f:
-            saved_offsets = cPickle.load(f)
-
-        # check that stored offsets size matches that of trajectory file
-        assert_equal(saved_offsets['size'], os.path.getsize(self.traj))
-
-    @dec.slow
-    def test_persistent_offsets_autoload(self):
-        # build offsets
-        self.trajectory.numframes
-
-        # check that stored offsets are loaded for new universe
-        u = mda.Universe(self.top, self.traj)
-        assert_equal((u.trajectory._offsets is not None), True)
-
-    @dec.slow
-    def test_persistent_offsets_ctime_mismatch(self):
-        # build offsets
-        self.trajectory.numframes
-
-        # check that stored offsets are not loaded when trajectory ctime
-        # differs from stored ctime
-        with open(self.trajectory._offset_filename(), 'rb') as f:
-            saved_offsets = cPickle.load(f)
-        saved_offsets['ctime'] = saved_offsets['ctime'] - 1
-        with open(self.trajectory._offset_filename(), 'wb') as f:
-            cPickle.dump(saved_offsets, f)
-
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")  # Drop the warnings silently
-            u = mda.Universe(self.top, self.traj)
-            assert_equal((u.trajectory._offsets is None), True)
-        
-    @dec.slow
-    def test_persistent_offsets_size_mismatch(self):
-        # build offsets
-        self.trajectory.numframes
-
-        # check that stored offsets are not loaded when trajectory size differs
-        # from stored size
-        with open(self.trajectory._offset_filename(), 'rb') as f:
-            saved_offsets = cPickle.load(f)
-        saved_offsets['size'] += 1
-        with open(self.trajectory._offset_filename(), 'wb') as f:
-            cPickle.dump(saved_offsets, f)
-
-        u = mda.Universe(self.top, self.traj)
-        assert_equal((u.trajectory._offsets is None), True)
-        
-    @dec.slow
-    def test_persistent_offsets_last_frame_wrong(self):
-        # build offsets
-        self.trajectory.numframes
-
-        # check that stored offsets are not loaded when the offsets themselves
-        # appear to be wrong
-        with open(self.trajectory._offset_filename(), 'rb') as f:
-            saved_offsets = cPickle.load(f)
-        saved_offsets['offsets'] += 1
-        with open(self.trajectory._offset_filename(), 'wb') as f:
-            cPickle.dump(saved_offsets, f)
-
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")  # Drop the warnings silently
-            u = mda.Universe(self.top, self.traj)
-            assert_equal((u.trajectory._offsets is None), True)
-
-    @dec.slow
-    def test_persistent_offsets_readonly(self):
-        # build offsets
-        self.trajectory.numframes
-
-        # check that if directory is read-only offsets aren't stored
-        os.unlink(self.trajectory._offset_filename())
-        for root, dirs, files in os.walk(self.tmpdir, topdown=False):  
-            for item in dirs:  
-                os.chmod(os.path.join(root, item), 0444)
-            for item in files:
-                os.chmod(os.path.join(root, item), 0444)
-
-        u = mda.Universe(self.top, self.traj)
-        assert_equal(os.path.exists(self.trajectory._offset_filename()), False)
-
-    @dec.slow
-    def test_persistent_offsets_refreshTrue(self):
-        # build offsets
-        self.trajectory.numframes
-
-        # check that the *refresh_offsets* keyword ensures stored offsets
-        # aren't retrieved
-        u = mda.Universe(self.top, self.traj, refresh_offsets=True)
-        assert_equal((u.trajectory._offsets is None), True)
-
-    @dec.slow
-    def test_persistent_offsets_refreshFalse(self):
-        # build offsets
-        self.trajectory.numframes
-
-        # check that the *refresh_offsets* keyword as False grabs offsets
-        u = mda.Universe(self.top, self.traj, refresh_offsets=False)
-        assert_equal((u.trajectory._offsets is None), False)
-
-
-class TestXTCReader_offsets(_GromacsReader_offsets):
-    filename = XTC
-    ref_offsets = np.array([0,  165188,  330364,  495520,  660708,  825872,  991044, 1156212,
-                            1321384, 1486544])
-
-class TestTRRReader_offsets(_GromacsReader_offsets):
-    filename = TRR
-    ref_offsets = np.array([0,  1144464,  2288928,  3433392,  4577856,  5722320,
-                       6866784,  8011248,  9155712, 10300176])
-
-class _XDRNoConversion(TestCase):
+class _XDRNoConversion(MemleakTest):
     filename = None
 
     def setUp(self):
@@ -2628,7 +2415,7 @@ class TestTRRNoConversion(_XDRNoConversion):
     filename = TRR
 
 
-class _GromacsWriter(TestCase):
+class _GromacsWriter(MemleakTest):
     infilename = None  # XTC or TRR
     Writers = {
         '.trr': MDAnalysis.coordinates.TRR.TRRWriter,
@@ -2745,7 +2532,7 @@ class TestTRRWriter(_GromacsWriter):
                 assert_raises(NoDataError, getattr, written_ts, 'velocities')
 
 
-class _GromacsWriterIssue101(TestCase):
+class _GromacsWriterIssue101(MemleakTest):
     Writers = {
         '.trr': MDAnalysis.coordinates.TRR.TRRWriter,
         '.xtc': MDAnalysis.coordinates.XTC.XTCWriter,
@@ -2798,7 +2585,7 @@ class TestTRRWriterSingleFrame(_GromacsWriterIssue101):
     ext = ".trr"
 
 
-class _GromacsWriterIssue117(TestCase):
+class _GromacsWriterIssue117(MemleakTest):
     """Issue 117: Cannot write XTC or TRR from AMBER NCDF"""
     ext = None
     prec = 5
@@ -2870,7 +2657,7 @@ class RefTRZ(object):
     ref_time = 0.01
 
 
-class TestTRZReader(TestCase, RefTRZ):
+class TestTRZReader(MemleakTest, RefTRZ):
     def setUp(self):
         self.universe = mda.Universe(TRZ_psf, TRZ)
         self.trz = self.universe.trajectory
@@ -2966,7 +2753,7 @@ class TestTRZReader(TestCase, RefTRZ):
         except OSError:
             pass
 
-class TestTRZWriter(TestCase, RefTRZ):
+class TestTRZWriter(MemleakTest, RefTRZ):
     def setUp(self):
         self.universe = mda.Universe(TRZ_psf, TRZ)
         self.prec = 3
@@ -3032,7 +2819,7 @@ class TestTRZWriter2(object):
         assert_array_almost_equal(self.u.atoms.positions, u2.atoms.positions, 3)
 
 
-class TestWrite_Partial_Timestep(TestCase):
+class TestWrite_Partial_Timestep(MemleakTest):
     """Test writing a partial timestep made by passing only an atomgroup to Writer. (Issue 163)
 
     The contents of the AtomGroup.ts are checked in test_atomgroup, this test just checks that Writer
@@ -3089,7 +2876,7 @@ def test_datareader_VE():
     assert_raises(ValueError, DATAReader, 'filename')
 
 
-class _TestLammpsData_Coords(TestCase):
+class _TestLammpsData_Coords(MemleakTest):
     """Tests using a .data file for loading single frame.
 
     All topology loading from MDAnalysisTests.data is done in test_topology

--- a/testsuite/MDAnalysisTests/test_persistence.py
+++ b/testsuite/MDAnalysisTests/test_persistence.py
@@ -15,15 +15,19 @@
 #
 
 import MDAnalysis
-from MDAnalysis.tests.datafiles import PSF, DCD, PDB_small
+from MDAnalysis.tests.datafiles import PSF, DCD, PDB_small, GRO, XTC, TRR
 import MDAnalysis.core.AtomGroup
 from MDAnalysis.core.AtomGroup import AtomGroup
 
 import numpy
-from numpy.testing import assert_, assert_equal, assert_array_equal, assert_raises
+from numpy.testing import *
 from MDAnalysisTests import MemleakTest
 
+import os
+import shutil
 import cPickle
+import tempfile
+import warnings
 
 class TestAtomGroupPickle(MemleakTest):
     def setUp(self):
@@ -100,12 +104,219 @@ class TestAtomGroupPickle(MemleakTest):
         assert_array_equal(self.ag_n.indices(), newag.indices())
         assert_(newag.universe is self.universe, "Unpickled AtomGroup on wrong Universe.")
 
-def test_pickle_unpickle_empty():
-    """Test that an empty AtomGroup can be pickled/unpickled (Issue 293)"""
-    ag = AtomGroup([])
-    pickle_str = cPickle.dumps(ag, protocol=cPickle.HIGHEST_PROTOCOL)
-    newag = cPickle.loads(pickle_str)
-    assert_equal(len(newag), 0)
+class TestEmptyAtomGroupPickle(MemleakTest):
+    # This comes in a class just to get memleak testing
+    def test_pickle_unpickle_empty(self):
+        """Test that an empty AtomGroup can be pickled/unpickled (Issue 293)"""
+        ag = AtomGroup([])
+        pickle_str = cPickle.dumps(ag, protocol=cPickle.HIGHEST_PROTOCOL)
+        newag = cPickle.loads(pickle_str)
+        assert_equal(len(newag), 0)
+
+class _GromacsReader_offsets(MemleakTest):
+    # This base class assumes same lengths and dt for XTC and TRR test cases!
+    filename = None
+    ref_unitcell = numpy.array([80.017, 80.017, 80.017, 60., 60., 90.], dtype=numpy.float32)
+    ref_volume = 362270.0  # computed with Gromacs: 362.26999999999998 nm**3 * 1000 A**3/nm**3
+    ref_offsets = None
+
+    def setUp(self):
+        # since offsets are automatically generated in the same directory
+        # as the trajectory, we do everything from a temporary directory
+
+        self.tmpdir = tempfile.mkdtemp()
+        # loading from GRO is 4x faster than the PDB reader
+        shutil.copy(GRO, self.tmpdir)
+        shutil.copy(self.filename, self.tmpdir)
+
+        self.top = os.path.join(self.tmpdir, os.path.basename(GRO))
+        self.traj = os.path.join(self.tmpdir, os.path.basename(self.filename))
+
+        self.universe = MDAnalysis.Universe(self.top, self.traj, convert_units=True)
+        self.trajectory = self.universe.trajectory
+        self.prec = 3
+        self.ts = self.universe.coord
+        
+        # dummy output file
+        ext = os.path.splitext(self.filename)[1]
+        fd, self.outfile = tempfile.mkstemp(suffix=ext)
+        os.close(fd)
+        fd, self.outfile_offsets = tempfile.mkstemp(suffix='.pkl')
+        os.close(fd)
+
+    def tearDown(self):
+        try:
+            os.unlink(self.outfile)
+            os.unlink(self.outfile_offsets)
+            shutil.rmtree(self.tmpdir)
+        except:
+            pass
+        del self.universe
+
+    @dec.slow
+    def test_offsets(self):
+        if self.trajectory._offsets is None:
+            self.trajectory.numframes
+        assert_array_almost_equal(self.trajectory._offsets, self.ref_offsets,
+                                  err_msg="wrong frame offsets")
+
+        # Saving
+        self.trajectory.save_offsets(self.outfile_offsets)
+        with open(self.outfile_offsets, 'rb') as f:
+            saved_offsets = cPickle.load(f)
+        assert_array_almost_equal(self.trajectory._offsets, saved_offsets['offsets'],
+                                  err_msg="error saving frame offsets")
+        assert_array_almost_equal(self.ref_offsets, saved_offsets['offsets'],
+                                  err_msg="saved frame offsets don't match the known ones")
+
+        # Loading
+        self.trajectory.load_offsets(self.outfile_offsets)
+        assert_array_almost_equal(self.trajectory._offsets, self.ref_offsets,
+                                  err_msg="error loading frame offsets")
+
+    @dec.slow
+    def test_persistent_offsets_new(self):
+        # check that offsets will be newly generated and not loaded from stored
+        # offsets
+        assert_equal(self.trajectory._offsets, None)
+
+    @dec.slow
+    def test_persistent_offsets_stored(self):
+        # build offsets
+        self.trajectory.numframes
+        assert_equal((self.trajectory._offsets is None), False)
+    
+        # check that stored offsets present
+        assert_equal(os.path.exists(self.trajectory._offset_filename()), True)
+
+    @dec.slow
+    def test_persistent_offsets_ctime_match(self):
+        # build offsets
+        self.trajectory.numframes
+
+        with open(self.trajectory._offset_filename(), 'rb') as f:
+            saved_offsets = cPickle.load(f)
+
+        # check that stored offsets ctime matches that of trajectory file
+        assert_equal(saved_offsets['ctime'], os.path.getctime(self.traj))
+    
+    @dec.slow
+    def test_persistent_offsets_size_match(self):
+        # build offsets
+        self.trajectory.numframes
+
+        with open(self.trajectory._offset_filename(), 'rb') as f:
+            saved_offsets = cPickle.load(f)
+
+        # check that stored offsets size matches that of trajectory file
+        assert_equal(saved_offsets['size'], os.path.getsize(self.traj))
+
+    @dec.slow
+    def test_persistent_offsets_autoload(self):
+        # build offsets
+        self.trajectory.numframes
+
+        # check that stored offsets are loaded for new universe
+        u = MDAnalysis.Universe(self.top, self.traj)
+        assert_equal((u.trajectory._offsets is not None), True)
+
+    @dec.slow
+    def test_persistent_offsets_ctime_mismatch(self):
+        # build offsets
+        self.trajectory.numframes
+
+        # check that stored offsets are not loaded when trajectory ctime
+        # differs from stored ctime
+        with open(self.trajectory._offset_filename(), 'rb') as f:
+            saved_offsets = cPickle.load(f)
+        saved_offsets['ctime'] = saved_offsets['ctime'] - 1
+        with open(self.trajectory._offset_filename(), 'wb') as f:
+            cPickle.dump(saved_offsets, f)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")  # Drop the warnings silently
+            u = MDAnalysis.Universe(self.top, self.traj)
+            assert_equal((u.trajectory._offsets is None), True)
+        
+    @dec.slow
+    def test_persistent_offsets_size_mismatch(self):
+        # build offsets
+        self.trajectory.numframes
+
+        # check that stored offsets are not loaded when trajectory size differs
+        # from stored size
+        with open(self.trajectory._offset_filename(), 'rb') as f:
+            saved_offsets = cPickle.load(f)
+        saved_offsets['size'] += 1
+        with open(self.trajectory._offset_filename(), 'wb') as f:
+            cPickle.dump(saved_offsets, f)
+
+        u = MDAnalysis.Universe(self.top, self.traj)
+        assert_equal((u.trajectory._offsets is None), True)
+        
+    @dec.slow
+    def test_persistent_offsets_last_frame_wrong(self):
+        # build offsets
+        self.trajectory.numframes
+
+        # check that stored offsets are not loaded when the offsets themselves
+        # appear to be wrong
+        with open(self.trajectory._offset_filename(), 'rb') as f:
+            saved_offsets = cPickle.load(f)
+        saved_offsets['offsets'] += 1
+        with open(self.trajectory._offset_filename(), 'wb') as f:
+            cPickle.dump(saved_offsets, f)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")  # Drop the warnings silently
+            u = MDAnalysis.Universe(self.top, self.traj)
+            assert_equal((u.trajectory._offsets is None), True)
+
+    @dec.slow
+    def test_persistent_offsets_readonly(self):
+        # build offsets
+        self.trajectory.numframes
+
+        # check that if directory is read-only offsets aren't stored
+        os.unlink(self.trajectory._offset_filename())
+        for root, dirs, files in os.walk(self.tmpdir, topdown=False):  
+            for item in dirs:  
+                os.chmod(os.path.join(root, item), 0444)
+            for item in files:
+                os.chmod(os.path.join(root, item), 0444)
+
+        u = MDAnalysis.Universe(self.top, self.traj)
+        assert_equal(os.path.exists(self.trajectory._offset_filename()), False)
+
+    @dec.slow
+    def test_persistent_offsets_refreshTrue(self):
+        # build offsets
+        self.trajectory.numframes
+
+        # check that the *refresh_offsets* keyword ensures stored offsets
+        # aren't retrieved
+        u = MDAnalysis.Universe(self.top, self.traj, refresh_offsets=True)
+        assert_equal((u.trajectory._offsets is None), True)
+
+    @dec.slow
+    def test_persistent_offsets_refreshFalse(self):
+        # build offsets
+        self.trajectory.numframes
+
+        # check that the *refresh_offsets* keyword as False grabs offsets
+        u = MDAnalysis.Universe(self.top, self.traj, refresh_offsets=False)
+        assert_equal((u.trajectory._offsets is None), False)
+
+
+class TestXTCReader_offsets(_GromacsReader_offsets):
+    filename = XTC
+    ref_offsets = numpy.array([0,  165188,  330364,  495520,  660708,  825872,  991044, 1156212,
+                            1321384, 1486544])
+
+class TestTRRReader_offsets(_GromacsReader_offsets):
+    filename = TRR
+    ref_offsets = numpy.array([0,  1144464,  2288928,  3433392,  4577856,  5722320,
+                       6866784,  8011248,  9155712, 10300176])
 
 class TestMemleak(MemleakTest):
     def test_that_memleaks(self):
@@ -115,7 +326,7 @@ class TestMemleak(MemleakTest):
         # We actually clean up after ourselves there.
         class A():
             def __init__(self):
-                self.s = self
+                self.self_ref = self
             def __del__(self):
                 pass
         self.a = A()


### PR DESCRIPTION
Most tests in `test_atomgroup.py`, `test_coordinates.py`, and `test_persistence.py` are now checked for memleaks. This should cover most of the candidate cases for memleaks (Universes and Readers). As far as I could tell there was no slowdown in testing.

Renamed private members of `MemleakTest` to underscored names. Improved the class docs.

Moved the persistent offset tests to the newly-created `test_persistence.py`.