### PR TITLE
Natoms kwarg

### DIFF
--- a/testsuite/MDAnalysisTests/coordinates/test_xyz.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_xyz.py
@@ -19,6 +19,7 @@ class XYZReference(BaseReference):
         self.ext = 'xyz'
         self.volume = 0
         self.dimensions = np.zeros(6)
+        self.container_format = True
 
 
 class TestXYZReader(BaseReaderTest):


### PR DESCRIPTION
This tests that all writer accept an n_atoms kwarg. Only special container formats that can write a different model for each frame (PDB, XYZ) don't need that argument.  I also added the option that XYZReader.Writer now accepts a general `atoms` argument that can be either an integer or an AtomGroup.  (btw all Readers that we port to the new tests will have to follow that API)

See #511 for discussions