### PR TITLE
Feature blankuniverse

### DIFF
--- a/package/MDAnalysis/coordinates/__init__.py
+++ b/package/MDAnalysis/coordinates/__init__.py
@@ -695,6 +695,8 @@ __all__ = ['reader', 'writer']
 
 from . import base
 from .core import reader, writer
+from . import dummy
+
 from . import CRD
 from . import DCD
 from . import DLPoly
@@ -742,6 +744,7 @@ _trajectory_readers = {
     'TRZ': TRZ.TRZReader,
     'DATA': LAMMPS.DATAReader,
     'GMS': GMS.GMSReader,
+    'DUMMY': dummy.DummyReader,
 }
 
 #: formats of readers that can also handle gzip or bzip2 compressed files

--- a/package/MDAnalysis/coordinates/dummy.py
+++ b/package/MDAnalysis/coordinates/dummy.py
@@ -1,0 +1,37 @@
+# -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 fileencoding=utf-8
+#
+# MDAnalysis --- http://www.MDAnalysis.org
+# Copyright (c) 2006-2015 Naveen Michaud-Agrawal, Elizabeth J. Denning, Oliver Beckstein
+# and contributors (see AUTHORS for the full list)
+#
+# Released under the GNU Public Licence, v2 or any higher version
+#
+# Please cite your use of MDAnalysis in published work:
+#
+# N. Michaud-Agrawal, E. J. Denning, T. B. Woolf, and O. Beckstein.
+# MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
+# J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
+#
+"""Dummy Reader ---:mod:`MDAnalysis.coordinates.dummy`
+
+Doesn't actually read anything! Designed to allow systems
+to be built from nothing.
+
+.. versionadded:: 0.13.0
+"""
+from . import base
+
+
+class DummyReader(base.SingleFrameReader):
+    format = 'Dummy'
+    units = {}
+
+    def _read_first_frame(self):
+        # Uses self.filename as hack for number of atoms
+        self.n_atoms = self.filename
+
+        # Start with not even positions
+        self.ts = self._Timestep(self.n_atoms,
+                                 positions=False,
+                                 **self._ts_kwargs)

--- a/package/MDAnalysis/core/AtomGroup.py
+++ b/package/MDAnalysis/core/AtomGroup.py
@@ -3812,6 +3812,25 @@ class Universe(object):
             self.make_anchor()
         self.anchor_name = kwargs.get('anchor_name')
 
+    @classmethod
+    def create_dummy(cls, natoms):
+        """Create an empty Universe with size *natoms*
+
+        .. versionadded:: 0.13.0
+        """
+        from ..topology.dummy import DummyParser
+        from ..coordinates.dummy import DummyReader
+
+        u = cls()
+        with DummyParser(natoms, universe=u) as p:
+            u._topology = p.parse()
+        # Generate atoms, residues and segments
+        u._init_topology()
+
+        u.trajectory = DummyReader(natoms)
+
+        return u
+
     def _clear_caches(self, *args):
         """Clear cache for all *args*.
 

--- a/package/MDAnalysis/core/AtomGroup.py
+++ b/package/MDAnalysis/core/AtomGroup.py
@@ -3816,6 +3816,33 @@ class Universe(object):
     def create_dummy(cls, natoms):
         """Create an empty Universe with size *natoms*
 
