### PR TITLE
fixed "division by zero" bug in analysis.waterdynamics

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -57,7 +57,7 @@ Chronological list of authors
   - Caio S. Souza
   - Sean L. Seyler
   - David L. Dotson
-
+  - Carlos Yanez S.
 
 External code
 -------------

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -11,7 +11,7 @@ The rules for this file:
 
 ------------------------------------------------------------------------------
 ??/??/15  tyler.je.reddy, richardjgowers, alejob, orbeckst, dotsdl,
-        manuel.nuno.melo
+        manuel.nuno.melo, cyanezstange
 
   * 0.11.0
 
@@ -58,6 +58,8 @@ The rules for this file:
   * Fixed TRZWriter failing when passed a non TRZTimestep (Issue #302)
   * relative imports are now banned in unit testing modules
     (Issue #189)
+  * Fixed bug and added DivisionByZero exception in analysis/waterdinamics.py 
+    in SurvivalProbability.
 
 
 06/01/15  richardjgowers, caio s. souza, manuel.nuno.melo, orbeckst, 

--- a/package/MDAnalysis/analysis/waterdynamics.py
+++ b/package/MDAnalysis/analysis/waterdynamics.py
@@ -1022,7 +1022,10 @@ class SurvivalProbability(object):
         n = 0.0
         sumDeltaP = 0.0
         for frame in range(totalFrames-wint):
-            a = self._getOneDeltaPoint(selection1,totalFrames ,frame, wint)
+            try:
+                a = self._getOneDeltaPoint(selection1,totalFrames ,frame, wint)
+            except ZeroDivisionError:
+                continue
             sumDeltaP += a
             n += 1
 

--- a/package/MDAnalysis/analysis/waterdynamics.py
+++ b/package/MDAnalysis/analysis/waterdynamics.py
@@ -1022,6 +1022,8 @@ class SurvivalProbability(object):
         n = 0.0
         sumDeltaP = 0.0
         for frame in range(totalFrames-wint):
+            #This "try" is to avoid a division by zero when there is no particles in time t0,
+            #this happens in very small selection regions.
             try:
                 a = self._getOneDeltaPoint(selection1,totalFrames ,frame, wint)
             except ZeroDivisionError:

--- a/package/doc/sphinx/source/conf.py
+++ b/package/doc/sphinx/source/conf.py
@@ -91,7 +91,7 @@ authors = u"""Naveen Michaud-Agrawal, Elizabeth J. Denning, Joshua Adelman,
     Lennard van der Feltz, Philip Fowler, Joseph Goose, Richard J. Gowers, Lukas Grossar,
     Benjamin Hall, Joe Jordan, Jinju Lu, Robert McGibbon, Alex Nesterenko,
     Manuel Nuno Melo, Caio S. Souza, Danny Parton, Joshua L. Phillips, Tyler Reddy,
-    Paul Rigor, Sean L. Seyler, Andy Somogyi, Lukas Stelzl, Zhuyi Xue,
+    Paul Rigor, Sean L. Seyler, Andy Somogyi, Lukas Stelzl, Zhuyi Xue, Carlos Yáñez S.,
     and Oliver Beckstein"""
 project = u'MDAnalysis'
 copyright = u'2005-2015, ' + authors


### PR DESCRIPTION
Hi, I'm working with the analysis/waterdinamics.py module and I fixed a bug and added DivisionByZero exception  in SurvivalProbability class.
I also changed the CHANGELOG and AUTHORS files.