### PR TITLE
Feature louddeprecation

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -93,6 +93,7 @@ The rules for this file:
   * distances.contact_matrix now treats the particle distance with
     itself as a contact for sparse matrices and numpy arrays. The
     progress reporting for sparse calculations has been removed.
+  * deprecated selectAtoms in favour of select_atoms (Issue #389)
 
   Fixes
   * Amber TRJ and NCDF Reader & Writers now use 'dt' instead of 'delta'

--- a/package/MDAnalysis/__init__.py
+++ b/package/MDAnalysis/__init__.py
@@ -71,7 +71,7 @@ testing (see below under `Examples`_)::
 
 Select the C-alpha atoms and store them as a group of atoms::
 
-  >>> ca = u.selectAtoms('name CA')
+  >>> ca = u.select_atoms('name CA')
   >>> len(ca)
   214
 
@@ -137,6 +137,7 @@ the OPLS/AA force field.
 __all__ = ['Timeseries', 'Universe', 'asUniverse', 'Writer', 'collection']
 
 import logging
+import warnings
 
 from .version import __version__
 
@@ -145,6 +146,9 @@ from .lib.log import start_logging, stop_logging
 
 logging.getLogger("MDAnalysis").addHandler(log.NullHandler())
 del logging
+
+# DeprecationWarnings are loud by default
+warnings.simplefilter('always', DeprecationWarning)
 
 # custom exceptions and warnings
 from .exceptions import (

--- a/package/MDAnalysis/analysis/align.py
+++ b/package/MDAnalysis/analysis/align.py
@@ -200,7 +200,7 @@ def rotation_matrix(a, b, weights=None):
     :meth:`MDAnalysis.core.AtomGroup.AtomGroup.rotate` to generate a rotated
     selection, e.g. ::
 
-      >>> R = rotation_matrix(A.selectAtoms('backbone').coordinates(), B.selectAtoms('backbone').coordinates())
+      >>> R = rotation_matrix(A.select_atoms('backbone').coordinates(), B.select_atoms('backbone').coordinates())
       >>> A.atoms.rotate(R)
       >>> A.atoms.write("rotated.pdb")
 
@@ -228,8 +228,8 @@ def alignto(mobile, reference, select="all", mass_weighted=False,
     The superposition is done in the following way:
 
     1. A rotation matrix is computed that minimizes the RMSD between
-       the coordinates of `mobile.selectAtoms(sel1)` and
-       `reference.selectAtoms(sel2)`; before the rotation, *mobile* is
+       the coordinates of `mobile.select_atoms(sel1)` and
+       `reference.select_atoms(sel2)`; before the rotation, *mobile* is
        translated so that its center of geometry (or center of mass)
        coincides with the one of *reference*. (See below for explanation of
        how *sel1* and *sel2* are derived from *select*.)
@@ -259,7 +259,7 @@ def alignto(mobile, reference, select="all", mass_weighted=False,
          or a whole :class:`~MDAnalysis.core.AtomGroup.Universe`
       *select*
          1. any valid selection string for
-            :meth:`~MDAnalysis.core.AtomGroup.AtomGroup.selectAtoms` that produces identical
+            :meth:`~MDAnalysis.core.AtomGroup.AtomGroup.select_atoms` that produces identical
             selections in *mobile* and *reference*; or
          2. dictionary ``{'mobile':sel1, 'reference':sel2}``.
             (the :func:`fasta2select` function returns such a
@@ -291,7 +291,7 @@ def alignto(mobile, reference, select="all", mass_weighted=False,
              context of the selection from *mobile* such as the rest of a
              protein, ligands and the surrounding water)
          *selection-string*
-             Apply to `mobile.selectAtoms(selection-string)`
+             Apply to `mobile.select_atoms(selection-string)`
          :class:`~MDAnalysis.core.AtomGroup.AtomGroup`
              Apply to the arbitrary group of atoms
 
@@ -310,15 +310,15 @@ def alignto(mobile, reference, select="all", mass_weighted=False,
        the old behavior was the equivalent of *strict* = ``True``.
     """
     if select in ('all', None):
-        # keep the EXACT order in the input AtomGroups; selectAtoms('all')
+        # keep the EXACT order in the input AtomGroups; select_atoms('all')
         # orders them by index, which can lead to wrong results if the user
         # has crafted mobile and reference to match atom by atom
         mobile_atoms = mobile.atoms
         ref_atoms = reference.atoms
     else:
         select = rms._process_selection(select)
-        mobile_atoms = mobile.selectAtoms(*select['mobile'])
-        ref_atoms = reference.selectAtoms(*select['reference'])
+        mobile_atoms = mobile.select_atoms(*select['mobile'])
+        ref_atoms = reference.select_atoms(*select['reference'])
 
     ref_atoms, mobile_atoms = get_matching_atoms(ref_atoms, mobile_atoms,
                                                  tol_mass=tol_mass, strict=strict)
@@ -342,7 +342,7 @@ def alignto(mobile, reference, select="all", mass_weighted=False,
     if subselection is None:
         atoms = mobile.universe.atoms
     elif type(subselection) is str:
-        atoms = mobile.selectAtoms(subselection)
+        atoms = mobile.select_atoms(subselection)
     else:
         try:
             atoms = subselection.atoms
@@ -374,7 +374,7 @@ def rms_fit_trj(traj, reference, select='all', filename=None, rmsdfile=None, pre
          (uses the current time step of the object)
       *select*
          1. any valid selection string for
-            :meth:`~MDAnalysis.core.AtomGroup.AtomGroup.selectAtoms` that produces identical
+            :meth:`~MDAnalysis.core.AtomGroup.AtomGroup.select_atoms` that produces identical
             selections in *mobile* and *reference*; or
          2. a dictionary ``{'mobile':sel1, 'reference':sel2}`` (the
             :func:`fasta2select` function returns such a
@@ -454,8 +454,8 @@ def rms_fit_trj(traj, reference, select='all', filename=None, rmsdfile=None, pre
     del _Writer
 
     select = rms._process_selection(select)
-    ref_atoms = reference.selectAtoms(*select['reference'])
-    traj_atoms = traj.selectAtoms(*select['mobile'])
+    ref_atoms = reference.select_atoms(*select['reference'])
+    traj_atoms = traj.select_atoms(*select['mobile'])
     natoms = traj_atoms.n_atoms
 
     ref_atoms, traj_atoms = get_matching_atoms(ref_atoms, traj_atoms,
@@ -597,7 +597,7 @@ def fasta2select(fastafilename, is_aligned=False,
     sequence of resids as they appear in the psf in *ref_resids* or
     *target_resids*, e.g. ::
 
-       target_resids = [a.resid for a in trj.selectAtoms('name CA')]
+       target_resids = [a.resid for a in trj.select_atoms('name CA')]
 
     (This translation table *is* combined with any value for *xxx_offset*!)
 

--- a/package/MDAnalysis/analysis/contacts.py
+++ b/package/MDAnalysis/analysis/contacts.py
@@ -81,8 +81,8 @@ in MDAnalysis. ::
     sel_acidic = "(resname ASP or resname GLU) and (name OE* or name OD*)"
 
     # reference groups (first frame of the trajectory, but you could also use a separate PDB, eg crystal structure)
-    acidic = u.selectAtoms(sel_acidic)
-    basic = u.selectAtoms(sel_basic)
+    acidic = u.select_atoms(sel_acidic)
+    basic = u.select_atoms(sel_basic)
 
     # set up analysis of native contacts ("salt bridges"); salt bridges have a distance <6 A
     CA1 = MDAnalysis.analysis.contacts.ContactAnalysis1(u, selection=(sel_acidic, sel_basic), refgroup=(acidic,
@@ -267,9 +267,9 @@ class ContactAnalysis(object):
         r1 = MDAnalysis.Universe(topology, self.ref1)
         r2 = MDAnalysis.Universe(topology, self.ref2)
 
-        self.ca = self.u.selectAtoms(self.selection)
-        ca1 = r1.selectAtoms(self.selection)
-        ca2 = r2.selectAtoms(self.selection)
+        self.ca = self.u.select_atoms(self.selection)
+        ca1 = r1.select_atoms(self.selection)
+        ca2 = r2.select_atoms(self.selection)
 
         # NOTE: self_distance_array() produces a 1D array; this works here
         #       but is not the same as the 2D output from distance_array()!
@@ -426,16 +426,16 @@ class ContactAnalysis1(object):
     the reference atoms; this example uses some arbitrary selections::
 
       ref = Universe('crystal.pdb')
-      refA = re.selectAtoms('name CA and segid A and resid 6:100')
-      refB = re.selectAtoms('name CA and segid B and resid 1:40')
+      refA = re.select_atoms('name CA and segid A and resid 6:100')
+      refB = re.select_atoms('name CA and segid B and resid 1:40')
 
     Load the trajectory::
 
       u = Universe(topology, trajectory)
 
     We then need two selection strings *selA* and *selB* that, when applied as
-    ``u.selectAtoms(selA)`` produce a list of atoms that is equivalent to the
-    reference (i.e. ``u.selectAtoms(selA)`` must select the same atoms as
+    ``u.select_atoms(selA)`` produce a list of atoms that is equivalent to the
+    reference (i.e. ``u.select_atoms(selA)`` must select the same atoms as
     ``refA`` in this example)::
 
       selA = 'name CA and resid 1:95'     # corresponds to refA
@@ -540,7 +540,7 @@ class ContactAnalysis1(object):
         self.filenames = args
         self.universe = MDAnalysis.asUniverse(*args, **kwargs)
 
-        self.selections = [self.universe.selectAtoms(s) for s in self.selection_strings]
+        self.selections = [self.universe.select_atoms(s) for s in self.selection_strings]
 
         # sanity checkes
         for x in self.references:

--- a/package/MDAnalysis/analysis/density.py
+++ b/package/MDAnalysis/analysis/density.py
@@ -458,7 +458,7 @@ def density_from_Universe(universe, delta=1.0, atomselection='name OH2',
 
     """
     try:
-        universe.selectAtoms('all')
+        universe.select_atoms('all')
         universe.trajectory.ts
     except AttributeError:
         raise TypeError("The universe must be a proper MDAnalysis.Universe instance.")
@@ -471,14 +471,14 @@ def density_from_Universe(universe, delta=1.0, atomselection='name OH2',
         def current_coordinates():
             return notwithin_coordinates()
     else:
-        group = u.selectAtoms(atomselection)
+        group = u.select_atoms(atomselection)
 
         def current_coordinates():
             return group.coordinates()
 
     coord = current_coordinates()
     logger.info("Selected %d atoms out of %d atoms (%s) from %d total." %
-                (coord.shape[0], len(u.selectAtoms(atomselection)), atomselection, len(u.atoms)))
+                (coord.shape[0], len(u.select_atoms(atomselection)), atomselection, len(u.atoms)))
 
     # mild warning; typically this is run on RMS-fitted trajectories and
     # so the box information is rather meaningless
@@ -578,8 +578,8 @@ def notwithin_coordinates_factory(universe, sel1, sel2, cutoff, not_within=True,
     # distance matrix    633        1          1           False
     # AROUND + kdtree    420        0.66       1.5         n/a ('name OH2 around 4 protein')
     # manual + kdtree    182        0.29       3.5         True
-    solvent = universe.selectAtoms(sel1)
-    protein = universe.selectAtoms(sel2)
+    solvent = universe.select_atoms(sel1)
+    protein = universe.select_atoms(sel2)
     if use_kdtree:
         # using faster hand-coded 'not within' selection with kd-tree
         import MDAnalysis.lib.KDTree.NeighborSearch as NS
@@ -750,7 +750,7 @@ class BfactorDensityCreator(object):
         from MDAnalysis import asUniverse
 
         u = asUniverse(pdb)
-        group = u.selectAtoms(atomselection)
+        group = u.select_atoms(atomselection)
         coord = group.coordinates()
         logger.info("Selected %d atoms (%s) out of %d total." %
                     (coord.shape[0], atomselection, len(u.atoms)))

--- a/package/MDAnalysis/analysis/gnm.py
+++ b/package/MDAnalysis/analysis/gnm.py
@@ -172,8 +172,8 @@ class GNMAnalysis(object):
         # (its a popular way of treating small ligands eg drugs)
         # be careful that it doesn't have any atoms which can be caught by the global selection as this could lead to
         #  double counting
-        self.Bonus_groups = [self.u.selectAtoms(item) for item in Bonus_groups]
-        self.ca = self.u.selectAtoms(self.selection)
+        self.Bonus_groups = [self.u.select_atoms(item) for item in Bonus_groups]
+        self.ca = self.u.select_atoms(self.selection)
 
     def generate_output(self, w, v, outputobject, time, matrix, nmodes=2, ReportVector=None, counter=0):
         '''Appends eigenvalues and eigenvectors to results.
@@ -201,14 +201,14 @@ class GNMAnalysis(object):
         near-neighbours and then calculating which are are within
         the cutoff. Returns the resulting matrix
         '''
-        #ca = self.u.selectAtoms(self.selection)
+        #ca = self.u.select_atoms(self.selection)
         positions = self.ca.coordinates()
 
         natoms = len(positions)
 
         #add the com from each bonus group to the ca_positions list
         for item in self.Bonus_groups:
-            #bonus = self.u.selectAtoms(item)
+            #bonus = self.u.select_atoms(item)
             positions = numpy.vstack((positions, item.centerOfMass()))
             natoms += 1
 
@@ -305,7 +305,7 @@ class closeContactGNMAnalysis(GNMAnalysis):
         self.ReportVector = ReportVector
         # no bonus groups in this version of the GNM analysis tool; this is because this version doesn't use CA atoms
         #  or centroids, and so doesn't need them
-        self.ca = self.u.selectAtoms(self.selection)
+        self.ca = self.u.select_atoms(self.selection)
         self.MassWeight = MassWeight
 
     def generate_kirchoff(self):

--- a/package/MDAnalysis/analysis/hbonds/hbond_analysis.py
+++ b/package/MDAnalysis/analysis/hbonds/hbond_analysis.py
@@ -678,7 +678,7 @@ class HydrogenBondAnalysis(object):
         .. versionadded:: 0.7.6
         """
         try:
-            return atom.residue.selectAtoms(
+            return atom.residue.select_atoms(
                 "(name H* or name 1H* or name 2H* or name 3H* or type H) and around %f name %s" %
                 (self.r_cov[atom.name[0]], atom.name))
         except NoDataError:
@@ -724,7 +724,7 @@ class HydrogenBondAnalysis(object):
         return hydrogens
 
     def _update_selection_1(self):
-        self._s1 = self.u.selectAtoms(self.selection1)
+        self._s1 = self.u.select_atoms(self.selection1)
         self.logger_debug("Size of selection 1: {0} atoms".format(len(self._s1)))
         if not self._s1:
             logger.warn("Selection 1 '{0}' did not select any atoms.".format(str(self.selection1)[:80]))
@@ -732,7 +732,7 @@ class HydrogenBondAnalysis(object):
         self._s1_donors_h = {}
         self._s1_acceptors = {}
         if self.selection1_type in ('donor', 'both'):
-            self._s1_donors = self._s1.selectAtoms(' or '.join(['name {0}'.format(name) for name in self.donors]))
+            self._s1_donors = self._s1.select_atoms(' or '.join(['name {0}'.format(name) for name in self.donors]))
             self._s1_donors_h = {}
             for i, d in enumerate(self._s1_donors):
                 tmp = self._get_bonded_hydrogens(d)
@@ -741,11 +741,11 @@ class HydrogenBondAnalysis(object):
             self.logger_debug("Selection 1 donors: {0}".format(len(self._s1_donors)))
             self.logger_debug("Selection 1 donor hydrogens: {0}".format(len(self._s1_donors_h)))
         if self.selection1_type in ('acceptor', 'both'):
-            self._s1_acceptors = self._s1.selectAtoms(' or '.join(['name {0}'.format(name) for name in self.acceptors]))
+            self._s1_acceptors = self._s1.select_atoms(' or '.join(['name {0}'.format(name) for name in self.acceptors]))
             self.logger_debug("Selection 1 acceptors: {0}".format(len(self._s1_acceptors)))
 
     def _update_selection_2(self):
-        self._s2 = self.u.selectAtoms(self.selection2)
+        self._s2 = self.u.select_atoms(self.selection2)
         if self.filter_first and len(self._s2) > 0:
             self.logger_debug("Size of selection 2 before filtering: {0} atoms".format(len(self._s2)))
             ns_selection_2 = NS.AtomNeighborSearch(self._s2)
@@ -757,10 +757,10 @@ class HydrogenBondAnalysis(object):
         self._s2_donors_h = {}
         self._s2_acceptors = {}
         if self.selection1_type in ('donor', 'both'):
-            self._s2_acceptors = self._s2.selectAtoms(' or '.join(['name %s' % i for i in self.acceptors]))
+            self._s2_acceptors = self._s2.select_atoms(' or '.join(['name %s' % i for i in self.acceptors]))
             self.logger_debug("Selection 2 acceptors: %d" % len(self._s2_acceptors))
         if self.selection1_type in ('acceptor', 'both'):
-            self._s2_donors = self._s2.selectAtoms(' or '.join(['name %s' % i for i in self.donors]))
+            self._s2_donors = self._s2.select_atoms(' or '.join(['name %s' % i for i in self.donors]))
             self._s2_donors_h = {}
             for i, d in enumerate(self._s2_donors):
                 tmp = self._get_bonded_hydrogens(d)

--- a/package/MDAnalysis/analysis/hbonds/hbond_autocorrel.py
+++ b/package/MDAnalysis/analysis/hbonds/hbond_autocorrel.py
@@ -112,9 +112,9 @@ Examples
 
   from MDAnalysis.analysis import hbonds
   import matplotlib.pyplot as plt
-  H = u.selectAtoms('name Hn')
-  O = u.selectAtoms('name O')
-  N = u.selectAtoms('name N')
+  H = u.select_atoms('name Hn')
+  O = u.select_atoms('name O')
+  N = u.select_atoms('name N')
   hb_ac = hbonds.HydrogenBondAutoCorrel(u, acceptors = u.atoms.O,
               hydrogens = u.atoms.Hn, donors = u.atoms.N,bond_type='continuous',
               sample_time = 2, nruns = 20, nsamples = 1000)

--- a/package/MDAnalysis/analysis/helanal.py
+++ b/package/MDAnalysis/analysis/helanal.py
@@ -277,7 +277,7 @@ def helanal_trajectory(universe, selection="name CA", start=None, end=None, begi
         if end is None:
             end = universe.atoms[-1].resid
         selection += " and resid %(start)d:%(end)d" % vars()
-    ca = universe.selectAtoms(selection)
+    ca = universe.select_atoms(selection)
     trajectory = universe.trajectory
 
     if finish is not None:
@@ -535,7 +535,7 @@ def helanal_main(pdbfile, selection="name CA", start=None, end=None, ref_axis=No
         if end is None:
             end = universe.atoms[-1].resid
         selection += " and resid %(start)d:%(end)d" % vars()
-    ca = universe.selectAtoms(selection)
+    ca = universe.select_atoms(selection)
     print "Analysing %d/%d residues" % (ca.n_atoms, universe.atoms.n_residues)
 
     twist, bending_angles, height, rnou, origins, local_helix_axes, local_screw_angles = \

--- a/package/MDAnalysis/analysis/hole.py
+++ b/package/MDAnalysis/analysis/hole.py
@@ -1026,7 +1026,7 @@ class HOLEtraj(BaseHOLE):
                ``universe.trajectory[start, stop, step]``
 
           *selection*
-               selection string for :meth:`~MDAnalysis.core.AtomGroup.Universe.selectAtoms` to select
+               selection string for :meth:`~MDAnalysis.core.AtomGroup.Universe.select_atoms` to select
                the group of atoms that is to be analysed by HOLE ["protein"]
 
           *cpoint*
@@ -1068,7 +1068,7 @@ class HOLEtraj(BaseHOLE):
         This method simply uses the center of geometry of the protein selection
         as a guess. *selection* is "protein" by default.
         """
-        return self.universe.selectAtoms(kwargs.get("selection", "protein")).centerOfGeometry()
+        return self.universe.select_atoms(kwargs.get("selection", "protein")).centerOfGeometry()
 
     def _process_orderparameters(self, data):
         """Read orderparameters from *data*
@@ -1119,7 +1119,7 @@ class HOLEtraj(BaseHOLE):
 
         # TODO: alternatively, dump all frames with leading framenumber and use a wildcard
         #       (although the file renaming might create problems...)
-        protein = self.universe.selectAtoms(self.selection)
+        protein = self.universe.select_atoms(self.selection)
         for q, ts in izip(self.orderparameters[start:stop:step], self.universe.trajectory[start:stop:step]):
             logger.info("HOLE analysis frame %4d (orderparameter %g)", ts.frame, q)
             fd, pdbfile = tempfile.mkstemp(suffix=".pdb")

--- a/package/MDAnalysis/analysis/leaflet.py
+++ b/package/MDAnalysis/analysis/leaflet.py
@@ -87,7 +87,7 @@ class LeafletFinder(object):
                  :class:`MDAnalysis.Universe` or a PDB file name.
              *selection*
                  :class:`MDAnalysis.core.AtomGroup.AtomGroup` or a
-                 :meth:`MDAnalysis.Universe.selectAtoms` selection string
+                 :meth:`MDAnalysis.Universe.select_atoms` selection string
                  for atoms that define the lipid head groups, e.g.
                  universe.atoms.PO4 or "name PO4" or "name P*"
         :Keywords:
@@ -109,7 +109,7 @@ class LeafletFinder(object):
         if type(self.selectionstring) == MDAnalysis.core.AtomGroup.AtomGroup:
             self.selection = self.selectionstring
         else:
-            self.selection = universe.selectAtoms(self.selectionstring)
+            self.selection = universe.select_atoms(self.selectionstring)
         self.pbc = pbc
         self.sparse = sparse
         self._init_graph(cutoff)

--- a/package/MDAnalysis/analysis/nuclinfo.py
+++ b/package/MDAnalysis/analysis/nuclinfo.py
@@ -127,11 +127,11 @@ def wc_pair(universe, i, bp, seg1="SYSTEM", seg2="SYSTEM"):
 
     .. versionadded:: 0.7.6
     """
-    if universe.selectAtoms(" resid %s " % (i,)).resnames[0] in ["DC", "DT", "U", "C", "T", "CYT", "THY", "URA"]:
+    if universe.select_atoms(" resid %s " % (i,)).resnames[0] in ["DC", "DT", "U", "C", "T", "CYT", "THY", "URA"]:
         a1, a2 = "N3", "N1"
-    if universe.selectAtoms(" resid %s " % (i,)).resnames[0] in ["DG", "DA", "A", "G", "ADE", "GUA"]:
+    if universe.select_atoms(" resid %s " % (i,)).resnames[0] in ["DG", "DA", "A", "G", "ADE", "GUA"]:
         a1, a2 = "N1", "N3"
-    wc_dist = universe.selectAtoms(
+    wc_dist = universe.select_atoms(
         " (segid %s and resid %s and name %s)  or (segid %s and resid %s and name %s) " % (seg1, i, a1, seg2, bp, a2))
     wc = mdamath.norm(wc_dist[0].pos - wc_dist[1].pos)
     return wc
@@ -159,11 +159,11 @@ def minor_pair(universe, i, bp, seg1="SYSTEM", seg2="SYSTEM"):
 
     .. versionadded:: 0.7.6
     """
-    if universe.selectAtoms(" resid %s " % (i,)).resnames[0] in ["DC", "DT", "U", "C", "T", "CYT", "THY", "URA"]:
+    if universe.select_atoms(" resid %s " % (i,)).resnames[0] in ["DC", "DT", "U", "C", "T", "CYT", "THY", "URA"]:
         a1, a2 = "O2", "C2"
-    if universe.selectAtoms(" resid %s " % (i,)).resnames[0] in ["DG", "DA", "A", "G", "ADE", "GUA"]:
+    if universe.select_atoms(" resid %s " % (i,)).resnames[0] in ["DG", "DA", "A", "G", "ADE", "GUA"]:
         a1, a2 = "C2", "O2"
-    c2o2_dist = universe.selectAtoms(
+    c2o2_dist = universe.select_atoms(
         " (segid %s and resid %s and name %s)  or (segid %s and resid %s and name %s) " % (seg1, i, a1, seg2, bp, a2))
     c2o2 = mdamath.norm(c2o2_dist[0].pos - c2o2_dist[1].pos)
     return c2o2
@@ -191,17 +191,17 @@ def major_pair(universe, i, bp, seg1="SYSTEM", seg2="SYSTEM"):
 
     .. versionadded:: 0.7.6
     """
-    if universe.selectAtoms(" resid %s " % (i,)).resnames[0] in ["DC", "DG", "C", "G", "CYT", "GUA"]:
-        if universe.selectAtoms(" resid %s " % (i,)).resnames[0] in ["DC", "C", "CYT"]:
+    if universe.select_atoms(" resid %s " % (i,)).resnames[0] in ["DC", "DG", "C", "G", "CYT", "GUA"]:
+        if universe.select_atoms(" resid %s " % (i,)).resnames[0] in ["DC", "C", "CYT"]:
             a1, a2 = "N4", "O6"
         else:
             a1, a2 = "O6", "N4"
-    if universe.selectAtoms(" resid %s " % (i,)).resnames[0] in ["DT", "DA", "A", "T", "U", "ADE", "THY", "URA"]:
-        if universe.selectAtoms(" resid %s " % (i,)).resnames[0] in ["DT", "T", "THY", "U", "URA"]:
+    if universe.select_atoms(" resid %s " % (i,)).resnames[0] in ["DT", "DA", "A", "T", "U", "ADE", "THY", "URA"]:
+        if universe.select_atoms(" resid %s " % (i,)).resnames[0] in ["DT", "T", "THY", "U", "URA"]:
             a1, a2 = "O4", "N6"
         else:
             a1, a2 = "N6", "O4"
-    no_dist = universe.selectAtoms(
+    no_dist = universe.select_atoms(
         " (segid %s and resid %s and name %s)  or (segid %s and resid %s and name %s) " % (seg1, i, a1, seg2, bp, a2))
     major = mdamath.norm(no_dist[0].pos - no_dist[1].pos)
     return major
@@ -223,11 +223,11 @@ def phase_cp(universe, seg, i):
 
     .. versionadded:: 0.7.6
     """
-    atom1 = universe.selectAtoms(" atom %s %s O4\' " % (seg, i))
-    atom2 = universe.selectAtoms(" atom %s %s C1\' " % (seg, i))
-    atom3 = universe.selectAtoms(" atom %s %s C2\' " % (seg, i))
-    atom4 = universe.selectAtoms(" atom %s %s C3\' " % (seg, i))
-    atom5 = universe.selectAtoms(" atom %s %s C4\' " % (seg, i))
+    atom1 = universe.select_atoms(" atom %s %s O4\' " % (seg, i))
+    atom2 = universe.select_atoms(" atom %s %s C1\' " % (seg, i))
+    atom3 = universe.select_atoms(" atom %s %s C2\' " % (seg, i))
+    atom4 = universe.select_atoms(" atom %s %s C3\' " % (seg, i))
+    atom5 = universe.select_atoms(" atom %s %s C4\' " % (seg, i))
 
     data1 = atom1.coordinates()
     data2 = atom2.coordinates()
@@ -287,15 +287,15 @@ def phase_as(universe, seg, i):
 
     .. versionadded:: 0.7.6
     """
-    angle1 = universe.selectAtoms(" atom %s %s C1\' " % (seg, i), " atom %s %s C2\' " % (seg, i),
+    angle1 = universe.select_atoms(" atom %s %s C1\' " % (seg, i), " atom %s %s C2\' " % (seg, i),
                                   " atom %s %s C3\' " % (seg, i), " atom %s %s C4\' " % (seg, i))
-    angle2 = universe.selectAtoms(" atom %s %s C2\' " % (seg, i), " atom %s %s C3\' " % (seg, i),
+    angle2 = universe.select_atoms(" atom %s %s C2\' " % (seg, i), " atom %s %s C3\' " % (seg, i),
                                   " atom %s %s C4\' " % (seg, i), " atom %s %s O4\' " % (seg, i))
-    angle3 = universe.selectAtoms(" atom %s %s C3\' " % (seg, i), " atom %s %s C4\' " % (seg, i),
+    angle3 = universe.select_atoms(" atom %s %s C3\' " % (seg, i), " atom %s %s C4\' " % (seg, i),
                                   " atom %s %s O4\' " % (seg, i), " atom %s %s C1\' " % (seg, i))
-    angle4 = universe.selectAtoms(" atom %s %s C4\' " % (seg, i), " atom %s %s O4\' " % (seg, i),
+    angle4 = universe.select_atoms(" atom %s %s C4\' " % (seg, i), " atom %s %s O4\' " % (seg, i),
                                   " atom %s %s C1\' " % (seg, i), " atom %s %s C2\' " % (seg, i))
-    angle5 = universe.selectAtoms(" atom %s %s O4\' " % (seg, i), " atom %s %s C1\' " % (seg, i),
+    angle5 = universe.select_atoms(" atom %s %s O4\' " % (seg, i), " atom %s %s C1\' " % (seg, i),
                                   " atom %s %s C2\' " % (seg, i), " atom %s %s C3\' " % (seg, i))
 
     data1 = angle1.dihedral()
@@ -336,23 +336,23 @@ def tors(universe, seg, i):
     .. NOTE:: If failure occurs be sure to check the segment identification
 
     """
-    a = universe.selectAtoms(" atom %s %s O3\' " % (seg, i - 1), " atom %s %s P  " % (seg, i),
+    a = universe.select_atoms(" atom %s %s O3\' " % (seg, i - 1), " atom %s %s P  " % (seg, i),
                              " atom %s %s O5\' " % (seg, i), " atom %s %s C5\' " % (seg, i))
-    b = universe.selectAtoms(" atom %s %s P    " % (seg, i), " atom %s %s O5\' " % (seg, i),
+    b = universe.select_atoms(" atom %s %s P    " % (seg, i), " atom %s %s O5\' " % (seg, i),
                              " atom %s %s C5\' " % (seg, i), " atom %s %s C4\' " % (seg, i))
-    g = universe.selectAtoms(" atom %s %s O5\' " % (seg, i), " atom %s %s C5\' " % (seg, i),
+    g = universe.select_atoms(" atom %s %s O5\' " % (seg, i), " atom %s %s C5\' " % (seg, i),
                              " atom %s %s C4\' " % (seg, i), " atom %s %s C3\' " % (seg, i))
-    d = universe.selectAtoms(" atom %s %s C5\' " % (seg, i), " atom %s %s C4\' " % (seg, i),
+    d = universe.select_atoms(" atom %s %s C5\' " % (seg, i), " atom %s %s C4\' " % (seg, i),
                              " atom %s %s C3\' " % (seg, i), " atom %s %s O3\' " % (seg, i))
-    e = universe.selectAtoms(" atom %s %s C4\' " % (seg, i), " atom %s %s C3\' " % (seg, i),
+    e = universe.select_atoms(" atom %s %s C4\' " % (seg, i), " atom %s %s C3\' " % (seg, i),
                              " atom %s %s O3\' " % (seg, i), " atom %s %s P    " % (seg, i + 1))
-    z = universe.selectAtoms(" atom %s %s C3\' " % (seg, i), " atom %s %s O3\' " % (seg, i),
+    z = universe.select_atoms(" atom %s %s C3\' " % (seg, i), " atom %s %s O3\' " % (seg, i),
                              " atom %s %s P    " % (seg, i + 1), " atom %s %s O5\' " % (seg, i + 1))
     try:
-        c = universe.selectAtoms(" atom %s %s O4\' " % (seg, i), " atom %s %s C1\' " % (seg, i),
+        c = universe.select_atoms(" atom %s %s O4\' " % (seg, i), " atom %s %s C1\' " % (seg, i),
                                  " atom %s %s N1 " % (seg, i), " atom %s %s C2  " % (seg, i))
     except:
-        c = universe.selectAtoms(" atom %s %s O4\' " % (seg, i), " atom %s %s C1\' " % (seg, i),
+        c = universe.select_atoms(" atom %s %s O4\' " % (seg, i), " atom %s %s C1\' " % (seg, i),
                                  " atom %s %s N9 " % (seg, i), " atom %s %s C4  " % (seg, i))
 
     alpha = a.dihedral()
@@ -393,7 +393,7 @@ def tors_alpha(universe, seg, i):
 
     .. versionadded:: 0.7.6
     """
-    a = universe.selectAtoms(" atom %s %s O3\' " % (seg, i - 1), " atom %s %s P  " % (seg, i),
+    a = universe.select_atoms(" atom %s %s O3\' " % (seg, i - 1), " atom %s %s P  " % (seg, i),
                              " atom %s %s O5\' " % (seg, i), " atom %s %s C5\' " % (seg, i))
     alpha = a.dihedral()
     if alpha < 0:
@@ -416,7 +416,7 @@ def tors_beta(universe, seg, i):
 
     .. versionadded:: 0.7.6
     """
-    b = universe.selectAtoms(" atom %s %s P    " % (seg, i), " atom %s %s O5\' " % (seg, i),
+    b = universe.select_atoms(" atom %s %s P    " % (seg, i), " atom %s %s O5\' " % (seg, i),
                              " atom %s %s C5\' " % (seg, i), " atom %s %s C4\' " % (seg, i))
     beta = b.dihedral()
     if beta < 0:
@@ -439,7 +439,7 @@ def tors_gamma(universe, seg, i):
 
     .. versionadded:: 0.7.6
     """
-    g = universe.selectAtoms(" atom %s %s O5\' " % (seg, i), " atom %s %s C5\' " % (seg, i),
+    g = universe.select_atoms(" atom %s %s O5\' " % (seg, i), " atom %s %s C5\' " % (seg, i),
                              " atom %s %s C4\' " % (seg, i), " atom %s %s C3\' " % (seg, i))
     gamma = g.dihedral()
     if gamma < 0:
@@ -462,7 +462,7 @@ def tors_delta(universe, seg, i):
 
     .. versionadded:: 0.7.6
     """
-    d = universe.selectAtoms(" atom %s %s C5\' " % (seg, i), " atom %s %s C4\' " % (seg, i),
+    d = universe.select_atoms(" atom %s %s C5\' " % (seg, i), " atom %s %s C4\' " % (seg, i),
                              " atom %s %s C3\' " % (seg, i), " atom %s %s O3\' " % (seg, i))
     delta = d.dihedral()
     if delta < 0:
@@ -485,7 +485,7 @@ def tors_eps(universe, seg, i):
 
     .. versionadded:: 0.7.6
     """
-    e = universe.selectAtoms(" atom %s %s C4\' " % (seg, i), " atom %s %s C3\' " % (seg, i),
+    e = universe.select_atoms(" atom %s %s C4\' " % (seg, i), " atom %s %s C3\' " % (seg, i),
                              " atom %s %s O3\' " % (seg, i), " atom %s %s P    " % (seg, i + 1))
     epsilon = e.dihedral()
     if epsilon < 0:
@@ -508,7 +508,7 @@ def tors_zeta(universe, seg, i):
 
     .. versionadded:: 0.7.6
     """
-    z = universe.selectAtoms(" atom %s %s C3\' " % (seg, i), " atom %s %s O3\' " % (seg, i),
+    z = universe.select_atoms(" atom %s %s C3\' " % (seg, i), " atom %s %s O3\' " % (seg, i),
                              " atom %s %s P    " % (seg, i + 1), " atom %s %s O5\' " % (seg, i + 1))
     zeta = z.dihedral()
     if zeta < 0:
@@ -532,10 +532,10 @@ def tors_chi(universe, seg, i):
     .. versionadded:: 0.7.6
     """
     try:
-        c = universe.selectAtoms(" atom %s %s O4\' " % (seg, i), " atom %s %s C1\' " % (seg, i),
+        c = universe.select_atoms(" atom %s %s O4\' " % (seg, i), " atom %s %s C1\' " % (seg, i),
                                  " atom %s %s N1 " % (seg, i), " atom %s %s C2  " % (seg, i))
     except:
-        c = universe.selectAtoms(" atom %s %s O4\' " % (seg, i), " atom %s %s C1\' " % (seg, i),
+        c = universe.select_atoms(" atom %s %s O4\' " % (seg, i), " atom %s %s C1\' " % (seg, i),
                                  " atom %s %s N9 " % (seg, i), " atom %s %s C4  " % (seg, i))
     chi = c.dihedral()
     if chi < 0:
@@ -559,7 +559,7 @@ def hydroxyl(universe, seg, i):
 
     .. versionadded:: 0.7.6
     """
-    h = universe.selectAtoms(" atom %s %s C1\' " % (seg, i), " atom %s %s C2\' " % (seg, i),
+    h = universe.select_atoms(" atom %s %s C1\' " % (seg, i), " atom %s %s C2\' " % (seg, i),
                              " atom %s %s O2\' " % (seg, i), " atom %s %s H2\'\' " % (seg, i))
     try:
         hydr = h.dihedral()
@@ -597,12 +597,12 @@ def pseudo_dihe_baseflip(universe, bp1, bp2, i, seg1="SYSTEM", seg2="SYSTEM", se
 
     .. versionadded:: 0.8.0
     """
-    bf1 = universe.selectAtoms(
+    bf1 = universe.select_atoms(
         " ( segid %s and resid %s and nucleicbase ) or ( segid %s and resid %s and nucleicbase ) " % (
         seg1, bp1, seg2, bp2))
-    bf4 = universe.selectAtoms(" ( segid %s and resid %s and nucleicbase ) " % (seg3, i))
-    bf2 = universe.selectAtoms(" ( segid %s and resid %s and nucleicsugar ) " % (seg2, bp2))
-    bf3 = universe.selectAtoms(" ( segid %s and resid %s and nucleicsugar ) " % (seg3, i))
+    bf4 = universe.select_atoms(" ( segid %s and resid %s and nucleicbase ) " % (seg3, i))
+    bf2 = universe.select_atoms(" ( segid %s and resid %s and nucleicsugar ) " % (seg2, bp2))
+    bf3 = universe.select_atoms(" ( segid %s and resid %s and nucleicsugar ) " % (seg3, i))
     x = [bf1.centerOfMass(), bf2.centerOfMass(), bf3.centerOfMass(), bf4.centerOfMass()]
     pseudo = mdamath.dihedral(x[0] - x[1], x[1] - x[2], x[2] - x[3])
     pseudo = numpy.rad2deg(pseudo)

--- a/package/MDAnalysis/analysis/psa.py
+++ b/package/MDAnalysis/analysis/psa.py
@@ -97,13 +97,13 @@ Classes, methods, and functions
    .. attribute:: ref_select
 
       string, selection for
-      :meth:`~MDAnalysis.core.AtomGroup.AtomGroup.selectAtoms` to select frame
+      :meth:`~MDAnalysis.core.AtomGroup.AtomGroup.select_atoms` to select frame
       from :attr:`Path.u_reference`
 
    .. attribute:: path_select
 
       string, selection for
-      :meth:`~MDAnalysis.core.AtomGroup.AtomGroup.selectAtoms` to select atoms
+      :meth:`~MDAnalysis.core.AtomGroup.AtomGroup.select_atoms` to select atoms
       to compose :attr:`Path.path`
 
    .. attribute:: ref_frame
@@ -133,13 +133,13 @@ Classes, methods, and functions
    .. attribute:: ref_select
 
       string, selection for
-      :meth:`~MDAnalysis.core.AtomGroup.AtomGroup.selectAtoms` to select frame
+      :meth:`~MDAnalysis.core.AtomGroup.AtomGroup.select_atoms` to select frame
       from :attr:`PSA.u_reference`
 
    .. attribute:: path_select
 
       string, selection for
-      :meth:`~MDAnalysis.core.AtomGroup.AtomGroup.selectAtoms` to select atoms
+      :meth:`~MDAnalysis.core.AtomGroup.AtomGroup.select_atoms` to select atoms
       to compose :attr:`Path.path`
 
    .. attribute:: ref_frame
@@ -230,7 +230,7 @@ def hausdorff(P,Q, N=None):
     Example::
      >>> u = Universe(PSF,DCD)
      >>> mid = len(u.trajectory)/2
-     >>> ca = u.selectAtoms('name CA')
+     >>> ca = u.select_atoms('name CA')
      >>> P = numpy.array([
      ...                ca.positions for _ in u.trajectory[:mid:]
      ...              ]) # first half of trajectory
@@ -275,7 +275,7 @@ def discrete_frechet(P,Q, N=None):
     Example::
      >>> u = Universe(PSF,DCD)
      >>> mid = len(u.trajectory)/2
-     >>> ca = u.selectAtoms('name CA')
+     >>> ca = u.select_atoms('name CA')
      >>> P = numpy.array([
      ...                ca.positions for _ in u.trajectory[:mid:]
      ...              ]) # first half of trajectory
@@ -391,7 +391,7 @@ class Path(object):
              The selection to operate on for rms fitting; can be one of:
 
              1. any valid selection string for
-                :meth:`~MDAnalysis.core.AtomGroup.AtomGroup.selectAtoms` that
+                :meth:`~MDAnalysis.core.AtomGroup.AtomGroup.select_atoms` that
                 produces identical selections in *mobile* and *reference*; or
              2. a dictionary ``{'mobile':sel1, 'reference':sel2}`` (the
                 :func:`MDAnalysis.analysis.align.fasta2select` function returns
@@ -500,7 +500,7 @@ class Path(object):
         else:
             u = self.u_original
         frames = u.trajectory
-        atoms = u.selectAtoms(select)
+        atoms = u.select_atoms(select)
         frames.rewind()
         if flat:
             return numpy.array([atoms.positions.flatten() for _ in frames])
@@ -592,7 +592,7 @@ class PSA(object):
              The selection to operate on; can be one of:
 
              1. any valid selection string for
-                :meth:`~MDAnalysis.core.AtomGroup.AtomGroup.selectAtoms` that
+                :meth:`~MDAnalysis.core.AtomGroup.AtomGroup.select_atoms` that
                 produces identical selections in *mobile* and *reference*; or
              2. a dictionary ``{'mobile':sel1, 'reference':sel2}`` (the
                 :func:`MDAnalysis.analysis.align.fasta2select` function returns

--- a/package/MDAnalysis/analysis/rms.py
+++ b/package/MDAnalysis/analysis/rms.py
@@ -164,7 +164,7 @@ def rmsd(a, b, weights=None, center=False):
 
     Example::
      >>> u = Universe(PSF,DCD)
-     >>> bb = u.selectAtoms('backbone')
+     >>> bb = u.select_atoms('backbone')
      >>> A = bb.coordinates()  # coordinates of first frame
      >>> u.trajectory[-1]      # forward to last frame
      >>> B = bb.coordinates()  # coordinates of last frame
@@ -194,7 +194,7 @@ def _process_selection(select):
     :Arguments:
       *select*
          - any valid selection string for
-           :meth:`~MDAnalysis.core.AtomGroup.AtomGroup.selectAtoms` that produces identical
+           :meth:`~MDAnalysis.core.AtomGroup.AtomGroup.select_atoms` that produces identical
            selections in *mobile* and *reference*; or
          - dictionary ``{'mobile':sel1, 'reference':sel2}``.
            The :func:`fasta2select` function returns such a
@@ -266,7 +266,7 @@ class RMSD(object):
              The selection to operate on; can be one of:
 
              1. any valid selection string for
-                :meth:`~MDAnalysis.core.AtomGroup.AtomGroup.selectAtoms` that produces identical
+                :meth:`~MDAnalysis.core.AtomGroup.AtomGroup.select_atoms` that produces identical
                 selections in *mobile* and *reference*; or
              2. a dictionary ``{'mobile':sel1, 'reference':sel2}`` (the
                 :func:`MDAnalysis.analysis.align.fasta2select` function returns such a
@@ -314,8 +314,8 @@ class RMSD(object):
         self.ref_frame = ref_frame
         self.filename = filename
 
-        self.ref_atoms = self.reference.selectAtoms(*self.select['reference'])
-        self.traj_atoms = self.universe.selectAtoms(*self.select['mobile'])
+        self.ref_atoms = self.reference.select_atoms(*self.select['reference'])
+        self.traj_atoms = self.universe.select_atoms(*self.select['mobile'])
         natoms = self.traj_atoms.n_atoms
         if len(self.ref_atoms) != len(self.traj_atoms):
             logger.exception()
@@ -344,8 +344,8 @@ class RMSD(object):
         # each a dict with reference/mobile
         self.groupselections_atoms = [
             {
-                'reference': self.reference.selectAtoms(*s['reference']),
-                'mobile': self.universe.selectAtoms(*s['mobile']),
+                'reference': self.reference.select_atoms(*s['reference']),
+                'mobile': self.universe.select_atoms(*s['mobile']),
             }
             for s in self.groupselections]
         # sanity check
@@ -406,7 +406,7 @@ class RMSD(object):
             ref_coordinates = self.ref_atoms.positions - ref_com  # makes a copy
             if self.groupselections_atoms:
                 groupselections_ref_coords_T_64 = [
-                    self.reference.selectAtoms(*s['reference']).positions.T.astype(numpy.float64) for s in
+                    self.reference.select_atoms(*s['reference']).positions.T.astype(numpy.float64) for s in
                     self.groupselections]
         finally:
             # Move back to the original frame

--- a/package/MDAnalysis/analysis/waterdynamics.py
+++ b/package/MDAnalysis/analysis/waterdynamics.py
@@ -665,7 +665,7 @@ class WaterOrientationalRelaxation(object):
     def _selection_serial(self,universe,selection_str):
         selection = []
         for ts in universe.trajectory:
-            selection.append(universe.selectAtoms(selection_str))
+            selection.append(universe.select_atoms(selection_str))
             print ts.frame
         return selection
 
@@ -822,7 +822,7 @@ class AngularDistribution(object):
     def _selection_serial(self,universe,selection_str):
         selection = []
         for ts in universe.trajectory:
-            selection.append(universe.selectAtoms(selection_str))
+            selection.append(universe.select_atoms(selection_str))
             print ts.frame
         return selection
 
@@ -943,7 +943,7 @@ class  MeanSquareDisplacement(object):
     def _selection_serial(self,universe,selection_str):
         selection = []
         for ts in universe.trajectory:
-            selection.append(universe.selectAtoms(selection_str))
+            selection.append(universe.select_atoms(selection_str))
             print ts.frame
         return selection
 
@@ -1053,7 +1053,7 @@ class SurvivalProbability(object):
     def _selection_serial(self,universe,selection_str):
         selection = []
         for ts in universe.trajectory:
-            selection.append(universe.selectAtoms(selection_str))
+            selection.append(universe.select_atoms(selection_str))
             print ts.frame
         return selection
 

--- a/package/MDAnalysis/analysis/x3dna.py
+++ b/package/MDAnalysis/analysis/x3dna.py
@@ -695,7 +695,7 @@ class X3DNAtraj(BaseX3DNA):
 
         profiles = {}
 
-        nucleic = self.universe.selectAtoms(self.selection)
+        nucleic = self.universe.select_atoms(self.selection)
         for ts in self.universe.trajectory[start:stop:step]:
             print ts.frame
             print nucleic.atoms

--- a/package/MDAnalysis/coordinates/MOL2.py
+++ b/package/MDAnalysis/coordinates/MOL2.py
@@ -28,7 +28,7 @@ Examples
 To open a mol2, remove all hydrogens and save as a new file, use the following::
 
   u = Universe("MDAnalysis/testsuite/MDAnalysisTests/data/mol2/Molecule.mol2")
-  gr = u.selectAtoms("not name H*")
+  gr = u.select_atoms("not name H*")
   print len(u.atoms), len(gr)
   gr.write("Molecule_noh.mol2")
 

--- a/package/MDAnalysis/coordinates/PDB.py
+++ b/package/MDAnalysis/coordinates/PDB.py
@@ -34,7 +34,7 @@ a trajectory with only one frame.
 In order to write a selection to a PDB file one typically uses the
 :meth:`MDAnalysis.core.AtomGroup.AtomGroup.write` method of the selection::
 
-  calphas = universe.selectAtoms("name CA")
+  calphas = universe.select_atoms("name CA")
   calphas.write("calpha_only.pdb")
 
 This uses the coordinates from the current timestep of the trajectory.
@@ -43,7 +43,7 @@ In order to write a PDB trajectory one needs to first obtain a multi-frame
 writer (keyword *multiframe* = ``True``) and then iterate through the
 trajectory, while writing each frame::
 
-  calphas = universe.selectAtoms("name CA")
+  calphas = universe.select_atoms("name CA")
   W = MDAnalysis.Writer("calpha_traj.pdb", multiframe=True)
   for ts in u.trajectory:
       W.write(calphas)
@@ -113,7 +113,7 @@ do the following::
 Similarly, writing only a protein::
 
   pdb = MDAnalysis.Writer("protein.pdb", multiframe=True)
-  protein = u.selectAtoms("protein")
+  protein = u.select_atoms("protein")
   for ts in u.trajectory:
       pdb.write(protein)
   pdb.close()
@@ -122,14 +122,14 @@ A single frame can be written with the
 :meth:`~MDAnalysis.core.AtomGroup.AtomGroup.write` method of any
 :class:`~MDAnalysis.core.AtomGroup.AtomGroup`::
 
-   protein = u.selectAtoms("protein")
+   protein = u.select_atoms("protein")
    protein.write("protein.pdb")
 
 Alternatively, get the single frame writer and supply the
 :class:`~MDAnalysis.core.AtomGroup.AtomGroup`::
 
   pdb = MDAnalysis.Writer("protein.pdb")
-  protein = u.selectAtoms("protein")
+  protein = u.select_atoms("protein")
   pdb.write(protein)
   pdb.close()
 
@@ -366,7 +366,7 @@ class PDBWriter(base.Writer):
                 return
             # primitive PDB writing (ignores timestep argument)
             ppw = PrimitivePDBWriter(self.filename)
-            ppw.write(self.universe.selectAtoms('all'))
+            ppw.write(self.universe.select_atoms('all'))
             ppw.close()
         else:
             # full fledged PDB writer

--- a/package/MDAnalysis/coordinates/__init__.py
+++ b/package/MDAnalysis/coordinates/__init__.py
@@ -93,7 +93,7 @@ A typical approach is to generate a new trajectory from an old one, e.g. to
 only keep the protein::
 
   u = MDAnalysis.Universe(PDB, XTC)
-  protein = u.selectAtoms("protein")
+  protein = u.select_atoms("protein")
   with MDAnalysis.Writer("protein.xtc", protein.n_atoms) as W:
       for ts in u.trajectory:
           W.write(protein)

--- a/package/MDAnalysis/core/AtomGroup.py
+++ b/package/MDAnalysis/core/AtomGroup.py
@@ -795,6 +795,7 @@ class AtomGroup(object):
        The follow methods were changed to properties: indices, masses, charges, names,
        types, radii, resids, resnames, resnums, segids
        Added altLocs and serials properties and setters
+       Deprecated selectAtoms in favour of select_atoms
     """
     # for generalized __getitem__ __iter__ and __len__
     # (override _containername for ResidueGroup and SegmentGroup)
@@ -3430,6 +3431,7 @@ class Universe(object):
        :meth:`make_anchor`, :meth:`remove_anchor`, :attr:`is_anchor`, and
        :attr:`anchor_name` were added to support the pickling/unpickling of
        :class:`AtomGroup`.
+       Deprecated selectAtoms in favour of select_atoms
     """
 
     def __init__(self, *args, **kwargs):

--- a/package/MDAnalysis/core/AtomGroup.py
+++ b/package/MDAnalysis/core/AtomGroup.py
@@ -72,13 +72,13 @@ derived from :class:`Atom` instances: all :class:`Atom` objects with the same
 :class:`Residue.id` = *resid*. This means that just changing, say, the residue
 name with a command such as ::
 
-  >>> r = u.selectAtoms("resid 99").residues[0]
+  >>> r = u.select_atoms("resid 99").residues[0]
   >>> print(r)
   <Residue 'ALA', 99>
   >>> r.name = "UNK"
   >>> print(r)
   <Residue 'UNK', 99>
-  >>> rnew = u.selectAtoms("resid 99").residues[0]
+  >>> rnew = u.select_atoms("resid 99").residues[0]
   >>> print(rnew)
   <Residue 'UNK', 99>
 
@@ -107,10 +107,10 @@ rearrangements are carried out. Manipulating segments might be more useful in
 order to add additional structure to a :class:`Universe` and provide instant
 segment selectors for interactive work::
 
-  u.selectAtoms("protein").set_segid("protein")
-  u.selectAtoms("resname POPE or resname POPC").set_segid("lipids")
-  u.selectAtoms("resname SOL").set_segid("water")
-  u.selectAtoms("resname NA or resname CL").set_segid("ions")
+  u.select_atoms("protein").set_segid("protein")
+  u.select_atoms("resname POPE or resname POPC").set_segid("lipids")
+  u.select_atoms("resname SOL").set_segid("water")
+  u.select_atoms("resname NA or resname CL").set_segid("ions")
 
   u.protein.n_residues
   water_oxygens = u.water.OW
@@ -121,7 +121,7 @@ lists. For instance, many MD codes number residues consecutively starting from
 N-terminus. Let's say that the first residue is really residue 10. In order to
 store the canonical residue IDs ("resnum") one could the use ::
 
-  protein = u.selectAtoms("protein").residues
+  protein = u.select_atoms("protein").residues
   protein.set_resnum(protein.resnums + 9)
 
 One can then use ``protein.select("resnum 42")`` to select the residue that has
@@ -130,7 +130,7 @@ the canonical residue id 42 (instead of ``resid 33``).
 One can also read the resids directly from  an original PDB file::
 
   orig = MDAnalysis.Universe("2jln.pdb")
-  protein.set_resnum(orig.selectAtoms("protein").resids)
+  protein.set_resnum(orig.select_atoms("protein").resids)
 
 
 Working with Topologies
@@ -215,7 +215,7 @@ combine all of them together::
     u1 = MDAnalysis.Universe("protein.pdb")
     u2 = MDAnalysis.Universe("ligand.pdb")
     u3 = MDAnalysis.Universe("solvent.pdb")
-    u = MDAnalysis.Merge(u1.selectAtoms("protein"), u2.atoms, u3.atoms)
+    u = MDAnalysis.Merge(u1.select_atoms("protein"), u2.atoms, u3.atoms)
     u.atoms.write("system.pdb")
 
 The complete system is then written out to a new PDB file.
@@ -229,16 +229,16 @@ AdK molecule and then translate and rotate the second copy::
 
     import MDAnalysis; from MDAnalysis.tests.datafiles import *
     u = MDAnalysis.Universe(PSF, DCD)
-    p = u.selectAtoms("protein")
+    p = u.select_atoms("protein")
     m = MDAnalysis.Merge(p,p)
 
     # now renumber resids and segids for each copy
 
     # first copy of the protein (need to use atom indices because currently that's the only reliable property in the
     merged universe)
-    p1 = m.selectAtoms("bynum 1:3341")
+    p1 = m.select_atoms("bynum 1:3341")
     # second copy
-    p2 = m.selectAtoms("bynum 3342:6682")
+    p2 = m.select_atoms("bynum 3342:6682")
 
     p1.set_segid("A")
     p2.set_segid("B")
@@ -247,8 +247,8 @@ AdK molecule and then translate and rotate the second copy::
 
     # you must regenerate the selections after modifying them (see notes in the docs!)
     # because the changed resids are not reflected in the selection (due to how residues are referenced internally)
-    p1 = m.selectAtoms("segid A")       # or as before:  m.selectAtoms("bynum 1:3341")
-    p2 = m.selectAtoms("segid B")
+    p1 = m.select_atoms("segid A")       # or as before:  m.select_atoms("bynum 1:3341")
+    p2 = m.select_atoms("segid B")
 
     # rotate and translate
     p2.rotateby(180, [0,0,1])
@@ -397,6 +397,7 @@ from __future__ import print_function, absolute_import
 import warnings
 import numpy
 from numpy.linalg import eig
+from numpy.lib.utils import deprecate
 import itertools
 from collections import defaultdict
 import copy
@@ -703,7 +704,7 @@ class Atom(object):
 class AtomGroup(object):
     """A group of atoms.
 
-      ag = universe.selectAtoms(atom-list)
+      ag = universe.select_atoms(atom-list)
 
     The AtomGroup contains a list of atoms; typically, a AtomGroup is generated
     from a selection. It is build from any list-like collection of
@@ -1341,7 +1342,7 @@ class AtomGroup(object):
            import Bio.SeqIO
 
            # get the sequence record of a protein component of a Universe
-           protein = u.selectAtoms("protein")
+           protein = u.select_atoms("protein")
            record = protein.sequence(id="myseq1", name="myprotein")
 
            Bio.SeqIO.write(record, "single.fasta", "fasta")
@@ -2674,12 +2675,12 @@ class AtomGroup(object):
             if not all(s == 0.0):
                 o.translate(s)
 
-    def selectAtoms(self, sel, *othersel, **selgroups):
+    def select_atoms(self, sel, *othersel, **selgroups):
         """Selection of atoms using the MDAnalysis selection syntax.
 
-        AtomGroup.selectAtoms(selection[,selection[,...]], [groupname=atomgroup[,groupname=atomgroup[,...]]])
+        AtomGroup.select_atoms(selection[,selection[,...]], [groupname=atomgroup[,groupname=atomgroup[,...]]])
 
-        .. SeeAlso:: :meth:`Universe.selectAtoms`
+        .. SeeAlso:: :meth:`Universe.select_atoms`
         """
         from . import Selection  # can ONLY import in method, otherwise cyclical import!
 
@@ -2694,6 +2695,9 @@ class AtomGroup(object):
                 #atomselections.append(Selection.Parser.parse(sel).apply(self))
             #return tuple(atomselections)
             return atomgrp
+
+    selectAtoms = deprecate(select_atoms, old_name='selectAtoms',
+                            new_name='select_atoms')
 
     def split(self, level):
         """Split atomgroup into a list of atomgroups by *level*.
@@ -2945,10 +2949,10 @@ class Residue(AtomGroup):
                   found in the previous residue (by resid) then this
                   method returns ``None``.
         """
-        sel = self.universe.selectAtoms(
+        sel = self.universe.select_atoms(
             'segid %s and resid %d and name C' % (self.segment.id, self.id - 1)) + \
               self['N'] + self['CA'] + self['C']
-        if len(sel) == 4:  # selectAtoms doesnt raise errors if nothing found, so check size
+        if len(sel) == 4:  # select_atoms doesnt raise errors if nothing found, so check size
             return sel
         else:
             return None
@@ -2961,7 +2965,7 @@ class Residue(AtomGroup):
                   method returns ``None``.
         """
         sel = self['N'] + self['CA'] + self['C'] + \
-              self.universe.selectAtoms(
+              self.universe.select_atoms(
                   'segid %s and resid %d and name N' % (self.segment.id, self.id + 1))
         if len(sel) == 4:
             return sel
@@ -2983,7 +2987,7 @@ class Residue(AtomGroup):
         nextres = self.id + 1
         segid = self.segment.id
         sel = self['CA'] + self['C'] + \
-              self.universe.selectAtoms(
+              self.universe.select_atoms(
                   'segid %s and resid %d and name N' % (segid, nextres),
                   'segid %s and resid %d and name CA' % (segid, nextres))
         if len(sel) == 4:
@@ -3383,9 +3387,9 @@ class Universe(object):
        u.load_new(trajectory)                      # read from a new trajectory file
 
     Select atoms, with syntax similar to CHARMM (see
-    :class:`~Universe.selectAtoms` for details)::
+    :class:`~Universe.select_atoms` for details)::
 
-       u.selectAtoms(...)
+       u.select_atoms(...)
 
     *Attributes:*
 
@@ -4133,7 +4137,7 @@ class Universe(object):
 
         return filename, self.trajectory.format
 
-    def selectAtoms(self, sel, *othersel, **selgroups):
+    def select_atoms(self, sel, *othersel, **selgroups):
         """Select atoms using a CHARMM selection string.
 
         Returns an :class:`AtomGroup` with atoms sorted according to their
@@ -4146,11 +4150,11 @@ class Universe(object):
         Subselections can be grouped with parentheses.
 
         Example::
-           >>> sel = universe.selectAtoms("segid DMPC and not ( name H* or name O* )")
+           >>> sel = universe.select_atoms("segid DMPC and not ( name H* or name O* )")
            >>> sel
            <AtomGroup with 3420 atoms>
 
-           >>> universe.selectAtoms("around 10 group notHO", notHO=sel)
+           >>> universe.select_atoms("around 10 group notHO", notHO=sel)
            <AtomGroup with 1250 atoms>
 
         .. Note::
@@ -4250,7 +4254,7 @@ class Universe(object):
             group *group-name*
                 selects the atoms in the :class:`AtomGroup` passed to the function as an
                 argument named *group-name*. Only the atoms common to *group-name* and the
-                instance :meth:`~selectAtoms` was called from will be considered.
+                instance :meth:`~select_atoms` was called from will be considered.
                 *group-name* will be included in the parsing just by comparison of atom indices.
                 This means that it is up to the user to make sure they were defined in an
                 appropriate :class:`Universe`.
@@ -4258,7 +4262,7 @@ class Universe(object):
             fullgroup *group-name*
                 just like the ``group`` keyword with the difference that all the atoms of
                 *group-name* are included. The resulting selection may therefore have atoms
-                that were initially absent from the instance :meth:`~selectAtoms` was
+                that were initially absent from the instance :meth:`~select_atoms` was
                 called from.
 
 
@@ -4280,6 +4284,9 @@ class Universe(object):
                 #atomselections.append(Selection.Parser.parse(sel).apply(self))
             #return tuple(atomselections)
             return atomgrp
+
+    selectAtoms = deprecate(select_atoms, old_name='selectAtoms',
+                            new_name='select_atoms')
 
     def __repr__(self):
         return "<Universe with {n_atoms} atoms{bonds}>".format(
@@ -4416,7 +4423,7 @@ def Merge(*args):
     """Return a :class:`Universe` from two or more :class:`AtomGroup` instances.
 
     :class:`AtomGroup` instances can come from different Universes, or come
-    directly from a :meth:`~Universe.selectAtoms` call.
+    directly from a :meth:`~Universe.select_atoms` call.
 
     It can also be used with a single :class:`AtomGroup` if the user wants to,
     for example, re-order the atoms in the Universe.
@@ -4440,7 +4447,7 @@ def Merge(*args):
        u1 = Universe("protein.pdb")
        u2 = Universe("ligand.pdb")
        u3 = Universe("solvent.pdb")
-       u = Merge(u1.selectAtoms("protein"), u2.atoms, u3.atoms)
+       u = Merge(u1.select_atoms("protein"), u2.atoms, u3.atoms)
        u.atoms.write("system.pdb")
 
     The complete system is then written out to a new PDB file.

--- a/package/MDAnalysis/core/Selection.py
+++ b/package/MDAnalysis/core/Selection.py
@@ -233,7 +233,7 @@ class SphericalLayerSelection(Selection):
             str(sel_CoG[0]) + " " + str(sel_CoG[1]) + " " + str(sel_CoG[2]) + " " +\
             str(self.exRadius) + " and not point " + str(sel_CoG[0]) + " " + str(sel_CoG[1]) + " " + \
             str(sel_CoG[2]) + " " + str(self.inRadius)
-        sel = sys_ag.selectAtoms(sel_CoG_str)
+        sel = sys_ag.select_atoms(sel_CoG_str)
         res_atoms = AtomGroup(set(sel))
         if self.periodic:
             box = group.dimensions[:3]  # ignored with KDTree
@@ -286,7 +286,7 @@ class SphericalZoneSelection(Selection):
         sys_ag = AtomGroup(sys_atoms_list)
         sel_CoG_str = str("point ") + str(sel_CoG[0]) + " " + str(sel_CoG[1]) + " " + str(sel_CoG[2]) + " " + str(
             self.cutoff)
-        sel = sys_ag.selectAtoms(sel_CoG_str)
+        sel = sys_ag.select_atoms(sel_CoG_str)
         res_atoms = AtomGroup(set(sel))
         if self.periodic:
             box = group.dimensions[:3]  # ignored with KDTree

--- a/package/MDAnalysis/core/__init__.py
+++ b/package/MDAnalysis/core/__init__.py
@@ -33,7 +33,7 @@ To get started, load the Universe::
 
 A simple selection of all water oxygens within 4 A of the protein::
 
-  water_shell = u.selectAtoms('name OH2 and around 4.0 protein')
+  water_shell = u.select_atoms('name OH2 and around 4.0 protein')
   water_shell.n_atoms           # how many waters were selected
   water_shell.totalMass()       # their total mass
 

--- a/package/MDAnalysis/lib/KDTree/NeighborSearch.py
+++ b/package/MDAnalysis/lib/KDTree/NeighborSearch.py
@@ -35,8 +35,8 @@ Example::
   import MDAnalysis.lib.KDTree.NeighborSearch as NS
 
   u = Universe(psf,dcd)
-  water = u.selectAtoms('name OH2')
-  protein = u.selectAtoms('protein')
+  water = u.select_atoms('name OH2')
+  protein = u.select_atoms('protein')
 
   # when analyzing a trajectory, carry out the next two steps
   # for every frame

--- a/package/MDAnalysis/visualization/streamlines.py
+++ b/package/MDAnalysis/visualization/streamlines.py
@@ -120,7 +120,7 @@ def per_core_work(coordinate_file_path, trajectory_file_path, list_square_vertex
     for ts in universe_object.trajectory:
         if ts.frame < start_frame:  # don't start until first specified frame
             continue
-        relevant_particle_coordinate_array_xy = universe_object.selectAtoms(MDA_selection).coordinates()[..., :-1]
+        relevant_particle_coordinate_array_xy = universe_object.select_atoms(MDA_selection).coordinates()[..., :-1]
           # only 2D / xy coords for now
         #I will need a list of indices for relevant particles falling within each square in THIS frame:
         list_indices_in_squares_this_frame = produce_list_indices_point_in_polygon_this_frame(

--- a/package/MDAnalysis/visualization/streamlines_3D.py
+++ b/package/MDAnalysis/visualization/streamlines_3D.py
@@ -39,7 +39,7 @@ def determine_container_limits(coordinate_file_path, trajectory_file_path, buffe
     '''A function for the parent process which should take the input trajectory and calculate the limits of the
     container for the system and return these limits.'''
     universe_object = MDAnalysis.Universe(coordinate_file_path, trajectory_file_path)
-    all_atom_selection = universe_object.selectAtoms('all')  # select all particles
+    all_atom_selection = universe_object.select_atoms('all')  # select all particles
     all_atom_coordinate_array = all_atom_selection.coordinates()
     x_min, x_max, y_min, y_max, z_min, z_max = [
         all_atom_coordinate_array[..., 0].min(),
@@ -245,7 +245,7 @@ def produce_coordinate_arrays_single_process(coordinate_file_path, trajectory_fi
     send these coordinate arrays to all child processes rather than having each child process open a trajectoryand
     waste memory.'''
     universe_object = MDAnalysis.Universe(coordinate_file_path, trajectory_file_path)
-    relevant_particles = universe_object.selectAtoms(MDA_selection)
+    relevant_particles = universe_object.select_atoms(MDA_selection)
     # pull out coordinate arrays from desired frames:
     for ts in universe_object.trajectory:
         if ts.frame > end_frame:

--- a/package/doc/sphinx/source/documentation_pages/overview.rst
+++ b/package/doc/sphinx/source/documentation_pages/overview.rst
@@ -13,7 +13,7 @@ object ("attributes"). For example, a
 returns the center of mass of the group of atoms. It also contains an
 attribute called :attr:`~MDAnalysis.core.AtomGroup.AtomGroup.residues`
 that lists all the residues that belong to the group. Using methods
-such as :meth:`~MDAnalysis.core.AtomGroup.AtomGroup.selectAtoms`
+such as :meth:`~MDAnalysis.core.AtomGroup.AtomGroup.select_atoms`
 (which uses `CHARMM-style`_ atom :ref:`selection-commands-label`) one
 can create new objects (in this case, another
 :class:`~MDAnalysis.core.AtomGroup.AtomGroup`).
@@ -28,7 +28,7 @@ of a protein and the radius of gyration of the backbone atoms are calculated::
   u = MDAnalysis.Universe(PSF,DCD)                 # always start with a Universe
   nterm = u.s4AKE.N[0]   # can access structure via segid (s4AKE) and atom name
   cterm = u.s4AKE.C[-1]  # ... takes the last atom named 'C'
-  bb = u.selectAtoms('protein and backbone')  # a selection (a AtomGroup)
+  bb = u.select_atoms('protein and backbone')  # a selection (a AtomGroup)
   for ts in u.trajectory:     # iterate through all frames
     r = cterm.pos - nterm.pos # end-to-end vector from atom positions
     d = numpy.linalg.norm(r)  # end-to-end distance
@@ -117,10 +117,10 @@ over time::
   >>> print u.trajectory
   < DCDReader '/..../MDAnalysis/tests/data/adk_dims.dcd' with 98 frames of 3341 atoms (0 fixed) >
 
-Finally, the :meth:`MDAnalysis.Universe.selectAtoms` method generates a new
+Finally, the :meth:`MDAnalysis.Universe.select_atoms` method generates a new
 :class:`~MDAnalysis.core.AtomGroup.AtomGroup` according to a selection criterion
 
-  >>> calphas = u.selectAtoms("name CA")
+  >>> calphas = u.select_atoms("name CA")
   >>> print calphas
   <AtomGroup with 214 atoms>
 

--- a/package/doc/sphinx/source/documentation_pages/selections.rst
+++ b/package/doc/sphinx/source/documentation_pages/selections.rst
@@ -9,12 +9,12 @@ Once you have the :meth:`~MDAnalysis.core.AtomGroup.Universe` object, you can
 select atoms (using a syntax very similar to `CHARMM's atom selection
 syntax`_)::
 
-  >>> kalp = universe.selectAtoms("segid KALP")
+  >>> kalp = universe.select_atoms("segid KALP")
 
 .. _`CHARMM's atom selection syntax`: 
    http://www.charmm.org/documentation/c37b1/select.html
 
-The :meth:`~MDAnalysis.core.AtomGroup.Universe.selectAtoms` of a
+The :meth:`~MDAnalysis.core.AtomGroup.Universe.select_atoms` of a
 :class:`~MDAnalysis.core.AtomGroup.Universe` returns a
 :class:`~MDAnalysis.core.AtomGroup.AtomGroup`, so you can use all the methods
 defined for AtomGroups on them. Selections always return an :class:`AtomGroup` with
@@ -23,7 +23,7 @@ there aren't any duplicates, which can happen with complicated selections).
 
 One can group subselections using parentheses::
 
- >>> universe.selectAtoms("segid DMPC and not (name H* or name O*)")
+ >>> universe.select_atoms("segid DMPC and not (name H* or name O*)")
  <AtomGroup with 3420 atoms>
 
 Almost all the basic CHARMM selections work.
@@ -177,7 +177,7 @@ Preexisting selections
     group *group-name*
         selects the atoms in the :class:`AtomGroup` passed to the function as an
         argument named *group-name*. Only the atoms common to *group-name* and the
-        instance :meth:`~selectAtoms` was called from will be considered.
+        instance :meth:`~select_atoms` was called from will be considered.
         *group-name* will be included in the parsing just by comparison of atom indices.
         This means that it is up to the user to make sure they were defined in an
         appropriate :class:`Universe`.
@@ -185,7 +185,7 @@ Preexisting selections
     fullgroup *group-name*
         just like the ``group`` keyword with the difference that all the atoms of
         *group-name* are included. The resulting selection may therefore have atoms
-        that were initially absent from the instance :meth:`~selectAtoms` was
+        that were initially absent from the instance :meth:`~select_atoms` was
         called from.
         
 
@@ -267,7 +267,7 @@ Atom name selector
 Ordered selections
 ==================
 
-:meth:`~MDAnalysis.Universe.selectAtoms` sorts the atoms in the
+:meth:`~MDAnalysis.Universe.select_atoms` sorts the atoms in the
 :class:`~MDAnalysis.core.AtomGroup.AtomGroup` by atom index before returning them (this is to
 eliminate possible duplicates in the selection). If the ordering of atoms is
 crucial (for instance when describing angles or dihedrals) or if duplicate
@@ -277,16 +277,16 @@ not sort them.
 The most straightforward way to concatentate two AtomGroups is by using the
 **+** operator::
 
- >>> ordered = u.selectAtoms("segid DMPC and resid 3 and name P") + u.selectAtoms("segid DMPC and resid 2 and name P")
+ >>> ordered = u.select_atoms("segid DMPC and resid 3 and name P") + u.select_atoms("segid DMPC and resid 2 and name P")
  >>> print list(ordered)
  [< Atom 570: name 'P' of type '180' of resid 'DMPC', 3 and 'DMPC'>,
  < Atom 452: name 'P' of type '180' of resid 'DMPC', 2 and 'DMPC'>]
 
 A shortcut is to provide *two or more* selections to
-:meth:`~MDAnalysis.Universe.selectAtoms`, which then does the concatenation
+:meth:`~MDAnalysis.Universe.select_atoms`, which then does the concatenation
 automatically::
 
- >>> print list(universe.selectAtoms("segid DMPC and resid 3 and name P", "segid DMPC and resid 2 and name P"))
+ >>> print list(universe.select_atoms("segid DMPC and resid 3 and name P", "segid DMPC and resid 2 and name P"))
  [< Atom 570: name 'P' of type '180' of resid 'DMPC', 3 and 'DMPC'>,
  < Atom 452: name 'P' of type '180' of resid 'DMPC', 2 and 'DMPC'>]
 
@@ -294,7 +294,7 @@ Just for comparison to show that a single selection string does not work as one
 might expect::
 
  # WRONG!
- >>> print list(universe.selectAtoms("segid DMPC and ( resid 3 or resid 2 ) and name P"))
+ >>> print list(universe.select_atoms("segid DMPC and ( resid 3 or resid 2 ) and name P"))
  [< Atom 452: name 'P' of type '180' of resid 'DMPC', 2 and 'DMPC'>,
  < Atom 570: name 'P' of type '180' of resid 'DMPC', 3 and 'DMPC'>]
  

--- a/package/examples/backbone_dihedral.py
+++ b/package/examples/backbone_dihedral.py
@@ -26,7 +26,7 @@ except ImportError:
     have_matplotlib = False
 
 universe = Universe(PSF, DCD)
-protein = universe.selectAtoms("protein")
+protein = universe.select_atoms("protein")
 
 numresidues = protein.numberOfResidues()
 
@@ -34,7 +34,7 @@ collection.clear()
 for res in range(2, numresidues - 1):
     print "Processing residue %d" % res
     # selection of the atoms involved for the phi for resid '%d' %res
-    ## selectAtoms("atom 4AKE %d C"%(res-1), "atom 4AKE %d N"%res, "atom %d 4AKE CA"%res, "atom 4AKE %d C" % res)
+    ## select_atoms("atom 4AKE %d C"%(res-1), "atom 4AKE %d N"%res, "atom %d 4AKE CA"%res, "atom 4AKE %d C" % res)
     phi_sel = universe.residues[res].phi_selection()
 
     #  selection of the atoms involved for the psi for resid '%d' %res

--- a/package/examples/blocks.py
+++ b/package/examples/blocks.py
@@ -32,7 +32,7 @@ def blocked(universe, nblocks, analyze):
 
 
 def rgyr(universe):
-    return universe.selectAtoms('protein').radiusOfGyration()
+    return universe.select_atoms('protein').radiusOfGyration()
 
 
 if __name__ == "__main__":

--- a/package/examples/example_cap_peptide/capping.py
+++ b/package/examples/example_cap_peptide/capping.py
@@ -26,7 +26,7 @@ import numpy as np
 
 
 def capping(ref, ace, nma, output):
-    resids = ref.selectAtoms("all").resids
+    resids = ref.select_atoms("all").resids
     resid_min, resid_max = min(resids), max(resids)
 
     for a in ace.atoms:
@@ -54,10 +54,10 @@ def capping(ref, ace, nma, output):
 
     # TODO remove the Hydrogen closest to ACE's oxygen
     u = Merge(
-        ace.selectAtoms("resname ACE"),
-        ref.selectAtoms("not (resid {} and name HT*) and not (resid {} and (name HT* or name OT1))".format(resid_min,
+        ace.select_atoms("resname ACE"),
+        ref.select_atoms("not (resid {} and name HT*) and not (resid {} and (name HT* or name OT1))".format(resid_min,
                                                                                                            resid_max)),
-        nma.selectAtoms("resname NME or resname NMA"))
+        nma.select_atoms("resname NME or resname NMA"))
     u.trajectory.ts.dimensions = ref.trajectory.ts.dimensions
     u.atoms.write(output)
     return u

--- a/package/examples/lipid_order_parameters.py
+++ b/package/examples/lipid_order_parameters.py
@@ -11,7 +11,7 @@ order_param = numpy.zeros(len(tail_carbons))
 for i, carbon in enumerate(tail_carbons):
     selection = "resname DMPC and ( name C2%d or name H%dR or name H%dS or name C3%d or name H%dX or name H%dY )" % \
                 ((carbon,) * 6)
-    group = universe.selectAtoms(selection)
+    group = universe.select_atoms(selection)
 
     data = universe.dcd.timeseries(group, format="afc", skip=skip)
 

--- a/package/examples/make_MthK_tetramer.py
+++ b/package/examples/make_MthK_tetramer.py
@@ -12,8 +12,8 @@ import MDAnalysis
 
 # need permissive to read HETATM (apparently...)
 P = MDAnalysis.Universe('./data/3ldd.pdb', permissive=True)
-filterK = P.selectAtoms('resname K and resid 1:4')
-monomer = P.selectAtoms('protein')
+filterK = P.select_atoms('resname K and resid 1:4')
+monomer = P.select_atoms('protein')
 axis = (filterK[0], filterK[-1])  # first to last filter ion
 monomer.write('A.pdb')
 monomer.rotateby(90, axis, filterK)

--- a/package/examples/multimers-analysis.py
+++ b/package/examples/multimers-analysis.py
@@ -125,7 +125,7 @@ def find_partners(peptide_list, lookup):
     """
     ret = {}
     for id, selection in peptide_list.items():
-        atom_list = universe.selectAtoms("around %d (%s) and not resname W" % (cutoff, selection))
+        atom_list = universe.select_atoms("around %d (%s) and not resname W" % (cutoff, selection))
         ret[id] = set()
         for atom in atom_list:
             if atom.resname == "CHOL" or atom.resname == "DPPC" or atom.resname == "DUPC":

--- a/package/examples/radial_distribution_function.py
+++ b/package/examples/radial_distribution_function.py
@@ -44,7 +44,7 @@ from MDAnalysis.tests.datafiles import GRO, XTC
 universe = Universe(GRO, XTC)
 
 # adjust the selection, e.g. "resname TIP3 and name OH2" for CHARMM
-solvent = universe.selectAtoms("resname SOL and name OW")
+solvent = universe.select_atoms("resname SOL and name OW")
 
 dmin, dmax = 0.0, 8.0
 nbins = 80

--- a/package/examples/rmsd.py
+++ b/package/examples/rmsd.py
@@ -26,8 +26,8 @@ def rmsd_traj(traj, ref, **kwargs):
     nframes = len(frames)
     rmsd = numpy.zeros((nframes,))
 
-    ref_atoms = ref.selectAtoms(selections['reference'])
-    traj_atoms = traj.selectAtoms(selections['mobile'])
+    ref_atoms = ref.select_atoms(selections['reference'])
+    traj_atoms = traj.select_atoms(selections['mobile'])
     natoms = traj_atoms.numberOfAtoms()
 
     # if performing a mass-weighted alignment/rmsd calculation

--- a/package/examples/rmsfit_qcp.py
+++ b/package/examples/rmsfit_qcp.py
@@ -37,8 +37,8 @@ writer = mda.coordinates.DCD.DCDWriter(
     frames.delta,
     remarks='RMS fitted trajectory to ref')
 
-ref_atoms = ref.selectAtoms(selections['reference'])
-traj_atoms = traj.selectAtoms(selections['target'])
+ref_atoms = ref.select_atoms(selections['reference'])
+traj_atoms = traj.select_atoms(selections['target'])
 natoms = traj_atoms.numberOfAtoms()
 
 # if performing a mass-weighted alignment/rmsd calculation

--- a/package/examples/rotational_autocorrelation.py
+++ b/package/examples/rotational_autocorrelation.py
@@ -4,7 +4,7 @@ from pylab import *
 
 universe = Universe(...)
 
-group = universe.selectAtoms("resname DMPC and ( name N or name P )")
+group = universe.select_atoms("resname DMPC and ( name N or name P )")
 
 skip = 5  # probably don't have enough memory to load the entire trajectory
 data = universe.dcd.timeseries(group, skip=skip, format="afc")

--- a/package/examples/schlitter_determ.py
+++ b/package/examples/schlitter_determ.py
@@ -6,7 +6,7 @@ from numpy import *
 from numpy import linalg
 
 system = AtomGroup.Universe(".psf", ".dcd")
-asel = system.selectAtoms(' ( name CA ) ')
+asel = system.select_atoms(' ( name CA ) ')
 # print asel
 
 #---------------------------------

--- a/package/examples/schlitter_quasiharmonic.py
+++ b/package/examples/schlitter_quasiharmonic.py
@@ -4,7 +4,7 @@ from MDAnalysis import *
 import Numeric
 
 system = AtomGroup.System("data/beta_op_adp-vmd.psf", "data/step1.dcd")
-asel = system.selectAtoms('segid F and backbone and not type O')
+asel = system.select_atoms('segid F and backbone and not type O')
 
 masses = Numeric.repeat(asel.masses, 3)
 mass_matrix = Numeric.sqrt(Numeric.identity(len(masses)) * masses)

--- a/package/src/pyqcprot/mdanalysis_example_py
+++ b/package/src/pyqcprot/mdanalysis_example_py
@@ -30,8 +30,8 @@ writer = mda.coordinates.DCD.DCDWriter(
     frames.delta,
     remarks='RMS fitted trajectory to ref')
 
-ref_atoms = ref.selectAtoms(selections['reference'])
-traj_atoms = traj.selectAtoms(selections['target'])
+ref_atoms = ref.select_atoms(selections['reference'])
+traj_atoms = traj.select_atoms(selections['target'])
 natoms = traj_atoms.n_atoms
 
 # if performing a mass-weighted alignment/rmsd calculation

--- a/testsuite/MDAnalysisTests/test_altloc.py
+++ b/testsuite/MDAnalysisTests/test_altloc.py
@@ -34,25 +34,25 @@ class TestAltloc(TestCase):
 
     def test_atomgroups(self):
         u = Universe(self.filename)
-        segidB0 = len(u.selectAtoms("segid B and (not altloc B)"))
-        segidB1 = len(u.selectAtoms("segid B and (not altloc A)"))
+        segidB0 = len(u.select_atoms("segid B and (not altloc B)"))
+        segidB1 = len(u.select_atoms("segid B and (not altloc A)"))
         assert_equal(segidB0, segidB1)
-        altlocB0 = len(u.selectAtoms("segid B and (altloc A)"))
-        altlocB1 = len(u.selectAtoms("segid B and (altloc B)"))
+        altlocB0 = len(u.select_atoms("segid B and (altloc A)"))
+        altlocB1 = len(u.select_atoms("segid B and (altloc B)"))
         assert_equal(altlocB0, altlocB1)
-        sum = len(u.selectAtoms("segid B"))
+        sum = len(u.select_atoms("segid B"))
         assert_equal(sum, segidB0 + altlocB0)
 
     def test_bonds(self):
         u = Universe(self.filename, guess_bonds=True)
         # need to force topology to load before querying individual atom bonds
         u.build_topology()
-        bonds0 = u.selectAtoms("segid B and (altloc A)")[0].bonds
-        bonds1 = u.selectAtoms("segid B and (altloc B)")[0].bonds
+        bonds0 = u.select_atoms("segid B and (altloc A)")[0].bonds
+        bonds1 = u.select_atoms("segid B and (altloc B)")[0].bonds
         assert_equal(len(bonds0), len(bonds1))
 
     def test_write_read(self):
         u = Universe(self.filename)
-        u.selectAtoms("all").write(self.outfile)
+        u.select_atoms("all").write(self.outfile)
         u2 = Universe(self.outfile)
         assert_equal(len(u.atoms), len(u2.atoms))

--- a/testsuite/MDAnalysisTests/test_analysis.py
+++ b/testsuite/MDAnalysisTests/test_analysis.py
@@ -105,7 +105,7 @@ class TestAlign(TestCase):
 
     def test_rmsd(self):
         self.universe.trajectory[0]  # ensure first frame
-        bb = self.universe.selectAtoms('backbone')
+        bb = self.universe.select_atoms('backbone')
         A = bb.coordinates(copy=True)  # coordinates of first frame (copy=True just in case)
         self.universe.trajectory[-1]  # forward to last frame
         B = bb.coordinates()  # coordinates of last frame
@@ -175,7 +175,7 @@ class TestRMSF(TestCase):
         del self.universe
 
     def test_rmsf(self):
-        rmsfs = MDAnalysis.analysis.rms.RMSF(self.universe.selectAtoms('name CA'))
+        rmsfs = MDAnalysis.analysis.rms.RMSF(self.universe.select_atoms('name CA'))
         rmsfs.run(quiet=True)
         test_rmsfs = numpy.load(rmsfArray)
 
@@ -184,7 +184,7 @@ class TestRMSF(TestCase):
                             "values")
 
     def test_rmsf_single_frame(self):
-        rmsfs = MDAnalysis.analysis.rms.RMSF(self.universe.selectAtoms('name CA'))
+        rmsfs = MDAnalysis.analysis.rms.RMSF(self.universe.select_atoms('name CA'))
         rmsfs.run(start=5, stop=6, quiet=True)
 
         assert_almost_equal(rmsfs.rmsf, 0, 5,
@@ -197,7 +197,7 @@ class TestRMSF(TestCase):
                 W.write(self.universe)
 
         self.universe = MDAnalysis.Universe(GRO, self.outfile)
-        rmsfs = MDAnalysis.analysis.rms.RMSF(self.universe.selectAtoms('name CA'))
+        rmsfs = MDAnalysis.analysis.rms.RMSF(self.universe.select_atoms('name CA'))
         rmsfs.run(quiet=True)
 
         assert_almost_equal(rmsfs.rmsf, 0, 5,

--- a/testsuite/MDAnalysisTests/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/test_atomgroup.py
@@ -73,7 +73,7 @@ class TestAtom(TestCase):
         assert_almost_equal(a.position, pos)
 
     def test_atom_selection(self):
-        asel = self.universe.selectAtoms('atom 4AKE 67 CG').atoms[0]
+        asel = self.universe.select_atoms('atom 4AKE 67 CG').atoms[0]
         assert_equal(self.atom, asel)
 
     def test_hierarchy(self):
@@ -175,8 +175,8 @@ class TestAtomGroup(TestCase):
 
     def test_getitem_str(self):
         ag1 = self.universe.atoms['HT1']
-        # selectAtoms always returns an AtomGroup even if single result
-        ag2 = self.universe.selectAtoms('name HT1')[0]
+        # select_atoms always returns an AtomGroup even if single result
+        ag2 = self.universe.select_atoms('name HT1')[0]
         assert_equal(ag1, ag2)
 
     def test_getitem_list(self):
@@ -310,11 +310,11 @@ class TestAtomGroup(TestCase):
         assert_array_equal(bfactors[0:3], numpy.array([None, None, None]))
 
     def test_sequence_string(self):
-        p = self.universe.selectAtoms("protein")
+        p = self.universe.select_atoms("protein")
         assert_equal(p.sequence(format="string"), self.ref_adk_sequence)
 
     def test_sequence_SeqRecord(self):
-        p = self.universe.selectAtoms("protein")
+        p = self.universe.select_atoms("protein")
         s = p.sequence(format="SeqRecord",
                        id="P69441", name="KAD_ECOLI Adenylate kinase",
                        description="EcAdK from pdb 4AKE")
@@ -322,21 +322,21 @@ class TestAtomGroup(TestCase):
         assert_equal(s.seq.tostring(), self.ref_adk_sequence)
 
     def test_sequence_SeqRecord_default(self):
-        p = self.universe.selectAtoms("protein")
+        p = self.universe.select_atoms("protein")
         s = p.sequence(id="P69441", name="KAD_ECOLI Adenylate kinase",
                        description="EcAdK from pdb 4AKE")
         assert_equal(s.id, "P69441")
         assert_equal(s.seq.tostring(), self.ref_adk_sequence)
 
     def test_sequence_Seq(self):
-        p = self.universe.selectAtoms("protein")
+        p = self.universe.select_atoms("protein")
         s = p.sequence(format="Seq")
         assert_equal(s.tostring(), self.ref_adk_sequence)
 
     def test_sequence_nonIUPACresname(self):
         """test_sequence_nonIUPACresname: non recognized amino acids raise ValueError"""
         # fake non-IUPAC residue name for this test
-        self.universe.selectAtoms("resname MET").set_resname("MSE")
+        self.universe.select_atoms("resname MET").set_resname("MSE")
         self.universe.atoms._rebuild_caches()
         def wrong_res():
             self.universe.atoms.sequence()
@@ -403,7 +403,7 @@ class TestAtomGroup(TestCase):
             assert_equal(at.resname, v)
         assert_equal(all(ag.resnames == new), True)
 
-    # TODO: add all other methods except selectAtoms(), see test_atomselections.py
+    # TODO: add all other methods except select_atoms(), see test_atomselections.py
     def test_set_charge(self):
         # Charges are initially 0
         at1 = Atom(1, 'dave', 'C', 'a', 1, 1, 0.1, 0.0)
@@ -475,13 +475,13 @@ class TestAtomGroup(TestCase):
     def test_residues(self):
         u = self.universe
         assert_equal(u.residues[100]._atoms,
-                     u.selectAtoms('resname ILE and resid 101')._atoms,
+                     u.select_atoms('resname ILE and resid 101')._atoms,
                      "Direct selection from residue group does not match expected I101.")
 
     def test_segments(self):
         u = self.universe
         assert_equal(u.segments.s4AKE._atoms,
-                     u.selectAtoms('segid 4AKE')._atoms,
+                     u.select_atoms('segid 4AKE')._atoms,
                      "Direct selection of segment 4AKE from segments failed.")
 
     def test_index_integer(self):
@@ -590,15 +590,15 @@ class TestAtomGroup(TestCase):
 
     def test_dihedral_ValueError(self):
         """test that AtomGroup.dihedral() raises ValueError if not exactly 4 atoms given"""
-        nodih = self.universe.selectAtoms("resid 3:10")
+        nodih = self.universe.select_atoms("resid 3:10")
         assert_raises(ValueError, nodih.dihedral)
-        nodih = self.universe.selectAtoms("resid 3:5")
+        nodih = self.universe.select_atoms("resid 3:5")
         assert_raises(ValueError, nodih.dihedral)
 
     def test_improper(self):
         u = self.universe
         u.trajectory.rewind()  # just to make sure...
-        peptbond = u.selectAtoms("atom 4AKE 20 C", "atom 4AKE 21 CA",
+        peptbond = u.select_atoms("atom 4AKE 20 C", "atom 4AKE 21 CA",
                                  "atom 4AKE 21 N", "atom 4AKE 21 HN")
         assert_almost_equal(peptbond.improper(), 168.52952575683594, self.dih_prec,
                             "Peptide bond improper dihedral for M21 calculated wrongly.")
@@ -606,20 +606,20 @@ class TestAtomGroup(TestCase):
     def test_dihedral_equals_improper(self):
         u = self.universe
         u.trajectory.rewind()  # just to make sure...
-        peptbond = u.selectAtoms("atom 4AKE 20 C", "atom 4AKE 21 CA",
+        peptbond = u.select_atoms("atom 4AKE 20 C", "atom 4AKE 21 CA",
                                  "atom 4AKE 21 N", "atom 4AKE 21 HN")
         assert_equal(peptbond.improper(), peptbond.dihedral(),
                      "improper() and proper dihedral() give different results")
 
     def test_bond(self):
         self.universe.trajectory.rewind()  # just to make sure...
-        sel2 = self.universe.s4AKE.r98.selectAtoms("name OE1", "name OE2")
+        sel2 = self.universe.s4AKE.r98.select_atoms("name OE1", "name OE2")
         assert_almost_equal(sel2.bond(), 2.1210737228393555, 3,
                             "distance of Glu98 OE1--OE2 wrong")
 
     def test_bond_pbc(self):
         self.universe.trajectory.rewind()
-        sel2 = self.universe.s4AKE.r98.selectAtoms("name OE1", "name OE2")
+        sel2 = self.universe.s4AKE.r98.select_atoms("name OE1", "name OE2")
         assert_almost_equal(sel2.bond(pbc=True), 2.1210737228393555, 3,
                             "distance of Glu98 OE1--OE2 wrong")
 
@@ -629,7 +629,7 @@ class TestAtomGroup(TestCase):
 
     def test_angle(self):
         self.universe.trajectory.rewind()  # just to make sure...
-        sel3 = self.universe.s4AKE.r98.selectAtoms("name OE1", "name CD", "name OE2")
+        sel3 = self.universe.s4AKE.r98.select_atoms("name OE1", "name CD", "name OE2")
         assert_almost_equal(sel3.angle(), 117.46187591552734, 3,
                             "angle of Glu98 OE1-CD-OE2 wrong")
 
@@ -652,7 +652,7 @@ class TestAtomGroup(TestCase):
     # - rotateby
 
     def test_positions(self):
-        ag = self.universe.selectAtoms("bynum 12:42")
+        ag = self.universe.select_atoms("bynum 12:42")
         pos = ag.positions + 3.14
         ag.positions = pos
         # should work
@@ -665,14 +665,14 @@ class TestAtomGroup(TestCase):
         assert_raises(ValueError, set_badarr)
 
     def test_set_positions(self):
-        ag = self.universe.selectAtoms("bynum 12:42")
+        ag = self.universe.select_atoms("bynum 12:42")
         pos = ag.get_positions() + 3.14
         ag.set_positions(pos)
         assert_almost_equal(ag.coordinates(), pos,
                             err_msg="failed to update atoms 12:42 position to new position")
 
     def test_no_velocities_raises_NoDataError(self):
-        def get_vel(ag=self.universe.selectAtoms("bynum 12:42")):
+        def get_vel(ag=self.universe.select_atoms("bynum 12:42")):
             v = ag.get_velocities()
         # trj has no velocities
         assert_raises(NoDataError, get_vel)
@@ -693,7 +693,7 @@ class TestAtomGroup(TestCase):
         assert_raises(NoDataError, set_for)
 
     def test_set_resid(self):
-        ag = self.universe.selectAtoms("bynum 12:42")
+        ag = self.universe.select_atoms("bynum 12:42")
         resid = 999
         ag.set_resid(resid)
         # check individual atoms
@@ -713,7 +713,7 @@ class TestAtomGroup(TestCase):
 
     def test_set_resids(self):
         """test_set_resid: set AtomGroup resids on a per-atom basis"""
-        ag = self.universe.selectAtoms("bynum 12:42")
+        ag = self.universe.select_atoms("bynum 12:42")
         resids = numpy.array([a.resid for a in ag]) + 1000
         ag.set_resid(resids)
         # check individual atoms
@@ -724,20 +724,20 @@ class TestAtomGroup(TestCase):
                      err_msg="failed to set_resid of residues belonging to atoms 12:42 to same resid")
 
     def test_merge_residues(self):
-        ag = self.universe.selectAtoms("resid 12:14")
+        ag = self.universe.select_atoms("resid 12:14")
         nres_old = self.universe.atoms.n_residues
         natoms_old = ag.n_atoms
         ag.set_resid(12)  # merge all into one with resid 12
         nres_new = self.universe.atoms.n_residues
-        r_merged = self.universe.selectAtoms("resid 12:14").residues
-        natoms_new = self.universe.selectAtoms("resid 12").n_atoms
+        r_merged = self.universe.select_atoms("resid 12:14").residues
+        natoms_new = self.universe.select_atoms("resid 12").n_atoms
         assert_equal(len(r_merged), 1, err_msg="set_resid failed to merge residues: merged = {0}".format(r_merged))
         assert_equal(nres_new, nres_old - 2,
                      err_msg="set_resid failed to merge residues: merged = {0}".format(r_merged))
         assert_equal(natoms_new, natoms_old, err_msg="set_resid lost atoms on merge".format(r_merged))
 
     def test_set_mass(self):
-        ag = self.universe.selectAtoms("bynum 12:42 and name H*")
+        ag = self.universe.select_atoms("bynum 12:42 and name H*")
         mass = 2.0
         ag.set_mass(mass)
         # check individual atoms
@@ -747,9 +747,9 @@ class TestAtomGroup(TestCase):
 
     def test_set_segid(self):
         u = self.universe
-        u.selectAtoms("(resid 1-29 or resid 60-121 or resid 160-214)").set_segid("CORE")
-        u.selectAtoms("resid 122-159").set_segid("LID")
-        u.selectAtoms("resid 30-59").set_segid("NMP")
+        u.select_atoms("(resid 1-29 or resid 60-121 or resid 160-214)").set_segid("CORE")
+        u.select_atoms("resid 122-159").set_segid("LID")
+        u.select_atoms("resid 30-59").set_segid("NMP")
         assert_equal(u.atoms.segids, ["CORE", "NMP", "CORE", "LID", "CORE"],
                      err_msg="failed to change segids = {0}".format(u.atoms.segids))
 
@@ -758,7 +758,7 @@ class TestAtomGroup(TestCase):
         assert_raises(ValueError, self.ag.set_mass, [0.1, 0.2])
 
     def test_split_atoms(self):
-        ag = self.universe.selectAtoms("resid 1:50 and not resname LYS and (name CA or name CB)")
+        ag = self.universe.select_atoms("resid 1:50 and not resname LYS and (name CA or name CB)")
         sg = ag.split("atom")
         assert_equal(len(sg), len(ag))
         for g, ref_atom in itertools.izip(sg, ag):
@@ -768,7 +768,7 @@ class TestAtomGroup(TestCase):
             assert_equal(atom.resid, ref_atom.resid)
 
     def test_split_residues(self):
-        ag = self.universe.selectAtoms("resid 1:50 and not resname LYS and (name CA or name CB)")
+        ag = self.universe.select_atoms("resid 1:50 and not resname LYS and (name CA or name CB)")
         sg = ag.split("residue")
         assert_equal(len(sg), len(ag.resids))
         for g, ref_resname in itertools.izip(sg, ag.resnames):
@@ -780,7 +780,7 @@ class TestAtomGroup(TestCase):
                 assert_equal(atom.resname, ref_resname)
 
     def test_split_segments(self):
-        ag = self.universe.selectAtoms("resid 1:50 and not resname LYS and (name CA or name CB)")
+        ag = self.universe.select_atoms("resid 1:50 and not resname LYS and (name CA or name CB)")
         sg = ag.split("segment")
         assert_equal(len(sg), len(ag.segids))
         for g, ref_segname in itertools.izip(sg, ag.segids):
@@ -1037,7 +1037,7 @@ class TestResidueGroup(TestCase):
         assert_equal(len(self.rg), self.rg.n_residues, "len and n_residues disagree")
 
     def test_set_resid(self):
-        rg = self.universe.selectAtoms("bynum 12:42").residues
+        rg = self.universe.select_atoms("bynum 12:42").residues
         resid = 999
         rg.set_resid(resid)
         # check individual atoms
@@ -1050,7 +1050,7 @@ class TestResidueGroup(TestCase):
 
     def test_set_resids(self):
         """test_set_resid: set ResidueGroup resids on a per-residue basis"""
-        rg = self.universe.selectAtoms("resid 10:18").residues
+        rg = self.universe.select_atoms("resid 10:18").residues
         resids = numpy.array(rg.resids) + 1000
         rg.set_resid(resids)
         # check individual atoms
@@ -1062,15 +1062,15 @@ class TestResidueGroup(TestCase):
         # check residues
         # NOTE: need to create a new selection because underlying Residue objects are not changed;
         #       only Atoms are changed, and Residues are rebuilt from Atoms.
-        rgnew = self.universe.selectAtoms("resid 1010:1018").residues
+        rgnew = self.universe.select_atoms("resid 1010:1018").residues
         assert_equal(rgnew.resids, numpy.unique(resids),
                      err_msg="failed to set_resid of residues belonging to residues 10:18 to new resids")
 
     def test_set_resids_updates_self(self):
-        rg = self.universe.selectAtoms("resid 10:18").residues
+        rg = self.universe.select_atoms("resid 10:18").residues
         resids = numpy.array(rg.resids) + 1000
         rg.set_resid(resids)
-        #rgnew = self.universe.selectAtoms("resid 1000:1008").residues
+        #rgnew = self.universe.select_atoms("resid 1000:1008").residues
         assert_equal(rg.resids, numpy.unique(resids),
                      err_msg="old selection was not changed in place after set_resid")
 
@@ -1123,13 +1123,13 @@ class TestResidueGroup(TestCase):
         assert_raises(ValueError, rg.set_resname, new)
 
     def test_merge_residues(self):
-        rg = self.universe.selectAtoms("resid 12:14").residues
+        rg = self.universe.select_atoms("resid 12:14").residues
         nres_old = self.universe.atoms.n_residues
         natoms_old = rg.n_atoms
         rg.set_resid(12)  # merge all into one with resid 12
         nres_new = self.universe.atoms.n_residues
-        r_merged = self.universe.selectAtoms("resid 12:14").residues
-        natoms_new = self.universe.selectAtoms("resid 12").n_atoms
+        r_merged = self.universe.select_atoms("resid 12:14").residues
+        natoms_new = self.universe.select_atoms("resid 12").n_atoms
         assert_equal(len(r_merged), 1, err_msg="set_resid failed to merge residues: merged = {0}".format(r_merged))
         assert_equal(nres_new, nres_old - 2,
                      err_msg="set_resid failed to merge residues: merged = {0}".format(r_merged))
@@ -1140,7 +1140,7 @@ class TestResidueGroup(TestCase):
                              "merge.")
 
     def test_set_mass(self):
-        rg = self.universe.selectAtoms("bynum 12:42 and name H*").residues
+        rg = self.universe.select_atoms("bynum 12:42 and name H*").residues
         mass = 2.0
         rg.set_mass(mass)
         # check individual atoms
@@ -1207,7 +1207,7 @@ class TestSegmentGroup(TestCase):
         assert_equal(self.g.n_residues, 214)
 
     def test_set_resid(self):
-        g = self.universe.selectAtoms("bynum 12:42").segments
+        g = self.universe.select_atoms("bynum 12:42").segments
         resid = 999
         g.set_resid(resid)
         # check individual atoms
@@ -1219,7 +1219,7 @@ class TestSegmentGroup(TestCase):
                      err_msg="failed to set_resid of segments belonging to atoms 12:42 to same resid")
 
     def test_set_resids(self):
-        g = self.universe.selectAtoms("resid 10:18").segments
+        g = self.universe.select_atoms("resid 10:18").segments
         resid = 999
         g.set_resid(resid * numpy.ones(len(g)))
         # note: all is now one residue... not meaningful but it is the correct behaviour
@@ -1227,19 +1227,19 @@ class TestSegmentGroup(TestCase):
                      err_msg="failed to set_resid  in Segment {0}".format(g))
 
     def test_set_segid(self):
-        s = self.universe.selectAtoms('all').segments
+        s = self.universe.select_atoms('all').segments
         s.set_segid(['ADK'])
         assert_equal(self.universe.segments.segids, ['ADK'],
                      err_msg="failed to set_segid on segments")
 
     def test_set_segid_updates_self(self):
-        g = self.universe.selectAtoms("resid 10:18").segments
+        g = self.universe.select_atoms("resid 10:18").segments
         g.set_segid('ADK')
         assert_equal(g.segids, ['ADK'],
                      err_msg="old selection was not changed in place after set_segid")
 
     def test_set_mass(self):
-        g = self.universe.selectAtoms("bynum 12:42 and name H*").segments
+        g = self.universe.select_atoms("bynum 12:42 and name H*").segments
         mass = 2.0
         g.set_mass(mass)
         # check individual atoms
@@ -1256,7 +1256,7 @@ class TestAtomGroupVelocities(TestCase):
 
     def setUp(self):
         self.universe = MDAnalysis.Universe(GRO, TRR)
-        self.ag = self.universe.selectAtoms("bynum 12:42")
+        self.ag = self.universe.select_atoms("bynum 12:42")
 
     @dec.slow
     def test_get_velocities(self):
@@ -1297,7 +1297,7 @@ class TestAtomGroupTimestep(TestCase):
         del self.prec
 
     def test_partial_timestep(self):
-        ag = self.universe.selectAtoms('name Ca')
+        ag = self.universe.select_atoms('name Ca')
         idx = ag.indices
 
         assert_equal(len(ag.ts._pos), len(ag))
@@ -1342,10 +1342,10 @@ class _WriteAtoms(TestCase):
                                   err_msg="atom coordinate mismatch between original and %s file" % self.ext)
 
     def test_write_selection(self):
-        CA = self.universe.selectAtoms('name CA')
+        CA = self.universe.select_atoms('name CA')
         CA.write(self.outfile)
         u2 = self.universe_from_tmp()
-        CA2 = u2.selectAtoms('all')  # check EVERYTHING, otherwise we might get false positives!
+        CA2 = u2.select_atoms('all')  # check EVERYTHING, otherwise we might get false positives!
         assert_equal(len(u2.atoms), len(CA.atoms), "written CA selection does not match original selection")
         assert_almost_equal(CA2.coordinates(), CA.coordinates(), self.precision,
                             err_msg="CA coordinates do not agree with original")
@@ -1354,7 +1354,7 @@ class _WriteAtoms(TestCase):
         G = self.universe.s4AKE.ARG[-2]  # 2nd but last Arg
         G.write(self.outfile)
         u2 = self.universe_from_tmp()
-        G2 = u2.selectAtoms('all')  # check EVERYTHING, otherwise we might get false positives!
+        G2 = u2.select_atoms('all')  # check EVERYTHING, otherwise we might get false positives!
         assert_equal(len(u2.atoms), len(G.atoms), "written R206 Residue does not match original ResidueGroup")
         assert_almost_equal(G2.coordinates(), G.coordinates(), self.precision,
                             err_msg="Residue R206 coordinates do not agree with original")
@@ -1363,7 +1363,7 @@ class _WriteAtoms(TestCase):
         G = self.universe.s4AKE.LEU
         G.write(self.outfile)
         u2 = self.universe_from_tmp()
-        G2 = u2.selectAtoms('all')  # check EVERYTHING, otherwise we might get false positives!
+        G2 = u2.select_atoms('all')  # check EVERYTHING, otherwise we might get false positives!
         assert_equal(len(u2.atoms), len(G.atoms), "written LEU ResidueGroup does not match original ResidueGroup")
         assert_almost_equal(G2.coordinates(), G.coordinates(), self.precision,
                             err_msg="ResidueGroup LEU coordinates do not agree with original")
@@ -1372,7 +1372,7 @@ class _WriteAtoms(TestCase):
         G = self.universe.s4AKE
         G.write(self.outfile)
         u2 = self.universe_from_tmp()
-        G2 = u2.selectAtoms('all')  # check EVERYTHING, otherwise we might get false positives!
+        G2 = u2.select_atoms('all')  # check EVERYTHING, otherwise we might get false positives!
         assert_equal(len(u2.atoms), len(G.atoms), "written s4AKE segment does not match original segment")
         assert_almost_equal(G2.coordinates(), G.coordinates(), self.precision,
                             err_msg="segment s4AKE coordinates do not agree with original")

--- a/testsuite/MDAnalysisTests/test_atomselections.py
+++ b/testsuite/MDAnalysisTests/test_atomselections.py
@@ -33,129 +33,129 @@ class TestSelectionsCHARMM(TestCase):
         del self.universe
 
     def test_segid(self):
-        sel = self.universe.selectAtoms('segid 4AKE')
+        sel = self.universe.select_atoms('segid 4AKE')
         assert_equal(sel.n_atoms, 3341, "failed to select segment 4AKE")
         assert_equal(sel._atoms, self.universe.s4AKE._atoms,
                      "selected segment 4AKE is not the same as auto-generated segment s4AKE")
 
     def test_protein(self):
-        sel = self.universe.selectAtoms('protein')
+        sel = self.universe.select_atoms('protein')
         assert_equal(sel.n_atoms, 3341, "failed to select protein")
         assert_equal(sel._atoms, self.universe.s4AKE._atoms,
                      "selected protein is not the same as auto-generated protein segment s4AKE")
 
     def test_backbone(self):
-        sel = self.universe.selectAtoms('backbone')
+        sel = self.universe.select_atoms('backbone')
         assert_equal(sel.n_atoms, 855)
 
     def test_resid_single(self):
-        sel = self.universe.selectAtoms('resid 100')
+        sel = self.universe.select_atoms('resid 100')
         assert_equal(sel.n_atoms, 7)
         assert_equal(sel.resnames, ['GLY'])
 
     def test_resid_range(self):
-        sel = self.universe.selectAtoms('resid 100:105')
+        sel = self.universe.select_atoms('resid 100:105')
         assert_equal(sel.n_atoms, 89)
         assert_equal(sel.resnames, ['GLY', 'ILE', 'ASN', 'VAL', 'ASP', 'TYR'])
 
     def test_selgroup(self):
-        sel = self.universe.selectAtoms('not resid 100')
-        sel2 = self.universe.selectAtoms('not group notr100', notr100=sel)
+        sel = self.universe.select_atoms('not resid 100')
+        sel2 = self.universe.select_atoms('not group notr100', notr100=sel)
         assert_equal(sel2.n_atoms, 7)
         assert_equal(sel2.resnames, ['GLY'])
 
     def test_fullselgroup(self):
-        sel1 = self.universe.selectAtoms('resid 101')
-        sel2 = self.universe.selectAtoms('resid 100')
-        sel3 = sel1.selectAtoms('fullgroup r100', r100=sel2)
+        sel1 = self.universe.select_atoms('resid 101')
+        sel2 = self.universe.select_atoms('resid 100')
+        sel3 = sel1.select_atoms('fullgroup r100', r100=sel2)
         assert_equal(sel2.n_atoms, 7)
         assert_equal(sel2.resnames, ['GLY'])
 
     # resnum selections are boring here because we haven't really a mechanism yet
     # to assign the canonical PDB resnums
     def test_resnum_single(self):
-        sel = self.universe.selectAtoms('resnum 100')
+        sel = self.universe.select_atoms('resnum 100')
         assert_equal(sel.n_atoms, 7)
         assert_equal(sel.resids, [100])
         assert_equal(sel.resnames, ['GLY'])
 
     def test_resnum_range(self):
-        sel = self.universe.selectAtoms('resnum 100:105')
+        sel = self.universe.select_atoms('resnum 100:105')
         assert_equal(sel.n_atoms, 89)
         assert_equal(sel.resids, range(100, 106))
         assert_equal(sel.resnames, ['GLY', 'ILE', 'ASN', 'VAL', 'ASP', 'TYR'])
 
     def test_resname(self):
-        sel = self.universe.selectAtoms('resname LEU')
+        sel = self.universe.select_atoms('resname LEU')
         assert_equal(sel.n_atoms, 304, "Failed to find all 'resname LEU' atoms.")
         assert_equal(sel.n_residues, 16, "Failed to find all 'resname LEU' residues.")
         assert_equal(sel._atoms, self.universe.s4AKE.LEU._atoms,
                      "selected 'resname LEU' atoms are not the same as auto-generated s4AKE.LEU")
 
     def test_name(self):
-        sel = self.universe.selectAtoms('name CA')
+        sel = self.universe.select_atoms('name CA')
         assert_equal(sel.n_atoms, 214)
 
     def test_atom(self):
-        sel = self.universe.selectAtoms('atom 4AKE 100 CA')
+        sel = self.universe.select_atoms('atom 4AKE 100 CA')
         assert_equal(len(sel), 1)
         assert_equal(sel.resnames, ['GLY'])
         assert_array_almost_equal(sel.coordinates(),
                                   array([[20.38685226, -3.44224262, -5.92158318]], dtype=float32))
 
     def test_type(self):
-        sel = self.universe.selectAtoms("type 1")
+        sel = self.universe.select_atoms("type 1")
         assert_equal(len(sel), 253)
 
     def test_and(self):
-        sel = self.universe.selectAtoms('resname GLY and resid 100')
+        sel = self.universe.select_atoms('resname GLY and resid 100')
         assert_equal(len(sel), 7)
 
     def test_or(self):
-        sel = self.universe.selectAtoms('resname LYS or resname ARG')
+        sel = self.universe.select_atoms('resname LYS or resname ARG')
         assert_equal(sel.n_residues, 31)
 
     def test_not(self):
-        sel = self.universe.selectAtoms('not backbone')
+        sel = self.universe.select_atoms('not backbone')
         assert_equal(len(sel), 2486)
 
     def test_around(self):
-        sel = self.universe.selectAtoms('around 4.0 bynum 1943')
+        sel = self.universe.select_atoms('around 4.0 bynum 1943')
         assert_equal(len(sel), 32)
 
     def test_sphlayer(self):
-        sel = self.universe.selectAtoms('sphlayer 4.0 6.0 bynum 1281')
+        sel = self.universe.select_atoms('sphlayer 4.0 6.0 bynum 1281')
         assert_equal(len(sel), 66)
 
     def test_sphzone(self):
-        sel = self.universe.selectAtoms('sphzone 6.0 bynum 1281')
+        sel = self.universe.select_atoms('sphzone 6.0 bynum 1281')
         assert_equal(len(sel), 86)
 
     def test_cylayer(self):
-        sel = self.universe.selectAtoms('cylayer 4.0 6.0 10 -10 bynum 1281')
+        sel = self.universe.select_atoms('cylayer 4.0 6.0 10 -10 bynum 1281')
         assert_equal(len(sel), 88)
 
     def test_cyzone(self):
-        sel = self.universe.selectAtoms('cyzone 6.0 10 -10 bynum 1281')
+        sel = self.universe.select_atoms('cyzone 6.0 10 -10 bynum 1281')
         assert_equal(len(sel), 166)
 
     def test_prop(self):
-        sel = self.universe.selectAtoms('prop y <= 16')
-        sel2 = self.universe.selectAtoms('prop abs z < 8')
+        sel = self.universe.select_atoms('prop y <= 16')
+        sel2 = self.universe.select_atoms('prop abs z < 8')
         assert_equal(len(sel), 3194)
         assert_equal(len(sel2), 2001)
 
     def test_bynum(self):
         "Tests the bynum selection, also from AtomGroup instances (Issue 275)"
-        sel = self.universe.selectAtoms('bynum 5')
+        sel = self.universe.select_atoms('bynum 5')
         assert_equal(sel[0].index, 4)
-        sel = self.universe.selectAtoms('bynum 1:10')
+        sel = self.universe.select_atoms('bynum 1:10')
         assert_equal(len(sel), 10)
         assert_equal(sel[0].index, 0)
         assert_equal(sel[-1].index, 9)
-        subsel = sel.selectAtoms('bynum 5')
+        subsel = sel.select_atoms('bynum 5')
         assert_equal(subsel[0].index, 4)
-        subsel = sel.selectAtoms('bynum 2:5')
+        subsel = sel.select_atoms('bynum 2:5')
         assert_equal(len(subsel), 4)
         assert_equal(subsel[0].index, 1)
         assert_equal(subsel[-1].index, 4)
@@ -166,7 +166,7 @@ class TestSelectionsCHARMM(TestCase):
 
     def test_same_resname(self):
         """Test the 'same ... as' construct (Issue 217)"""
-        sel = self.universe.selectAtoms("same resname as resid 10 or resid 11")
+        sel = self.universe.select_atoms("same resname as resid 10 or resid 11")
         assert_equal(len(sel), 331, "Found a wrong number of atoms with same resname as resids 10 or 11")
         target_resids = array([ 7, 8, 10, 11, 12, 14, 17, 25, 32, 37, 38, 42, 46,
                                49, 55, 56, 66, 73, 80, 85, 93, 95, 99, 100, 122, 127,
@@ -180,17 +180,17 @@ class TestSelectionsCHARMM(TestCase):
         self.universe.residues[150:].set_segid("C")
 
         target_resids = arange(100)+1 
-        sel = self.universe.selectAtoms("same segment as resid 10")
+        sel = self.universe.select_atoms("same segment as resid 10")
         assert_equal(len(sel), 1520, "Found a wrong number of atoms in the same segment of resid 10")
         assert_array_equal(sel.resids, target_resids, "Found wrong residues in the same segment of resid 10")
 
         target_resids = arange(100,150)+1 
-        sel = self.universe.selectAtoms("same segment as resid 110")
+        sel = self.universe.select_atoms("same segment as resid 110")
         assert_equal(len(sel), 797, "Found a wrong number of atoms in the same segment of resid 110")
         assert_array_equal(sel.resids, target_resids, "Found wrong residues in the same segment of resid 110")
 
         target_resids = arange(150,self.universe.atoms.n_residues)+1
-        sel = self.universe.selectAtoms("same segment as resid 160")
+        sel = self.universe.select_atoms("same segment as resid 160")
         assert_equal(len(sel), 1024, "Found a wrong number of atoms in the same segment of resid 160")
         assert_array_equal(sel.resids, target_resids, "Found wrong residues in the same segment of resid 160")
 
@@ -201,16 +201,16 @@ class TestSelectionsCHARMM(TestCase):
 
     def test_empty_selection(self):
         """Test that empty selection can be processed (see Issue 12)"""
-        assert_equal(len(self.universe.selectAtoms('resname TRP')), 0)  # no Trp in AdK
+        assert_equal(len(self.universe.select_atoms('resname TRP')), 0)  # no Trp in AdK
 
     def test_parenthesized_expression(self):
-        sel = self.universe.selectAtoms('( name CA or name CB ) and resname LEU')
+        sel = self.universe.select_atoms('( name CA or name CB ) and resname LEU')
         assert_equal(len(sel), 32)
 
     def test_no_space_around_parentheses(self):
         """Test that no space is needed around parentheses (Issue 43)."""
         # note: will currently be ERROR because it throws a ParseError
-        sel = self.universe.selectAtoms('(name CA or name CB) and resname LEU')
+        sel = self.universe.select_atoms('(name CA or name CB) and resname LEU')
         assert_equal(len(sel), 32)
 
     # TODO:
@@ -218,7 +218,7 @@ class TestSelectionsCHARMM(TestCase):
     def test_concatenated_selection(self):
         E151 = self.universe.s4AKE.r151
         # note that this is not quite phi... HN should be C of prec. residue
-        phi151 = E151.selectAtoms('name HN', 'name N', 'name CA', 'name CB')
+        phi151 = E151.select_atoms('name HN', 'name N', 'name CA', 'name CB')
         assert_equal(len(phi151), 4)
         assert_equal(phi151[0].name, 'HN', "wrong ordering in selection, should be HN-N-CA-CB")
 
@@ -233,20 +233,20 @@ class TestSelectionsAMBER(TestCase):
         del self.universe
 
     def test_protein(self):
-        sel = self.universe.selectAtoms('protein')
+        sel = self.universe.select_atoms('protein')
         assert_equal(sel.n_atoms, 22, "failed to select protein")
 
     def test_backbone(self):
-        sel = self.universe.selectAtoms('backbone')
+        sel = self.universe.select_atoms('backbone')
         assert_equal(sel.n_atoms, 7)
 
     def test_resid_single(self):
-        sel = self.universe.selectAtoms('resid 3')
+        sel = self.universe.select_atoms('resid 3')
         assert_equal(sel.n_atoms, 6)
         assert_equal(sel.resnames, ['NME'])
 
     def test_type(self):
-        sel = self.universe.selectAtoms('type 1')
+        sel = self.universe.select_atoms('type 1')
         assert_equal(len(sel), 6)
         assert_equal(sel.names, ['HH31', 'HH32', 'HH33', 'HB1', 'HB2', 'HB3'])
 
@@ -261,17 +261,17 @@ class TestSelectionsNAMD(TestCase):
         del self.universe
 
     def test_protein(self):
-        sel = self.universe.selectAtoms('protein or resname HAO or resname ORT')  # must include non-standard residues
+        sel = self.universe.select_atoms('protein or resname HAO or resname ORT')  # must include non-standard residues
         assert_equal(sel.n_atoms, self.universe.atoms.n_atoms, "failed to select peptide")
         assert_equal(sel.n_residues, 6, "failed to select all peptide residues")
 
     def test_resid_single(self):
-        sel = self.universe.selectAtoms('resid 12')
+        sel = self.universe.select_atoms('resid 12')
         assert_equal(sel.n_atoms, 26)
         assert_equal(sel.resnames, ['HAO'])
 
     def test_type(self):
-        sel = self.universe.selectAtoms('type H')
+        sel = self.universe.select_atoms('type H')
         assert_equal(len(sel), 5)
         assert_array_equal(sel.names, ['HN', 'HN', 'HN', 'HH', 'HN'])  # note 4th HH
 
@@ -283,31 +283,31 @@ class TestSelectionsGRO(TestCase):
 
     @dec.slow
     def test_protein(self):
-        sel = self.universe.selectAtoms('protein')
+        sel = self.universe.select_atoms('protein')
         assert_equal(sel.n_atoms, 3341, "failed to select protein")
 
     @dec.slow
     def test_backbone(self):
-        sel = self.universe.selectAtoms('backbone')
+        sel = self.universe.select_atoms('backbone')
         assert_equal(sel.n_atoms, 855)
 
     @dec.slow
     def test_type(self):
-        sel = self.universe.selectAtoms('type H')
+        sel = self.universe.select_atoms('type H')
         assert_equal(len(sel), 23853)
-        sel = self.universe.selectAtoms('type S')
+        sel = self.universe.select_atoms('type S')
         assert_equal(len(sel), 7)
-        assert_equal(sel.resnames, self.universe.selectAtoms("resname CYS or resname MET").resnames)
+        assert_equal(sel.resnames, self.universe.select_atoms("resname CYS or resname MET").resnames)
 
     @dec.slow
     def test_resid_single(self):
-        sel = self.universe.selectAtoms('resid 100')
+        sel = self.universe.select_atoms('resid 100')
         assert_equal(sel.n_atoms, 7)
         assert_equal(sel.resnames, ['GLY'])
 
     @dec.slow
     def test_atom(self):
-        sel = self.universe.selectAtoms('atom SYSTEM 100 CA')
+        sel = self.universe.select_atoms('atom SYSTEM 100 CA')
         assert_equal(len(sel), 1)
         assert_equal(sel.resnames, ['GLY'])
 
@@ -318,21 +318,21 @@ class TestSelectionsGRO(TestCase):
         #  The 'same' construct uses numpy.in1d to compare floats. It might be sensitive to
         #  precision issues, but I am expecting .gro coordinates with the same values to
         #  be converted to the exact same floats, at least in the same machine.
-        sel = self.universe.selectAtoms("same x as bynum 1 or bynum 10")
+        sel = self.universe.select_atoms("same x as bynum 1 or bynum 10")
         assert_equal(len(sel), 12, "Found a wrong number of atoms with same x as ids 1 or 10")
         target_ids = array([ 0, 8, 9, 224, 643, 3515, 11210, 14121, 18430, 25418, 35811, 43618])
         assert_array_equal(sel.indices, target_ids, "Found wrong atoms with same x as ids 1 or 10")
 
     def test_cylayer(self):
         """Test cylinder layer selections from AtomGroups, and with tricilinic periodicity (Issue 274)"""
-        atgp = self.universe.selectAtoms('name OW')
-        sel = atgp.selectAtoms('cylayer 10 20 20 -20 bynum 3554')
+        atgp = self.universe.select_atoms('name OW')
+        sel = atgp.select_atoms('cylayer 10 20 20 -20 bynum 3554')
         assert_equal(len(sel), 1155)
 
     def test_cyzone(self):
         """Test cylinder zone selections from AtomGroups, and with tricilinic periodicity (Issue 274)"""
-        atgp = self.universe.selectAtoms('name OW')
-        sel = atgp.selectAtoms('cyzone 20 20 -20 bynum 3554')
+        atgp = self.universe.select_atoms('name OW')
+        sel = atgp.select_atoms('cyzone 20 20 -20 bynum 3554')
         assert_equal(len(sel), 1556)
 
 
@@ -348,7 +348,7 @@ class TestSelectionsXTC(TestCase):
         """Test the 'same ... as' construct (Issue 217)"""
         # This test comes here because it's a system with solvent, and thus multiple fragments.
         try:
-            sel = self.universe.selectAtoms("same fragment as bynum 1")
+            sel = self.universe.select_atoms("same fragment as bynum 1")
             assert_equal(len(sel), 3341, "Found a wrong number of atoms on the same fragment as id 1")
             assert_equal(sel._atoms, self.universe.atoms[0].fragment._atoms, "Found a different set of atoms when using the 'same fragment as' construct vs. the .fragment prperty")
         except MDAnalysis.NoDataError:
@@ -359,12 +359,12 @@ class TestSelectionsNucleicAcids(TestCase):
         self.universe = MDAnalysis.Universe(NUCL)
 
     def test_nucleic(self):
-        rna = self.universe.selectAtoms("nucleic")
+        rna = self.universe.select_atoms("nucleic")
         assert_equal(rna.n_atoms, 739)
         assert_equal(rna.n_residues, 23)
 
     def test_nucleicbackbone(self):
-        rna = self.universe.selectAtoms("nucleicbackbone")
+        rna = self.universe.select_atoms("nucleicbackbone")
         assert_equal(rna.n_residues, 23)
         assert_equal(rna.n_atoms, rna.n_residues * 5 - 1)
         # -1 because this is a single strand of RNA and on P is missing at the 5' end
@@ -372,11 +372,11 @@ class TestSelectionsNucleicAcids(TestCase):
     # todo: need checks for other selection resnames such as DT DA DG DC DU 
 
     def test_nucleicbase(self):
-        rna = self.universe.selectAtoms("nucleicbase")
+        rna = self.universe.select_atoms("nucleicbase")
         assert_equal(rna.n_residues, 23)
         assert_equal(rna.n_atoms, 214)
 
     def test_nucleicsugar(self):
-        rna = self.universe.selectAtoms("nucleicsugar")
+        rna = self.universe.select_atoms("nucleicsugar")
         assert_equal(rna.n_residues, 23)
         assert_equal(rna.n_atoms, rna.n_residues * 5)

--- a/testsuite/MDAnalysisTests/test_coordinates.py
+++ b/testsuite/MDAnalysisTests/test_coordinates.py
@@ -163,7 +163,7 @@ class TestXYZReader(TestCase, Ref2r9r):
         centreOfGeometry = 0
 
         for i in self.universe.trajectory:
-            sel = self.universe.selectAtoms("all")
+            sel = self.universe.select_atoms("all")
             centreOfGeometry += sum(sel.centerOfGeometry())
 
         assert_almost_equal(centreOfGeometry, self.ref_sum_centre_of_geometry, self.prec,
@@ -229,7 +229,7 @@ class TestCompressedXYZReader(TestCase, Ref2r9r):
         centreOfGeometry = 0
 
         for i in self.universe.trajectory:
-            sel = self.universe.selectAtoms("all")
+            sel = self.universe.select_atoms("all")
             centreOfGeometry += sum(sel.centerOfGeometry())
 
         assert_almost_equal(centreOfGeometry, self.ref_sum_centre_of_geometry, self.prec,
@@ -362,7 +362,7 @@ class RefVGV(object):
 
       w = MDAnalysis.Universe(PRMncdf, TRJncdf)
       ref_n_atoms = len(w.atoms)
-      ref_proteinatoms = len(w.selectAtoms("protein"))
+      ref_proteinatoms = len(w.select_atoms("protein"))
       ref_sum_centre_of_geometry = np.sum([protein.centerOfGeometry() for ts in w.trajectory])
     """
     ref_n_atoms = 2661
@@ -391,11 +391,11 @@ class _TRJReaderTest(TestCase):
         assert_equal(self.universe.trajectory.periodic, self.ref_periodic)
 
     def test_amber_proteinselection(self):
-        protein = self.universe.selectAtoms('protein')
+        protein = self.universe.select_atoms('protein')
         assert_equal(protein.n_atoms, self.ref_proteinatoms, "error in protein selection (HIS or termini?)")
 
     def test_sum_centres_of_geometry(self):
-        protein = self.universe.selectAtoms('protein')
+        protein = self.universe.select_atoms('protein')
         total = np.sum([protein.centerOfGeometry() for ts in self.universe.trajectory])
         assert_almost_equal(total, self.ref_sum_centre_of_geometry, self.prec,
                             err_msg="sum of centers of geometry over the trajectory do not match")
@@ -604,7 +604,7 @@ class TestNCDFWriter(TestCase, RefVGV):
     @attr('issue')
     def test_write_AtomGroup(self):
         """test to write NCDF from AtomGroup (Issue 116)"""
-        p = self.universe.selectAtoms("not resname WAT")
+        p = self.universe.select_atoms("not resname WAT")
         p.write(self.outtop)
         W = self.Writer(self.outfile, n_atoms=p.n_atoms)
         for ts in self.universe.trajectory:
@@ -739,7 +739,7 @@ class _SingleFrameReader(TestCase, RefAdKSmall):
     def test_load_file(self):
         U = self.universe
         assert_equal(len(U.atoms), self.ref_n_atoms, "load Universe from file %s" % U.trajectory.filename)
-        assert_equal(U.atoms.selectAtoms('resid 150 and name HA2').atoms[0],
+        assert_equal(U.atoms.select_atoms('resid 150 and name HA2').atoms[0],
                      U.atoms[self.ref_E151HA2_index], "Atom selections")
 
     def test_n_atoms(self):
@@ -914,7 +914,7 @@ class TestExtendedPDBReader(_SingleFrameReader):
     def test_long_resSeq(self):
         #it checks that it can read a 5-digit resid
         self.universe = mda.Universe(XPDB_small, topology_format="XPDB")
-        u = self.universe.selectAtoms('resid 1 or resid 10 or resid 100 or resid 1000 or resid 10000')
+        u = self.universe.select_atoms('resid 1 or resid 10 or resid 100 or resid 1000 or resid 10000')
         assert_equal(u[4].resid, 10000, "can't read a five digit resid")
 
 
@@ -958,7 +958,7 @@ class TestPrimitivePDBWriter(TestCase):
         u = self.universe2
         W = mda.Writer(self.outfile)
         u.trajectory[50]
-        W.write(u.selectAtoms('all'))
+        W.write(u.select_atoms('all'))
         W.close()
         u2 = mda.Universe(self.outfile)
         assert_equal(u2.trajectory.n_frames, 1, err_msg="The number of frames should be 1.")
@@ -1247,7 +1247,7 @@ class TestMultiPDBWriter(TestCase):
     def test_write_atomselection(self):
         """Test if multiframe writer can write selected frames for an atomselection."""
         u = self.multiverse
-        group = u.selectAtoms('name CA', 'name C')
+        group = u.select_atoms('name CA', 'name C')
         desired_group = 56
         desired_frames = 6
         pdb = MDAnalysis.Writer(self.outfile, multiframe=True, start=12, step=2)
@@ -1271,7 +1271,7 @@ class TestMultiPDBWriter(TestCase):
         Test write_all_timesteps() of the  multiframe writer (selected frames for an atomselection)
         """
         u = self.multiverse
-        group = u.selectAtoms('name CA', 'name C')
+        group = u.select_atoms('name CA', 'name C')
         desired_group = 56
         desired_frames = 6
 
@@ -1394,7 +1394,7 @@ class TestGROReader(TestCase, RefAdK):
     def test_load_gro(self):
         U = self.universe
         assert_equal(len(U.atoms), self.ref_n_atoms, "load Universe from small GRO")
-        assert_equal(U.atoms.selectAtoms('resid 150 and name HA2').atoms[0],
+        assert_equal(U.atoms.select_atoms('resid 150 and name HA2').atoms[0],
                      U.atoms[self.ref_E151HA2_index], "Atom selections")
 
     def test_n_atoms(self):
@@ -1428,7 +1428,7 @@ class TestGROReader(TestCase, RefAdK):
                             err_msg="distance between M1:N and G214:C")
 
     def test_selection(self):
-        na = self.universe.selectAtoms('resname NA+')
+        na = self.universe.select_atoms('resname NA+')
         assert_equal(len(na), self.ref_Na_sel_size, "Atom selection of last atoms in file")
 
     def test_unitcell(self):
@@ -1614,12 +1614,12 @@ class TestPDBReaderBig(TestCase, RefAdK):
     def test_load_pdb(self):
         U = self.universe
         assert_equal(len(U.atoms), self.ref_n_atoms, "load Universe from big PDB")
-        assert_equal(U.atoms.selectAtoms('resid 150 and name HA2').atoms[0],
+        assert_equal(U.atoms.select_atoms('resid 150 and name HA2').atoms[0],
                      U.atoms[self.ref_E151HA2_index], "Atom selections")
 
     @dec.slow
     def test_selection(self):
-        na = self.universe.selectAtoms('resname NA+')
+        na = self.universe.select_atoms('resname NA+')
         assert_equal(len(na), self.ref_Na_sel_size, "Atom selection of last atoms in file")
 
     @dec.slow
@@ -1659,7 +1659,7 @@ class TestPDBReaderBig(TestCase, RefAdK):
 
     @dec.slow
     def test_selection(self):
-        na = self.universe.selectAtoms('resname NA+')
+        na = self.universe.select_atoms('resname NA+')
         assert_equal(len(na), self.ref_Na_sel_size, "Atom selection of last atoms in file")
 
     @dec.slow
@@ -2018,7 +2018,7 @@ class TestDCDCorrel(_TestDCD):
         ca = self.universe.s4AKE.CA
         ca_termini = mda.core.AtomGroup.AtomGroup([ca[0], ca[-1]])
         # note that this is not quite phi... HN should be C of prec. residue
-        phi151 = self.universe.selectAtoms('resid 151').selectAtoms('name HN', 'name N', 'name CA', 'name CB')
+        phi151 = self.universe.select_atoms('resid 151').select_atoms('name HN', 'name N', 'name CA', 'name CB')
         C.addTimeseries(TS.Atom('v', ca_termini))  # 0
         C.addTimeseries(TS.Bond(ca_termini))  # 1
         C.addTimeseries(TS.Bond([ca[0], ca[-1]]))  # 2
@@ -2099,7 +2099,7 @@ def compute_correl_references():
     all = universe.atoms
     ca = universe.s4AKE.CA
     ca_termini = mda.core.AtomGroup.AtomGroup([ca[0], ca[-1]])
-    phi151 = universe.selectAtoms('resid 151').selectAtoms('name HN', 'name N', 'name CA', 'name CB')
+    phi151 = universe.select_atoms('resid 151').select_atoms('name HN', 'name N', 'name CA', 'name CB')
 
     C = MDAnalysis.collection
     C.clear()
@@ -2236,7 +2236,7 @@ class TestTRRReader_Sub(TestCase):
         later compare to using 'sub'
         """
         usol = mda.Universe(PDB_sub_sol, TRR_sub_sol)
-        atoms = usol.selectAtoms("not resname SOL")
+        atoms = usol.select_atoms("not resname SOL")
         self.pos = atoms.positions
         self.vel = atoms.velocities
         self.force = atoms.forces
@@ -2336,7 +2336,7 @@ class _GromacsReader(TestCase):
         T.next()
         T.next()
         assert_equal(self.ts.frame, 2, "failed to step to frame 3")
-        ca = U.selectAtoms('name CA and resid 122')
+        ca = U.select_atoms('name CA and resid 122')
         # low precision match (2 decimals in A, 3 in nm) because the above are the trr coords
         assert_array_almost_equal(ca.coordinates(), ca_Angstrom, 2,
                                   err_msg="coords of Ca of resid 122 do not match for frame 3")
@@ -2483,7 +2483,7 @@ class _XDRNoConversion(TestCase):
         T.next()
         T.next()
         assert_equal(self.ts.frame, 2, "failed to step to frame 3")
-        ca = U.selectAtoms('name CA and resid 122')
+        ca = U.select_atoms('name CA and resid 122')
         # low precision match because we also look at the trr: only 3 decimals in nm in xtc!
         assert_array_almost_equal(ca.coordinates(), ca_nm, 3,
                                   err_msg="native coords of Ca of resid 122 do not match for frame 3 "
@@ -2799,7 +2799,7 @@ class TestTRZReader(TestCase, RefTRZ):
         assert_almost_equal(fortytwo.pos, self.ref_coordinates, self.prec, "wrong coordinates in trz")
 
     def test_velocities(self):
-        fortytwo = self.universe.selectAtoms('bynum 42')
+        fortytwo = self.universe.select_atoms('bynum 42')
         assert_almost_equal(fortytwo.velocities, self.ref_velocities, self.prec, "wrong velocities in trz")
 
     def test_delta(self):
@@ -2905,7 +2905,7 @@ class TestWrite_Partial_Timestep(TestCase):
 
     def setUp(self):
         self.universe = mda.Universe(TRZ_psf, TRZ)
-        self.ag = self.universe.selectAtoms('name N')
+        self.ag = self.universe.select_atoms('name N')
         self.prec = 3
         fd, self.outfile = tempfile.mkstemp(suffix='.pdb')
         os.close(fd)

--- a/testsuite/MDAnalysisTests/test_distances.py
+++ b/testsuite/MDAnalysisTests/test_distances.py
@@ -72,7 +72,7 @@ class TestDistanceArrayDCD(TestCase):
     def setUp(self):
         self.universe = MDAnalysis.Universe(PSF, DCD)
         self.trajectory = self.universe.trajectory
-        self.ca = self.universe.selectAtoms('name CA')
+        self.ca = self.universe.select_atoms('name CA')
         # reasonable precision so that tests succeed on 32 and 64 bit machines
         # (the reference values were obtained on 64 bit)
         # Example:
@@ -134,7 +134,7 @@ class TestSelfDistanceArrayDCD(TestCase):
     def setUp(self):
         self.universe = MDAnalysis.Universe(PSF, DCD)
         self.trajectory = self.universe.trajectory
-        self.ca = self.universe.selectAtoms('name CA')
+        self.ca = self.universe.select_atoms('name CA')
         # see comments above on precision
         self.prec = 5
 

--- a/testsuite/MDAnalysisTests/test_modelling.py
+++ b/testsuite/MDAnalysisTests/test_modelling.py
@@ -37,7 +37,7 @@ from MDAnalysis.analysis.align import alignto
 
 
 def capping(ref, ace, nma, output):
-    resids = ref.selectAtoms("all").resids
+    resids = ref.select_atoms("all").resids
     resid_min, resid_max = min(resids), max(resids)
 
     # There is probably some cache i need to update both the atom and residues
@@ -63,11 +63,11 @@ def capping(ref, ace, nma, output):
             strict=True)
 
     #  TODO remove the Hydrogen closest to ACE's oxygen
-    u = Merge(ace.selectAtoms("resname ACE"),
-              ref.selectAtoms(
+    u = Merge(ace.select_atoms("resname ACE"),
+              ref.select_atoms(
                   "not (resid {0} and name HT*) and not (resid {1} and (name HT* or name OT1))"
                   "".format(resid_min, resid_max)),
-              nma.selectAtoms("resname NME or resname NMA"))
+              nma.select_atoms("resname NME or resname NMA"))
     u.trajectory.ts.dimensions = ref.trajectory.ts.dimensions
     u.atoms.write(output)
     return u
@@ -94,12 +94,12 @@ class TestCapping(TestCase):
         nma = MDAnalysis.Universe(capping_nma)
 
         u = capping(peptide, ace, nma, self.outfile)
-        assert_equal(len(u.selectAtoms("not name H*")), len(ref.selectAtoms("not name H*")))
+        assert_equal(len(u.select_atoms("not name H*")), len(ref.select_atoms("not name H*")))
 
         u = MDAnalysis.Universe(self.outfile)
 
-        ace = u.selectAtoms("resname ACE")
-        nma = u.selectAtoms("resname NMA")
+        ace = u.select_atoms("resname ACE")
+        nma = u.select_atoms("resname NMA")
 
         # Check if the resids were assigned correctly
         assert_equal(ace.resids[0], 1)
@@ -114,10 +114,10 @@ class TestCapping(TestCase):
         nma = MDAnalysis.Universe(capping_nma)
 
         u = capping(peptide, ace, nma, self.outfile)
-        assert_equal(len(u.selectAtoms("not name H*")), len(ref.selectAtoms("not name H*")))
+        assert_equal(len(u.select_atoms("not name H*")), len(ref.select_atoms("not name H*")))
 
-        ace = u.selectAtoms("resname ACE")
-        nma = u.selectAtoms("resname NMA")
+        ace = u.select_atoms("resname ACE")
+        nma = u.select_atoms("resname NMA")
 
         # Check if the resids were assigned correctly
         assert_equal(ace.resids[0], 1)

--- a/testsuite/MDAnalysisTests/test_mol2.py
+++ b/testsuite/MDAnalysisTests/test_mol2.py
@@ -53,10 +53,10 @@ class TestMol2(TestCase):
 
     def test_write_selection(self):
         ref = Universe(mol2_molecule)
-        gr0 = ref.selectAtoms("name C*")
+        gr0 = ref.select_atoms("name C*")
         gr0.write(self.outfile)
         u = Universe(self.outfile)
-        gr1 = u.selectAtoms("name C*")
+        gr1 = u.select_atoms("name C*")
         assert_equal(len(gr0), len(gr1))
 
     def test_broken_molecule(self):

--- a/testsuite/MDAnalysisTests/test_pdbqt.py
+++ b/testsuite/MDAnalysisTests/test_pdbqt.py
@@ -42,19 +42,19 @@ class TestPDBQT(TestCase):
             pass
 
     def test_segid(self):
-        sel = self.universe.selectAtoms('segid A')
+        sel = self.universe.select_atoms('segid A')
         assert_equal(sel.n_atoms, 909, "failed to select segment A")
-        sel = self.universe.selectAtoms('segid B')
+        sel = self.universe.select_atoms('segid B')
         assert_equal(sel.n_atoms, 896, "failed to select segment B")
 
     def test_protein(self):
-        sel = self.universe.selectAtoms('protein')
+        sel = self.universe.select_atoms('protein')
         assert_equal(sel.n_atoms, 1805, "failed to select protein")
         assert_equal(sel._atoms, self.universe.atoms._atoms,
                      "selected protein is not the same as auto-generated protein segment A+B")
 
     def test_backbone(self):
-        sel = self.universe.selectAtoms('backbone')
+        sel = self.universe.select_atoms('backbone')
         assert_equal(sel.n_atoms, 796)
 
     def test_neighborhood(self):
@@ -64,7 +64,7 @@ class TestPDBQT(TestCase):
         the atoms in the query pdb to create a list of protein
         residues within 4.0A of the query atoms.
         '''
-        protein = self.universe.selectAtoms("protein")
+        protein = self.universe.select_atoms("protein")
         ns_protein = kdNS.AtomNeighborSearch(protein)
         query_atoms = self.query_universe.atoms
         residue_neighbors = ns_protein.search_list(query_atoms, 4.0)

--- a/testsuite/MDAnalysisTests/test_selections.py
+++ b/testsuite/MDAnalysisTests/test_selections.py
@@ -45,7 +45,7 @@ class _SelectionWriter(TestCase):
         del self.namedfile
 
     def _selection(self):
-        return self.universe.selectAtoms("protein and name CA and bynum 1-{0}".format(self.max_number))
+        return self.universe.select_atoms("protein and name CA and bynum 1-{0}".format(self.max_number))
 
     def _write(self, **kwargs):
         g = self._selection()

--- a/testsuite/MDAnalysisTests/test_streamio.py
+++ b/testsuite/MDAnalysisTests/test_streamio.py
@@ -273,11 +273,11 @@ class TestStreamIO(TestCase, RefAdKSmall):
 
     def test_PDBQTReader(self):
         u = MDAnalysis.Universe(streamData.as_NamedStream('PDBQT'))
-        sel = u.selectAtoms('backbone')
+        sel = u.select_atoms('backbone')
         assert_equal(sel.n_atoms, 796)
-        sel = u.selectAtoms('segid A')
+        sel = u.select_atoms('segid A')
         assert_equal(sel.n_atoms, 909, "failed to select segment A")
-        sel = u.selectAtoms('segid B')
+        sel = u.select_atoms('segid B')
         assert_equal(sel.n_atoms, 896, "failed to select segment B")
 
     def test_GROReader(self):

--- a/testsuite/MDAnalysisTests/test_topology.py
+++ b/testsuite/MDAnalysisTests/test_topology.py
@@ -949,16 +949,16 @@ class TestDMSReader(_TestTopology, RefDMS):
 
     def test_atomsels(self):
         # Desired value taken from VMD atomsel
-        s0 = self.universe.selectAtoms("name CA")
+        s0 = self.universe.select_atoms("name CA")
         assert_equal(len(s0), 214)
 
-        s1 = self.universe.selectAtoms("resid 33")
+        s1 = self.universe.select_atoms("resid 33")
         assert_equal(len(s1), 12)
 
-        s2 = self.universe.selectAtoms("segid 4AKE")
+        s2 = self.universe.select_atoms("segid 4AKE")
         assert_equal(len(s2), 3341)
 
-        s3 = self.universe.selectAtoms("resname ALA")
+        s3 = self.universe.select_atoms("resname ALA")
         assert_equal(len(s3), 190)
 
     def test_atom_number(self):
@@ -1002,7 +1002,7 @@ class TestTopologyGuessers(TestCase):
 
     def test_guess_bonds_badtype(self):
         # rename my carbons and watch it get confused about missing types
-        self.u.selectAtoms('type C').set_type('QQ')
+        self.u.select_atoms('type C').set_type('QQ')
         assert_raises(ValueError, guess_bonds, self.u.atoms, self.u.atoms.positions)
 
     def test_guess_bonds_withag(self):

--- a/testsuite/MDAnalysisTests/test_velocities_forces.py
+++ b/testsuite/MDAnalysisTests/test_velocities_forces.py
@@ -68,7 +68,7 @@ class TestGROVelocities(TestCase):
         #read the velocities from the GRO_velocity file and compare the AtomGroup and individual Atom velocities
         # parsed with the reference values:
         u = MDAnalysis.Universe(GRO_velocity)
-        all_atoms = u.selectAtoms('all')
+        all_atoms = u.select_atoms('all')
         #check for read-in and unit conversion for .gro file velocities for the entire AtomGroup:
         assert_almost_equal(all_atoms.velocities, self.reference_velocities, self.prec,
                             err_msg="problem reading .gro file velocities")
@@ -104,7 +104,7 @@ class TestTRRForces(TestCase):
 
     @attr('slow')
     def testForces(self):
-        protein = self.universe.selectAtoms("protein")
+        protein = self.universe.select_atoms("protein")
         assert_equal(len(protein), 918)
         mean_F = numpy.mean([protein.forces.mean(axis=0) for ts in self.universe.trajectory], axis=0)
         assert_almost_equal(mean_F, self.reference_mean_protein_force, self.prec,


### PR DESCRIPTION
Part of #389 

DeprecationWarnings are now ALWAYS LOUD

Two commits, first to deprecate selectAtoms with the old tests, to check that the old method still works

Then update the tests to see that the new method works.

Yay/Nay?