### PR TITLE
Skip tests if scipy or NetCDF are missing

### DIFF
--- a/testsuite/MDAnalysisTests/analysis/test_distances.py
+++ b/testsuite/MDAnalysisTests/analysis/test_distances.py
@@ -16,14 +16,18 @@
 from __future__ import print_function
 
 import MDAnalysis
-import MDAnalysis.analysis.distances
+from MDAnalysisTests import module_not_found
 
-from numpy.testing import TestCase, assert_equal
+from numpy.testing import TestCase, assert_equal, dec
 import numpy as np
 
 
 class TestContactMatrix(TestCase):
+
+    @dec.skipif(module_not_found('scipy'),
+                "Test skipped because scipy is not available.")
     def setUp(self):
+        import MDAnalysis.analysis.distances
         self.coord = np.array([[1, 1, 1],
                                   [5, 5, 5],
                                   [1.1, 1.1, 1.1],

--- a/testsuite/MDAnalysisTests/analysis/test_leaflet.py
+++ b/testsuite/MDAnalysisTests/analysis/test_leaflet.py
@@ -14,14 +14,16 @@
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
 import MDAnalysis
-from MDAnalysis.analysis.leaflet import LeafletFinder
+from MDAnalysisTests import module_not_found
 
-from numpy.testing import TestCase, assert_equal
+from numpy.testing import TestCase, assert_equal, dec
 import numpy as np
 
 from MDAnalysisTests.datafiles import Martini_membrane_gro
 
 class TestLeafletFinder(TestCase):
+    @dec.skipif(module_not_found('scipy'),
+                "Test skipped because scipy is not available.")
     def setUp(self):
         self.universe = MDAnalysis.Universe(Martini_membrane_gro, Martini_membrane_gro)
         self.lipid_heads = self.universe.select_atoms("name PO4")
@@ -30,6 +32,7 @@ class TestLeafletFinder(TestCase):
         del self.universe
 
     def test_leaflet_finder(self):
+        from MDAnalysis.analysis.leaflet import LeafletFinder
         lfls = LeafletFinder(self.universe, self.lipid_heads, pbc=True)
         top_heads, bottom_heads = lfls.groups()
         # Make top be... on top.

--- a/testsuite/MDAnalysisTests/coordinates/test_dcd.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_dcd.py
@@ -6,7 +6,7 @@ from six.moves import zip
 from nose.plugins.attrib import attr
 from numpy.testing import (assert_equal, assert_array_equal, assert_raises,
                            assert_almost_equal, assert_array_almost_equal,
-                           assert_allclose)
+                           assert_allclose, dec)
 import tempdir
 from unittest import TestCase
 
@@ -14,6 +14,7 @@ from MDAnalysisTests.datafiles import (DCD, PSF, DCD_empty, CRD, PRMncdf, NCDF)
 from MDAnalysisTests.coordinates.reference import (RefCHARMMtriclinicDCD,
                                                    RefNAMDtriclinicDCD)
 from MDAnalysisTests.coordinates.base import BaseTimestepTest
+from MDAnalysisTests import module_not_found
 
 
 @attr('issue')
@@ -369,6 +370,8 @@ class TestDCDReader_NAMD_Unitcell(_TestDCDReader_TriclinicUnitcell,
 
 
 class TestNCDF2DCD(TestCase):
+    @dec.skipif(module_not_found("netCDF4"),
+                "Test skipped because netCDF is not available.")
     def setUp(self):
         self.u = mda.Universe(PRMncdf, NCDF)
         # create the DCD


### PR DESCRIPTION
Some tests requires scipy or NetCDF. Scipy and NetCDRF are optional dependencies, so thay can be
missing leading to the tests to fail.

This commit decorate the tests that need scipy or NetCDF—and were nor decorated already—with the dec.skipif decorator. This follows the guideline discussed in #124.

Fix #566 