### PR TITLE
Feature timesteptimes

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -37,6 +37,8 @@ The rules for this file:
   * Timesteps can now allocate velocities and forces if they weren't
     originally created with these through the use of the has_ flags.
     (Issue #213)
+  * Timesteps now store 'dt' and 'time_offset' if passed to them by Reader
+    (Issues 306 and 307)
 
   Changes
   * A ProtoReader class intermediate between IObase and Reader was added so

--- a/package/MDAnalysis/coordinates/CRD.py
+++ b/package/MDAnalysis/coordinates/CRD.py
@@ -73,7 +73,8 @@ class CRDReader(base.SingleFrameReader):
 
         self.numatoms = len(coords_list)
 
-        self.ts = self._Timestep.from_coordinates(np.array(coords_list))
+        self.ts = self._Timestep.from_coordinates(np.array(coords_list),
+                                                  **self._ts_kwargs)
         self.ts.frame = 0  # 0-based frame number
         # if self.convert_units:
         #    self.convert_pos_from_native(self.ts._pos)             # in-place !

--- a/package/MDAnalysis/coordinates/DCD.py
+++ b/package/MDAnalysis/coordinates/DCD.py
@@ -402,7 +402,9 @@ class DCDReader(base.Reader):
     _Timestep = Timestep
 
     def __init__(self, dcdfilename, **kwargs):
-        self.filename = self.dcdfilename = dcdfilename  # dcdfilename is legacy
+        super(DCDReader, self).__init__(dcdfilename, **kwargs)
+
+        self.dcdfilename = self.filename # dcdfilename is legacy
         self.dcdfile = None  # set right away because __del__ checks
 
         # Issue #32: segfault if dcd is 0-size
@@ -415,11 +417,10 @@ class DCDReader(base.Reader):
         self.numatoms = 0
         self.numframes = 0
         self.fixed = 0
-        self.skip = 1
         self.periodic = False
 
         self._read_dcd_header()
-        self.ts = self._Timestep(self.numatoms)
+        self.ts = self._Timestep(self.numatoms, **self._ts_kwargs)
         # Read in the first timestep
         self._read_next_timestep()
 

--- a/package/MDAnalysis/coordinates/DLPoly.py
+++ b/package/MDAnalysis/coordinates/DLPoly.py
@@ -118,7 +118,8 @@ class ConfigReader(base.SingleFrameReader):
 
         ts = self.ts = self._Timestep(self.numatoms,
                                       velocities=has_vels,
-                                      forces=has_forces)
+                                      forces=has_forces,
+                                      **self._ts_kwargs)
         ts._pos = coords
         if has_vels:
             ts._velocities = velocities
@@ -142,19 +143,8 @@ class HistoryReader(base.Reader):
     units = _DLPOLY_UNITS
     _Timestep = Timestep
 
-    def __init__(self, filename, convert_units=None, **kwargs):
-        if convert_units is None:
-            convert_units = MDAnalysis.core.flags['convert_lengths']
-        self.convert_units = convert_units
-
-        self.filename = filename
-
-        self.fixed = False
-        self.periodic = True
-        self.skip = 1
-        self._delta = None
-        self._dt = None
-        self._skip_timestep = None
+    def __init__(self, filename, **kwargs):
+        super(HistoryReader, self).__init__(filename, **kwargs)
 
         # "private" file handle
         self._file = open(self.filename, 'r')
@@ -165,7 +155,8 @@ class HistoryReader(base.Reader):
 
         self.ts = self._Timestep(self.numatoms,
                                  velocities=self._has_vels,
-                                 forces=self._has_forces)
+                                 forces=self._has_forces,
+                                 **self._ts_kwargs)
         self._read_next_timestep()
 
     def _read_next_timestep(self, ts=None):

