### PR TITLE
Fixes #434: trying to write empty AtomGroup gives clear message.

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -12,7 +12,7 @@ The rules for this file:
   * accompany each entry with github issue/PR number (Issue #xyz)
 
 ------------------------------------------------------------------------------
-??/??/?? kain88-de, richardjgowers
+??/??/?? kain88-de, richardjgowers, dotsdl
 
   * 0.11.1
 
@@ -28,6 +28,8 @@ Enhancements
   * XYZReader now supports frame indexing (Issue #428)
 
 Changes
+  * An AtomGroup with 0 atoms now yields an `IndexError` on call to
+    `AtomGroup.write` (Issue #434)
 
 Fixes
 

--- a/package/MDAnalysis/core/AtomGroup.py
+++ b/package/MDAnalysis/core/AtomGroup.py
@@ -2911,6 +2911,10 @@ class AtomGroup(object):
         import MDAnalysis.coordinates
         import MDAnalysis.selections
 
+        # check that AtomGroup actually has any atoms (Issue #434)
+        if len(self.atoms) == 0:
+            raise IndexError("Cannot write an AtomGroup with 0 atoms")
+
         trj = self.universe.trajectory  # unified trajectory API
         frame = trj.ts.frame
 

--- a/testsuite/MDAnalysisTests/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/test_atomgroup.py
@@ -1381,6 +1381,10 @@ class _WriteAtoms(TestCase):
         assert_array_almost_equal(self.universe.atoms.coordinates(), u2.atoms.coordinates(), self.precision,
                                   err_msg="atom coordinate mismatch between original and %s file" % self.ext)
 
+    def test_write_empty_atomgroup(self):
+        sel = self.universe.select_atoms('name doesntexist')
+        assert_raises(IndexError, sel.write, self.outfile)
+
     def test_write_selection(self):
         CA = self.universe.select_atoms('name CA')
         CA.write(self.outfile)


### PR DESCRIPTION
Fixes #434.

Also added an explicit test that writing an AtomGroup with no atoms
raises on IndexError.