### PR TITLE
MDAnalysis.selection testing (partially addresses #353)

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -39,6 +39,7 @@ The rules for this file:
     (Issue #213)
   * Timesteps now store 'dt' and 'time_offset' if passed to them by Reader
     (Issues 306 and 307)
+  * MDAnalysis.selection: can also be written to a NamedStream
 
   Changes
   * A ProtoReader class intermediate between IObase and Reader was added so
@@ -66,6 +67,11 @@ The rules for this file:
   * __iter__ removed from many Readers (now use base.Reader implementation)
   * numpy >= 1.5 required
   * Timestep._x _y and _z are now read only (Issue #213)
+  * moved MDAnalysis.selections.base.get_writer() to
+    MDAnalysis.selections.get_writer() to break a circular import. This
+    should not affect any code because
+    MDAnalysis.selections.get_writer() already existed.
+
 
   Fixes
   * Fixed TPRParser considering LJ 1..4 exclusions as bonds (Issue #351)

--- a/package/MDAnalysis/selections/__init__.py
+++ b/package/MDAnalysis/selections/__init__.py
@@ -32,15 +32,19 @@ to a file so that it can be used in another programme.
     CHARMM_ selections
 
 The :class:`MDAnalysis.selections.base.SelectionWriter` base class and
-helper functions are in :mod:`MDAnalysis.selections.base`.
+helper functions are in :mod:`MDAnalysis.selections.base`, with the
+exception of `:func:get_writer`:
+
+.. autofunction:: get_writer
 """
+from __future__ import absolute_import
 
-import vmd
-import pymol
-import gromacs
-import charmm
-from base import get_writer
+import os.path
 
+from . import vmd
+from . import pymol
+from . import gromacs
+from . import charmm
 
 # Signature:
 #   W = SelectionWriter(filename, **kwargs)
@@ -51,3 +55,19 @@ _selection_writers = {
     'pymol': pymol.SelectionWriter, 'pml': pymol.SelectionWriter,
     'gromacs': gromacs.SelectionWriter, 'ndx': gromacs.SelectionWriter,
 }
+
+def get_writer(filename, defaultformat):
+    """Return a :class:`SelectionWriter` for *filename* or a *defaultformat*."""
+
+    if filename:
+        format = os.path.splitext(filename)[1][1:]  # strip initial dot!
+    format = format or defaultformat  # use default if no fmt from fn
+    format = format.strip().lower()  # canonical for lookup
+    try:
+        return _selection_writers[format]
+    except KeyError:
+        raise NotImplementedError("Writing as %r is not implemented; only %r will work."
+                                  % (format, _selection_writers.keys()))
+
+
+

--- a/package/MDAnalysis/selections/charmm.py
+++ b/package/MDAnalysis/selections/charmm.py
@@ -32,8 +32,9 @@ The selection is named *mdanalysis001*.
 .. _CHARMM: http://www.charmm.org
 .. _CHARMM selection: http://www.charmm.org/documentation/c34b1/select.html
 """
-import base
+from __future__ import absolute_import
 
+from . import base
 
 class SelectionWriter(base.SelectionWriter):
     format = "CHARMM"

--- a/package/MDAnalysis/selections/gromacs.py
+++ b/package/MDAnalysis/selections/gromacs.py
@@ -32,8 +32,9 @@ The index groups are named *mdanalysis001*, *mdanalysis002*, etc.
 .. autoclass:: SelectionWriter
    :inherited-members:
 """
-import base
+from __future__ import absolute_import
 
+from . import base
 
 class SelectionWriter(base.SelectionWriter):
     format = "Gromacs"

--- a/package/MDAnalysis/selections/pymol.py
+++ b/package/MDAnalysis/selections/pymol.py
@@ -33,9 +33,9 @@ The selections should appear in the user interface.
 .. autoclass:: SelectionWriter
    :inherited-members:
 """
+from __future__ import absolute_import
 
-import base
-
+from . import base
 
 class SelectionWriter(base.SelectionWriter):
     format = "PyMol"

--- a/package/MDAnalysis/selections/vmd.py
+++ b/package/MDAnalysis/selections/vmd.py
@@ -31,8 +31,9 @@ that defines `atomselect macros`_. To be used in VMD like this::
 .. autoclass:: SelectionWriter
    :inherited-members:
 """
-import base
+from __future__ import absolute_import
 
+from . import base
 
 class SelectionWriter(base.SelectionWriter):
     format = "VMD"

--- a/testsuite/CHANGELOG
+++ b/testsuite/CHANGELOG
@@ -13,7 +13,7 @@ Also see https://github.com/MDAnalysis/mdanalysis/wiki/MDAnalysisTests
 and https://github.com/MDAnalysis/mdanalysis/wiki/UnitTests
 
 ------------------------------------------------------------------------------
-??/??/2015 manuel.nuno.melo
+??/??/2015 manuel.nuno.melo, orbeckst
   * 0.11.0
 
     - Overhaul of the test subsystem.
@@ -21,6 +21,8 @@ and https://github.com/MDAnalysis/mdanalysis/wiki/UnitTests
       Available plugins are: memleak testing, stderr capturing (for quieter
       test runs), and proper knownfailure implementation (Issue 338).
     - renamed test_selections.py to test_atomselections.py
+    - new test_selections.py is now testing MDAnalysis.selections
+      (Issue #353)
 
 02/11/2012 orbeckst, seb-buch
 

--- a/testsuite/MDAnalysisTests/test_selections.py
+++ b/testsuite/MDAnalysisTests/test_selections.py
@@ -1,0 +1,101 @@
+# -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 fileencoding=utf-8
+#
+# MDAnalysis --- http://www.MDAnalysis.org
+# Copyright (c) 2006-2015 Naveen Michaud-Agrawal, Elizabeth J. Denning, Oliver Beckstein
+# and contributors (see AUTHORS for the full list)
+#
+# Released under the GNU Public Licence, v2 or any higher version
+#
+# Please cite your use of MDAnalysis in published work:
+#
+# N. Michaud-Agrawal, E. J. Denning, T. B. Woolf, and O. Beckstein.
+# MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
+# J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
+#
+
+# Test the selection exporters in MDAnalysis.selections
+
+# use cStringIO and NamedStream to write to memory instead to temp files
+import cStringIO
+
+import numpy as np
+from numpy.testing import TestCase, assert_equal, assert_array_equal
+from nose.plugins.attrib import attr
+
+from MDAnalysisTests.plugins.knownfailure import knownfailure
+from MDAnalysis.lib.util import NamedStream
+
+import MDAnalysis
+from MDAnalysis.tests.datafiles import PSF, DCD
+
+
+# add more tests, see Issue #353
+
+class _SelectionWriter(TestCase):
+    filename = None
+
+    def setUp(self):
+        self.universe = MDAnalysis.Universe(PSF, DCD)
+        stream = cStringIO.StringIO()
+        self.namedfile = NamedStream(stream, self.filename)
+
+    def tearDown(self):
+        del self.universe
+        del self.namedfile
+
+def ndx2array(lines):
+    """Convert Gromacs NDX text file lines to integer array"""
+    return np.array(" ".join(lines).replace("\n", "").split(), dtype=int)
+
+class TestSelectionWriter_Gromacs(_SelectionWriter):
+    filename = "CA.ndx"
+
+    ref_name = "CA_selection"
+    ref_indices = ndx2array(
+        [ '5 22 46 65 84 103 122 129 141 153 160 170 \n',
+          '177 199 206 220 237 247 264 284 303 320 335 357 \n',
+          '378 385 406 418 435 454 465 479 486 498 515 534 \n',
+          '558 568 578 594 616 627 634 645 660 679 686 708 \n',
+          '725 735 757 769 788 805 817 827 834 856 875 891 \n',
+          '905 917 932 951 967 986 996 1015 1031 1053 1068 1092 \n',
+          '1111 1121 1138 1153 1165 1176 1200 1214 1221 1241 1260 1279 \n',
+          '1291 1298 1320 1332 1356 1370 1391 1403 1420 1430 1442 1452 \n',
+          '1469 1491 1506 1516 1523 1542 1556 1572 1584 1605 1621 1640 \n',
+          '1655 1675 1687 1705 1717 1729 1744 1763 1782 1798 1810 1834 \n',
+          '1853 1869 1876 1900 1924 1940 1957 1969 1981 1992 1999 2023 \n',
+          '2039 2060 2077 2093 2115 2135 2151 2165 2177 2199 2215 2230 \n',
+          '2237 2259 2271 2283 2299 2313 2320 2335 2350 2369 2383 2397 \n',
+          '2421 2443 2455 2467 2484 2499 2514 2528 2544 2568 2590 2614 \n',
+          '2633 2649 2664 2685 2702 2719 2736 2750 2762 2774 2793 2812 \n',
+          '2819 2840 2861 2872 2894 2909 2919 2934 2944 2951 2965 2979 \n',
+          '3001 3022 3032 3054 3070 3082 3089 3103 3127 3139 3155 3165 \n',
+          '3180 3196 3220 3230 3242 3261 3276 3298 3317 3336 \n']
+        )
+
+    def test_write_ndx(self):
+        CA = self.universe.selectAtoms("protein and name CA")
+        CA.write(self.namedfile, name=self.ref_name)
+
+        header = self.namedfile.readline().strip()
+        assert_equal(header, "[ {0} ]".format(self.ref_name),
+                     err_msg="NDX file has wrong selection name")
+        indices = ndx2array(self.namedfile.readlines())
+        assert_array_equal(indices, self.ref_indices,
+                           err_msg="indices were not written correctly")
+
+    def test_writeselection_ndx(self):
+        CA = self.universe.selectAtoms("protein and name CA")
+        CA.write_selection(self.namedfile, name=self.ref_name)
+
+        header = self.namedfile.readline().strip()
+        assert_equal(header, "[ {0} ]".format(self.ref_name),
+                     err_msg="NDX file has wrong selection name")
+        indices = ndx2array(self.namedfile.readlines())
+        assert_array_equal(indices, self.ref_indices,
+                           err_msg="indices were not written correctly")
+
+
+
+
+


### PR DESCRIPTION
- test_selections.py is now used for testing selection writers
- added example test for Gromacs NDX file writer
- selection writers can now write to streams (uses util.openany())
  but format recognition does not work yet with bzipped of gzipped
  files