--- a/package/MDAnalysis/coordinates/DMS.py
+++ b/package/MDAnalysis/coordinates/DMS.py
@@ -111,7 +111,9 @@ class DMSReader(base.SingleFrameReader):
             velocities = None
 
         self.ts = self._Timestep.from_coordinates(
-            np.array(coords_list, dtype=np.float32), velocities=velocities)
+            np.array(coords_list, dtype=np.float32),
+            velocities=velocities,
+            **self._ts_kwargs)
         self.ts.frame = 0  # 0-based frame number
 
         self.ts._unitcell = unitcell

--- a/package/MDAnalysis/coordinates/GMS.py
+++ b/package/MDAnalysis/coordinates/GMS.py
@@ -54,6 +54,7 @@ class GMSReader(base.Reader):
 
     .. versionchanged:: 0.11.0
        Frames now 0-based instead of 1-based
+       Added dt and time_offset keywords (passed to Timestep)
     """
 
     format = "GMS"
@@ -62,7 +63,7 @@ class GMSReader(base.Reader):
     units = {'time': 'ps', 'length': 'Angstrom'}
 
     def __init__(self, outfilename, **kwargs):
-        self.filename = outfilename
+        super(GMSReader, self).__init__(outfilename, **kwargs)
 
         # the filename has been parsed to be either b(g)zipped or not
         self.outfile = util.anyopen(self.filename, 'r')
@@ -75,8 +76,6 @@ class GMSReader(base.Reader):
         self._runtyp = None
 
         self.ts = self._Timestep(0) # need for properties initial calculations
-        self.fixed = 0
-        self.skip = 1
         self.periodic = False
         self.delta = kwargs.pop("delta", 1.0)   # there is no time, so let delta be 1
         # update runtyp property
@@ -85,12 +84,11 @@ class GMSReader(base.Reader):
             raise AttributeError('Wrong RUNTYP= '+self.runtyp)
         self.skip_timestep = 1
 
-        self.ts = self._Timestep(self.numatoms)
+        self.ts = self._Timestep(self.numatoms, **self._ts_kwargs)
         # update numframes property
         self.numframes
 
         # Read in the first timestep
-
         self._read_next_timestep()
 
     @property

--- a/package/MDAnalysis/coordinates/GRO.py
+++ b/package/MDAnalysis/coordinates/GRO.py
@@ -120,10 +120,12 @@ class GROReader(base.SingleFrameReader):
                     unitcell = np.array(map(float, line.split()))
 
         self.numatoms = len(coords_list)
+        vels = np.array(velocities_list, dtype=np.float32) if velocities_list else None
 
         self.ts = self._Timestep.from_coordinates(
             np.array(coords_list),
-            velocities=np.array(velocities_list, dtype=np.float32) if velocities_list else None)
+            velocities=vels,
+            **self._ts_kwargs)
 
         self.ts.frame = 0  # 0-based frame number
 

--- a/package/MDAnalysis/coordinates/INPCRD.py
+++ b/package/MDAnalysis/coordinates/INPCRD.py
@@ -42,7 +42,7 @@ class INPReader(base.SingleFrameReader):
             except IndexError:
                 time = 0.0
 
-            self.ts = self._Timestep(self.numatoms)
+            self.ts = self._Timestep(self.numatoms, **self._ts_kwargs)
             self.ts.time = time
             self.ts.frame = 0
 

--- a/package/MDAnalysis/coordinates/LAMMPS.py
+++ b/package/MDAnalysis/coordinates/LAMMPS.py
@@ -135,7 +135,8 @@ class DATAReader(base.SingleFrameReader):
 
     def _read_first_frame(self):
         with DATAParser(self.filename) as p:
-            self.ts = p.read_DATA_timestep(self.numatoms, self._Timestep)
+            self.ts = p.read_DATA_timestep(self.numatoms, self._Timestep,
+                                           self._ts_kwargs)
 
         self.ts.frame = 0
         if self.convert_units:

--- a/package/MDAnalysis/coordinates/MOL2.py
+++ b/package/MDAnalysis/coordinates/MOL2.py
@@ -55,15 +55,9 @@ class MOL2Reader(base.Reader):
     format = 'MOL2'
     units = {'time': None, 'length': 'Angstrom'}
 
-    def __init__(self, filename, convert_units=None, **kwargs):
-        """Read coordinates from *filename*.
-
-        
-        """
-        self.filename = filename
-        if convert_units is None:
-            convert_units = flags['convert_lengths']
-        self.convert_units = convert_units  # convert length and time to base units
+    def __init__(self, filename, **kwargs):
+        """Read coordinates from *filename*."""
+        super(MOL2Reader, self).__init__(filename, **kwargs)
 
         blocks = []
 
@@ -79,7 +73,8 @@ class MOL2Reader(base.Reader):
         sections, coords = self.parse_block(block)
 
         self.numatoms = len(coords)
-        self.ts = self._Timestep.from_coordinates(np.array(coords, dtype=np.float32))
+        self.ts = self._Timestep.from_coordinates(np.array(coords, dtype=np.float32),
+                                                  **self._ts_kwargs)
         self.ts.frame = 0  # 0-based frame number as starting frame
 
         if self.convert_units:
@@ -90,8 +85,6 @@ class MOL2Reader(base.Reader):
         self.substructure = {}
         self.frames = blocks
         self.numframes = len(blocks)
-        self.fixed = 0
-        self.skip = 1
         self.periodic = False
         self.delta = 0
         self.skip_timestep = 1

--- a/package/MDAnalysis/coordinates/PDBQT.py
+++ b/package/MDAnalysis/coordinates/PDBQT.py
@@ -168,7 +168,8 @@ class PDBQTReader(base.SingleFrameReader):
                     atoms.append(
                         (serial, name, resName, chainID, resSeq, occupancy, tempFactor, partialCharge, atomtype))
         self.numatoms = len(coords)
-        self.ts = self._Timestep.from_coordinates(np.array(coords, dtype=np.float32))
+        self.ts = self._Timestep.from_coordinates(np.array(coords, dtype=np.float32),
+                                                  **self._ts_kwargs)
         self.ts._unitcell[:] = unitcell
         self.ts.frame = 0  # 0-based frame number
         if self.convert_units:

--- a/package/MDAnalysis/coordinates/PQR.py
+++ b/package/MDAnalysis/coordinates/PQR.py
@@ -128,7 +128,8 @@ class PQRReader(base.SingleFrameReader):
                     atoms.append(
                         (int(serial), name, resName, chainID, int(resSeq), float(charge), float(radius), segID))
         self.numatoms = len(coords)
-        self.ts = self._Timestep.from_coordinates(np.array(coords, dtype=np.float32))
+        self.ts = self._Timestep.from_coordinates(np.array(coords, dtype=np.float32),
+                                                  **self._ts_kwargs)
         self.ts._unitcell[:] = unitcell
         self.ts.frame = 0  # 0-based frame number
         if self.convert_units:

--- a/package/MDAnalysis/coordinates/TRZ.py
+++ b/package/MDAnalysis/coordinates/TRZ.py
@@ -137,7 +137,7 @@ class TRZReader(base.Reader):
 
     units = {'time': 'ps', 'length': 'nm', 'velocity': 'nm/ps'}
 
-    def __init__(self, trzfilename, numatoms=None, convert_units=None, **kwargs):
+    def __init__(self, trzfilename, numatoms=None, **kwargs):
         """Creates a TRZ Reader
 
         :Arguments:
