### PR TITLE
netCDF tests now skipped if library missing (closes #124)

### DIFF
--- a/testsuite/MDAnalysisTests/__init__.py
+++ b/testsuite/MDAnalysisTests/__init__.py
@@ -178,9 +178,7 @@ def executable_not_found(*args):
     return lambda: executable_not_found_runtime(*args)
 
 def module_not_found(module):
-    sys.stderr.write("Outer\n")
     def module_not_found_runtime(module):
-        sys.stderr.write("Inner\n")
         try:
             importlib.import_module(module)
         except ImportError:

--- a/testsuite/MDAnalysisTests/coordinates/test_netcdf.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_netcdf.py
@@ -5,7 +5,7 @@ from six.moves import zip
 
 from nose.plugins.attrib import attr
 from numpy.testing import (assert_equal, assert_array_almost_equal,
-                           assert_almost_equal, assert_raises)
+                           assert_almost_equal, assert_raises, dec)
 import tempdir
 from unittest import TestCase
 
@@ -14,8 +14,16 @@ from MDAnalysisTests.datafiles import (PRMncdf, NCDF, PFncdf_Top, PFncdf_Trj,
 from MDAnalysisTests.coordinates.test_trj import _TRJReaderTest
 from MDAnalysisTests.coordinates.reference import (RefVGV,)
 
+def netcdf_missing():
+    try:
+        import netCDF4
+    except ImportError:
+        return True
+    else:
+        return False
 
 class TestNCDFReader(_TRJReaderTest, RefVGV):
+    @dec.skipif(netcdf_missing(), "Test skipped because netCDF is not available.")
     def setUp(self):
         self.universe = mda.Universe(PRMncdf, NCDF)
         self.prec = 3
@@ -38,6 +46,7 @@ class TestNCDFReader2(TestCase):
     Contributed by Albert Solernou
     """
 
+    @dec.skipif(netcdf_missing(), "Test skipped because netCDF is not available.")
     def setUp(self):
         self.u = mda.Universe(PFncdf_Top, PFncdf_Trj)
         self.prec = 3
@@ -94,6 +103,7 @@ class TestNCDFReader2(TestCase):
 
 
 class TestNCDFWriter(TestCase, RefVGV):
+    @dec.skipif(netcdf_missing(), "Test skipped because netCDF is not available.")
     def setUp(self):
         self.universe = mda.Universe(PRMncdf, NCDF)
         self.prec = 6
@@ -211,6 +221,7 @@ class TestNCDFWriter(TestCase, RefVGV):
 class TestNCDFWriterVelsForces(TestCase):
     """Test writing NCDF trajectories with a mixture of options"""
 
+    @dec.skipif(netcdf_missing(), "Test skipped because netCDF is not available.")
     def setUp(self):
         self.tmpdir = tempdir.TempDir()
         self.outfile = self.tmpdir.name + '/ncdf-write-vels-force.ncdf'

--- a/testsuite/MDAnalysisTests/coordinates/test_netcdf.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_netcdf.py
@@ -8,22 +8,16 @@ from numpy.testing import (assert_equal, assert_array_almost_equal,
                            assert_almost_equal, assert_raises, dec)
 import tempdir
 from unittest import TestCase
+from MDAnalysisTests import module_not_found
 
 from MDAnalysisTests.datafiles import (PRMncdf, NCDF, PFncdf_Top, PFncdf_Trj,
                                        GRO, TRR, XYZ_mini)
 from MDAnalysisTests.coordinates.test_trj import _TRJReaderTest
 from MDAnalysisTests.coordinates.reference import (RefVGV,)
 
-def netcdf_missing():
-    try:
-        import netCDF4
-    except ImportError:
-        return True
-    else:
-        return False
 
 class TestNCDFReader(_TRJReaderTest, RefVGV):
-    @dec.skipif(netcdf_missing(), "Test skipped because netCDF is not available.")
+    @dec.skipif(module_not_found("netCDF4"), "Test skipped because netCDF is not available.")
     def setUp(self):
         self.universe = mda.Universe(PRMncdf, NCDF)
         self.prec = 3
@@ -46,7 +40,7 @@ class TestNCDFReader2(TestCase):
     Contributed by Albert Solernou
     """
 
-    @dec.skipif(netcdf_missing(), "Test skipped because netCDF is not available.")
+    @dec.skipif(module_not_found("netCDF4"), "Test skipped because netCDF is not available.")
     def setUp(self):
         self.u = mda.Universe(PFncdf_Top, PFncdf_Trj)
         self.prec = 3
@@ -103,7 +97,7 @@ class TestNCDFReader2(TestCase):
 
 
 class TestNCDFWriter(TestCase, RefVGV):
-    @dec.skipif(netcdf_missing(), "Test skipped because netCDF is not available.")
+    @dec.skipif(module_not_found("netCDF4"), "Test skipped because netCDF is not available.")
     def setUp(self):
         self.universe = mda.Universe(PRMncdf, NCDF)
         self.prec = 6
@@ -221,7 +215,7 @@ class TestNCDFWriter(TestCase, RefVGV):
 class TestNCDFWriterVelsForces(TestCase):
     """Test writing NCDF trajectories with a mixture of options"""
 
-    @dec.skipif(netcdf_missing(), "Test skipped because netCDF is not available.")
+    @dec.skipif(module_not_found("netCDF4"), "Test skipped because netCDF is not available.")
     def setUp(self):
         self.tmpdir = tempdir.TempDir()
         self.outfile = self.tmpdir.name + '/ncdf-write-vels-force.ncdf'

--- a/testsuite/MDAnalysisTests/coordinates/test_xdr.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_xdr.py
@@ -10,6 +10,7 @@ from numpy.testing import (assert_equal, assert_array_almost_equal, dec,
                            assert_array_equal)
 import tempdir
 from unittest import TestCase
+from MDAnalysisTests import module_not_found
 
 from MDAnalysisTests.datafiles import (PDB_sub_dry, PDB_sub_sol, TRR_sub_sol,
                                        TRR, XTC, GRO, PDB, CRD, PRMncdf, NCDF)
@@ -532,6 +533,7 @@ class _GromacsWriterIssue117(TestCase):
     ext = None
     prec = 5
 
+    @dec.skipif(module_not_found("netCDF4"), "Test skipped because netCDF is not available.")
     def setUp(self):
         self.universe = mda.Universe(PRMncdf, NCDF)
         self.tmpdir = tempdir.TempDir()

--- a/testsuite/MDAnalysisTests/test_analysis.py
+++ b/testsuite/MDAnalysisTests/test_analysis.py
@@ -37,7 +37,7 @@ import warnings
 import shutil
 
 from MDAnalysisTests.datafiles import PSF, DCD, DCD2, FASTA, PDB_helix, PDB_HOLE, XTC_HOLE, GRO, XTC, waterDCD, waterPSF, rmsfArray
-from MDAnalysisTests import executable_not_found_runtime
+from MDAnalysisTests import executable_not_found
 
 
 class TestContactMatrix(TestCase):
@@ -396,7 +396,7 @@ class TestAlignmentProcessing(TestCase):
         assert_equal(len(sel['mobile']), 30623, err_msg="selection string has unexpected length")
 
     @attr('issue')
-    @dec.skipif(executable_not_found_runtime("clustalw2"),
+    @dec.skipif(executable_not_found("clustalw2"),
                 msg="Test skipped because clustalw executable not found")
     def test_fasta2select_ClustalW(self):
         """test align.fasta2select() with calling ClustalW (Issue 113)"""
@@ -437,7 +437,7 @@ class TestHoleModule(TestCase):
     @attr('slow')
     @attr('issue')
     @dec.skipif(rlimits_missing, msg="Test skipped because platform does not allow setting rlimits")
-    @dec.skipif(executable_not_found_runtime("hole"), msg="Test skipped because HOLE not found")
+    @dec.skipif(executable_not_found("hole"), msg="Test skipped because HOLE not found")
     def test_hole_module_fd_closure(self):
         """Issue 129: ensure low level file descriptors to PDB files used by Hole program are properly closed"""
         # If Issue 129 isn't resolved, this function will produce an OSError on

--- a/testsuite/MDAnalysisTests/test_timestep_api.py
+++ b/testsuite/MDAnalysisTests/test_timestep_api.py
@@ -26,10 +26,11 @@ _TestTimestepInterface tests the Readers are correctly using Timesteps
 import itertools
 import numpy as np
 from numpy.testing import (TestCase, assert_raises, assert_equal, assert_allclose,
-                           assert_array_almost_equal, assert_)
+                           assert_array_almost_equal, assert_, dec)
 from nose.plugins.attrib import attr
 from nose.tools import assert_not_equal
 from MDAnalysisTests.plugins.knownfailure import knownfailure
+from MDAnalysisTests import module_not_found
 
 import MDAnalysis as mda
 from MDAnalysis.lib.mdamath import triclinic_vectors
@@ -817,6 +818,7 @@ class TestTRJ(_TestTimestepInterface):
 
 
 class TestNCDF(_TestTimestepInterface):
+    @dec.skipif(module_not_found("netCDF4"), "Test skipped because netCDF is not available.")
     def setUp(self):
         u = self.u = mda.Universe(PRMncdf, NCDF)
         self.ts = u.trajectory.ts


### PR DESCRIPTION
I think this simple approach covers it. @richardjgowers solution to decorate the `setUp` methods did the trick.

I guess in the future we might want to generalize the import-checking function into something like:
```python
def is_missing(module):
    import importlib
    try:
        importlib.import_module(module)
    except ImportError:
        return True
    else:
        return False
```
Right now I didn't want to muddle with python 2.6 compatibility, for which there's no `importlib`.