### PR TITLE
Basetest fix

### DIFF
--- a/package/MDAnalysis/coordinates/XYZ.py
+++ b/package/MDAnalysis/coordinates/XYZ.py
@@ -207,7 +207,10 @@ class XYZWriter(base.Writer):
             # update atom names
             self.atomnames = atoms.names
         else:
-            ts = obj
+            if isinstance(obj, base.Timestep):
+                ts = obj
+            else:
+                raise TypeError("No Timestep found in obj argument")
 
         self.write_next_timestep(ts)
 
@@ -219,7 +222,6 @@ class XYZWriter(base.Writer):
                                   'trajectory file')
             else:
                 ts = self.ts
-
 
         if self.n_atoms is not None:
             if self.n_atoms != ts.n_atoms:

--- a/testsuite/MDAnalysisTests/coordinates/base.py
+++ b/testsuite/MDAnalysisTests/coordinates/base.py
@@ -280,7 +280,7 @@ class BaseWriterTest(object):
             assert_timestep_almost_equal(
                 copy_ts, orig_ts, decimal=self.ref.prec)
 
-    @raises(mda.NoDataError)
+    @raises(TypeError)
     def test_write_none(self):
         outfile = self.tmp_file('write-none')
         with self.ref.writer(outfile) as w:


### PR DESCRIPTION
Now the `XYZWriter.write` method follows the API defined in the base class. Tests are also corrected.