### PR TITLE
Fixes issue #385

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -4,7 +4,7 @@
 
 The rules for this file:
   * entries are sorted newest-first.
-  * summarize sets of changes - don't reproduce every subversion log comment here.
+  * summarize sets of changes - don't reproduce every git log comment here.
   * don't ever delete anything.
   * keep the format consistent (79 char width, M/D/Y date format) and do not
     use tabs but use spaces for formatting
@@ -121,6 +121,12 @@ The rules for this file:
   * deprecate lib.distances.applyPBC in favour of apply_PBC (Issue #389)
   * Consolidated coordinates.guess_format and topology.guess_format to
     lib.util.guess_format  (Issue #336)
+  * AtomGroup.res[names,ids,nums] and AtomGroup.segids now give arrays of equal
+    size to AtomGroup (Issue #385)
+  * ResidueGroup.segids now gives arrays of equal size to ResidueGroup 
+    (Issue #385)
+  * AtomGroup setters `set_<property>` now plural for consistency with property
+    names
 
   Fixes
   * Topology files can now be compressed (Issue #336)

--- a/package/MDAnalysis/core/AtomGroup.py
+++ b/package/MDAnalysis/core/AtomGroup.py
@@ -1113,7 +1113,7 @@ class AtomGroup(object):
     @masses.setter
     def masses(self, new):
         self._clear_caches('masses')
-        self.set_mass(new)
+        self.set_masses(new)
 
     def total_mass(self):
         """Total mass of the selection (masses are taken from the topology or guessed)."""
@@ -1132,7 +1132,7 @@ class AtomGroup(object):
 
     @charges.setter
     def charges(self, new):
-        self.set_charge(new)
+        self.set_charges(new)
 
     def total_charge(self):
         """Sum of all partial charges (must be defined in topology)."""
@@ -1142,7 +1142,7 @@ class AtomGroup(object):
 
     @property
     def names(self):
-        """Returns a list of atom names.
+        """Returns an array of atom names.
 
         .. versionchanged:: 0.8
            Returns a :class:`numpy.ndarray`
@@ -1153,7 +1153,7 @@ class AtomGroup(object):
 
     @names.setter
     def names(self, new):
-        self.set_name(new)
+        self.set_names(new)
 
     @property
     def types(self):
@@ -1167,7 +1167,7 @@ class AtomGroup(object):
 
     @types.setter
     def types(self, new):
-        self.set_type(new)
+        self.set_types(new)
 
     @property
     def radii(self):
@@ -1180,7 +1180,7 @@ class AtomGroup(object):
 
     @radii.setter
     def radii(self, new):
-        self.set_radius(new)
+        self.set_radii(new)
 
     @property
     def bfactors(self):
@@ -1190,7 +1190,7 @@ class AtomGroup(object):
 
     @bfactors.setter
     def bfactors(self, new):
-        self.set_bfactor(new)
+        self.set_bfactors(new)
 
     @property
     def altLocs(self):
@@ -1202,7 +1202,7 @@ class AtomGroup(object):
 
     @altLocs.setter
     def altLocs(self, new):
-        self.set_altloc(new)
+        self.set_altlocs(new)
 
     @property
     def serials(self):
@@ -1214,7 +1214,7 @@ class AtomGroup(object):
 
     @serials.setter
     def serials(self, new):
-        self.set_serial(new)
+        self.set_serials(new)
 
     @property
     @cached('residues')
@@ -1262,64 +1262,64 @@ class AtomGroup(object):
 
     @property
     def resids(self):
-        """Returns a list of residue numbers.
+        """Returns an array of residue numbers.
 
         .. versionchanged:: 0.8
            Returns a :class:`numpy.ndarray`
         .. versionchanged:: 0.11.0
-           Now a property
+           Now a property and returns array of length `len(self)`
         """
-        return numpy.array([r.id for r in self.residues])
+        return numpy.array([a.resid for a in self._atoms])
 
     @resids.setter
     def resids(self, new):
-        self.set_resid(new)
+        self.set_resids(new)
 
     @property
     def resnames(self):
-        """Returns a list of residue names.
+        """Returns an array of residue names.
 
         .. versionchanged:: 0.8
            Returns a :class:`numpy.ndarray`
         .. versionchanged:: 0.11.0
-           Now a property
+           Now a property and returns array of length `len(self)`
         """
-        return numpy.array([r.name for r in self.residues])
+        return numpy.array([a.resname for a in self._atoms])
 
     @resnames.setter
     def resnames(self, new):
-        self.set_resname(new)
+        self.set_resnames(new)
 
     @property
     def resnums(self):
-        """Returns a list of canonical residue numbers.
+        """Returns an array of canonical residue numbers.
 
         .. versionadded:: 0.7.4
         .. versionchanged:: 0.8
            Returns a :class:`numpy.ndarray`
         .. versionchanged:: 0.11.0
-           Now a property
+           Now a property and returns array of length `len(self)`
         """
-        return numpy.array([r.resnum for r in self.residues])
+        return numpy.array([a.resnum for a in self._atoms])
 
     @resnums.setter
     def resnums(self, new):
-        self.set_resnum(new)
+        self.set_resnums(new)
 
     @property
     def segids(self):
-        """Returns a list of segment ids (=segment names).
+        """Returns an array of segment names.
 
         .. versionchanged:: 0.8
            Returns a :class:`numpy.ndarray`
         .. versionchanged:: 0.11.0
-           Now a property
+           Now a property and returns array of length `len(self)`
         """
-        return numpy.array([s.name for s in self.segments])
+        return numpy.array([a.segid for a in self._atoms])
 
     @segids.setter
     def segids(self, new):
-        self.set_segid(new)
+        self.set_segids(new)
 
     def sequence(self, **kwargs):
         """Returns the amino acid sequence.
@@ -1602,8 +1602,8 @@ class AtomGroup(object):
     # override for ResidueGroup, SegmentGroup accordingly
     set = _set_atoms
 
-    def set_name(self, name):
-        """Set the atom name to string for *all atoms* in the AtomGroup.
+    def set_names(self, name):
+        """Set the atom names to string for *all atoms* in the AtomGroup.
 
         If *value* is a sequence of the same length as the :class:`AtomGroup`
         then each :attr:`Atom.name` is set to the corresponding value. If
@@ -1613,11 +1613,13 @@ class AtomGroup(object):
         .. versionadded:: 0.7.4
         .. versionchanged:: 0.8
            Can set atoms to distinct values by providing a sequence or iterable.
+        .. versionchanged:: 0.11.0
+           Made plural to make consistent with corresponding property
         """
         self.set("name", name, conversion=str)
 
-    def set_resid(self, resid):
-        """Set the resid to integer *resid* for **all atoms** in the :class:`AtomGroup`.
+    def set_resids(self, resid):
+        """Set the resids to integer *resid* for **all atoms** in the :class:`AtomGroup`.
 
         If *resid* is a sequence of the same length as the :class:`AtomGroup`
         then each :attr:`Atom.resid` is set to the corresponding value together
@@ -1641,20 +1643,25 @@ class AtomGroup(object):
            Can set atoms and residues to distinct values by providing a
            sequence or iterable and can change the topology via
            :func:`MDAnalysis.topology.core.build_residues`.
-
+        .. versionchanged:: 0.11.0
+           Made plural to make consistent with corresponding property
         """
         from MDAnalysis.topology.core import build_residues
 
         self.set("resid", resid, conversion=int)
         # Note that this also automagically updates THIS AtomGroup;
         # the side effect of build_residues(self.atoms) is to update all Atoms!!!!
-        self._fill_cache('residues', build_residues(self.atoms))
-        # make sure to update the whole universe: the Atoms are shared but ResidueGroups are not
-        if self.atoms is not self.universe.atoms:
-            self.universe.atoms._fill_cache('residues', build_residues(self.universe.atoms))
+        self._fill_cache('residues', ResidueGroup(build_residues(self.atoms)))
 
-    def set_resnum(self, resnum):
-        """Set the resnum to *resnum* for **all atoms** in the :class:`AtomGroup`.
+        # make sure to update the whole universe: the Atoms are shared but
+        # ResidueGroups are not
+        if self.atoms is not self.universe.atoms:
+            self.universe.atoms._fill_cache(
+                    'residues',
+                    ResidueGroup(build_residues(self.universe.atoms)))
+
+    def set_resnums(self, resnum):
+        """Set the resnums to *resnum* for **all atoms** in the :class:`AtomGroup`.
 
         If *resnum* is a sequence of the same length as the :class:`AtomGroup`
         then each :attr:`Atom.resnum` is set to the corresponding value together
@@ -1674,20 +1681,13 @@ class AtomGroup(object):
            Also changes the residues.
         .. versionchanged:: 0.8
            Can set atoms and residues to distinct values by providing a sequence or iterable.
+        .. versionchanged:: 0.11.0
+           Made plural to make consistent with corresponding property
         """
-        from MDAnalysis.topology.core import build_residues
-
         self.set("resnum", resnum)
-        # build_residues() is the easiest (though expensive) way to make sure
-        # that all residues get their new resnum. There's no easy way to parse
-        # a per-atom resnum list (with potential duplicates) into a list of
-        # corresponding residues.
-        #
-        # (This comment applies to the analogous methods below as well.)
-        build_residues(self.atoms)
 
-    def set_resname(self, resname):
-        """Set the resname to string *resname* for **all atoms** in the :class:`AtomGroup`.
+    def set_resnames(self, resname):
+        """Set the resnames to string *resname* for **all atoms** in the :class:`AtomGroup`.
 
         If *resname* is a sequence of the same length as the :class:`AtomGroup`
         then each :attr:`Atom.resname` is set to the corresponding value together
@@ -1700,14 +1700,15 @@ class AtomGroup(object):
            Also changes the residues.
         .. versionchanged:: 0.8
            Can set atoms and residues to distinct values by providing a sequence or iterable.
+        .. versionchanged:: 0.11.0
+           Made plural to make consistent with corresponding property
         """
         from MDAnalysis.topology.core import build_residues
 
         self.set("resname", resname, conversion=str)
-        build_residues(self.atoms)
 
-    def set_segid(self, segid, buildsegments=True):
-        """Set the segid to *segid* for all atoms in the :class:`AtomGroup`.
+    def set_segids(self, segid):
+        """Set the segids to *segid* for all atoms in the :class:`AtomGroup`.
 
         If *segid* is a sequence of the same length as the :class:`AtomGroup`
         then each :attr:`Atom.segid` is set to the corresponding value together
@@ -1719,89 +1720,132 @@ class AtomGroup(object):
 
            :meth:`set_segid` can change the topology.
 
-           With the default *buildsegments* = ``True`` it can be used to join
-           segments or to break groups into multiple disjoint segments. Note
-           that each :class:`Atom` can only belong to a single
-           :class:`Segment`.
-
-        For performance reasons, *buildsegments* can be set to ``False``. Then
-        one needs to run :meth:`Universe._build_segments` manually later in
-        order to update the list of :class:`Segment` instances and regenerate
-        the segid instant selectors.
-
         .. versionadded:: 0.7.4
         .. versionchanged:: 0.8
            Can set atoms and residues to distinct values by providing a sequence or iterable.
+        .. versionchanged:: 0.11.0
+           Stale caches are problematic; though it can be expensive, changing segid
+           results in Segments being regenerated
+        .. versionchanged:: 0.11.0
+           Made plural to make consistent with corresponding property
         """
-        self.set("segid", segid)
-        self._clear_caches('segments')
-        if buildsegments:
-            self.universe._build_segments()
-        else:
-            # do not even update the local segment
-            pass
-        self.universe.atoms._clear_caches('segments')
+        from MDAnalysis.topology.core import build_segments
 
-    def set_mass(self, mass):
-        """Set the atom mass to float *mass* for **all atoms** in the AtomGroup.
+        self.set("segid", segid, conversion=str)
+
+        # also updates convenience handles for segments in universe
+        segments = self.universe._build_segments()
+
+        # Note that this also automagically updates THIS AtomGroup;
+        # the side effect of build_residues(self.atoms) is to update all Atoms!!!!
+        self._fill_cache('segments', SegmentGroup(segments))
+
+        # make sure to update the whole universe: the Atoms are shared but
+        # ResidueGroups are not
+        if self.atoms is not self.universe.atoms:
+            self.universe.atoms._fill_cache(
+                    'segments',
+                    SegmentGroup(segments))
+
+    def set_masses(self, mass):
+        """Set the atom masses to float *mass* for **all atoms** in the AtomGroup.
+
+        If *mass* is a sequence of the same length as the :class:`AtomGroup`
+        then each :attr:`Atom.mass` is set to the corresponding value. If
+        *value* is neither of length 1 (or a scalar) nor of the length of the
+        :class:`AtomGroup` then a :exc:`ValueError` is raised.
 
         .. versionadded:: 0.7.4
         .. versionchanged:: 0.8
            Can set atoms and residues to distinct values by providing a sequence or iterable.
+        .. versionchanged:: 0.11.0
+           Made plural to make consistent with corresponding property
         """
         self.set("mass", mass, conversion=float, cache="masses")
 
-    def set_type(self, atype):
-        """Set the atom type to *atype* for **all atoms** in the AtomGroup.
+    def set_types(self, atype):
+        """Set the atom types to *atype* for **all atoms** in the AtomGroup.
+
+        If *atype* is a sequence of the same length as the :class:`AtomGroup`
+        then each :attr:`Atom.atype` is set to the corresponding value. If
+        *value* is neither of length 1 (or a scalar) nor of the length of the
+        :class:`AtomGroup` then a :exc:`ValueError` is raised.
 
         .. versionadded:: 0.7.4
         .. versionchanged:: 0.8
            Can set atoms and residues to distinct values by providing a sequence or iterable.
+        .. versionchanged:: 0.11.0
+           Made plural to make consistent with corresponding property
         """
         self.set("type", atype)
 
-    def set_charge(self, charge):
-        """Set the partial charge to float *charge* for **all atoms** in the AtomGroup.
+    def set_charges(self, charge):
+        """Set the partial charges to float *charge* for **all atoms** in the AtomGroup.
+
+        If *charge* is a sequence of the same length as the :class:`AtomGroup`
+        then each :attr:`Atom.charge` is set to the corresponding value. If
+        *value* is neither of length 1 (or a scalar) nor of the length of the
+        :class:`AtomGroup` then a :exc:`ValueError` is raised.
 
         .. versionadded:: 0.7.4
         .. versionchanged:: 0.8
            Can set atoms and residues to distinct values by providing a sequence or iterable.
+        .. versionchanged:: 0.11.0
+           Made plural to make consistent with corresponding property
         """
         self.set("charge", charge, conversion=float)
 
-    def set_radius(self, radius):
-        """Set the atom radius to float *radius* for **all atoms** in the AtomGroup.
+    def set_radii(self, radius):
+        """Set the atom radii to float *radius* for **all atoms** in the AtomGroup.
+
+        If *radius* is a sequence of the same length as the :class:`AtomGroup`
+        then each :attr:`Atom.radius` is set to the corresponding value. If
+        *value* is neither of length 1 (or a scalar) nor of the length of the
+        :class:`AtomGroup` then a :exc:`ValueError` is raised.
 
         .. versionadded:: 0.7.4
         .. versionchanged:: 0.8
            Can set atoms and residues to distinct values by providing a sequence or iterable.
+        .. versionchanged:: 0.11.0
+           Made plural to make consistent with corresponding property
         """
         self.set("radius", radius, conversion=float)
 
-    def set_bfactor(self, bfactor):
-        """Set the atom bfactor to float *bfactor* for **all atoms** in the AtomGroup.
+    def set_bfactors(self, bfactor):
+        """Set the atom bfactors to float *bfactor* for **all atoms** in the AtomGroup.
+
+        If *bfactor* is a sequence of the same length as the :class:`AtomGroup`
+        then each :attr:`Atom.bfactor` is set to the corresponding value. If
+        *value* is neither of length 1 (or a scalar) nor of the length of the
+        :class:`AtomGroup` then a :exc:`ValueError` is raised.
 
         .. versionadded:: 0.7.4
         .. versionchanged:: 0.8
            Can set atoms and residues to distinct values by providing a sequence or iterable.
+        .. versionchanged:: 0.11.0
+           Made plural to make consistent with corresponding property
         """
         self.set("bfactor", bfactor, conversion=float)
 
-    def set_altLoc(self, altLoc):
-        """Set the altLoc of atoms in this group
+    def set_altLocs(self, altLoc):
+        """Set the altLocs to *altLoc for **all atoms** in the AtomGroup.
 
-        This can apply a single value to all atoms, or a series of
-        values to each atom
+        If *altLoc* is a sequence of the same length as the :class:`AtomGroup`
+        then each :attr:`Atom.altLoc` is set to the corresponding value. If
+        *value* is neither of length 1 (or a scalar) nor of the length of the
+        :class:`AtomGroup` then a :exc:`ValueError` is raised.
 
         .. versionadded:: 0.11.0
         """
         self.set("altLoc", altLoc, conversion=str)
 
-    def set_serial(self, serial):
-        """Set the serial of atoms in this group
+    def set_serials(self, serial):
+        """Set the serials to *serial* for **all atoms** in the AtomGroup.
 
-        This can apply a single value to all atoms, or a series of
-        values to each atom
+        If *serial* is a sequence of the same length as the :class:`AtomGroup`
+        then each :attr:`Atom.serial` is set to the corresponding value. If
+        *value* is neither of length 1 (or a scalar) nor of the length of the
+        :class:`AtomGroup` then a :exc:`ValueError` is raised.
 
         .. versionadded:: 0.11.0
         """
@@ -3062,8 +3106,58 @@ class ResidueGroup(AtomGroup):
 
     set = _set_residues
 
-    def set_resid(self, resid):
-        """Set the resid to integer *resid* for **all residues** in the :class:`ResidueGroup`.
+    @property
+    def resids(self):
+        """Returns an array of residue numbers.
+
+        .. versionchanged:: 0.8
+           Returns a :class:`numpy.ndarray`
+        .. versionchanged:: 0.11.0
+           Now a property and returns array of length `len(self)`
+        """
+        return numpy.array([r.id for r in self.residues])
+
+    @property
+    def resnames(self):
+        """Returns an array of residue names.
+
+        .. versionchanged:: 0.8
+           Returns a :class:`numpy.ndarray`
+        .. versionchanged:: 0.11.0
+           Now a property and returns array of length `len(self)`
+        """
+        return numpy.array([r.name for r in self.residues])
+
+    @property
+    def resnums(self):
+        """Returns an array of canonical residue numbers.
+
+        .. versionadded:: 0.7.4
+        .. versionchanged:: 0.8
+           Returns a :class:`numpy.ndarray`
+        .. versionchanged:: 0.11.0
+           Now a property and returns array of length `len(self)`
+        """
+        return numpy.array([r.resnum for r in self.residues])
+
+    @property
+    def segids(self):
+        """Returns an array of segment names.
+
+        .. note:: uses the segment of the first atom in each residue for the
+                  segment name returned
+
+        .. versionchanged:: 0.8
+           Returns a :class:`numpy.ndarray`
+        .. versionchanged:: 0.11.0
+           Now a property and returns array of length `len(self)`
+        """
+        # a bit of a hack to use just
+        return numpy.array([r[0].segid for r in self.residues])
+
+    def set_resids(self, resid):
+        """Set the resids to integer *resid* for **all residues** in the
+        :class:`ResidueGroup`.
 
         If *resid* is a sequence of the same length as the :class:`ResidueGroup`
         then each :attr:`Atom.resid` is set to the corresponding value together
@@ -3087,19 +3181,13 @@ class ResidueGroup(AtomGroup):
            everything else is derived from these atoms.
 
         .. versionadded:: 0.8
+        .. versionchanged:: 0.11.0
+           Made plural to make consistent with corresponding property
         """
-        from MDAnalysis.topology.core import build_residues
+        super(ResidueGroup, self).set_resids(resid)
 
-        self.set('resid', resid)
-        residues = build_residues(self.atoms)
-        # update THIS residue group
-        self.residues._residues = residues
-        # make sure to update the whole universe: the Atoms are shared but ResidueGroups are not
-        if self.atoms is not self.universe.atoms:
-            self.universe.atoms._fill_cache('residues', build_residues(self.universe.atoms))
-
-    def set_resnum(self, resnum):
-        """Set the resnum to *resnum* for **all residues** in the :class:`ResidueGroup`.
+    def set_resnums(self, resnum):
+        """Set the resnums to *resnum* for **all residues** in the :class:`ResidueGroup`.
 
         If *resnum* is a sequence of the same length as the :class:`ResidueGroup`
         then each :attr:`Atom.resnum` is set to the corresponding value together
@@ -3119,11 +3207,14 @@ class ResidueGroup(AtomGroup):
            Also changes the residues.
         .. versionchanged:: 0.8
            Can set atoms and residues to distinct values by providing a sequence or iterable.
+        .. versionchanged:: 0.11.0
+           Made plural to make consistent with corresponding property
         """
-        self.set("resnum", resnum)
+        super(ResidueGroup, self).set_resnums(resnum)
 
-    def set_resname(self, resname):
-        """Set the resname to string *resname* for **all residues** in the :class:`ResidueGroup`.
+    def set_resnames(self, resname):
+        """Set the resnames to string *resname* for **all residues** in the
+        :class:`ResidueGroup`.
 
         If *resname* is a sequence of the same length as the :class:`ResidueGroup`
         then each :attr:`Atom.resname` is set to the corresponding value together
@@ -3136,8 +3227,10 @@ class ResidueGroup(AtomGroup):
            Also changes the residues.
         .. versionchanged:: 0.8
            Can set atoms and residues to distinct values by providing a sequence or iterable.
+        .. versionchanged:: 0.11.0
+           Made plural to make consistent with corresponding property
         """
-        self.set("resname", resname, conversion=str)
+        super(ResidueGroup, self).set_resnames(resname)
 
     # All other AtomGroup.set_xxx() methods should just work as
     # ResidueGroup.set_xxx() because we overrode self.set(); the ones above
@@ -3146,7 +3239,7 @@ class ResidueGroup(AtomGroup):
 
     def __repr__(self):
         return "<ResidueGroup {res}>".format(
-            res=repr(self._residues))
+            res=repr(list(self.residues)))
 
 
 class Segment(ResidueGroup):
@@ -3181,7 +3274,7 @@ class Segment(ResidueGroup):
         """Initialize a Segment with segid *name* from a list of :class:`Residue` instances."""
         super(Segment, self).__init__(residues)
         self.name = name
-        for res in self._residues:
+        for res in self.residues:
             res.segment = self
             for atom in res:
                 atom.segment = self
@@ -3203,7 +3296,7 @@ class Segment(ResidueGroup):
         else:
             # There can be multiple residues with the same name
             r = []
-            for res in self._residues:
+            for res in self.residues:
                 if (res.name == attr):
                     r.append(res)
             if (len(r) == 0):
@@ -3271,8 +3364,19 @@ class SegmentGroup(ResidueGroup):
 
     set = _set_segments
 
-    def set_segid(self, segid, buildsegments=True):
-        """Set the segid to *segid* for all atoms in the :class:`SegmentGroup`.
+    @property
+    def segids(self):
+        """Returns an array of segment names.
+
+        .. versionchanged:: 0.8
+           Returns a :class:`numpy.ndarray`
+        .. versionchanged:: 0.11.0
+           Now a property and returns array of length `len(self)`
+        """
+        return numpy.array([s.name for s in self.segments])
+
+    def set_segids(self, segid):
+        """Set the segids to *segid* for all atoms in the :class:`SegmentGroup`.
 
         If *segid* is a sequence of the same length as the :class:`SegmentGroup`
         then each :attr:`Atom.segid` is set to the corresponding value together
@@ -3284,47 +3388,22 @@ class SegmentGroup(ResidueGroup):
 
            :meth:`set_segid` can change the topology.
 
-           With the default *buildsegments* = ``True`` it can be used to join
-           segments or to break groups into multiple disjoint segments. Note
-           that each :class:`Atom` can only belong to a single
-           :class:`Segment`.
-
-        For performance reasons, *buildsegments* can be set to ``False``. Then
-        one needs to run :meth:`Universe._build_segments` manually later in
-        order to update the list of :class:`Segment` instances and regenerate
-        the segid instant selectors.
-
-        .. Warning::
-
-           The values of *this* :class:`SegmentGroup` are not being changed
-           (i.e. if you assign multiple segids this instance will not be broken
-           in multiple segments, rather you will have one :class:`SegmentGroup`
-           that groups multiple segments together). You **must create a new**
-           :class:`SegmentGroup` **from the** :class:`Universe` --- only
-           :class:`Atom` instances are changed, everything else is derived from
-           these atoms.
-
+           This can be used to join segments or to break groups into multiple
+           disjoint segments. Note that each :class:`Atom` can only belong to a
+           single :class:`Segment`.
 
         .. versionadded:: 0.7.4
         .. versionchanged:: 0.8
            Can set atoms and residues to distinct values by providing a sequence or iterable.
+        .. versionchanged:: 0.11.0
+           Made plural to make consistent with corresponding property
         """
-        super(SegmentGroup, self).set_segid(segid, buildsegments=buildsegments)
-
-        # Is the following needed? -- orbeckst
-        # also fix self --- otherwise users will get confused if the changes are not reflected in the
-        # object they are currently using (it works automatically for AtomGroup but not higher order groups)
-        #
-        # This is a hack to be able to set properties on Segment/Atom
-        # instances where they have different names
-        #attr = {'segid': 'id'}
-        for seg, value in itertools.izip(self.segments, itertools.cycle(util.asiterable(segid))):
-            setattr(seg, 'name', value)
+        super(SegmentGroup, self).set_segids(segid)
 
     def __getattr__(self, attr):
         if attr.startswith('s') and attr[1].isdigit():
             attr = attr[1:]  # sNxxx only used for python, the name is stored without s-prefix
-        seglist = [segment for segment in self._segments if segment.name == attr]
+        seglist = [segment for segment in self.segments if segment.name == attr]
         if len(seglist) == 0:
             return super(SegmentGroup, self).__getattr__(attr)
         if len(seglist) > 1:
@@ -3337,7 +3416,7 @@ class SegmentGroup(ResidueGroup):
 
     def __repr__(self):
         return "<SegmentGroup {segnames}>".format(
-            segnames=repr(self._segments))
+            segnames=repr(list(self.segments)))
 
 
 class Universe(object):
@@ -3634,34 +3713,41 @@ class Universe(object):
         self.atoms = AtomGroup(self._topology['atoms'])
 
         # XXX: add H-bond information here if available from psf (or other sources)
+
         # segment instant selectors
         self._build_segments()
 
     def _build_segments(self):
         """Parse list of atoms into segments.
 
-        * updates :attr:`Universe.atoms` as a side effect
-        * updates :attr:`Universe.segments` and :attr:`Universe.residues`
-        * creates the segid instant selectors
-
         Because of Python's syntax rules, attribute names cannot start with a
         digit and so we prefix any segments starting with a digit with the
         letter 's'. For instance, '4AKE' becomes the segid instant selector
         's4AKE'.
+
+        .. warning:: this method also sets convenience attributes for segment
+                     access from tne universe
+
+        :Returns:
+            *segments*
+                segment names modified with leading 's' characters if starting
+                with a digit
+
+        .. versionchanged:: 0.11.0
+           Now returns segment names, and does not modify ``self.atoms`` or
+           ``self.residues``
         """
         from MDAnalysis.topology.core import build_segments
 
         segments = build_segments(self.atoms)
-        for seg in segments.keys():
-            if seg[0].isdigit():
-                newsegname = 's' + seg
-                segments[newsegname] = segments.pop(seg)
-        self.__dict__.update(segments)
-        # convenience access to residues and segments (these are managed attributes
-        # (properties) and are built on the fly or read from a cache) -- does this
-        # create memory problems?
-        self.segments = self.atoms.segments
-        self.residues = self.atoms.residues
+        for seg in segments:
+            if seg.id[0].isdigit():
+                name = 's' + seg.id
+            else:
+                name = seg.id
+            self.__dict__[name] = seg
+
+        return segments
 
     def _init_top(self, cat, Top):
         """Initiate a generic form of topology.
@@ -3690,7 +3776,7 @@ class Universe(object):
     def _init_bonds(self):
         """Set bond information from u._topology['bonds']
 
-        .. versionchanged 0.9.0
+        .. versionchanged:: 0.9.0
            Now returns a :class:`~MDAnalysis.core.topologyobjects.TopologyGroup`
         """
         bonds = self._init_top('bonds', top.Bond)
@@ -3934,6 +4020,14 @@ class Universe(object):
             self._cache['dihedrals'] = self._init_dihedrals()
         if 'impropers' not in self._cache:
             self._cache['impropers'] = self._init_impropers()
+
+    @property
+    def residues(self):
+        return self.atoms.residues
+
+    @property
+    def segments(self):
+        return self.atoms.segments
 
     @property
     @cached('bonds')

--- a/package/MDAnalysis/core/AtomGroup.py
+++ b/package/MDAnalysis/core/AtomGroup.py
@@ -1618,6 +1618,8 @@ class AtomGroup(object):
         """
         self.set("name", name, conversion=str)
 
+    set_name = deprecate(set_names, old_name='set_name', new_name='set_names')
+
     def set_resids(self, resid):
         """Set the resids to integer *resid* for **all atoms** in the :class:`AtomGroup`.
 
@@ -1660,6 +1662,8 @@ class AtomGroup(object):
                     'residues',
                     ResidueGroup(build_residues(self.universe.atoms)))
 
+    set_resid = deprecate(set_resids, old_name='set_resid', new_name='set_resids')
+
     def set_resnums(self, resnum):
         """Set the resnums to *resnum* for **all atoms** in the :class:`AtomGroup`.
 
@@ -1686,6 +1690,8 @@ class AtomGroup(object):
         """
         self.set("resnum", resnum)
 
+    set_resnum = deprecate(set_resnums, old_name='set_resnum', new_name='set_resnums')
+
     def set_resnames(self, resname):
         """Set the resnames to string *resname* for **all atoms** in the :class:`AtomGroup`.
 
@@ -1706,6 +1712,8 @@ class AtomGroup(object):
         from MDAnalysis.topology.core import build_residues
 
         self.set("resname", resname, conversion=str)
+
+    set_resname = deprecate(set_resnames, old_name='set_resname', new_name='set_resnames')
 
     def set_segids(self, segid):
         """Set the segids to *segid* for all atoms in the :class:`AtomGroup`.
@@ -1747,6 +1755,8 @@ class AtomGroup(object):
                     'segments',
                     SegmentGroup(segments))
 
+    set_segid = deprecate(set_segids, old_name='set_segid', new_name='set_segids')
+
     def set_masses(self, mass):
         """Set the atom masses to float *mass* for **all atoms** in the AtomGroup.
 
@@ -1762,6 +1772,8 @@ class AtomGroup(object):
            Made plural to make consistent with corresponding property
         """
         self.set("mass", mass, conversion=float, cache="masses")
+
+    set_mass = deprecate(set_masses, old_name='set_mass', new_name='set_masses')
 
     def set_types(self, atype):
         """Set the atom types to *atype* for **all atoms** in the AtomGroup.
@@ -1779,6 +1791,8 @@ class AtomGroup(object):
         """
         self.set("type", atype)
 
+    set_type = deprecate(set_types, old_name='set_type', new_name='set_types')
+
     def set_charges(self, charge):
         """Set the partial charges to float *charge* for **all atoms** in the AtomGroup.
 
@@ -1794,6 +1808,8 @@ class AtomGroup(object):
            Made plural to make consistent with corresponding property
         """
         self.set("charge", charge, conversion=float)
+
+    set_charge = deprecate(set_charges, old_name='set_charge', new_name='set_charges')
 
     def set_radii(self, radius):
         """Set the atom radii to float *radius* for **all atoms** in the AtomGroup.
@@ -1811,6 +1827,8 @@ class AtomGroup(object):
         """
         self.set("radius", radius, conversion=float)
 
+    set_radius = deprecate(set_radii, old_name='set_radius', new_name='set_radii')
+
     def set_bfactors(self, bfactor):
         """Set the atom bfactors to float *bfactor* for **all atoms** in the AtomGroup.
 
@@ -1827,6 +1845,8 @@ class AtomGroup(object):
         """
         self.set("bfactor", bfactor, conversion=float)
 
+    set_bfactor = deprecate(set_bfactors, old_name='set_bfactor', new_name='set_bfactors')
+
     def set_altLocs(self, altLoc):
         """Set the altLocs to *altLoc for **all atoms** in the AtomGroup.
 
@@ -1839,6 +1859,8 @@ class AtomGroup(object):
         """
         self.set("altLoc", altLoc, conversion=str)
 
+    set_altLoc = deprecate(set_altLocs, old_name='set_altLoc', new_name='set_altLocs')
+
     def set_serials(self, serial):
         """Set the serials to *serial* for **all atoms** in the AtomGroup.
 
@@ -1850,6 +1872,8 @@ class AtomGroup(object):
         .. versionadded:: 0.11.0
         """
         self.set("serial", serial, conversion=int)
+
+    set_serial = deprecate(set_serials, old_name='set_serial', new_name='set_serials')
 
     def center_of_geometry(self, **kwargs):
         """Center of geometry (also known as centroid) of the selection.
@@ -3186,6 +3210,8 @@ class ResidueGroup(AtomGroup):
         """
         super(ResidueGroup, self).set_resids(resid)
 
+    set_resid = deprecate(set_resids, old_name='set_resid', new_name='set_resids')
+
     def set_resnums(self, resnum):
         """Set the resnums to *resnum* for **all residues** in the :class:`ResidueGroup`.
 
@@ -3212,6 +3238,8 @@ class ResidueGroup(AtomGroup):
         """
         super(ResidueGroup, self).set_resnums(resnum)
 
+    set_resnum = deprecate(set_resnums, old_name='set_resnum', new_name='set_resnums')
+
     def set_resnames(self, resname):
         """Set the resnames to string *resname* for **all residues** in the
         :class:`ResidueGroup`.
@@ -3231,6 +3259,8 @@ class ResidueGroup(AtomGroup):
            Made plural to make consistent with corresponding property
         """
         super(ResidueGroup, self).set_resnames(resname)
+
+    set_resname = deprecate(set_resnames, old_name='set_resname', new_name='set_resnames')
 
     # All other AtomGroup.set_xxx() methods should just work as
     # ResidueGroup.set_xxx() because we overrode self.set(); the ones above
@@ -3399,6 +3429,8 @@ class SegmentGroup(ResidueGroup):
            Made plural to make consistent with corresponding property
         """
         super(SegmentGroup, self).set_segids(segid)
+
+    set_segid = deprecate(set_segids, old_name='set_segid', new_name='set_segids')
 
     def __getattr__(self, attr):
         if attr.startswith('s') and attr[1].isdigit():

--- a/package/MDAnalysis/topology/core.py
+++ b/package/MDAnalysis/topology/core.py
@@ -51,13 +51,16 @@ def build_segments(atoms):
     :class:`~MDAnalysis.core.AtomGroup.Atom` instances, which record
     to which residue and segment an atom belongs.
 
-    :Returns: structure dict, which associates a segname with a
-              :class:`~MDAnalysis.core.AtomGroup.Segment`
+    :Returns: List of :class:`~MDAnalysis.core.AtomGroup.Segment`
+              instances
 
     .. versionchanged:: 0.9.0
        Now allows resids in a given :class:`Segment` to be given in non sequential order.
+    .. versionchanged:: 0.11.0
+       Returns a list instead of a dict for consistency with the outputs of
+       :func:`build_residues`
     """
-    struc = {}
+    struc = list()
     resatomlist = defaultdict(list)
     curr_segname = atoms[0].segid
 
@@ -69,7 +72,7 @@ def build_segments(atoms):
             # Build the Segment we just left
             residues = [AtomGroup.Residue(ats[0].resname, k, ats)
                         for k, ats in resatomlist.iteritems()]
-            struc[curr_segname] = AtomGroup.Segment(curr_segname, residues)
+            struc.append(AtomGroup.Segment(curr_segname, residues))
 
             # Reset things and start again
             resatomlist = defaultdict(list)
@@ -79,7 +82,7 @@ def build_segments(atoms):
     # Add the last segment
     residues = [AtomGroup.Residue(ats[0].resname, k, ats)
                 for k, ats in resatomlist.iteritems()]
-    struc[curr_segname] = AtomGroup.Segment(curr_segname, residues)
+    struc.append(AtomGroup.Segment(curr_segname, residues))
     return struc
 
 

--- a/testsuite/MDAnalysisTests/__init__.py
+++ b/testsuite/MDAnalysisTests/__init__.py
@@ -125,6 +125,7 @@ except ImportError:
     raise ImportError("""numpy>=1.5  is required to run the test suite. Please install it first. """
                       """(For example, try "easy_install 'numpy>=1.5'").""")
 
+
 def run(*args, **kwargs):
     """Test-running function that loads plugins, sets up arguments, and calls `nose.run_exit()`"""
     try:
@@ -146,6 +147,7 @@ def run(*args, **kwargs):
     # By default, test our testsuite
     kwargs['defaultTest'] = dirname(__file__)
     return nose.run_exit(*args, **kwargs)
+
 
 def executable_not_found_runtime(*args):
     """Factory function that returns a :func:`executable_not_found`.
@@ -173,5 +175,3 @@ def executable_not_found_runtime(*args):
         return not found
 
     return lambda: executable_not_found(*args)
-
-

--- a/testsuite/MDAnalysisTests/test_analysis.py
+++ b/testsuite/MDAnalysisTests/test_analysis.py
@@ -286,6 +286,7 @@ class TestHydrogenBondAnalysisHeavyFail(TestHydrogenBondAnalysisHeavy):
         self.values['donor_resid'] = numpy.array([])
         self.values['acceptor_resnm'] = numpy.array([], dtype="|S3")
 
+
 class TestHydrogenBondAnalysisChecking(object):
     def _setUp(self):
         self.universe = u = MDAnalysis.Universe(PDB_helix)
@@ -365,6 +366,7 @@ class TestHydrogenBondAnalysisChecking(object):
                 yield run_HBA_dynamic_selections, s1, s2, s1type
         finally:
             self._tearDown() # manually tear down (because with yield cannot use TestCase)
+
 
 class TestAlignmentProcessing(TestCase):
     def setUp(self):
@@ -519,6 +521,7 @@ class Test_Helanal(TestCase):
         #        MDAnalysis.analysis.helanal.helanal_trajectory(u, selection=sel, finish=5)
          #   except IndexError:
          #       self.fail("IndexError consistent with Issue 188.")
+
 
 class TestWaterdynamics(TestCase):
     def setUp(self):

--- a/testsuite/MDAnalysisTests/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/test_atomgroup.py
@@ -207,6 +207,15 @@ class TestAtomGroup(TestCase):
     def test_n_segments(self):
         assert_equal(self.ag.n_segments, 1)
 
+    def test_resids_dim(self):
+        assert_equal(len(self.ag.resids), len(self.ag))
+
+    def test_resnums_dim(self):
+        assert_equal(len(self.ag.resnums), len(self.ag))
+
+    def test_segids_dim(self):
+        assert_equal(len(self.ag.segids), len(self.ag))
+
     def test_len(self):
         """testing that len(atomgroup) == atomgroup.n_atoms"""
         assert_equal(len(self.ag), self.ag.n_atoms, "len and n_atoms disagree")
@@ -252,19 +261,19 @@ class TestAtomGroup(TestCase):
         assert_equal(isinstance(self.ag.resids, numpy.ndarray), True)
 
     def test_resids(self):
-        assert_array_equal(self.ag.resids, numpy.arange(1, 215))
+        assert_array_equal(self.ag.residues.resids, numpy.arange(1, 215))
 
     def test_resnums_ndarray(self):
-        assert_equal(isinstance(self.ag.resnums, numpy.ndarray), True)
+        assert_equal(isinstance(self.ag.residues.resnums, numpy.ndarray), True)
 
     def test_resnums(self):
-        assert_array_equal(self.ag.resids, numpy.arange(1, 215))
+        assert_array_equal(self.ag.residues.resnums, numpy.arange(1, 215))
 
     def test_resnames_ndarray(self):
-        assert_equal(isinstance(self.ag.resnames, numpy.ndarray), True)
+        assert_equal(isinstance(self.ag.residues.resnames, numpy.ndarray), True)
 
     def test_resnames(self):
-        resnames = self.ag.resnames
+        resnames = self.ag.residues.resnames
         assert_array_equal(resnames[0:3], numpy.array(["MET", "ARG", "ILE"]))
 
     def test_names_ndarray(self):
@@ -311,11 +320,11 @@ class TestAtomGroup(TestCase):
 
     def test_sequence_string(self):
         p = self.universe.select_atoms("protein")
-        assert_equal(p.sequence(format="string"), self.ref_adk_sequence)
+        assert_equal(p.residues.sequence(format="string"), self.ref_adk_sequence)
 
     def test_sequence_SeqRecord(self):
         p = self.universe.select_atoms("protein")
-        s = p.sequence(format="SeqRecord",
+        s = p.residues.sequence(format="SeqRecord",
                        id="P69441", name="KAD_ECOLI Adenylate kinase",
                        description="EcAdK from pdb 4AKE")
         assert_equal(s.id, "P69441")
@@ -323,20 +332,20 @@ class TestAtomGroup(TestCase):
 
     def test_sequence_SeqRecord_default(self):
         p = self.universe.select_atoms("protein")
-        s = p.sequence(id="P69441", name="KAD_ECOLI Adenylate kinase",
+        s = p.residues.sequence(id="P69441", name="KAD_ECOLI Adenylate kinase",
                        description="EcAdK from pdb 4AKE")
         assert_equal(s.id, "P69441")
         assert_equal(s.seq.tostring(), self.ref_adk_sequence)
 
     def test_sequence_Seq(self):
         p = self.universe.select_atoms("protein")
-        s = p.sequence(format="Seq")
+        s = p.residues.sequence(format="Seq")
         assert_equal(s.tostring(), self.ref_adk_sequence)
 
     def test_sequence_nonIUPACresname(self):
         """test_sequence_nonIUPACresname: non recognized amino acids raise ValueError"""
         # fake non-IUPAC residue name for this test
-        self.universe.select_atoms("resname MET").set_resname("MSE")
+        self.universe.select_atoms("resname MET").set_resnames("MSE")
         self.universe.atoms._rebuild_caches()
         def wrong_res():
             self.universe.atoms.sequence()
@@ -368,20 +377,18 @@ class TestAtomGroup(TestCase):
         assert_equal(repr(self.ag), "<AtomGroup with 3341 atoms>")
 
     ## Issue 202 following 4 tests
-    @knownfailure()
     def test_set_resnum_single(self):
         ag = self.universe.atoms[:3]
         new = 5
-        ag.set_resnum(new)
+        ag.set_resnums(new)
         for at in ag:
             assert_equal(at.resnum, new)
         assert_equal(all(ag.resnums == new), True)
 
-    @knownfailure()
     def test_set_resnum_many(self):
         ag = self.universe.atoms[:3]
         new = [22, 23, 24]
-        ag.set_resnum(new)
+        ag.set_resnums(new)
         for at, v in zip(ag, new):
             assert_equal(at.resnum, v)
         assert_equal(all(ag.resnums == new), True)
@@ -389,49 +396,48 @@ class TestAtomGroup(TestCase):
     def test_set_resname_single(self):
         ag = self.universe.atoms[:3]
         new = 'abc'
-        ag.set_resname(new)
+        ag.set_resnames(new)
         for at in ag:
             assert_equal(at.resname, new)
         assert_equal(all(ag.resnames == new), True)
 
-    @knownfailure()
     def test_set_resname_many(self):
         ag = self.universe.atoms[:3]
         new = ['aa', 'bb', 'cc']
-        ag.set_resname(new)
+        ag.set_resnames(new)
         for at, v in zip(ag, new):
             assert_equal(at.resname, v)
         assert_equal(all(ag.resnames == new), True)
 
     # TODO: add all other methods except select_atoms(), see test_atomselections.py
-    def test_set_charge(self):
+    def test_set_charges(self):
         # Charges are initially 0
         at1 = Atom(1, 'dave', 'C', 'a', 1, 1, 0.1, 0.0)
         at2 = Atom(2, 'dave', 'C', 'a', 1, 1, 0.1, 0.0)
         ag = AtomGroup([at1, at2])
 
         charges = [1.0, 2.0]
-        ag.set_charge(charges)
+        ag.set_charges(charges)
         for at, val in zip(ag, charges):
             assert_equal(at.charge, val)
 
-    def test_set_radius(self):
+    def test_set_radii(self):
         at1 = Atom(1, 'dave', 'C', 'a', 1, 1, 0.1, 0.0)
         at2 = Atom(2, 'dave', 'C', 'a', 1, 1, 0.1, 0.0)
         ag = AtomGroup([at1, at2])
 
         radii = [1.0, 2.0]
-        ag.set_radius(radii)
+        ag.set_radii(radii)
         for at, val in zip(ag, radii):
             assert_equal(at.radius, val)
 
-    def test_set_bfactor(self):
+    def test_set_bfactors(self):
         at1 = Atom(1, 'dave', 'C', 'a', 1, 1, 0.1, 0.0)
         at2 = Atom(2, 'dave', 'C', 'a', 1, 1, 0.1, 0.0)
         ag = AtomGroup([at1, at2])
 
         bfacs = [1.0, 2.0]
-        ag.set_bfactor(bfacs)
+        ag.set_bfactors(bfacs)
         for at, val in zip(ag, bfacs):
             assert_equal(at.bfactor, val)
 
@@ -526,26 +532,26 @@ class TestAtomGroup(TestCase):
     def test_phi_selection(self):
         phisel = self.universe.s4AKE.r10.phi_selection()
         assert_equal(phisel.names, ['C', 'N', 'CA', 'C'])
-        assert_equal(phisel.resids, [9, 10])
-        assert_equal(phisel.resnames, ['PRO', 'GLY'])
+        assert_equal(phisel.residues.resids, [9, 10])
+        assert_equal(phisel.residues.resnames, ['PRO', 'GLY'])
 
     def test_psi_selection(self):
         psisel = self.universe.s4AKE.r10.psi_selection()
         assert_equal(psisel.names, ['N', 'CA', 'C', 'N'])
-        assert_equal(psisel.resids, [10, 11])
-        assert_equal(psisel.resnames, ['GLY', 'ALA'])
+        assert_equal(psisel.residues.resids, [10, 11])
+        assert_equal(psisel.residues.resnames, ['GLY', 'ALA'])
 
     def test_omega_selection(self):
         osel = self.universe.s4AKE.r8.omega_selection()
         assert_equal(osel.names, ['CA', 'C', 'N', 'CA'])
-        assert_equal(osel.resids, [8, 9])
-        assert_equal(osel.resnames, ['ALA', 'PRO'])
+        assert_equal(osel.residues.resids, [8, 9])
+        assert_equal(osel.residues.resnames, ['ALA', 'PRO'])
 
     def test_chi1_selection(self):
         sel = self.universe.s4AKE.r13.chi1_selection()  # LYS
         assert_equal(sel.names, ['N', 'CA', 'CB', 'CG'])
-        assert_equal(sel.resids, [13])
-        assert_equal(sel.resnames, ['LYS'])
+        assert_equal(sel.residues.resids, [13])
+        assert_equal(sel.residues.resnames, ['LYS'])
 
     # Test failed selections of phi/psi/omega/chi1
     def test_phi_sel_fail(self):
@@ -692,10 +698,10 @@ class TestAtomGroup(TestCase):
             return self.universe.atoms[:2].set_forces([0.2])
         assert_raises(NoDataError, set_for)
 
-    def test_set_resid(self):
+    def test_set_resids(self):
         ag = self.universe.select_atoms("bynum 12:42")
         resid = 999
-        ag.set_resid(resid)
+        ag.set_resids(resid)
         # check individual atoms
         assert_equal([a.resid for a in ag],
                      resid * numpy.ones(ag.n_atoms),
@@ -707,7 +713,7 @@ class TestAtomGroup(TestCase):
     def test_set_names(self):
         ag = self.universe.atoms[:2]
         names = ['One', 'Two']
-        ag.set_name(names)
+        ag.set_names(names)
         for a, b in zip(ag, names):
             assert_equal(a.name, b)
 
@@ -715,19 +721,19 @@ class TestAtomGroup(TestCase):
         """test_set_resid: set AtomGroup resids on a per-atom basis"""
         ag = self.universe.select_atoms("bynum 12:42")
         resids = numpy.array([a.resid for a in ag]) + 1000
-        ag.set_resid(resids)
+        ag.set_resids(resids)
         # check individual atoms
         assert_equal([a.resid for a in ag], resids,
                      err_msg="failed to set_resid atoms 12:42 to resids {0}".format(resids))
         # check residues
-        assert_equal(ag.resids, numpy.unique(resids),
+        assert_equal(ag.residues.resids, numpy.unique(resids),
                      err_msg="failed to set_resid of residues belonging to atoms 12:42 to same resid")
 
     def test_merge_residues(self):
         ag = self.universe.select_atoms("resid 12:14")
         nres_old = self.universe.atoms.n_residues
         natoms_old = ag.n_atoms
-        ag.set_resid(12)  # merge all into one with resid 12
+        ag.set_resids(12)  # merge all into one with resid 12
         nres_new = self.universe.atoms.n_residues
         r_merged = self.universe.select_atoms("resid 12:14").residues
         natoms_new = self.universe.select_atoms("resid 12").n_atoms
@@ -736,26 +742,26 @@ class TestAtomGroup(TestCase):
                      err_msg="set_resid failed to merge residues: merged = {0}".format(r_merged))
         assert_equal(natoms_new, natoms_old, err_msg="set_resid lost atoms on merge".format(r_merged))
 
-    def test_set_mass(self):
+    def test_set_masses(self):
         ag = self.universe.select_atoms("bynum 12:42 and name H*")
         mass = 2.0
-        ag.set_mass(mass)
+        ag.set_masses(mass)
         # check individual atoms
         assert_equal([a.mass for a in ag],
                      mass * numpy.ones(ag.n_atoms),
                      err_msg="failed to set_mass H* atoms in resid 12:42 to {0}".format(mass))
 
-    def test_set_segid(self):
+    def test_set_segids(self):
         u = self.universe
-        u.select_atoms("(resid 1-29 or resid 60-121 or resid 160-214)").set_segid("CORE")
-        u.select_atoms("resid 122-159").set_segid("LID")
-        u.select_atoms("resid 30-59").set_segid("NMP")
-        assert_equal(u.atoms.segids, ["CORE", "NMP", "CORE", "LID", "CORE"],
+        u.select_atoms("(resid 1-29 or resid 60-121 or resid 160-214)").set_segids("CORE")
+        u.select_atoms("resid 122-159").set_segids("LID")
+        u.select_atoms("resid 30-59").set_segids("NMP")
+        assert_equal(u.segments.segids, ["CORE", "NMP", "CORE", "LID", "CORE"],
                      err_msg="failed to change segids = {0}".format(u.atoms.segids))
 
     def test_wronglen_set(self):
         """Give the setter function a list of wrong length"""
-        assert_raises(ValueError, self.ag.set_mass, [0.1, 0.2])
+        assert_raises(ValueError, self.ag.set_masses, [0.1, 0.2])
 
     def test_split_atoms(self):
         ag = self.universe.select_atoms("resid 1:50 and not resname LYS and (name CA or name CB)")
@@ -770,8 +776,8 @@ class TestAtomGroup(TestCase):
     def test_split_residues(self):
         ag = self.universe.select_atoms("resid 1:50 and not resname LYS and (name CA or name CB)")
         sg = ag.split("residue")
-        assert_equal(len(sg), len(ag.resids))
-        for g, ref_resname in itertools.izip(sg, ag.resnames):
+        assert_equal(len(sg), len(ag.residues.resids))
+        for g, ref_resname in itertools.izip(sg, ag.residues.resnames):
             if ref_resname == "GLY":
                 assert_equal(len(g), 1)
             else:
@@ -782,8 +788,8 @@ class TestAtomGroup(TestCase):
     def test_split_segments(self):
         ag = self.universe.select_atoms("resid 1:50 and not resname LYS and (name CA or name CB)")
         sg = ag.split("segment")
-        assert_equal(len(sg), len(ag.segids))
-        for g, ref_segname in itertools.izip(sg, ag.segids):
+        assert_equal(len(sg), len(ag.segments.segids))
+        for g, ref_segname in itertools.izip(sg, ag.segments.segids):
             for atom in g:
                 assert_equal(atom.segid, ref_segname)
 
@@ -793,6 +799,7 @@ class TestAtomGroup(TestCase):
         def access_nonexistent_instantselector():
             self.universe.atoms.NO_SUCH_ATOM
         assert_raises(AttributeError, access_nonexistent_instantselector)
+
 
 class TestAtomGroupNoTop(TestCase):
     def setUp(self):
@@ -1032,14 +1039,23 @@ class TestResidueGroup(TestCase):
     def test_n_residues(self):
         assert_equal(self.rg.n_residues, 214)
 
+    def test_resids_dim(self):
+        assert_equal(len(self.rg.resids), len(self.rg))
+
+    def test_resnums_dim(self):
+        assert_equal(len(self.rg.resnums), len(self.rg))
+
+    def test_segids_dim(self):
+        assert_equal(len(self.rg.segids), len(self.rg))
+
     def test_len(self):
         """testing that len(residuegroup) == residuegroup.n_residues"""
         assert_equal(len(self.rg), self.rg.n_residues, "len and n_residues disagree")
 
-    def test_set_resid(self):
+    def test_set_resids(self):
         rg = self.universe.select_atoms("bynum 12:42").residues
         resid = 999
-        rg.set_resid(resid)
+        rg.set_resids(resid)
         # check individual atoms
         assert_equal([a.resid for a in rg.atoms],
                      resid * numpy.ones(rg.n_atoms),
@@ -1052,7 +1068,7 @@ class TestResidueGroup(TestCase):
         """test_set_resid: set ResidueGroup resids on a per-residue basis"""
         rg = self.universe.select_atoms("resid 10:18").residues
         resids = numpy.array(rg.resids) + 1000
-        rg.set_resid(resids)
+        rg.set_resids(resids)
         # check individual atoms
         for r, resid in itertools.izip(rg, resids):
             assert_equal([a.resid for a in r.atoms],
@@ -1069,7 +1085,7 @@ class TestResidueGroup(TestCase):
     def test_set_resids_updates_self(self):
         rg = self.universe.select_atoms("resid 10:18").residues
         resids = numpy.array(rg.resids) + 1000
-        rg.set_resid(resids)
+        rg.set_resids(resids)
         #rgnew = self.universe.select_atoms("resid 1000:1008").residues
         assert_equal(rg.resids, numpy.unique(resids),
                      err_msg="old selection was not changed in place after set_resid")
@@ -1077,7 +1093,7 @@ class TestResidueGroup(TestCase):
     def test_set_resnum_single(self):
         rg = self.universe.residues[:3]
         new = 22
-        rg.set_resnum(new)
+        rg.set_resnums(new)
 
         assert_equal(all(rg.resnums == new), True)
         for r in rg:
@@ -1086,7 +1102,7 @@ class TestResidueGroup(TestCase):
     def test_set_resnum_many(self):
         rg = self.universe.residues[:3]
         new = [22, 23, 24]
-        rg.set_resnum(new)
+        rg.set_resnums(new)
 
         assert_equal(all(rg.resnums == new), True)
         for r, v in zip(rg, new):
@@ -1096,13 +1112,13 @@ class TestResidueGroup(TestCase):
         rg = self.universe.residues[:3]
         new = [22, 23, 24, 25]
 
-        assert_raises(ValueError, rg.set_resnum, new)
+        assert_raises(ValueError, rg.set_resnums, new)
 
     def test_set_resname_single(self):
         rg = self.universe.residues[:3]
         new = 'newname'
 
-        rg.set_resname(new)
+        rg.set_resnames(new)
         assert_equal(all(rg.resnames == new), True)
         for r in rg:
             assert_equal(r.name, new)
@@ -1110,7 +1126,7 @@ class TestResidueGroup(TestCase):
     def test_set_resname_many(self):
         rg = self.universe.residues[:3]
         new = ['a', 'b', 'c']
-        rg.set_resname(new)
+        rg.set_resnames(new)
 
         assert_equal(all(rg.resnames == new), True)
         for r, v in zip(rg, new):
@@ -1120,13 +1136,13 @@ class TestResidueGroup(TestCase):
         rg = self.universe.residues[:3]
         new = ['a', 'b', 'c', 'd']
 
-        assert_raises(ValueError, rg.set_resname, new)
+        assert_raises(ValueError, rg.set_resnames, new)
 
     def test_merge_residues(self):
         rg = self.universe.select_atoms("resid 12:14").residues
         nres_old = self.universe.atoms.n_residues
         natoms_old = rg.n_atoms
-        rg.set_resid(12)  # merge all into one with resid 12
+        rg.set_resids(12)  # merge all into one with resid 12
         nres_new = self.universe.atoms.n_residues
         r_merged = self.universe.select_atoms("resid 12:14").residues
         natoms_new = self.universe.select_atoms("resid 12").n_atoms
@@ -1139,10 +1155,10 @@ class TestResidueGroup(TestCase):
                      err_msg="Universe.residues and Universe.atoms.n_residues do not agree after residue "
                              "merge.")
 
-    def test_set_mass(self):
+    def test_set_masses(self):
         rg = self.universe.select_atoms("bynum 12:42 and name H*").residues
         mass = 2.0
-        rg.set_mass(mass)
+        rg.set_masses(mass)
         # check individual atoms
         assert_equal([a.mass for a in rg.atoms],
                      mass * numpy.ones(rg.n_atoms),
@@ -1152,9 +1168,9 @@ class TestResidueGroup(TestCase):
 class TestSegment(TestCase):
     def setUp(self):
         self.universe = MDAnalysis.Universe(PSF, DCD)
-        self.universe.residues[:100].set_segid("A")  # make up some segments
-        self.universe.residues[100:150].set_segid("B")
-        self.universe.residues[150:].set_segid("C")
+        self.universe.residues[:100].set_segids("A")  # make up some segments
+        self.universe.residues[100:150].set_segids("B")
+        self.universe.residues[150:].set_segids("C")
         self.sB = self.universe.segments[1]
 
     def test_type(self):
@@ -1206,49 +1222,58 @@ class TestSegmentGroup(TestCase):
     def test_n_residues(self):
         assert_equal(self.g.n_residues, 214)
 
-    def test_set_resid(self):
+    def test_resids_dim(self):
+        assert_equal(len(self.g.resids), len(self.g.residues))
+
+    def test_resnums_dim(self):
+        assert_equal(len(self.g.resnums), len(self.g.residues))
+
+    def test_segids_dim(self):
+        assert_equal(len(self.g.segids), len(self.g))
+
+    def test_set_resids(self):
         g = self.universe.select_atoms("bynum 12:42").segments
         resid = 999
-        g.set_resid(resid)
+        g.set_resids(resid)
         # check individual atoms
         assert_equal([a.resid for a in g.atoms],
                      resid * numpy.ones(g.n_atoms),
                      err_msg="failed to set_resid for segment to same resid")
         # check residues
-        assert_equal(g.resids, resid * numpy.ones(g.n_residues),
+        assert_equal(g.residues.resids, resid * numpy.ones(g.n_residues),
                      err_msg="failed to set_resid of segments belonging to atoms 12:42 to same resid")
 
     def test_set_resids(self):
         g = self.universe.select_atoms("resid 10:18").segments
         resid = 999
-        g.set_resid(resid * numpy.ones(len(g)))
+        g.set_resids(resid * numpy.ones(len(g)))
         # note: all is now one residue... not meaningful but it is the correct behaviour
-        assert_equal(g.atoms.resids, [resid],
+        assert_equal(g.resids, [resid],
                      err_msg="failed to set_resid  in Segment {0}".format(g))
 
-    def test_set_segid(self):
+    def test_set_segids(self):
         s = self.universe.select_atoms('all').segments
-        s.set_segid(['ADK'])
+        s.set_segids(['ADK'])
         assert_equal(self.universe.segments.segids, ['ADK'],
                      err_msg="failed to set_segid on segments")
 
     def test_set_segid_updates_self(self):
         g = self.universe.select_atoms("resid 10:18").segments
-        g.set_segid('ADK')
+        g.set_segids('ADK')
         assert_equal(g.segids, ['ADK'],
                      err_msg="old selection was not changed in place after set_segid")
 
-    def test_set_mass(self):
+    def test_set_masses(self):
         g = self.universe.select_atoms("bynum 12:42 and name H*").segments
         mass = 2.0
-        g.set_mass(mass)
+        g.set_masses(mass)
         # check individual atoms
         assert_equal([a.mass for a in g.atoms],
                      mass * numpy.ones(g.n_atoms),
                      err_msg="failed to set_mass in segment of  H* atoms in resid 12:42 to {0}".format(mass))
 
     def test_set_segid_ValueError(self):
-        assert_raises(ValueError, self.g.set_resid, [1, 2, 3, 4])
+        assert_raises(ValueError, self.g.set_resids, [1, 2, 3, 4])
 
 
 class TestAtomGroupVelocities(TestCase):
@@ -1313,6 +1338,7 @@ def test_empty_AtomGroup():
     """Test that an empty AtomGroup can be constructed (Issue 12)"""
     ag = MDAnalysis.core.AtomGroup.AtomGroup([])
     assert_equal(len(ag), 0)
+
 
 class _WriteAtoms(TestCase):
     """Set up the standard AdK system in implicit solvent."""
@@ -1386,6 +1412,7 @@ class _WriteAtoms(TestCase):
         assert_equal(len(u2.atoms), len(U.atoms), "written 4AKE universe does not match original universe in size")
         assert_almost_equal(u2.atoms.coordinates(), U.atoms.coordinates(), self.precision,
                             err_msg="written universe 4AKE coordinates do not agree with original")
+
 
 class TestWritePDB(_WriteAtoms):
     ext = "pdb"
@@ -1508,6 +1535,7 @@ class TestUniverse(TestCase):
         box = numpy.array([10, 11, 12, 90, 90, 90])
         u.dimensions = numpy.array([10, 11, 12, 90, 90, 90])
         assert_allclose(u.dimensions, box)
+
 
 class TestPBCFlag(TestCase):
     def setUp(self):
@@ -1764,6 +1792,7 @@ class TestUnorderedResidues(TestCase):
     def test_build_residues(self):
         assert_equal(len(self.u.residues), 35)
 
+
 class TestCustomReaders(TestCase):
     """
     Can pass a reader as kwarg on Universe creation
@@ -1798,6 +1827,7 @@ class TestCustomReaders(TestCase):
         u = MDAnalysis.Universe(TRZ_psf, TRZ, format=MDAnalysis.coordinates.TRZ.TRZReader,
                                 topology_format=MDAnalysis.topology.PSFParser.PSFParser)
         assert_equal(len(u.atoms), 8184)
+
 
 class TestWrap(TestCase):
     def setUp(self):
@@ -2028,14 +2058,16 @@ class TestAtomGroupProperties(object):
         ag = master[idx]
 
         for att, atts, att_type, ag_set in (
-                ('name', 'names', 'string', ag.set_name),
-                ('type', 'types', 'string', ag.set_type),
-                ('altLoc', 'altLocs', 'string', ag.set_altLoc),
-                ('serial', 'serials', 'int', ag.set_serial),
-                ('charge', 'charges', 'float', ag.set_charge),
-                ('mass', 'masses', 'float', ag.set_mass),
-                ('radius', 'radii', 'float', ag.set_radius),
-                ('bfactor', 'bfactors', 'float', ag.set_bfactor)
+                ('name', 'names', 'string', ag.set_names),
+                ('resid', 'resids', 'int', ag.set_resids),
+                ('segid', 'segids', 'string', ag.set_segids),
+                ('type', 'types', 'string', ag.set_types),
+                ('altLoc', 'altLocs', 'string', ag.set_altLocs),
+                ('serial', 'serials', 'int', ag.set_serials),
+                ('charge', 'charges', 'float', ag.set_charges),
+                ('mass', 'masses', 'float', ag.set_masses),
+                ('radius', 'radii', 'float', ag.set_radii),
+                ('bfactor', 'bfactors', 'float', ag.set_bfactors)
         ):
             vals = self.get_new(att_type)
             yield self._check_plural, att, atts

--- a/testsuite/MDAnalysisTests/test_atomselections.py
+++ b/testsuite/MDAnalysisTests/test_atomselections.py
@@ -51,39 +51,39 @@ class TestSelectionsCHARMM(TestCase):
     def test_resid_single(self):
         sel = self.universe.select_atoms('resid 100')
         assert_equal(sel.n_atoms, 7)
-        assert_equal(sel.resnames, ['GLY'])
+        assert_equal(sel.residues.resnames, ['GLY'])
 
     def test_resid_range(self):
         sel = self.universe.select_atoms('resid 100:105')
         assert_equal(sel.n_atoms, 89)
-        assert_equal(sel.resnames, ['GLY', 'ILE', 'ASN', 'VAL', 'ASP', 'TYR'])
+        assert_equal(sel.residues.resnames, ['GLY', 'ILE', 'ASN', 'VAL', 'ASP', 'TYR'])
 
     def test_selgroup(self):
         sel = self.universe.select_atoms('not resid 100')
         sel2 = self.universe.select_atoms('not group notr100', notr100=sel)
         assert_equal(sel2.n_atoms, 7)
-        assert_equal(sel2.resnames, ['GLY'])
+        assert_equal(sel2.residues.resnames, ['GLY'])
 
     def test_fullselgroup(self):
         sel1 = self.universe.select_atoms('resid 101')
         sel2 = self.universe.select_atoms('resid 100')
         sel3 = sel1.select_atoms('fullgroup r100', r100=sel2)
         assert_equal(sel2.n_atoms, 7)
-        assert_equal(sel2.resnames, ['GLY'])
+        assert_equal(sel2.residues.resnames, ['GLY'])
 
     # resnum selections are boring here because we haven't really a mechanism yet
     # to assign the canonical PDB resnums
     def test_resnum_single(self):
         sel = self.universe.select_atoms('resnum 100')
         assert_equal(sel.n_atoms, 7)
-        assert_equal(sel.resids, [100])
-        assert_equal(sel.resnames, ['GLY'])
+        assert_equal(sel.residues.resids, [100])
+        assert_equal(sel.residues.resnames, ['GLY'])
 
     def test_resnum_range(self):
         sel = self.universe.select_atoms('resnum 100:105')
         assert_equal(sel.n_atoms, 89)
-        assert_equal(sel.resids, range(100, 106))
-        assert_equal(sel.resnames, ['GLY', 'ILE', 'ASN', 'VAL', 'ASP', 'TYR'])
+        assert_equal(sel.residues.resids, range(100, 106))
+        assert_equal(sel.residues.resnames, ['GLY', 'ILE', 'ASN', 'VAL', 'ASP', 'TYR'])
 
     def test_resname(self):
         sel = self.universe.select_atoms('resname LEU')
@@ -171,31 +171,31 @@ class TestSelectionsCHARMM(TestCase):
         target_resids = array([ 7, 8, 10, 11, 12, 14, 17, 25, 32, 37, 38, 42, 46,
                                49, 55, 56, 66, 73, 80, 85, 93, 95, 99, 100, 122, 127,
                               130, 144, 150, 176, 180, 186, 188, 189, 194, 198, 203, 207, 214])
-        assert_array_equal(sel.resids, target_resids, "Found wrong residues with same resname as resids 10 or 11")
+        assert_array_equal(sel.residues.resids, target_resids, "Found wrong residues with same resname as resids 10 or 11")
 
     def test_same_segment(self):
         """Test the 'same ... as' construct (Issue 217)"""
-        self.universe.residues[:100].set_segid("A")  # make up some segments
-        self.universe.residues[100:150].set_segid("B")
-        self.universe.residues[150:].set_segid("C")
+        self.universe.residues[:100].set_segids("A")  # make up some segments
+        self.universe.residues[100:150].set_segids("B")
+        self.universe.residues[150:].set_segids("C")
 
         target_resids = arange(100)+1 
         sel = self.universe.select_atoms("same segment as resid 10")
         assert_equal(len(sel), 1520, "Found a wrong number of atoms in the same segment of resid 10")
-        assert_array_equal(sel.resids, target_resids, "Found wrong residues in the same segment of resid 10")
+        assert_array_equal(sel.residues.resids, target_resids, "Found wrong residues in the same segment of resid 10")
 
         target_resids = arange(100,150)+1 
         sel = self.universe.select_atoms("same segment as resid 110")
         assert_equal(len(sel), 797, "Found a wrong number of atoms in the same segment of resid 110")
-        assert_array_equal(sel.resids, target_resids, "Found wrong residues in the same segment of resid 110")
+        assert_array_equal(sel.residues.resids, target_resids, "Found wrong residues in the same segment of resid 110")
 
         target_resids = arange(150,self.universe.atoms.n_residues)+1
         sel = self.universe.select_atoms("same segment as resid 160")
         assert_equal(len(sel), 1024, "Found a wrong number of atoms in the same segment of resid 160")
-        assert_array_equal(sel.resids, target_resids, "Found wrong residues in the same segment of resid 160")
+        assert_array_equal(sel.residues.resids, target_resids, "Found wrong residues in the same segment of resid 160")
 
         #cleanup
-        self.universe.residues.set_segid("4AKE")
+        self.universe.residues.set_segids("4AKE")
 
 
 
@@ -251,7 +251,7 @@ class TestSelectionsAMBER(TestCase):
     def test_resid_single(self):
         sel = self.universe.select_atoms('resid 3')
         assert_equal(sel.n_atoms, 6)
-        assert_equal(sel.resnames, ['NME'])
+        assert_equal(sel.residues.resnames, ['NME'])
 
     def test_type(self):
         sel = self.universe.select_atoms('type 1')
@@ -276,7 +276,7 @@ class TestSelectionsNAMD(TestCase):
     def test_resid_single(self):
         sel = self.universe.select_atoms('resid 12')
         assert_equal(sel.n_atoms, 26)
-        assert_equal(sel.resnames, ['HAO'])
+        assert_equal(sel.residues.resnames, ['HAO'])
 
     def test_type(self):
         sel = self.universe.select_atoms('type H')
@@ -305,13 +305,16 @@ class TestSelectionsGRO(TestCase):
         assert_equal(len(sel), 23853)
         sel = self.universe.select_atoms('type S')
         assert_equal(len(sel), 7)
-        assert_equal(sel.resnames, self.universe.select_atoms("resname CYS or resname MET").resnames)
+        assert_equal(
+                sel.residues.resnames,
+                self.universe.select_atoms(
+                    "resname CYS or resname MET").residues.resnames)
 
     @dec.slow
     def test_resid_single(self):
         sel = self.universe.select_atoms('resid 100')
         assert_equal(sel.n_atoms, 7)
-        assert_equal(sel.resnames, ['GLY'])
+        assert_equal(sel.residues.resnames, ['GLY'])
 
     @dec.slow
     def test_atom(self):
@@ -361,6 +364,7 @@ class TestSelectionsXTC(TestCase):
             assert_equal(sel._atoms, self.universe.atoms[0].fragment._atoms, "Found a different set of atoms when using the 'same fragment as' construct vs. the .fragment prperty")
         except MDAnalysis.NoDataError:
             assert_equal(True, False)
+
 
 class TestSelectionsNucleicAcids(TestCase):
     def setUp(self):

--- a/testsuite/MDAnalysisTests/test_coordinates.py
+++ b/testsuite/MDAnalysisTests/test_coordinates.py
@@ -1352,7 +1352,7 @@ class TestPQRWriter(TestCase, RefAdKSmall):
                             err_msg="Writing PQR file with PQRWriter does not reproduce original radii")
 
     def test_write_withChainID(self):
-        self.universe.atoms.set_segid('A')
+        self.universe.atoms.set_segids('A')
         assert_equal(self.universe.segments.segids[0], 'A')  # sanity check
         self.universe.atoms.write(self.outfile)
         u = mda.Universe(self.outfile)
@@ -3029,11 +3029,13 @@ class _DLPConfig(object):
         ref = np.array([-1979.558687, 739.7961625, 1027.996603])
         assert_allclose(self.ts._forces[0], ref)
 
+
 class TestConfigReader(_DLPConfig):
     f = DLP_CONFIG
 
     def test_read(self):
         assert self.rd.title == "DL_POLY: Potassium Chloride Test Case"
+
 
 class TestConfigOrder(_DLPConfig):
     f = DLP_CONFIG_order
@@ -3049,6 +3051,7 @@ class TestConfigMinimal(_DLPConfig):
 
     def test_forces(self):
         assert_raises(AttributeError, getattr, self.ts, "_forces")
+
 
 class _DLPConfig2(object):
     def setUp(self):
@@ -3076,6 +3079,7 @@ class _DLPConfig2(object):
     def test_number(self):
         ref = [0, 1, 2]
         assert_equal([a.index for a in self.u.atoms], ref)
+
 
 class TestConfigReader2(_DLPConfig2):
     f = DLP_CONFIG_order
@@ -3148,6 +3152,7 @@ class _DLHistory(object):
         for ts, r in itertools.izip(self.u.trajectory, [ref1, ref2, ref3]):
             assert_allclose(ts._unitcell, r)
 
+
 class TestDLPolyHistory(_DLHistory):
     f = DLP_HISTORY
 
@@ -3165,6 +3170,7 @@ class TestDLPolyHistoryMinimal(_DLHistory):
 
     def test_unitcell(self):
         pass
+
 
 class TestIncompletePDB(object):
     """Tests for Issue #396

--- a/testsuite/MDAnalysisTests/test_meta.py
+++ b/testsuite/MDAnalysisTests/test_meta.py
@@ -28,11 +28,13 @@ def test_import():
         raise AssertionError('Failed to import module MDAnalysis. Install MDAnalysis'
                 'first to run the tests, e.g. "pip install mdanalysis"')
 
+
 def test_matching_versions():
     import MDAnalysis.version
     assert_(MDAnalysis.version.__version__ == MDAnalysisTests.__version__,
             "MDAnalysis release {0} must be installed to have meaningful tests, not {1}".format(
             MDAnalysisTests.__version__, MDAnalysis.__version__))
+
 
 def test_version_format(version=None):
     if version is None:
@@ -42,6 +44,7 @@ def test_version_format(version=None):
     m = re.match('(?P<MAJOR>\d+)\.(?P<MINOR>\d+)\.(?P<PATCH>\d+)(-(?P<suffix>\w+))?$',
                  version)
     assert_(m, "version {0} does not match the MAJOR.MINOR.PATCH(-suffix) format".format(version))
+
 
 def test_version_at_packagelevel():
     import MDAnalysis

--- a/testsuite/MDAnalysisTests/test_mol2.py
+++ b/testsuite/MDAnalysisTests/test_mol2.py
@@ -69,6 +69,7 @@ class TestMol2(TestCase):
         #self.assertEqual("The mol2 block (BrokenMolecule.mol2:0) has no atoms" in context.exception.message,
         # True)
 
+
 class TestMol2_traj(TestCase):
     def setUp(self):
         self.universe = Universe(mol2_molecules)
@@ -107,4 +108,3 @@ class TestMol2_traj(TestCase):
 
     def test_n_frames(self):
         assert_equal(self.universe.trajectory.n_frames, 200, "wrong number of frames in traj")
-

--- a/testsuite/MDAnalysisTests/test_parallel.py
+++ b/testsuite/MDAnalysisTests/test_parallel.py
@@ -19,6 +19,7 @@ from MDAnalysis.lib.distances import distance_array as distance_array_reference
 import numpy as np
 from numpy.testing import *
 
+
 try:
     from numpy.testing import assert_allclose
 except ImportError:

--- a/testsuite/MDAnalysisTests/test_persistence.py
+++ b/testsuite/MDAnalysisTests/test_persistence.py
@@ -103,6 +103,7 @@ class TestAtomGroupPickle(TestCase):
         assert_array_equal(self.ag_n.indices, newag.indices)
         assert_(newag.universe is self.universe, "Unpickled AtomGroup on wrong Universe.")
 
+
 class TestEmptyAtomGroupPickle(TestCase):
     # This comes in a class just to get memleak testing
     def test_pickle_unpickle_empty(self):
@@ -111,6 +112,7 @@ class TestEmptyAtomGroupPickle(TestCase):
         pickle_str = cPickle.dumps(ag, protocol=cPickle.HIGHEST_PROTOCOL)
         newag = cPickle.loads(pickle_str)
         assert_equal(len(newag), 0)
+
 
 class _GromacsReader_offsets(TestCase):
     # This base class assumes same lengths and dt for XTC and TRR test cases!
@@ -312,8 +314,8 @@ class TestXTCReader_offsets(_GromacsReader_offsets):
     ref_offsets = numpy.array([0,  165188,  330364,  495520,  660708,  825872,  991044, 1156212,
                             1321384, 1486544])
 
+
 class TestTRRReader_offsets(_GromacsReader_offsets):
     filename = TRR
     ref_offsets = numpy.array([0,  1144464,  2288928,  3433392,  4577856,  5722320,
                        6866784,  8011248,  9155712, 10300176])
-

--- a/testsuite/MDAnalysisTests/test_reader_api.py
+++ b/testsuite/MDAnalysisTests/test_reader_api.py
@@ -115,7 +115,8 @@ class _Multi(object):
     n_atoms = 10
     readerclass = AmazingMultiFrameReader
     reference = [i for i in range(10)]
-    
+   
+
 class TestMultiFrameReader(_Multi, _TestReader):
     def _check_slice(self, sl):
         """Compare the slice applied to trajectory, to slice of list"""
@@ -174,10 +175,12 @@ class TestMultiFrameReader(_Multi, _TestReader):
             return list(self.reader[1.2:2.5:0.1])
         assert_raises(TypeError, sl)
 
+
 class _Single(TestCase):
     n_frames = 1
     n_atoms = 10
     readerclass = AmazingReader
+
 
 class TestSingleFrameReader(_Single, _TestReader):
     def test_next(self):
@@ -225,4 +228,3 @@ class TestSingleFrameReader(_Single, _TestReader):
 
     def test_read_frame(self):
         assert_raises(IndexError, self.reader._read_frame, 1)
-

--- a/testsuite/MDAnalysisTests/test_selections.py
+++ b/testsuite/MDAnalysisTests/test_selections.py
@@ -57,13 +57,16 @@ class _SelectionWriter(TestCase):
         g.write_selection(self.namedfile, **kwargs)
         return g
 
+
 def ndx2array(lines):
     """Convert Gromacs NDX text file lines to integer array"""
     return np.array(" ".join(lines).replace("\n", "").split(), dtype=int)
 
+
 def lines2one(lines):
     """Join lines and squash all whitespace"""
     return " ".join(" ".join(lines).split())
+
 
 class TestSelectionWriter_Gromacs(_SelectionWriter):
     filename = "CA.ndx"
@@ -89,6 +92,7 @@ class TestSelectionWriter_Gromacs(_SelectionWriter):
     def test_writeselection_ndx(self):
         self._write_selection(name=self.ref_name)
         self._assert_indices()
+
 
 class TestSelectionWriter_Charmm(_SelectionWriter):
     filename = "CA.str"
@@ -170,6 +174,7 @@ def spt2array(line):
     """Get name of and convert Jmol SPT definition to integer array"""
     match = re.search(r'\@~(\w+) \(\{([\d\s]*)\}\)', line)
     return match.group(1), np.array(match.group(2).split(), dtype=int)
+
 
 class TestSelectionWriter_Jmol(_SelectionWriter):
     filename = "CA.spt"

--- a/testsuite/MDAnalysisTests/test_timestep_api.py
+++ b/testsuite/MDAnalysisTests/test_timestep_api.py
@@ -731,95 +731,114 @@ class TestCRD(_TestTimestepInterface):
         u = self.u = mda.Universe(XYZ_five, INPCRD)
         self.ts = u.trajectory.ts
 
+
 class TestDCD(_TestTimestepInterface):
     def setUp(self):
         u = self.u = mda.Universe(PSF, DCD)
         self.ts = u.trajectory.ts
+
 
 class TestDLPConfig(_TestTimestepInterface):
     def setUp(self):
         u = self.u = mda.Universe(DLP_CONFIG, format='CONFIG')
         self.ts = u.trajectory.ts
 
+
 class TestDLPHistory(_TestTimestepInterface):
     def setUp(self):
         u = self.u = mda.Universe(DLP_HISTORY, format='HISTORY')
         self.ts = u.trajectory.ts
+
 
 class TestDMS(_TestTimestepInterface):
     def setUp(self):
         u = self.u = mda.Universe(DMS)
         self.ts = u.trajectory.ts
 
+
 class TestGMS(_TestTimestepInterface):
     def setUp(self):
         u = self.u = mda.Universe(GMS_ASYMOPT, GMS_ASYMOPT, format='GMS', topology_format='GMS')
         self.ts = u.trajectory.ts
+
 
 class TestGRO(_TestTimestepInterface):
     def setUp(self):
         u = self.u = mda.Universe(GRO)
         self.ts = u.trajectory.ts
 
+
 class TestINPCRD(_TestTimestepInterface):
     def setUp(self):
         u = self.u = mda.Universe(XYZ_five, INPCRD)
         self.ts = u.trajectory.ts
+
 
 class TestLAMMPS(_TestTimestepInterface):
     def setUp(self):
         u = self.u = mda.Universe(LAMMPSdata)
         self.ts = u.trajectory.ts
 
+
 class TestLAMMPSDCD(_TestTimestepInterface):
     def setUp(self):
         u = self.u = mda.Universe(LAMMPSdata2,LAMMPSdcd2, format='LAMMPS', topology_format='DATA', timeunit='fs')
         self.ts = u.trajectory.ts
+
 
 class TestMOL2(_TestTimestepInterface):
     def setUp(self):
         u = self.u = mda.Universe(mol2_molecules)
         self.ts = u.trajectory.ts
 
+
 class TestPDB(_TestTimestepInterface):
     def setUp(self):
         u = self.u = mda.Universe(PDB_small)
         self.ts = u.trajectory.ts
+
 
 class TestPDBQT(_TestTimestepInterface):
     def setUp(self):
         u = self.u = mda.Universe(PDBQT_input)
         self.ts = u.trajectory.ts
 
+
 class TestPQR(_TestTimestepInterface):
     def setUp(self):
         u = self.u = mda.Universe(PQR)
         self.ts = u.trajectory.ts
+
 
 class TestTRJ(_TestTimestepInterface):
     def setUp(self):
         u = self.u = mda.Universe(PRM, TRJ)
         self.ts = u.trajectory.ts
 
+
 class TestNCDF(_TestTimestepInterface):
     def setUp(self):
         u = self.u = mda.Universe(PRMncdf, NCDF)
         self.ts = u.trajectory.ts
+
 
 class TestTRR(_TestTimestepInterface):
     def setUp(self):
         u = self.u = mda.Universe(GRO, TRR)
         self.ts = u.trajectory.ts
 
+
 class TestTRZ(_TestTimestepInterface):
     def setUp(self):
         u = self.u = mda.Universe(TRZ_psf, TRZ)
         self.ts = u.trajectory.ts
 
+
 class TestXTC(_TestTimestepInterface):
     def setUp(self):
         u = self.u = mda.Universe(GRO, XTC)
         self.ts = u.trajectory.ts
+
 
 class TestXYZ(_TestTimestepInterface):
     def setUp(self):

--- a/testsuite/MDAnalysisTests/test_topology.py
+++ b/testsuite/MDAnalysisTests/test_topology.py
@@ -242,7 +242,7 @@ class TestPSF_Issue121(TestCase):
         except IndexError:
             raise AssertionError("Issue 121 not fixed: cannot load PSF with empty SEGID")
         assert_equal(u.atoms.n_atoms, 98)
-        assert_equal(u.atoms.segids, ["SYSTEM"])
+        assert_equal(u.segments.segids, ["SYSTEM"])
 
 
 class TestPSF_bonds(TestCase):
@@ -1038,7 +1038,7 @@ class TestTopologyGuessers(TestCase):
 
     def test_guess_bonds_badtype(self):
         # rename my carbons and watch it get confused about missing types
-        self.u.select_atoms('type C').set_type('QQ')
+        self.u.select_atoms('type C').set_types('QQ')
         assert_raises(ValueError, guess_bonds, self.u.atoms, self.u.atoms.positions)
 
     def test_guess_bonds_withag(self):
@@ -1175,14 +1175,17 @@ class TestXYZTopology(RefXYZ, _TestTopology):
     def test_segments(self):
         assert_equal(len(self.universe.segments), 1)
 
+
 class RefGMSsym(object):
     topology = GMS_SYMOPT
     parser = MDAnalysis.topology.GMSParser.GMSParser
     ref_n_atoms = 4
     ref_numresidues = 1
 
+
 class TestGMS_withSymmetry(_TestTopology, RefGMSsym):
     """Testing GAMESS output file format"""
+
 
 class RefGMSasym(object):
     topology = GMS_ASYMSURF
@@ -1190,8 +1193,10 @@ class RefGMSasym(object):
     ref_n_atoms = 6
     ref_numresidues = 1
 
+
 class TestGMS_noSymmetry(_TestTopology, RefGMSasym):
     """Testing GAMESS output file format"""
+
 
 class _DLPolyParser(object):
     """Test of real data"""
@@ -1215,10 +1220,12 @@ class _DLPolyParser(object):
         assert_equal(atoms[0].name, 'K+')
         assert_equal(atoms[4].name, 'Cl-')
 
+
 class TestDLPolyConfigParser(_DLPolyParser):
     def setUp(self):
         self.p = MDAnalysis.topology.DLPolyParser.ConfigParser
         self.f = DLP_CONFIG
+
 
 class TestDLPolyHistoryParser(_DLPolyParser):
     def setUp(self):
@@ -1249,20 +1256,24 @@ class _DLPoly(object):
         assert_equal(atoms[1].name, 'B')
         assert_equal(atoms[2].name, 'A')
 
+
 class TestDLPolyConfigOrder(_DLPoly):
     def setUp(self):
         self.p = MDAnalysis.topology.DLPolyParser.ConfigParser
         self.f = DLP_CONFIG_order
+
 
 class TestDLPolyConfigMinimal(_DLPoly):
     def setUp(self):
         self.p = MDAnalysis.topology.DLPolyParser.ConfigParser
         self.f = DLP_CONFIG_minimal
 
+
 class TestDLPolyHistoryOrder(_DLPoly):
     def setUp(self):
         self.p = MDAnalysis.topology.DLPolyParser.HistoryParser
         self.f = DLP_HISTORY_order
+
 
 class TestDLPolyHistoryMinimal(_DLPoly):
     def setUp(self):


### PR DESCRIPTION
Fixes issue #385.

AtomGroups now return arrays of length equal to the AtomGroup when calling
properties like `resids`, `resnames`, and `resnums`. Likewise,
ResidueGroups return arrays of length equal to the ResidueGroup when
calling `segids`.

Adjustments were made to fix issues with stale ResidueGroup and
SegmentGroup cacheing in light of these changes, and these happned to
fix some lonstanding known errors in the tests. Not all cacheing issues
were solved; these will have to wait for the AtomGroup overhaul in the
next release cycle.

Changed property setters in AtomGroups with names like `set_<property>`
to use the plural form to directly match the names of the properties
they correspond to.

Also added two spaces between many test classes to improve readability.
Couldn't resist.