@@ -148,27 +148,22 @@ class TRZReader(base.Reader):
           *convert_units*
             converts units to MDAnalysis defaults
         """
+        super(TRZReader, self).__init__(trzfilename,  **kwargs)
+
         if numatoms is None:
             raise ValueError('TRZReader requires the numatoms keyword')
 
-        if convert_units is None:
-            convert_units = flags['convert_lengths']
-        self.convert_units = convert_units
-
-        self.filename = trzfilename
         self.trzfile = util.anyopen(self.filename, 'rb')
 
         self._numatoms = numatoms
-        self.fixed = False
-        self.periodic = True
-        self.skip = 1
         self._numframes = None
         self._delta = None
         self._dt = None
         self._skip_timestep = None
 
         self._read_trz_header()
-        self.ts = Timestep(self.numatoms, velocities=True, forces=self.has_force)
+        self.ts = Timestep(self.numatoms, velocities=True, forces=self.has_force,
+                           **self._ts_kwargs)
 
         # structured dtype of a single trajectory frame
         readarg = str(numatoms) + 'f4'

--- a/package/MDAnalysis/coordinates/XYZ.py
+++ b/package/MDAnalysis/coordinates/XYZ.py
@@ -236,6 +236,7 @@ class XYZReader(base.Reader):
 
     .. versionchanged:: 0.11.0
        Frames now 0-based instead of 1-based
+       Added dt and time_offset keywords (passed to Timestep)
     """
 
     # this will be overidden when an instance is created and the file extension checked
