### PR TITLE
Removed _topology_coordinates_readers dict from coordinates

### DIFF
--- a/package/MDAnalysis/coordinates/__init__.py
+++ b/package/MDAnalysis/coordinates/__init__.py
@@ -685,7 +685,6 @@ PDB). In theses cases, the kind of writer is selected with the
 (or the writer itself).
 
 .. autodata:: _trajectory_readers
-.. autodata:: _topology_coordinates_readers
 .. autodata:: _compressed_formats
 .. autodata:: _frame_writers
 .. autodata:: _trajectory_writers
@@ -747,24 +746,6 @@ _trajectory_readers = {
 
 #: formats of readers that can also handle gzip or bzip2 compressed files
 _compressed_formats = ['XYZ', 'TRJ', 'MDCRD', 'PQR', 'PDBQT']
-
-#: readers of files that contain both topology/atom data and coordinates
-#: (currently only the keys are used)
-_topology_coordinates_readers = {
-    'PDB': PDB.PrimitivePDBReader,  # FIXME: should be able to use BioPython PDBReader for topolgy if permissive=False!
-    'XPDB': PDB.ExtendedPDBReader,
-    'PDBQT': PDBQT.PDBQTReader,
-    'GRO': GRO.GROReader,
-    'CRD': CRD.CRDReader,
-    'CONFIG': DLPoly.ConfigReader,
-    'HISTORY': DLPoly.HistoryReader,
-    'PQR': PQR.PQRReader,
-    'DMS': DMS.DMSReader,
-    'MOL2': MOL2.MOL2Reader,
-    'DATA': LAMMPS.DATAReader,
-    'GMS': GMS.GMSReader,
-    'XYZ': XYZ.XYZReader,
-}
 
 #: frame writers: export to single frame formats such as PDB, gro, crd
 #: Signature::

--- a/package/MDAnalysis/core/AtomGroup.py
+++ b/package/MDAnalysis/core/AtomGroup.py
@@ -3755,7 +3755,8 @@ class Universe(object):
                 # or if file is known as a topology & coordinate file, use that
                 if fmt is None:
                     fmt = util.guess_format(self.filename)
-                if fmt in MDAnalysis.coordinates._topology_coordinates_readers:
+                if (fmt in MDAnalysis.coordinates._trajectory_readers
+                    and fmt in MDAnalysis.topology._topology_parsers):
                     coordinatefile = self.filename
             # Fix by SB: make sure coordinatefile is never an empty tuple
             if len(coordinatefile) == 0:


### PR DESCRIPTION
Previously this dict listed all formats that could act as both
coordinate and topology files.  A more logical way to do this check
is to instead just see if the format is in both the coordinate
and parser dicts.

This means if someone adds a Topology parser for a previously only
coordinate format, that it would get picked up automatically, rather
than having to declare it as being able to do both.

Vaguely related to #431