+        Arguments
+        ---------
+        natoms: int
+          The desired size of the new Universe
+
+        Returns
+        -------
+        An empty Universe with size *natoms*
+
+        Example
+        -------
+
+        new_u = mda.Universe.create_dummy(20)
+
+        for i, atom in enumerate(new_u.atoms):
+            atom.name = 'Congaman{}'.format(i+1)
+        new_u.atoms.resnames = 'Congaline'
+
+        new_coords = np.stack([np.zeros(20), np.zeros(20), np.arange(20)]).T
+        new_u.trajectory.ts.positions = new_coords
+
+
+        SeeAlso
+        -------
+        :func:`MDAnalysis.core.AtomGroup.Merge` for creating a
+        new Universe from existing AtomGroups
+
         .. versionadded:: 0.13.0
         """
         from ..topology.dummy import DummyParser

--- a/package/MDAnalysis/topology/__init__.py
+++ b/package/MDAnalysis/topology/__init__.py
@@ -258,6 +258,7 @@ from . import XYZParser
 from . import GMSParser
 from . import DLPolyParser
 from . import HoomdXMLParser
+from . import dummy
 
 
 # dictionary of known file formats and the corresponding file parser
@@ -284,4 +285,5 @@ _topology_parsers = {'PSF': PSFParser.PSFParser,
                      'CONFIG': DLPolyParser.ConfigParser,
                      'HISTORY': DLPolyParser.HistoryParser,
                      'XML': HoomdXMLParser.HoomdXMLParser,
+                     'DUMMY': dummy.DummyParser,
                      }

--- a/package/MDAnalysis/topology/dummy.py
+++ b/package/MDAnalysis/topology/dummy.py
@@ -1,0 +1,39 @@
+# -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 fileencoding=utf-8
+#
+# MDAnalysis --- http://www.MDAnalysis.org
+# Copyright (c) 2006-2015 Naveen Michaud-Agrawal, Elizabeth J. Denning, Oliver Beckstein
+# and contributors (see AUTHORS for the full list)
+#
+# Released under the GNU Public Licence, v2 or any higher version
+#
+# Please cite your use of MDAnalysis in published work:
+# N. Michaud-Agrawal, E. J. Denning, T. B. Woolf, and O. Beckstein.
+# MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
+# J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
+#
+"""
+Dummy Topology parser class --- :mod:`MDAnalysis.topology.dummy`
+================================================================
+
+A rather simple Parser which just creates a number of blank
+:class:`MDAnalysis.core.AtomGroup.Atom` instances.
+These will have no unique properties except their index.
+Designed to act as a base for building a system from scratch.
+
+
+.. versionadded:: 0.13.0
+"""
+from .base import TopologyReader
+from ..core.AtomGroup import Atom
+
+
+class DummyParser(TopologyReader):
+    def parse(self):
+        # the 'filename' of this Parser is an int of the number
+        # of atoms to pass back.
+        # Yay for dynamic typing
+        atoms = [Atom(i, 'NAME', 'TYPE', 'RESNAME', 1, 'SEGID',
+                      0.0, 0.0, universe=self._u)
+                 for i in range(self.filename)]
+        return {"atoms": atoms}

--- a/package/doc/sphinx/source/documentation_pages/coordinates/dummy.rst
+++ b/package/doc/sphinx/source/documentation_pages/coordinates/dummy.rst
@@ -1,0 +1,2 @@
+.. automodule:: MDAnalysis.coordinates.dummy
+   :members:

--- a/package/doc/sphinx/source/documentation_pages/coordinates_modules.rst
+++ b/package/doc/sphinx/source/documentation_pages/coordinates_modules.rst
@@ -19,6 +19,7 @@ provide the format in the keyword argument *format* to
    :maxdepth: 1
 
    coordinates/init
+   coordinates/dummy
    coordinates/CRD
    coordinates/DCD
    coordinates/DLPoly

--- a/package/doc/sphinx/source/documentation_pages/topology/dummy.rst
+++ b/package/doc/sphinx/source/documentation_pages/topology/dummy.rst
@@ -1,0 +1,2 @@
+.. automodule:: MDAnalysis.topology.dummy
+   :members:

--- a/package/doc/sphinx/source/documentation_pages/topology_modules.rst
+++ b/package/doc/sphinx/source/documentation_pages/topology_modules.rst
@@ -25,6 +25,7 @@ topology file format in the *topology_format* keyword argument to
    :maxdepth: 1
 
    topology/init
+   topology/dummy
    topology/PSFParser
    topology/TOPParser
    topology/CRDParser

--- a/testsuite/MDAnalysisTests/test_topology.py
+++ b/testsuite/MDAnalysisTests/test_topology.py
@@ -16,7 +16,6 @@
 import MDAnalysis
 from MDAnalysis.core.AtomGroup import AtomGroup
 from MDAnalysis.lib.distances import calc_bonds, calc_angles, calc_dihedrals
-from MDAnalysis.lib.util import guess_format
 from MDAnalysis.topology.core import (
     guess_atom_type, guess_atom_element, get_atom_mass,
     guess_bonds, guess_angles, guess_dihedrals, guess_improper_dihedrals,

--- a/testsuite/MDAnalysisTests/test_topologybuilding.py
+++ b/testsuite/MDAnalysisTests/test_topologybuilding.py
@@ -1,0 +1,50 @@
+# -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 fileencoding=utf-8
+#
+# MDAnalysis --- http://www.MDAnalysis.org
+# Copyright (c) 2006-2015 Naveen Michaud-Agrawal, Elizabeth J. Denning, Oliver Beckstein
+# and contributors (see AUTHORS for the full list)
+#
+# Released under the GNU Public Licence, v2 or any higher version
+#
+# Please cite your use of MDAnalysis in published work:
+#
+# N. Michaud-Agrawal, E. J. Denning, T. B. Woolf, and O. Beckstein.
+# MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
+# J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
+#
+"""Tests for building systems from scratch
+
+Tests:
+ - DummyParser
+ - DummyReader
+ - Universe.create_dummy()
+"""
+from numpy.testing import (
+    assert_,
+)
+
+import MDAnalysis as mda
+
+
+class TestDummyParser(object):
+    def test_dummy(self):
+        with mda.topology.dummy.DummyParser(10) as p:
+            s = p.parse()
+        assert_(type(s) == type(dict()))
+        assert_(len(s['atoms']) == 10)
+
+    def test_create_dummy(self):
+        u = mda.Universe(10, topology_format='dummy')
+
+        assert_(len(u.atoms) == 10)
+        # Check unique indices
+        assert_(len(set(u.atoms.indices)) == 10)
+
+
+class TestDummyReader(object):
+    pass
+
+
+class TestDummyUniverse(object):
+    pass

--- a/testsuite/MDAnalysisTests/test_topologybuilding.py
+++ b/testsuite/MDAnalysisTests/test_topologybuilding.py
@@ -63,4 +63,9 @@ class TestDummyReader(object):
 
 
 class TestDummyUniverse(object):
-    pass
+    def test_create_dummy(self):
+        u = mda.Universe.create_dummy(10)
+
+        assert_(len(u.atoms) == 10)
+        assert_(u.atoms.universe is u)
+        assert_raises(mda.NoDataError, getattr, u.atoms, 'positions')

--- a/testsuite/MDAnalysisTests/test_topologybuilding.py
+++ b/testsuite/MDAnalysisTests/test_topologybuilding.py
@@ -27,6 +27,8 @@ from numpy.testing import (
 
 import MDAnalysis as mda
 
+from MDAnalysis.tests.datafiles import TRZ, TRZ_psf
+
 
 class TestDummyParser(object):
     def test_dummy(self):
@@ -69,3 +71,14 @@ class TestDummyUniverse(object):
         assert_(len(u.atoms) == 10)
         assert_(u.atoms.universe is u)
         assert_raises(mda.NoDataError, getattr, u.atoms, 'positions')
+
+
+class TestDummyTopology(object):
+    def test_use_dummy_top(self):
+        u = mda.Universe(8184, TRZ, topology_format='dummy')
+
+        assert_(len(u.atoms) == 8184)
+
+        u2 = mda.Universe(TRZ_psf, TRZ)
+
+        assert_(all(u.atoms[0].position == u2.atoms[0].position))

--- a/testsuite/MDAnalysisTests/test_topologybuilding.py
+++ b/testsuite/MDAnalysisTests/test_topologybuilding.py
@@ -22,6 +22,7 @@ Tests:
 """
 from numpy.testing import (
     assert_,
+    assert_raises,
 )
 
 import MDAnalysis as mda
