### PR TITLE
Updated PSA module with PR citation (PLOS Comput Biol). Fixes #453.

### DIFF
--- a/package/MDAnalysis/analysis/psa.py
+++ b/package/MDAnalysis/analysis/psa.py
@@ -1298,7 +1298,8 @@ class PSAnalysis(object):
             for j in xrange(i+1, numpaths):
                 P = self.paths[i][start:stop:step]
                 Q = self.paths[j][start:stop:step]
-                D[i,j] = D[j,i] = metric_func(P, Q)
+                D[i,j] = metric_func(P, Q)
+                D[j,i] = D[i,j]
         self.D = D
         if store:
             filename = kwargs.pop('filename', str(metric))

--- a/package/MDAnalysis/analysis/psa.py
+++ b/package/MDAnalysis/analysis/psa.py
@@ -54,11 +54,13 @@ preserve the triangle inequality.
 
 .. Rubric:: References
 
-.. [Seyler2015] Sean L. Seyler, Avishek Kumar, Michael F. Thorpe, Oliver Beckstein.
-   *Path Similarity Analysis: a Method for Quantifying Macromolecular
-   Pathways.* `arXiv:1505.04807`_ (2015).
 
-.. _`arXiv:1505.04807`: http://arxiv.org/abs/1505.04807
+.. [Seyler2015] Seyler SL, Kumar A, Thorpe MF, Beckstein O (2015)
+                Path Similarity Analysis: A Method for Quantifying
+                Macromolecular Pathways. PLoS Comput Biol 11(10): e1004568.
+                doi: `10.1371/journal.pcbi.1004568`_
+
+.. _`10.1371/journal.pcbi.1004568`: http://dx.doi.org/10.1371/journal.pcbi.1004568
 .. _`PSAnalysisTutorial`: https://github.com/Becksteinlab/PSAnalysisTutorial
 
 


### PR DESCRIPTION
Also split up assignment to (symmetric) distance matrix elements to permit the use of Cython (distance metric) functions.