### PR TITLE
AMBER NetCDF file writing -- enforcing float32 precision

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -39,6 +39,7 @@ Changes
   * built html doc files are no longer version controlled (Issue #491)
 
 Fixes
+  * AMBER netcdf writer now correctly uses float32 precision (Issue #518)
   * Fixed a numpy incompatibility in `analysis.leaflet.LeafletFinder`.
     (Issue #533)
   * Cleaned up `MDAnalysis.Writer` docs regarding `dt` usage. (Issue #522)

--- a/package/MDAnalysis/coordinates/TRJ.py
+++ b/package/MDAnalysis/coordinates/TRJ.py
@@ -691,14 +691,14 @@ class NCDFWriter(base.Writer):
         ncfile.createDimension('label', 5)  # needed for cell_angular
 
         # Create variables.
-        coords = ncfile.createVariable('coordinates', 'f8', ('frame', 'atom', 'spatial'),
+        coords = ncfile.createVariable('coordinates', 'f4', ('frame', 'atom', 'spatial'),
                                        zlib=self.zlib, complevel=self.cmplevel)
         setattr(coords, 'units', 'angstrom')
 
         spatial = ncfile.createVariable('spatial', 'c', ('spatial',))
         spatial[:] = np.asarray(list('xyz'))
         
-        time = ncfile.createVariable('time', 'f8', ('frame',),
+        time = ncfile.createVariable('time', 'f4', ('frame',),
                                      zlib=self.zlib, complevel=self.cmplevel)
         setattr(time, 'units', 'picosecond')
 

--- a/testsuite/MDAnalysisTests/coordinates/test_netcdf.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_netcdf.py
@@ -129,6 +129,16 @@ class _NCDFWriterTest(TestCase):
         with self.Writer(self.outfile, t.n_atoms, dt=t.dt) as W:
             self._copy_traj(W)
         self._check_new_traj()
+        import netCDF4
+        #for issue #518 -- preserve float32 data in ncdf output
+        dataset = netCDF4.Dataset(self.outfile, 'r', format='NETCDF3')
+        variable_dict = dataset.variables
+        coords = variable_dict['coordinates']
+        time = variable_dict['time']
+        self.assertTrue('float32' in coords.__repr__(),
+                'ncdf coord output not float32')
+        self.assertTrue('float32' in time.__repr__(),
+                'ncdf time output not float32')
 
     def test_OtherWriter(self):
         t = self.universe.trajectory


### PR DESCRIPTION
This is a fix for Issue #518. When MDAnalysis writes AMBER `.ncdf` files it will now use the `float32` data type instead of `float64` for the `time` and `coordinates` fields. Prior to this fix, MDAnalysis would produce `.ncdf` files that are ~ twice as large as the input `.ncdf` (when writing the same data that was read in).

The [AMBER NetCDF Trajectory / Restart Convention Version 1.0, Revision C] (http://ambermd.org/netcdf/nctraj.xhtml) clearly indicates that binary file creators should use `float` for `time` and `coordinates`, BUT also indicates that `double` is to be used for both when dealing with restarts. At the moment, I don't think MDAnalysis is intended for dealing with restarts, but if we'd like that to change then I suggest a separate issue be opened to allow for kwargs specifying double precision, or probably more accurately a `restart` flag that follows the requirements spelled out for their restart spec.

Note that switching between netCDF4 and scipy for `ncdf` I/O in MDAnalysis in (#506) may require a bit of thinking about the unit test additions I've made here, but I think this will only be a minor set of adjustments if the decision to make that switch is made. As it stands, the Python `netCDF4` module is required for the tests I've added. 

Although, in practice, I could have just checked the physical size of the output file, that is not really a unit test for the issue at hand--explicitly checking the `__repr__()` of the variable fields of the netCDF file header is a more specific check for the actual data types. I made some attempts at doing this by reading the binary data in pure python using i.e., `struct` module, but this was proving to be quite an effort, and this part of our test suite already has built-in skip switches when `netCDF4` is not available.

To-do:
- [x] add entry to changelog