### PR TITLE
Fixed documentation for AtomGroup in light of 0.11.0 changes.

### DIFF
--- a/package/MDAnalysis/analysis/align.py
+++ b/package/MDAnalysis/analysis/align.py
@@ -69,15 +69,15 @@ two structures, using :func:`rmsd`::
 
    >>> ref = Universe(PDB_small)
    >>> mobile = Universe(PSF,DCD)
-   >>> rmsd(mobile.atoms.CA.coordinates(), ref.atoms.CA.coordinates())
+   >>> rmsd(mobile.atoms.CA.positions, ref.atoms.CA.positions)
    18.858259026820352
 
 Note that in this example translations have not been removed. In order
 to look at the pure rotation one needs to superimpose the centres of
 mass (or geometry) first:
 
-   >>> ref0 =  ref.atoms.CA.coordinates() - ref.atoms.CA.center_of_mass()
-   >>> mobile0 = mobile.atoms.CA.coordinates() - mobile.atoms.CA.center_of_mass()
+   >>> ref0 =  ref.atoms.CA.positions - ref.atoms.CA.center_of_mass()
+   >>> mobile0 = mobile.atoms.CA.positions - mobile.atoms.CA.center_of_mass()
    >>> rmsd(mobile0, ref0)
     6.8093965864717951
 
@@ -106,9 +106,9 @@ Common usage
 
 To **fit a single structure** with :func:`alignto`::
 
-  >>> ref = Universe(PSF, PDB_small)
-  >>> mobile = Universe(PSF, DCD)     # we use the first frame
-  >>> alignto(mobile, ref, select="protein and name CA", mass_weighted=True)
+   >>> ref = Universe(PSF, PDB_small)
+   >>> mobile = Universe(PSF, DCD)     # we use the first frame
+   >>> alignto(mobile, ref, select="protein and name CA", mass_weighted=True)
 
 This will change *all* coordinates in *mobile* so that the protein
 C-alpha atoms are optimally superimposed (translation and rotation).

--- a/package/MDAnalysis/core/AtomGroup.py
+++ b/package/MDAnalysis/core/AtomGroup.py
@@ -84,33 +84,36 @@ name with a command such as ::
 
 will typically work as expected. When working with collections such as
 :class:`AtomGroup` or :class:`ResidueGroup` it is generally better to use
-provided setter methods such as :meth:`AtomGroup.set_resname` or
-:meth:`ResidueGroup.set_resname`.
+properties such as :attr:`AtomGroup.resnames` or :attr:`ResidueGroup.resnames`
+to modify their items' attributes.
 
-There are two cases when it is very important to use the setters:
+There are two cases when it is very important to use these collective
+properties:
 
-* changing *resid*: :meth:`AtomGroup.set_resid` and :meth:`ResidueGroup.set_resid`
-* changing *segid*: :meth:`AtomGroup.set_segid` and :meth:`ResidueGroup.set_segid`
+* changing *resid*: :attr:`AtomGroup.resids` and :attr:`ResidueGroup.resids`
+* changing *segid*: :attr:`AtomGroup.segids` and :attr:`ResidueGroup.segids`
 
 Because residues are determined by the :attr:`Atom.resid` and segments by
-:attr:`Atom.segid`, the above methods take extra care to rebuild the list of
-segments and residues.
+:attr:`Atom.segid`, the above properties take extra care to rebuild the list of
+segments and residues. Alternatively, the same effect can be obtained using
+the corresponding setter method, e.g. :meth:`AtomGroup.set_resids`.
 
 .. Note::
 
-   :meth:`AtomGroup.set_resid`, :meth:`ResidueGroup.set_resid`,
-   :meth:`AtomGroup.set_segid`, :meth:`ResidueGroup.set_segid` can change the
-   topology: they can split or merge residues or segments.
+   Setting any of
+   :attr:`AtomGroup.resids`, :attr:`ResidueGroup.resids`,
+   :attr:`AtomGroup.segids`, :attr:`ResidueGroup.segids` 
+   can change the topology: they can split or merge residues or segments.
 
 Splitting/merging of residues is probably not very useful because no chemical
 rearrangements are carried out. Manipulating segments might be more useful in
 order to add additional structure to a :class:`Universe` and provide instant
 segment selectors for interactive work::
 
