### PR TITLE
fixed parsing of PDB header data for PrimitivePDBReader (closes #332)

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -61,11 +61,11 @@ The rules for this file:
   * Fixed TRZWriter failing when passed a non TRZTimestep (Issue #302)
   * relative imports are now banned in unit testing modules
     (Issue #189)
-  * Fixed bug and added DivisionByZero exception in analysis/waterdinamics.py 
+  * Fixed bug and added DivisionByZero exception in analysis/waterdinamics.py
     in SurvivalProbability.
+  * Fixed parsing of PDB header data for PrimitivePDBReader (Issue #332)
 
-
-06/01/15  richardjgowers, caio s. souza, manuel.nuno.melo, orbeckst, 
+06/01/15  richardjgowers, caio s. souza, manuel.nuno.melo, orbeckst,
           sseyler
   * 0.10.0
 

--- a/testsuite/MDAnalysisTests/datafiles.py
+++ b/testsuite/MDAnalysisTests/datafiles.py
@@ -42,6 +42,7 @@ __all__ = [
     "PDB_multiframe",
     "PDB_helix",
     "XPDB_small",
+    "PDB_full",   # PDB 4E43 (full HEADER, TITLE, COMPND, REMARK, altloc)
     "NUCL",  # nucleic acid (PDB)
     "PDB", "GRO", "XTC", "TRR", "TPR", "GRO_velocity",  # Gromacs (AdK)
     "PDB_xvf", "TPR_xvf", "TRR_xvf",  # Gromacs coords/veloc/forces (cobrotoxin, OPLS-AA, Gromacs 4.5.5 tpr)
@@ -71,7 +72,6 @@ __all__ = [
     "merge_protein", "merge_ligand", "merge_water",
     "mol2_molecules", "mol2_molecule", "mol2_broken_molecule",
     "capping_input", "capping_output", "capping_ace", "capping_nma",
-    "altloc",
     "LAMMPSdata", "trz4data", "LAMMPSdata_mini",
     "unordered_res",  # pdb file with resids non sequential
     "GMS_ASYMOPT",  # GAMESS C1  optimization
@@ -184,7 +184,7 @@ TRZ_psf = resource_filename(__name__, 'data/trz_psf.psf')
 
 TRIC = resource_filename(__name__, 'data/dppc_vesicle_hg.gro')
 
-altloc = resource_filename(__name__, "data/4E43.pdb")
+PDB_full = resource_filename(__name__, "data/4E43.pdb")
 
 merge_protein = resource_filename(__name__, "data/merge/2zmm/protein.pdb")
 merge_ligand = resource_filename(__name__, "data/merge/2zmm/ligand.pdb")

--- a/testsuite/MDAnalysisTests/test_altloc.py
+++ b/testsuite/MDAnalysisTests/test_altloc.py
@@ -17,12 +17,13 @@ from MDAnalysis import Universe
 import tempfile
 import os
 from numpy.testing import *
-from MDAnalysisTests.datafiles import altloc
+from MDAnalysisTests.datafiles import PDB_full
 
 
 class TestAltloc(TestCase):
     def setUp(self):
-        fd, self.outfile = tempfile.mkstemp(suffix=".pdb")  # output is always same as input (=DCD)
+        self.filename = PDB_full
+        fd, self.outfile = tempfile.mkstemp(suffix=".pdb")  # output is always same as input
         os.close(fd)
 
     def tearDown(self):
@@ -32,7 +33,7 @@ class TestAltloc(TestCase):
             pass
 
     def test_atomgroups(self):
-        u = Universe(altloc)
+        u = Universe(self.filename)
         segidB0 = len(u.selectAtoms("segid B and (not altloc B)"))
         segidB1 = len(u.selectAtoms("segid B and (not altloc A)"))
         assert_equal(segidB0, segidB1)
@@ -43,7 +44,7 @@ class TestAltloc(TestCase):
         assert_equal(sum, segidB0 + altlocB0)
 
     def test_bonds(self):
-        u = Universe(altloc, guess_bonds=True)
+        u = Universe(self.filename, guess_bonds=True)
         # need to force topology to load before querying individual atom bonds
         u.build_topology()
         bonds0 = u.selectAtoms("segid B and (altloc A)")[0].bonds
@@ -51,7 +52,7 @@ class TestAltloc(TestCase):
         assert_equal(len(bonds0), len(bonds1))
 
     def test_write_read(self):
-        u = Universe(altloc)
+        u = Universe(self.filename)
         u.selectAtoms("all").write(self.outfile)
         u2 = Universe(self.outfile)
         assert_equal(len(u.atoms), len(u2.atoms))


### PR DESCRIPTION
Addresses #332 and adds TITLE parsing (together with unit tests).