@@ -43,7 +44,22 @@ class TestDummyParser(object):
 
 
 class TestDummyReader(object):
-    pass
+    def test_dummyreader(self):
+        r = mda.coordinates.dummy.DummyReader(10)
+
+        assert_(r.filename == 10)
+        assert_(r.n_atoms == 10)
+
+    def test_dummy_ts(self):
+        r = mda.coordinates.dummy.DummyReader(10)
+
+        assert_(len(r.ts) == 10)
+        assert_(r.ts.has_positions == False)
+        assert_raises(mda.NoDataError, getattr, r.ts, 'positions')
+        assert_(r.ts.has_velocities == False)
+        assert_raises(mda.NoDataError, getattr, r.ts, 'velocities')
+        assert_(r.ts.has_forces == False)
+        assert_raises(mda.NoDataError, getattr, r.ts, 'forces')
 
 
 class TestDummyUniverse(object):

--- a/testsuite/MDAnalysisTests/test_util.py
+++ b/testsuite/MDAnalysisTests/test_util.py
@@ -559,7 +559,7 @@ class TestGuessFormat(object):
         ('DATA', mda.topology.LAMMPSParser.DATAParser, mda.coordinates.LAMMPS.DATAReader),
         ('DCD', None, mda.coordinates.DCD.DCDReader),
         ('DMS', mda.topology.DMSParser.DMSParser, mda.coordinates.DMS.DMSReader),