@@ -245,7 +246,7 @@ class XYZReader(base.Reader):
     _Timestep = base.Timestep
 
     def __init__(self, filename, **kwargs):
-        self.filename = filename
+        super(XYZReader, self).__init__(filename, **kwargs)
 
         # the filename has been parsed to be either be foo.xyz or foo.xyz.bz2 by coordinates::core.py
         # so the last file extension will tell us if it is bzipped or not
@@ -259,13 +260,11 @@ class XYZReader(base.Reader):
         self._numatoms = None
         self._numframes = None
 
-        self.fixed = 0
-        self.skip = 1
         self.periodic = False
         self.delta = kwargs.pop("delta", 1.0)  # can set delta manually, default is 1ps (taken from TRJReader)
         self.skip_timestep = 1
 
-        self.ts = self._Timestep(self.numatoms)
+        self.ts = self._Timestep(self.numatoms, **self._ts_kwargs)
 
         #        Haven't quite figured out where to start with all the self._reopen() etc.
         #        (Also cannot just use seek() or reset() because that would break with urllib2.urlopen() streams)

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -159,6 +159,10 @@ class Timestep(object):
             Whether this Timestep has velocity information [``False``]
           *forces*
             Whether this Timestep has force information [``False``]
+          *dt*
+            The time difference between frames (ps)
+          *time_offset*
+            The starting time from which to calculate time
 
         .. versionchanged:: 0.11.0
            Added keywords for positions, velocities and forces
@@ -172,6 +176,12 @@ class Timestep(object):
         self.time = 0.0
 
         self.data = {}
+
+        for att in ('dt', 'time_offset'):
+            try:
+                self.data[att] = kwargs[att]
+            except KeyError:
+                pass
 
         # Stupid hack to make it allocate first time round
         # ie we have to go from not having, to having positions

--- a/package/MDAnalysis/coordinates/xdrfile/TRR.py
+++ b/package/MDAnalysis/coordinates/xdrfile/TRR.py
@@ -112,8 +112,9 @@ class Timestep(core.Timestep):
                   " by making use of the '{flag}' flag of Timestep objects.")
 
     def __init__(self, numatoms, **kwargs):
-        super(Timestep, self).__init__(numatoms, positions=True,
-                                       velocities=True, forces=True)
+        kwargs.update(positions=True, velocities=True, forces=True)
+        super(Timestep, self).__init__(numatoms, **kwargs)
+
         # Set initial sources to None, so they are never valid
         # _source is compared against current frame when accessing
         # if they do not match, then the Timestep returns _nodataerr

--- a/package/MDAnalysis/coordinates/xdrfile/core.py
+++ b/package/MDAnalysis/coordinates/xdrfile/core.py
@@ -331,7 +331,7 @@ class TrjReader(base.Reader):
     #: writer class that matches this reader (override appropriately)
     _Writer = TrjWriter
 
-    def __init__(self, filename, convert_units=None, sub=None, **kwargs):
+    def __init__(self, filename, sub=None, **kwargs):
         """
         :Arguments:
             *filename*
@@ -355,7 +355,8 @@ class TrjReader(base.Reader):
            New keyword *refresh_offsets*
 
         """
