### PR TITLE
Fixed misuse of delta arg in ChainReader and docs of MDAnalysis.Writer

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -20,6 +20,7 @@ The rules for this file:
 
 API Changes
 
+  * ChainReader `delta` keyword deprecated in favor of `frame_dt`. (Issue #522)
   * XYZWriter can now be used as a container format for different protein models
     as well as a normal trajectory. If `n_atoms` is None (default) MDAnalysis
     assumes that it is used as a container and won't give a warning if the
@@ -37,6 +38,7 @@ Changes
   * built html doc files are no longer version controlled (Issue #491)
 
 Fixes
+  * Cleaned up `MDAnalysis.Writer` docs regarding `dt` usage. (Issue #522)
   * Fixed setup-time dependency on numpy that broke pip installs. (Issue #479)
   * Fixed unpickling errors due to lingering dead universes. (Issue #487)
   * Fixed analysis.density modules requiring the defunct `skip` attribute

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -20,7 +20,7 @@ The rules for this file:
 
 API Changes
 
-  * ChainReader `delta` keyword deprecated in favor of `frame_dt`. (Issue #522)
+  * ChainReader `delta` keyword deprecated in favor of `dt`. (Issue #522)
   * XYZWriter can now be used as a container format for different protein models
     as well as a normal trajectory. If `n_atoms` is None (default) MDAnalysis
     assumes that it is used as a container and won't give a warning if the
@@ -29,6 +29,7 @@ API Changes
 
 Enhancement
 
+  * ChainReader now reports times properly summed over sub-readers (Issue #522)
   * GRO file reading approximately 50% faster for large files (Issue #212)
   * GRO file writing now will write velocities where possible (Issue #494)
   * Added bonded selection (Issue #362)

--- a/package/MDAnalysis/coordinates/core.py
+++ b/package/MDAnalysis/coordinates/core.py
@@ -172,7 +172,7 @@ def writer(filename, n_atoms=None, **kwargs):
                    starting time [0]
                *step*
                    step size in frames [1]
-               *delta*
+               *dt*
                    length of time between two frames, in ps [1.0]
 
             Some readers accept additional arguments, which need to be looked

--- a/testsuite/MDAnalysisTests/coordinates/test_coordinates.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_coordinates.py
@@ -64,10 +64,8 @@ class TestINPCRDReader(TestCase):
 class TestChainReader(TestCase):
 
     def setUp(self):
-        self.fake_dt = 100.0
         self.universe = mda.Universe(PSF,
-                                     [DCD, CRD, DCD, CRD, DCD, CRD, CRD],
-                                     frame_dt=self.fake_dt)
+                                     [DCD, CRD, DCD, CRD, DCD, CRD, CRD])
         self.trajectory = self.universe.trajectory
         self.prec = 3
         # dummy output DCD file
@@ -131,25 +129,12 @@ class TestChainReader(TestCase):
             self.universe.atoms.coordinates(), coord0,
             "coordinates at frame 1 and 100 should be the same!")
 
-    # We might want to revive this test once the ChainReader gets a cleverer
-    #  time counter.
-    #@knownfailure("time attribute not implemented for chained reader",
-    #              ValueError)
-    #def test_time(self):
-    #    self.trajectory[30]  # index is 0-based but frames are 1-based
-    #    assert_almost_equal(self.universe.trajectory.time,
-    #                        31.0,
-    #                        5,
-    #                        err_msg="wrong time of frame")
-
-    def test_faked_time(self):
-        # We test this for the beginning, middle and end of the trajectory.
-        for frame_n in (0, self.trajectory.n_frames/2, -1):
-            self.trajectory[frame_n]
-            assert_almost_equal(self.trajectory.time,
-                            self.trajectory.frame*self.fake_dt,
+    def test_time(self):
+        self.trajectory[30]  # index and frames 0-based
+        assert_almost_equal(self.universe.trajectory.time,
+                            30.0,
                             5,
-                            err_msg="wrong time of frame")
+                            err_msg="Wrong time of frame")
 
     @dec.slow
     def test_write_dcd(self):
@@ -168,6 +153,25 @@ class TestChainReader(TestCase):
                 ts_new._pos,
                 self.prec,
                 err_msg="Coordinates disagree at frame %d" % ts_orig.frame)
+
+class TestChainReaderCommonDt(TestCase):
+
+    def setUp(self):
+        self.common_dt = 100.0
+        self.universe = mda.Universe(PSF,
+                                     [DCD, CRD, DCD, CRD, DCD, CRD, CRD],
+                                     dt=self.common_dt)
+        self.trajectory = self.universe.trajectory
+        self.prec = 3
+
+    def test_time(self):
+        # We test this for the beginning, middle and end of the trajectory.
+        for frame_n in (0, self.trajectory.n_frames/2, -1):
+            self.trajectory[frame_n]
+            assert_almost_equal(self.trajectory.time,
+                            self.trajectory.frame*self.common_dt,
+                            5,
+                            err_msg="Wrong time for frame %d" % frame_n )
 
 
 class TestChainReaderFormats(TestCase):

--- a/testsuite/MDAnalysisTests/coordinates/test_coordinates.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_coordinates.py
@@ -64,7 +64,10 @@ class TestINPCRDReader(TestCase):
 class TestChainReader(TestCase):
 
     def setUp(self):
-        self.universe = mda.Universe(PSF, [DCD, CRD, DCD, CRD, DCD, CRD, CRD])
+        self.fake_dt = 100.0
+        self.universe = mda.Universe(PSF,
+                                     [DCD, CRD, DCD, CRD, DCD, CRD, CRD],
+                                     frame_dt=self.fake_dt)
         self.trajectory = self.universe.trajectory
         self.prec = 3
         # dummy output DCD file
@@ -128,12 +131,23 @@ class TestChainReader(TestCase):
             self.universe.atoms.coordinates(), coord0,
             "coordinates at frame 1 and 100 should be the same!")
 
-    @knownfailure("time attribute not implemented for chained reader",
-                  ValueError)
-    def test_time(self):
-        self.trajectory[30]  # index is 0-based but frames are 1-based
-        assert_almost_equal(self.universe.trajectory.time,
-                            31.0,
+    # We might want to revive this test once the ChainReader gets a cleverer
+    #  time counter.
+    #@knownfailure("time attribute not implemented for chained reader",
+    #              ValueError)
+    #def test_time(self):
+    #    self.trajectory[30]  # index is 0-based but frames are 1-based
+    #    assert_almost_equal(self.universe.trajectory.time,
+    #                        31.0,
+    #                        5,
+    #                        err_msg="wrong time of frame")
+
+    def test_faked_time(self):
+        # We test this for the beginning, middle and end of the trajectory.
+        for frame_n in (0, self.trajectory.n_frames/2, -1):
+            self.trajectory[frame_n]
+            assert_almost_equal(self.trajectory.time,
+                            self.trajectory.frame*self.fake_dt,
                             5,
                             err_msg="wrong time of frame")
 


### PR DESCRIPTION
If this gets merged do note that there's a mention to the version from which the `delta` keyword was deprecated. It must be updated when the actual version numbering is decided.