-        ('DUMMY', mda.topology.dummy.DummyParser, None),
+        ('DUMMY', mda.topology.dummy.DummyParser, mda.coordinates.dummy.DummyReader),
         ('GMS', mda.topology.GMSParser.GMSParser, mda.coordinates.GMS.GMSReader),
         ('GRO', mda.topology.GROParser.GROParser, mda.coordinates.GRO.GROReader),
         ('HISTORY', mda.topology.DLPolyParser.HistoryParser, mda.coordinates.DLPoly.HistoryReader),

--- a/testsuite/MDAnalysisTests/test_util.py
+++ b/testsuite/MDAnalysisTests/test_util.py
@@ -559,6 +559,7 @@ class TestGuessFormat(object):
         ('DATA', mda.topology.LAMMPSParser.DATAParser, mda.coordinates.LAMMPS.DATAReader),
         ('DCD', None, mda.coordinates.DCD.DCDReader),
         ('DMS', mda.topology.DMSParser.DMSParser, mda.coordinates.DMS.DMSReader),
+        ('DUMMY', mda.topology.dummy.DummyParser, None),
         ('GMS', mda.topology.GMSParser.GMSParser, mda.coordinates.GMS.GMSReader),
         ('GRO', mda.topology.GROParser.GROParser, mda.coordinates.GRO.GROReader),
         ('HISTORY', mda.topology.DLPolyParser.HistoryParser, mda.coordinates.DLPoly.HistoryReader),


### PR DESCRIPTION
Currently it's a pain to create a blank Universe to fill up with data then save.  This adds the classmethod `Universe.create_dummy` which lets you create a Universe of arbitrary size:

``` python
new_u = mda.Universe.create_dummy(20)

for i, atom in enumerate(new_u.atoms):
    atom.name = 'Congaman{}'.format(i+1)
new_u.atoms.resnames = 'Congaline'

new_coords = np.stack([np.zeros(20), np.zeros(20), np.arange(20)]).T
new_u.trajectory.ts.positions = new_coords
```
It's different from Merge because that merges existing populated structures, this just creates them from nothing.


Also allows reading a trajectory without having any topology information except the number of atoms:

``` python
u = mda.Universe(1000, 'mytraj.trr', topology_format='dummy')
```

And then obviously your atoms names etc are all defaults.