### PR TITLE
Fixes parallel builds in travis. nose>=1.3.7 now required.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
   - export PATH=/home/travis/miniconda/bin:$PATH
   - conda update --yes conda
 install:
-  - conda create --yes -q -n pyenv mkl python=2.7 numpy=1.9.1 scipy=0.14.0 nose=1.3.4
+  - conda create --yes -q -n pyenv mkl python=2.7 numpy=1.9.1 scipy=0.14.0 nose=1.3.7
   - source activate pyenv
   - conda install --yes python=$TRAVIS_PYTHON_VERSION cython biopython matplotlib networkx netcdf4
   - pip install package/
@@ -26,7 +26,7 @@ install:
   - chmod +x testsuite/MDAnalysisTests/mda_nosetests
 # command to run tests
 script:
-    - ./testsuite/MDAnalysisTests/mda_nosetests -v --with-coverage --cover-package MDAnalysis --with-memleak
+    - ./testsuite/MDAnalysisTests/mda_nosetests -v --with-coverage --cover-package MDAnalysis --processes=2 --process-timeout=120 --with-memleak
 after_success:
   - coveralls
 

--- a/package/setup.py
+++ b/package/setup.py
@@ -315,7 +315,7 @@ if __name__ == '__main__':
           },
           test_suite="MDAnalysisTests",
           tests_require=[
-              'nose>=0.10',
+              'nose>=1.3.7',
               'MDAnalysisTests==%s' % RELEASE,  # same as this release!
           ],
           zip_safe=False,  # as a zipped egg the *.so files are not found (at least in Ubuntu/Linux)

--- a/testsuite/MDAnalysisTests/__init__.py
+++ b/testsuite/MDAnalysisTests/__init__.py
@@ -113,31 +113,20 @@ __version__ = "0.11.0-dev"  # keep in sync with RELEASE in setup.py
 # If MDAnalysis is imported here coverage accounting might fail because all the import
 #  code won't be run again under coverage's watch. See Issue 344.
 
+from os.path import dirname
+# We get our nose from the plugins so that version-checking needs only be done there.
+from MDAnalysisTests.plugins import nose, loaded_plugins
+import sys
+# This is a de facto test for numpy's version, since we don't actually need assert_ here.
+#  Should we be clean about this and just call distutils to compare version strings?
 try:
     from numpy.testing import assert_
 except ImportError:
     raise ImportError("""numpy>=1.5  is required to run the test suite. Please install it first. """
                       """(For example, try "easy_install 'numpy>=1.5'").""")
 
-try:
-    import nose
-except ImportError:
-    raise ImportError('nose is required to run the test suite. Please install it first. '
-                      '(For example, try "pip install nose").')
-
-import nose.plugins.multiprocess
-_multiprocess_ok = hasattr(nose.plugins.multiprocess, "_instantiate_plugins")
-if not _multiprocess_ok:
-    raise ImportWarning("nose >= 1.1.0 is needed for multiprocess testing with external plugins, "
-                        "and your setup doesn't meet this requirement. If you're running "
-                        "tests in parallel external plugins will be disabled.")
-
-from os.path import dirname
-from MDAnalysisTests.plugins import loaded_plugins
-import sys
-
 def run(*args, **kwargs):
-    """Test-running function that loads plugins, sets up arguments, and calls `nose.main()`"""
+    """Test-running function that loads plugins, sets up arguments, and calls `nose.run_exit()`"""
     try:
         kwargs['argv'] = sys.argv + kwargs['argv'] #sys.argv takes precedence
     except KeyError:

--- a/testsuite/MDAnalysisTests/plugins/knownfailure.py
+++ b/testsuite/MDAnalysisTests/plugins/knownfailure.py
@@ -26,7 +26,7 @@ Beware that the decorator must be used as a function call: `@knownfailure()`, wi
 and, optionally, arguments.
 """
 
-from MDAnalysisTests.plugins import loaded_plugins, _check_plugins_loaded, _check_multiprocess 
+from MDAnalysisTests.plugins import loaded_plugins, _check_plugins_loaded
 # Since we're already doing import checks in MDAnalysisTests and .plugins no need to clutter here
 from numpy.testing.noseclasses import KnownFailure, KnownFailureTest
 import nose
@@ -42,7 +42,7 @@ def knownfailure(msg="Test skipped due to expected failure", exc_type=AssertionE
             except exc_type:
                 # We have to allow for a number of cases where KnownFailureTest won't be properly caught
                 #  (running from the command-line nosetests or using too old a multiprocess plugin)
-                if _check_plugins_loaded() and loaded_plugins["KnownFailure"].enabled and _check_multiprocess():
+                if _check_plugins_loaded() and loaded_plugins["KnownFailure"].enabled:
                     raise KnownFailureTest(msg)
                 else: #Fallback if run from command-line and the plugin isn't loaded 
                     raise nose.SkipTest(msg)

--- a/testsuite/setup.py
+++ b/testsuite/setup.py
@@ -126,7 +126,7 @@ For details see the report for `Issue 87`_.
           install_requires=[
               'MDAnalysis==%s' % RELEASE,  # same as this release!
               'numpy>=1.5',
-              'nose>=0.10',
+              'nose>=1.3.7',
           ],
           zip_safe=False,  # had 'KeyError' as zipped egg (2MB savings are not worth the trouble)
           )


### PR DESCRIPTION
All it took was to require a more recent nose version (something I had also seen might be important when debugging PR #341).

Travis build time is now down to 10m30s. Yay!

Are there any negative impacts on bumping the required nose version?