### PR TITLE
Fix ten2eleven

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -37,6 +37,8 @@ Fixes
   * Fixed analysis.density modules requiring the defunct `skip` attribute
     on trajectories. (Issue #489)
   * ten2eleven camelcase fixer now deals with centerOfMass (Issue #470)
+  * ten2eleven will now convert numatoms to n_atoms argument
+    for writer() functions (Issue #470)
 
 10/08/15
 

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -36,6 +36,7 @@ Fixes
   * Fixed unpickling errors due to lingering dead universes. (Issue #487)
   * Fixed analysis.density modules requiring the defunct `skip` attribute
     on trajectories. (Issue #489)
+  * ten2eleven camelcase fixer now deals with centerOfMass (Issue #470)
 
 10/08/15
 

--- a/package/MDAnalysis/migration/fixes/fix_camelcase.py
+++ b/package/MDAnalysis/migration/fixes/fix_camelcase.py
@@ -15,7 +15,7 @@ class FixCamelcase(BaseFix):
                 trailer< dot = '.' method=('totalMass'|'totalCharge'|'centerOfGeometry'|
                                          'radiusOfGyration'|'shapeParameter'|'momentOfInertia'|
                                          'principalAxes'|'packIntoBox'|'asUniverse'|
-                                         'applyPBC' | 'align_principalAxis')>
+                                         'applyPBC' | 'align_principalAxis' | 'centerOfMass')>
     """
 
     def transform(self, node, results):

--- a/package/MDAnalysis/migration/fixes/fix_writer.py
+++ b/package/MDAnalysis/migration/fixes/fix_writer.py
@@ -1,0 +1,17 @@
+'''
+run with: python ten2eleven.py -f writer test_dummy_old_MDA_code.py 
+Author: Tyler Reddy
+'''
+
+from lib2to3.fixer_base import BaseFix
+from lib2to3.fixer_util import Name
+
+class FixWriter(BaseFix):
+
+    PATTERN = """
+                power< any+ trailer< '.' method = ('Writer' | 'writer') > trailer< '(' arglist< any+ argument< argname = 'numatoms' '=' any*> any* > ')' > >
+    """
+
+    def transform(self, node, results):
+        argname = results['argname']
+        argname.replace(Name('n_atoms', prefix=argname.prefix))

--- a/package/MDAnalysis/migration/test_dummy_old_MDA_code.py
+++ b/package/MDAnalysis/migration/test_dummy_old_MDA_code.py
@@ -108,6 +108,8 @@ ag.totalMass
 ag.totalCharge
 #centerOfGeometry -> center_of_geometry
 ag.centerOfGeometry
+#centerOfMass -> center_of_mass
+ag.centerOfMass
 #radiusOfGyration -> radius_of_gyration
 ag.radiusOfGyration
 #shapeParameter -> shape_parameter

--- a/package/MDAnalysis/migration/test_dummy_old_MDA_code.py
+++ b/package/MDAnalysis/migration/test_dummy_old_MDA_code.py
@@ -219,3 +219,19 @@ class Dummy(object):
     assert_almost_equal(ts.frame, 544)
 
     ts.frame = 77
+
+#numatoms to n_atoms keyword argument conversion while preserving the conversion from numberOfAtoms() to n_atoms as well:
+with MDAnalysis.Writer(pdbtrj, multiframe=True, bonds=False, numatoms=u.atoms.numberOfAtoms()) as PDB:
+    pass
+
+#alternative call syntax:
+with MDAnalysis.coordinates.core.writer(pdbtrj, multiframe=True, bonds=False, numatoms=u.atoms.numberOfAtoms()) as PDB:
+    pass
+
+#the above fix should be specific to .writer or .Writer, so the following should not be recognized (as a probe for specificity) from the keyword argument standpoint [method replacement is ok]:
+with MDAnalysis.coordinates.core.writerr(pdbtrj, multiframe=True, bonds=False, numatoms=u.atoms.numberOfAtoms()) as PDB:
+    pass
+
+#however, the fixer should be sufficiently flexible to recognize a different input filename, the omission of default arguments, spacing between 'numatoms' and '=', and an explicit integer value for numatoms, along with some additional kwargs:
+with MDAnalysis.Writer(other_filename, numatoms = 55, start = 0, step = 2) as GRO:
+    pass


### PR DESCRIPTION
Fixes Issue #470 with `ten2eleven` conversion module

 * missing camelcase `centerOfMass` is now properly converted to `center_of_mass`
 * `numatoms` argument to writer() functions is now properly converted to `n_atoms`, with a wide range of flexiblity on the presence / absence of surrounding arguments in the call

 Note that:
 * We don't have proper unit tests to prevent reversion of behaviour for conversions when I modify `ten2eleven`, only the dummy text file where I try to carefully check the behaviour. It may be desirable to make this more robust in the future.