-  u.select_atoms("protein").set_segid("protein")
-  u.select_atoms("resname POPE or resname POPC").set_segid("lipids")
-  u.select_atoms("resname SOL").set_segid("water")
-  u.select_atoms("resname NA or resname CL").set_segid("ions")
+  u.select_atoms("protein").set_segids("protein")
+  u.select_atoms("resname POPE or resname POPC").set_segids("lipids")
+  u.select_atoms("resname SOL").set_segids("water")
+  u.select_atoms("resname NA or resname CL").set_segids("ions")
 
   u.protein.n_residues
   water_oxygens = u.water.OW
@@ -122,15 +125,15 @@ N-terminus. Let's say that the first residue is really residue 10. In order to
 store the canonical residue IDs ("resnum") one could the use ::
 
   protein = u.select_atoms("protein").residues
-  protein.set_resnum(protein.resnums + 9)
+  protein.set_resnums(protein.resnums + 9)
 
 One can then use ``protein.select("resnum 42")`` to select the residue that has
 the canonical residue id 42 (instead of ``resid 33``).
 
-One can also read the resids directly from  an original PDB file::
+One can also read the resids directly from an original PDB file::
 
   orig = MDAnalysis.Universe("2jln.pdb")
-  protein.set_resnum(orig.select_atoms("protein").resids)
+  protein.set_resnums(orig.select_atoms("protein").resids)
 
 
 Working with Topologies
@@ -171,11 +174,11 @@ For example::
      ('C', 'C', 'O'),
      ('H', 'C', 'O')]
 
-There is only C-C-H bonds and no H-C-C bonds.  Selection however is
+There are only C-C-H bonds and no H-C-C bonds.  Selection however is
 aware that sometimes types are reversed::
 
-    u.angles.select_bonds(('H', 'C', 'C'))  # note reversal of type
-    >>> <TopologyGroup containing 7365 Angles>
+    >>> u.angles.select_bonds(('H', 'C', 'C'))  # note reversal of type
+    <TopologyGroup containing 7365 Angles>
 
 TopologyGroups can be combined and indexed::
 
@@ -804,6 +807,10 @@ class AtomGroup(object):
        The ``bond``, ``angle``, ``dihedral`` and ``improper`` methods were removed and replaced
        with properties of the same name which return the corresponding object.
        Deprecated ``selectAtoms`` in favour of ``select_atoms``.
+       Setters are now plural to match property names.
+       Properties referring to residue (``resids``, ``resnames``, ``resnums``)
+       or segment [``segids``] properties now yield arrays of length equal to
+       ``n_atoms``
     """
     # for generalized __getitem__ __iter__ and __len__
     # (override _containername for ResidueGroup and SegmentGroup)

--- a/package/MDAnalysis/core/__init__.py
+++ b/package/MDAnalysis/core/__init__.py
@@ -41,7 +41,7 @@ A simple selection of all water oxygens within 4 A of the protein::
 calculation of simple properties. For more complicated analysis,
 obtain the coordinates as a numpy array ::
 
-  coords = water_shell.coordinates()
+  coords = water_shell.positions
 
 and write your own Python code.
 

--- a/package/doc/sphinx/source/documentation_pages/visualization_modules.rst
+++ b/package/doc/sphinx/source/documentation_pages/visualization_modules.rst
@@ -4,11 +4,14 @@
 Visualization modules
 *********************
 
-The MDAnalysis.visualization namespace contains code to carry out analyses which return data that is specifically-tailored for visualization.
+The MDAnalysis.visualization namespace contains code to carry out analyses
+which return data that is specifically-tailored for visualization.
 
-Please see the individual module documentation for additional references and citation information.
+Please see the individual module documentation for additional references and
+citation information.
 
-These modules are not imported by default; in order to use them one has to import them from :mod:`MDAnalysis.visualization`, for instance: ::
+These modules are not imported by default; in order to use them one has to
+import them from :mod:`MDAnalysis.visualization`, for instance: ::
 
     import MDAnalysis.visualization.streamlines
 


### PR DESCRIPTION
Updated AtomGroup docs to refer to properties for setters and to also
use the new (plural) setter names.