-        self.filename = filename
+        super(TrjReader, self).__init__(filename, **kwargs)
+
         # Convert filename to ascii because of SWIG bug.
         # See: http://sourceforge.net/p/swig/feature-requests/75
         # Only needed for Python < 3
@@ -363,15 +364,11 @@ class TrjReader(base.Reader):
             if isinstance(filename, unicode):
                 self.filename = filename.encode("UTF-8")
 
-        if convert_units is None:
-            convert_units = MDAnalysis.core.flags['convert_lengths']
-        self.convert_units = convert_units  # convert length and time to base units on the fly?
         self.xdrfile = None
 
         self._numframes = None  # takes a long time, avoid accessing self.numframes
         self.skip_timestep = 1  # always 1 for xdr files
         self._delta = None  # compute from time in first two frames!
-        self.fixed = 0  # not relevant for Gromacs xtc/trr
         self._offsets = None  # storage of offsets in the file
         self.skip = 1
         self.periodic = False
@@ -413,7 +410,7 @@ class TrjReader(base.Reader):
         # (same as the calling Universe)
         # at this time, _trr_numatoms and _sub are set, so self.numatoms has all it needs
         # to determine number of atoms.
-        self.ts = self._Timestep(self.numatoms)
+        self.ts = self._Timestep(self.numatoms, **self._ts_kwargs)
 
         # Read in the first timestep
         self._read_next_timestep()

--- a/package/MDAnalysis/core/AtomGroup.py
+++ b/package/MDAnalysis/core/AtomGroup.py
@@ -4292,7 +4292,7 @@ def Merge(*args):
             raise ValueError("cannot merge empty AtomGroup")
 
     coords = numpy.vstack([a.coordinates() for a in args])
-    trajectory = MDAnalysis.coordinates.base.Reader()
+    trajectory = MDAnalysis.coordinates.base.Reader(None)
     ts = MDAnalysis.coordinates.base.Timestep.from_coordinates(coords)
     setattr(trajectory, "ts", ts)
     trajectory.numframes = 1

--- a/package/MDAnalysis/topology/LAMMPSParser.py
+++ b/package/MDAnalysis/topology/LAMMPSParser.py
@@ -158,7 +158,7 @@ class DATAParser(TopologyReader):
 
             return structure
 
-    def read_DATA_timestep(self, numatoms, TS_class):
+    def read_DATA_timestep(self, numatoms, TS_class, TS_kwargs):
         """Read a DATA file and try and extract x, v, box.
 
         - positions
@@ -211,9 +211,10 @@ class DATAParser(TopologyReader):
         if not read_coords:  # Reaches here if StopIteration hit
             raise IOError("Position information not found")
 
-        ts = TS_class.from_coordinates(positions, velocities=velocities)
+        ts = TS_class.from_coordinates(positions, velocities=velocities,
+                                       **TS_kwargs)
         ts._unitcell = unitcell
-        
+
         return ts
 
     def _parse_pos(self, datafile, pos):

--- a/testsuite/MDAnalysisTests/test_timestep_api.py
+++ b/testsuite/MDAnalysisTests/test_timestep_api.py
@@ -348,6 +348,16 @@ class _TestTimestep(TestCase):
         assert_array_almost_equal(ts.velocities, refvel)
         assert_array_almost_equal(ts.forces, reffor)
 
+    def test_supply_dt(self):
+        ts = self.Timestep(20, dt=0.04)
+
+        assert_equal(ts.data['dt'], 0.04)
+
+    def test_supply_time_offset(self):
+        ts = self.Timestep(20, time_offset=100.0)
+
+        assert_equal(ts.data['time_offset'], 100.0)
+
 
 # Can add in custom tests for a given Timestep here!
 class TestBaseTimestep(_TestTimestep, _BaseTimestep):


### PR DESCRIPTION
I've added in time_offset and dt to the Reader init, and these are then passed to the Timestep.

I've added a `base.Reader.__init__` method, otherwise it was very messy to add the same code into every other Reader.

Still todo is to make Readers that can read `dt` properly pass this to their Timesteps.