### PR TITLE
WIP: Prototype metaclass implemenation of AtomGroup works.

### DIFF
--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -2,6 +2,41 @@
 
 
 """
+class AtomDescriptor(object):
+    """Make an atom-level descriptor from a Topology object.
+
+    This basically builds properties for, say, an AtomGroup based on what's
+    available in the topology.
+
+    """
+    def __init__(self, top, attr):
+        self.attr = getattr(top, attr)
+        self.__doc__ = self.attr.__doc__
+
+    def __get__(self, group, Group):
+        return self.attr.get_atoms(group._ix)
+
+    def __set__(self, group, values):
+        self.attr.set_atoms(group._ix, values)
+
+
+def make_atomgroup(top):
+    """Generate the AtomGroup class with attributes according to the topology.
+
+    """
+    # need to build a descriptor for each attribute
+    group_attrs = {}
+    for attr in top.attrs:
+        group_attrs[attr] = AtomDescriptor(top, attr)
+
+    group_attrs['level'] = 'atom'
+
+    return type('AtomGroup', (Group,), group_attrs)
+
+
+#class MetaAtomGroup(type):
+#    def __new__(mcs, name, bases, attrs, **kwargs):
+#        return super(MetaAtomGroup, mcs).__new__(mcs, name, bases, attrs)
 
 class Group(object):
     level = ''
@@ -99,6 +134,7 @@ class ResidueGroup(Group):
     @property
     def masses(self):
         return self._u._topology.masses.get_residues(self._ix)
+
 
 class SegmentGroup(Group):
     level = 'segment'

--- a/package/MDAnalysis/core/topology.py
+++ b/package/MDAnalysis/core/topology.py
@@ -271,6 +271,7 @@ class Topology(object):
                  attrs=None,
                  atom_resindex=None,
                  residue_segindex=None):
+
         self.n_atoms = n_atoms
         self.n_residues = n_res
         self.n_segments = n_seg
@@ -278,10 +279,14 @@ class Topology(object):
                              atom_resindex=atom_resindex,
                              residue_segindex=residue_segindex)
 
+        # list otf attribute names; needed for generating groups by Universe
+        self.attrs = list()
+
         # attach the TopologyAttrs
         for topologyattr in attrs:
             self.add_TopologyAttr(topologyattr)
 
+    # TODO: add checking for duplicate TopologyAttrs
     def add_TopologyAttr(self, topologyattr):
         """Add a new TopologyAttr to the Topology.
 
@@ -291,4 +296,5 @@ class Topology(object):
 
         """
         topologyattr.top = self
+        self.attrs.append(topologyattr.attrname)
         self.__setattr__(topologyattr.attrname, topologyattr)

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -152,6 +152,7 @@ class Atomnames(AtomAttr):
     """
     attrname = 'atomnames'
 
+
 class Atomtypes(AtomAttr):
     """Type for each atom"""
     attrname = 'atomtypes'
@@ -164,6 +165,7 @@ class Bonds(AtomAttr):
     ----------
     """
     pass
+
 
 #TODO: need to add cacheing
 class Masses(AtomAttr):

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -172,13 +172,20 @@ class Universe(object):
                              " with parser {1} \n"
                              "Error: {2}".format(self.filename, parser, err))
 
+        # generate group classes based on Topology
+        self._atomgroup = groups.make_atomgroup(self._topology)
+
+        # generate top-level group instances
+        self.atoms = self._atomgroup(np.arange(self._topology.n_atoms), self)
+        
+
         # Generate atoms, residues and segments
-        self.atoms = groups.AtomGroup(
-            np.arange(self._topology.n_atoms), self)
-        self.residues = groups.ResidueGroup(np.arange(
-            self._topology.n_residues), self)
-        self.segments = groups.SegmentGroup(np.arange(
-            self._topology.n_segments), self)
+        #self.atoms = groups.AtomGroup(
+        #    np.arange(self._topology.n_atoms), self)
+        #self.residues = groups.ResidueGroup(np.arange(
+        #    self._topology.n_residues), self)
+        #self.segments = groups.SegmentGroup(np.arange(
+        #    self._topology.n_segments), self)
 
         # Load coordinates
         self.load_new(coordinatefile, **kwargs)


### PR DESCRIPTION
Since the contents of what a topology file has to offer is determined
by the Reader by way of the Topology object it returns, and what
TopologyAttrs it has, we can define AtomGroup, ResidueGroup, and
SegmentGroup on Universe init based on the contents of Topology. We have
done this here for AtomGroup as a proof-of-concept.

This gives several advantages:
    * no hardcoding of attributes into any of the Group objects
    * allows custom TopologyAttrs fed to Topology to be used by Groups
      without additional effort.
    * Groups get attributes that are available, but not ones that the
      Reader didn't give the Topology

We will need to think carefully about any issues this scheme carries
with it. Also, at the moment can't get docstrings of TopologyAttrs to
get pulled into the corresponding AtomDescriptors.

This PR is meant mainly as a discussion point for progress on this idea.