### PR TITLE
Added 'global' selction keyword (closes #268) and deprecation warning for 'fullgroup'.

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -17,6 +17,7 @@ The rules for this file:
   * 0.11.0
 
   Enhancements
+  * Added the 'global' selection keyword (Issue #268)
   * Added Jmol selection writer (Issue #356)
   * Added reading of Hoomd XML files (Issue #333)
     These can only act as topology information for now
@@ -50,6 +51,7 @@ The rules for this file:
   * Added AtomGroup altLocs and serials properties with setters. (Issue #372)
 
   Changes
+  * Deprecated the use of the 'fullgroup' selection keyword (Issue #268)
   * Changed atom.number attribute to atom.index (Issue #372)
   * Changed many AtomGroup methods to properties.  These are: indices, masses,
     charges, names, types, radii, resids, resnames, resnums, segids

--- a/package/MDAnalysis/core/Selection.py
+++ b/package/MDAnalysis/core/Selection.py
@@ -27,7 +27,7 @@ Currently all atom arrays are handled internally as sets, but returned as AtomGr
 
 import re
 import numpy
-import warnings
+from numpy.lib.utils import deprecate
 from .AtomGroup import AtomGroup, Universe
 from MDAnalysis.core import flags
 from ..lib.KDTree.NeighborSearch import CoordinateNeighborSearch
@@ -508,11 +508,9 @@ class SelgroupSelection(Selection):
         return "<" + repr(self.__class__.__name__) + ">"
 
 
+@deprecate(old_name='fullgroup', new_name='global group')
 class FullSelgroupSelection(Selection):
     def __init__(self, selgroup):
-        warnings.warn("Use of 'fullgroup' in selections is deprecated "
-                "in MDAnalysis '0.11' and will be removed entirely in upcoming "
-                "releases. Use the equivalent syntax 'global group' instead.", DeprecationWarning)
         Selection.__init__(self)
         self._grp = selgroup
 

--- a/package/MDAnalysis/core/Selection.py
+++ b/package/MDAnalysis/core/Selection.py
@@ -27,7 +27,7 @@ Currently all atom arrays are handled internally as sets, but returned as AtomGr
 
 import re
 import numpy
-
+import warnings
 from .AtomGroup import AtomGroup, Universe
 from MDAnalysis.core import flags
 from ..lib.KDTree.NeighborSearch import CoordinateNeighborSearch
@@ -133,6 +133,14 @@ class OrSelection(Selection):
     def __repr__(self):
         return "<'OrSelection' " + repr(self.lsel) + "," + repr(self.rsel) + ">"
 
+class GlobalSelection(Selection):
+    def __init__(self, sel):
+        Selection.__init__(self)
+        self.sel = sel
+
+    def _apply(self, group):
+        sel = self.sel._apply(group.universe)
+        return sel
 
 class AroundSelection(Selection):
     def __init__(self, sel, cutoff, periodic=None):
@@ -502,6 +510,9 @@ class SelgroupSelection(Selection):
 
 class FullSelgroupSelection(Selection):
     def __init__(self, selgroup):
+        warnings.warn("Use of 'fullgroup' in selections is deprecated "
+                "in MDAnalysis '0.11' and will be removed entirely in upcoming "
+                "releases. Use the equivalent syntax 'global group' instead.", DeprecationWarning)
         Selection.__init__(self)
         self._grp = selgroup
 
@@ -903,6 +914,7 @@ class SelectionParser:
     BASE = 'nucleicbase'
     SUGAR = 'nucleicsugar'
     SAME = 'same'
+    GLOBAL = 'global'
     EOF = 'EOF'
     GT = '>'
     LT = '<'
@@ -926,11 +938,11 @@ class SelectionParser:
         (BASE, BaseSelection), (SUGAR, NucleicSugarSelection),
         #(BONDED, BondedSelection), not supported yet, need a better way to walk the bond lists
         (ATOM, AtomSelection), (SELGROUP, SelgroupSelection), (FULLSELGROUP, FullSelgroupSelection),
-        (SAME, SameSelection)])
+        (SAME, SameSelection), (GLOBAL, GlobalSelection)])
     associativity = dict([(AND, "left"), (OR, "left")])
     precedence = dict(
         [(AROUND, 1), (SPHLAYER, 1), (SPHZONE, 1), (CYLAYER, 1), (CYZONE, 1), (POINT, 1), (BYRES, 1), (BONDED, 1),
-            (SAME, 1), (AND, 3), (OR, 3), (NOT, 5)])
+            (SAME, 1), (AND, 3), (OR, 3), (NOT, 5), (GLOBAL, 5)])
 
     # Borg pattern: http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/66531
     _shared_state = {}
@@ -983,7 +995,7 @@ class SelectionParser:
 
     def __parse_subexp(self):
         op = self.__consume_token()
-        if op in (self.NOT, self.BYRES):  # unary operators
+        if op in (self.NOT, self.BYRES, self.GLOBAL):  # unary operators
             exp = self.__parse_expression(self.precedence[op])
             return self.classdict[op](exp)
         elif op in (self.AROUND):
@@ -1094,7 +1106,7 @@ class SelectionParser:
             else:
                 self.__error(prop, expected=False)
         else:
-            self.__error(op)
+            self.__error(op, expected=False)
 
 # The module level instance
 Parser = SelectionParser()

--- a/package/doc/sphinx/source/documentation_pages/selections.rst
+++ b/package/doc/sphinx/source/documentation_pages/selections.rst
@@ -171,8 +171,8 @@ Index
         :class:`MDAnalysis.Universe` are consecutively numbered, and the index
         runs from 1 up to the total number of atoms.
 
-Preexisting selections
-----------------------
+Preexisting selections and modifiers
+------------------------------------
 
     group *group-name*
         selects the atoms in the :class:`AtomGroup` passed to the function as an
@@ -187,7 +187,19 @@ Preexisting selections
         *group-name* are included. The resulting selection may therefore have atoms
         that were initially absent from the instance :meth:`~select_atoms` was
         called from.
+    .. deprecated:: 0.11
+        The use of ``fullgroup`` has been deprecated in favor of the equivalent ``global group``. 
         
+    global *selection*
+        by default, when issuing :meth:`~select_atoms` from an :class:`~MDAnalysis.AtomGroup.AtomGroup`
+        selections and subselections are returned intersected with the atoms of that instance.
+        Prefixing a selection term with ``global`` causes its selection to be returned in its entirety.
+        As an exmaple, the ``global`` keyword allows for ``lipids.select_atoms("around 10 global protein")`` ---
+        where ``lipids`` is a group that does not contain any proteins. Were ``global`` it absent the result
+        would be an empty selection since the ``protein`` subselection would itself be empty. 
+        When issuing :meth:`~select_atoms` from a :class:`~MDAnalysis.Universe` ``global`` is ignored.
+
+
 
 Instant selectors
 =================

--- a/testsuite/MDAnalysisTests/test_atomselections.py
+++ b/testsuite/MDAnalysisTests/test_atomselections.py
@@ -222,6 +222,14 @@ class TestSelectionsCHARMM(TestCase):
         assert_equal(len(phi151), 4)
         assert_equal(phi151[0].name, 'HN', "wrong ordering in selection, should be HN-N-CA-CB")
 
+    def test_global(self):
+        """Test the `global` modifier keyword (Issue 268)"""
+        ag = self.universe.select_atoms("resname LYS and name NZ")
+        # Lys amines within 4 angstrom of the backbone.
+        ag1 = self.universe.select_atoms("resname LYS and name NZ and around 4 backbone")
+        ag2 = ag.select_atoms("around 4 global backbone")
+        assert_(ag2._atoms == ag1._atoms)
+
 
 class TestSelectionsAMBER(TestCase):
     def setUp(self):


### PR DESCRIPTION
I propose this gets added now, since its a mildly breaking change.