### PR TITLE
Fixes Issue #512

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -43,6 +43,8 @@ Fixes
   * ten2eleven will now convert numatoms to n_atoms argument
     for writer() functions (Issue #470)
   * Fixed non-compliant Amber NCDFWriter (Issue #488)
+  * Fixed many Timestep methods failing when positions weren't present
+    (Issue #512)
 
 
 10/08/15

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -403,10 +403,16 @@ class Timestep(object):
             vel = self.velocities[sel]
         except NoDataError:
             vel = None
+        except:
+            raise TypeError("Selection type must be compatible with slicing"
+                            " the coordinates")
         try:
             force = self.forces[sel]
         except NoDataError:
             force = None
+        except:
+            raise TypeError("Selection type must be compatible with slicing"
+                            " the coordinates")
 
         new_TS = self.__class__.from_coordinates(
             positions=pos,

--- a/testsuite/MDAnalysisTests/coordinates/test_dcd.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_dcd.py
@@ -552,6 +552,7 @@ class TestDCDTimestep(BaseTimestepTest):
     has_box = True
     set_box = True
     unitcell = np.array([10., 90., 11., 90., 90., 12.])
+    uni_args = (PSF, DCD)
 
     def test_ts_order_define(self):
         """Check that users can hack in a custom unitcell order"""

--- a/testsuite/MDAnalysisTests/coordinates/test_dms.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_dms.py
@@ -69,6 +69,7 @@ class TestDMSTimestep(BaseTimestepTest):
     unitcell = {'x':np.array([10., 0, 0]),
                 'y':np.array([0, 11., 0]),
                 'z':np.array([0, 0, 12.])}
+    uni_args = (DMS,)
 
     def test_dimensions_set_box(self):
         self.ts.dimensions = self.newbox

--- a/testsuite/MDAnalysisTests/coordinates/test_gro.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_gro.py
@@ -266,6 +266,7 @@ class TestGROTimestep(BaseTimestepTest):
     unitcell = np.array([10., 11., 12.,
                          0., 0., 0.,
                          0., 0., 0.])
+    uni_args = (GRO,)
 
     def test_unitcell_set2(self):
         box = np.array([80.017, 80.017, 80.017, 60.00, 60.00, 90.00],

--- a/testsuite/MDAnalysisTests/coordinates/test_timestep_api.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_timestep_api.py
@@ -16,9 +16,6 @@
 
 """Tests for the API definition of Timestep
 
-These come in 2 parts
-
-_TestTimestep tests the functionality of a Timestep in isolation
 
 _TestTimestepInterface tests the Readers are correctly using Timesteps
 """
@@ -53,30 +50,6 @@ from MDAnalysisTests.coordinates.base import BaseTimestepTest
 
 # Can add in custom tests for a given Timestep here!
 class TestBaseTimestep(BaseTimestepTest):
-    #    def test_nothing(self):
-    #        assert_equal(1, 1)
-    pass
-
-
-# using test generator, don't change to TestCase
-class TestTimestepEquality(object):
-    def _get_pos(self):
-        # Get generic reference positions
-        return np.arange(30).reshape(10, 3) * 1.234
-
-    def _check_ts(self, a, b, err_msg):
-        assert_(a == b, err_msg)
-        assert_(b == a, err_msg)
-
-    def test_check_equal(self):
-        ts1 = mda.coordinates.base.Timestep(10)
-        ts1.positions = self._get_pos()
-
-        ts2 = mda.coordinates.base.Timestep(10)
-        ts2.positions = self._get_pos()
-
-        self._check_ts(ts1, ts2, 'Failed on base timestep')
-
     def test_other_timestep(self):
         # use a subclass to base.Timestep to check it works
         ts1 = mda.coordinates.base.Timestep(10)
@@ -92,120 +65,13 @@ class TestTimestepEquality(object):
                         mda.coordinates.XTC.Timestep]:
             ts2 = otherTS(10)
             ts2.positions = self._get_pos()
-            yield self._check_ts, ts1, ts2, "Failed on {0}".format(otherTS)
-
-    def test_trr_timestep(self):
-        ts1 = mda.coordinates.base.Timestep(10, velocities=True, forces=True)
-        ts1.positions = self._get_pos()
-        ts1.velocities = self._get_pos() + 10.0
-        ts1.forces = self._get_pos() + 100.0
-
-        ts2 = mda.coordinates.TRR.Timestep(10)
-        ts2.positions = self._get_pos()
-        ts2.velocities = self._get_pos() + 10.0
-        ts2.forces = self._get_pos() + 100.0
-
-        self._check_ts(ts1, ts2, "Failed on TRR Timestep")
-
-    def test_wrong_class(self):
-        ts1 = mda.coordinates.base.Timestep(10)
-        ts1.positions = self._get_pos()
-
-        b = tuple([0, 1, 2, 3])
-
-        assert_(ts1 != b)
-        assert_(b != ts1)
-
-    def test_wrong_frame(self):
-        ts1 = mda.coordinates.base.Timestep(10)
-        ts1.positions = self._get_pos()
-
-        ts2 = mda.coordinates.base.Timestep(10)
-        ts2.positions = self._get_pos()
-        ts2.frame = 987
-
-        assert_(ts1 != ts2)
-        assert_(ts2 != ts1)
-
-    def test_wrong_n_atoms(self):
-        ts1 = mda.coordinates.base.Timestep(10)
-        ts1.positions = self._get_pos()
-
-        ts3 = mda.coordinates.base.Timestep(20)
-
-        assert_(ts1 != ts3)
-        assert_(ts3 != ts1)
-
-    def test_wrong_pos(self):
-        ts1 = mda.coordinates.base.Timestep(10)
-        ts1.positions = self._get_pos()
-
-        ts2 = mda.coordinates.base.Timestep(10)
-        ts2.positions = self._get_pos() + 1.0
-
-        assert_(ts1 != ts2)
-        assert_(ts2 != ts1)
-
-    def test_check_vels(self):
-        ts1 = mda.coordinates.base.Timestep(10, velocities=True)
-        ts2 = mda.coordinates.base.Timestep(10, velocities=True)
-
-        ts1.velocities = self._get_pos()
-        ts2.velocities = self._get_pos()
-
-        assert_(ts1 == ts2)
-        assert_(ts2 == ts1)
-
-    def test_check_mismatched_vels(self):
-        ts1 = mda.coordinates.base.Timestep(10, velocities=True)
-        ts2 = mda.coordinates.base.Timestep(10, velocities=False)
-
-        ts1.velocities = self._get_pos()
-
-        assert_(ts1 != ts2)
-        assert_(ts2 != ts1)
-
-    def test_check_wrong_vels(self):
-        ts1 = mda.coordinates.base.Timestep(10, velocities=True)
-        ts2 = mda.coordinates.base.Timestep(10, velocities=True)
-
-        ts1.velocities = self._get_pos()
-        ts2.velocities = self._get_pos() + 1.0
-
-        assert_(ts1 != ts2)
-        assert_(ts2 != ts1)
-
-    def test_check_forces(self):
-        ts1 = mda.coordinates.base.Timestep(10, forces=True)
-        ts2 = mda.coordinates.base.Timestep(10, forces=True)
-
-        ts1.forces = self._get_pos()
-        ts2.forces = self._get_pos()
-
-        assert_(ts1 == ts2)
-        assert_(ts2 == ts1)
-
-    def test_check_mismatched_forces(self):
-        ts1 = mda.coordinates.base.Timestep(10, forces=True)
-        ts2 = mda.coordinates.base.Timestep(10, forces=False)
-
-        ts1.forces = self._get_pos()
-
-        assert_(ts1 != ts2)
-        assert_(ts2 != ts1)
-
-    def test_check_wrong_forces(self):
-        ts1 = mda.coordinates.base.Timestep(10, forces=True)
-        ts2 = mda.coordinates.base.Timestep(10, forces=True)
-
-        ts1.forces = self._get_pos()
-        ts2.forces = self._get_pos() + 1.0
-
-        assert_(ts1 != ts2)
-        assert_(ts2 != ts1)
+            yield (self._check_ts_equal, ts1, ts2,
+                   "Failed on {0}".format(otherTS))
 
 
 # TODO: Merge this into generic Reader tests
+# These tests are all included in BaseReaderTest
+# Once Readers use that TestClass, delete this one
 class BaseTimestepInterfaceTest(object):
     """Test the Timesteps created by Readers
 
@@ -344,96 +210,3 @@ class TestXTC(BaseTimestepInterfaceTest):
     def setUp(self):
         u = self.u = mda.Universe(GRO, XTC)
         self.ts = u.trajectory.ts
-
-
-class TestXYZ(BaseTimestepInterfaceTest):
-    def setUp(self):
-        u = self.u = mda.Universe(XYZ_mini)
-        self.ts = u.trajectory.ts
-
-
-# TODO: Merge these tests into BaseTimestepTest
-#       and move to per-format style
-class TestTimestepCopy(object):
-    """Test copy and copy_slice methods on Timestep"""
-    formats = [
-        ('DCD', (PSF, DCD)),
-        ('DMS', (DMS,)),
-        ('GRO', (GRO,)),
-        ('PDB', (PDB_small,)),
-        ('TRJ', (PRM, TRJ)),
-        ('TRR', (GRO, TRR)),
-        ('TRZ', (TRZ_psf, TRZ)),
-        ('XTC', (PDB, XTC)),
-    ]
-
-    def _check_copy(self, name, ref_ts):
-        """Check basic copy"""
-        ts2 = ref_ts.copy()
-
-        err_msg = ("Timestep copy failed for format {form}"
-                   " on attribute {att}")
-
-        # eq method checks:
-        # - frame
-        # - n_atoms
-        # - positions, vels and forces
-        assert_(ref_ts == ts2)
-
-        assert_array_almost_equal(ref_ts.dimensions, ts2.dimensions,
-                                  decimal=4)
-
-        # Check things not covered by eq
-        for d in ref_ts.data:
-            assert_(d in ts2.data)
-            if isinstance(ref_ts.data[d], np.ndarray):
-                assert_array_almost_equal(
-                    ref_ts.data[d], ts2.data[d])
-            else:
-                assert_(ref_ts.data[d] == ts2.data[d])
-
-    def _check_independent(self, name, ts):
-        """Check that copies made are independent"""
-        ts2 = ts.copy()
-
-        if ts.has_positions:
-            self._check_array(ts.positions, ts2.positions)
-        if ts.has_velocities:
-            self._check_array(ts.velocities, ts2.velocities)
-        if ts.has_forces:
-            self._check_array(ts.forces, ts2.forces)
-        self._check_array(ts.dimensions, ts2.dimensions)
-
-    def _check_array(self, arr1, arr2):
-        """Check modifying one array doesn't change other"""
-        ref = arr1.copy()
-        arr2 += 1.0
-        assert_array_almost_equal(ref, arr1)
-
-    def _check_copy_slice_indices(self, name, ts):
-        sl = slice(0, len(ts), 3)
-        ts2 = ts.copy_slice(sl)
-        self._check_slice(ts, ts2, sl)
-
-    def _check_copy_slice_slice(self, name, ts):
-        sl = [0, 1, 3, 5, 6, 7]
-        ts2 = ts.copy_slice(sl)
-        self._check_slice(ts, ts2, sl)
-
-    def _check_slice(self, ts1, ts2, sl):
-        if ts1.has_positions:
-            assert_array_almost_equal(ts1.positions[sl], ts2.positions)
-        if ts1.has_velocities:
-            assert_array_almost_equal(ts1.velocities[sl], ts2.velocities)
-        if ts1.has_forces:
-            assert_array_almost_equal(ts1.forces[sl], ts2.forces)
-
-    def test_copy(self):
-        for fname, args in self.formats:
-            u = mda.Universe(*args)
-            ts = u.trajectory.ts
-
-            yield self._check_copy, fname, ts
-            yield self._check_independent, fname, ts
-            yield self._check_copy_slice_indices, fname, ts
-            yield self._check_copy_slice_slice, fname, ts

--- a/testsuite/MDAnalysisTests/coordinates/test_trj.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_trj.py
@@ -108,3 +108,4 @@ class TestTRJTimestep(BaseTimestepTest):
     has_box = True
     set_box = True
     unitcell = np.array([10., 11., 12., 90., 90., 90.])
+    uni_args = (PRM, TRJ)

--- a/testsuite/MDAnalysisTests/coordinates/test_trz.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_trz.py
@@ -240,4 +240,5 @@ class TestTRZTimestep(BaseTimestepTest):
     unitcell = np.array([10., 0., 0.,
                          0., 11., 0.,
                          0., 0., 12.])
+    uni_args = (TRZ_psf, TRZ)
 

--- a/testsuite/MDAnalysisTests/coordinates/test_xdr.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_xdr.py
@@ -605,6 +605,7 @@ class TestXTCTimestep(BaseTimestepTest):
     unitcell = np.array([[10., 0., 0.],
                          [0., 11., 0.],
                          [0., 0., 12.]])
+    uni_args = (PDB, XTC)
 
 
 class TestTRRTimestep(BaseTimestepTest):
@@ -615,6 +616,7 @@ class TestTRRTimestep(BaseTimestepTest):
     unitcell = np.array([[10., 0., 0.],
                          [0., 11., 0.],
                          [0., 0., 12.]])
+    uni_args = (GRO, TRR)
 
     def test_velocities_remove(self):
         # This test is different because TRR requires that the
@@ -695,3 +697,16 @@ class TestTRRTimestep(BaseTimestepTest):
         self.ts.forces = self.refpos + 101
         assert_equal(self.ts.has_forces, True)
         assert_array_almost_equal(self.ts.forces, self.refpos + 101)
+
+    def test_trr_timestep(self):
+        ts1 = mda.coordinates.base.Timestep(10, velocities=True, forces=True)
+        ts1.positions = self._get_pos()
+        ts1.velocities = self._get_pos() + 10.0
+        ts1.forces = self._get_pos() + 100.0
+
+        ts2 = mda.coordinates.TRR.Timestep(10)
+        ts2.positions = self._get_pos()
+        ts2.velocities = self._get_pos() + 10.0
+        ts2.forces = self._get_pos() + 100.0
+
+        self._check_ts_equal(ts1, ts2, "Failed on TRR Timestep")


### PR DESCRIPTION
Added better support for Timesteps without positions

`Timestep.from_coordinates` now works without positions

`Timestep.__eq__` works without positions

`Timestep.copy_slice` works on Timesteps without positions

Many more tests for Timesteps through new BaseTimestepTest