### PR TITLE
Fixes for Issue #397

### DIFF
--- a/package/MDAnalysis/coordinates/DCD.py
+++ b/package/MDAnalysis/coordinates/DCD.py
@@ -424,7 +424,7 @@ class DCDReader(base.Reader):
         self._read_dcd_header()
 
         # Convert delta to ps
-        delta = mdaunits.convert(self.delta, 'AKMA', 'ps')
+        delta = mdaunits.convert(self.delta, self.units['time'], 'ps')
 
         self._ts_kwargs.update({'dt':self.skip_timestep * delta})
         self.ts = self._Timestep(self.n_atoms, **self._ts_kwargs)

--- a/package/MDAnalysis/coordinates/DLPoly.py
+++ b/package/MDAnalysis/coordinates/DLPoly.py
@@ -29,7 +29,7 @@ import numpy as np
 from . import base
 from . import core
 
-_DLPOLY_UNITS = {'length': 'Angstrom', 'velocity': 'Angstrom/ps'}
+_DLPOLY_UNITS = {'length': 'Angstrom', 'velocity': 'Angstrom/ps', 'time': 'ps'}
 
 
 class Timestep(base.Timestep):

--- a/package/MDAnalysis/coordinates/TRZ.py
+++ b/package/MDAnalysis/coordinates/TRZ.py
@@ -206,6 +206,8 @@ class TRZReader(base.Reader):
         self._dtype = np.dtype(frame_contents)
 
         self._read_next_timestep()
+        
+        self.ts.dt = self.dt
 
     def _read_trz_header(self):
         """Reads the header of the trz trajectory"""

--- a/package/MDAnalysis/coordinates/xdrfile/core.py
+++ b/package/MDAnalysis/coordinates/xdrfile/core.py
@@ -416,6 +416,8 @@ class TrjReader(base.Reader):
         if not kwargs.pop('refresh_offsets', False):
             self._retrieve_offsets()
 
+        self.ts.dt = self.dt
+
     @property
     def n_atoms(self):
         """The number of publically available atoms that this reader will store in the timestep.

--- a/testsuite/MDAnalysisTests/test_timestep_api.py
+++ b/testsuite/MDAnalysisTests/test_timestep_api.py
@@ -877,7 +877,6 @@ class _TestTimestepInterface(object):
     def test_frame(self):
         assert_equal(self.ts.frame, 0)
 
-    @knownfailure
     def test_dt(self):
         assert_equal(self.u.trajectory.dt, self.ts.dt)
 


### PR DESCRIPTION
When each trajectory reader initializes, it creates a Timestep which is
an attribute of the Reader. During ```__init__()``` for the XDR and TRZ readers,
the timestep's dt attribute was not set. During ```__init__()``` for the DCD reader,
```delta``` was converted without regard to value of ```self.units```.
DLPoly also gave a testing error because ```units['time']``` was undefined.

After fixing the above, the ```@known_failure``` decorator was removed from
test_dt.