### PR TITLE
 Travis run the test in minimal and full config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ env:
       - MDA_DOCDIR: package/doc/html
    matrix:
    - SETUP=full CYTHONIZE=true
-   - SETUP=full CYTHONIZE=false
    - SETUP=minimal CYTHONIZE=false
 language: python
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,6 @@ env:
       - GIT_CI_EMAIL: TravisCI@mdanalysis.org
       - MDA_DOCDIR: package/doc/html
    matrix:
-   - CYTHONIZE=true
-   - CYTHONIZE=false
-   - SETUP=full
-   - SETUP=minimal
+   - SETUP=full CYTHONIZE=true
+   - SETUP=full CYTHONIZE=false
+   - SETUP=minimal CYTHONIZE=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
   - chmod +x testsuite/MDAnalysisTests/mda_nosetests
 # command to run tests
 script:
-  - ./testsuite/MDAnalysisTests/mda_nosetests -v --with-coverage --cover-package MDAnalysis --processes=2 --process-timeout=120 --with-memleak
+  - ./testsuite/MDAnalysisTests/mda_nosetests -v --with-coverage --cover-package MDAnalysis --processes=2 --process-timeout=300 --with-memleak
   - |
      test ${TRAVIS_PULL_REQUEST} == "false" && \
      test ${TRAVIS_BRANCH} == ${GH_DOC_BRANCH} && \

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,11 @@ before_install:
   - export PATH=/home/travis/miniconda/bin:$PATH
   - conda update --yes conda
 install:
-  - conda create --yes -q -n pyenv mkl python=2.7 numpy=1.9.1 scipy=0.14.0 nose=1.3.7 sphinx=1.3
+  - if [[ $SETUP == 'full' ]]; then conda create --yes -q -n pyenv mkl python=2.7 numpy=1.9.1 scipy=0.14.0 nose=1.3.7 sphinx=1.3; fi
+  - if [[ $SETUP == 'minimal' ]]; then conda create --yes -q -n pyenv python=2.7 numpy=1.9.1 nose=1.3.7 sphinx=1.3; fi
   - source activate pyenv
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION cython biopython matplotlib networkx netcdf4
+  - if [[ $SETUP == 'full' ]]; then conda install --yes python=$TRAVIS_PYTHON_VERSION cython biopython matplotlib networkx netcdf4; fi
+  - if [[ $SETUP == 'minimal' ]]; then conda install --yes python=$TRAVIS_PYTHON_VERSION cython biopython networkx; fi
   - if [[ $CYTHONIZE == 'true' ]]; then find . -name '*.pyx' -exec touch '{}' \; ;fi
   - pip install -v package/
   - pip install testsuite/
@@ -54,3 +56,5 @@ env:
    matrix:
    - CYTHONIZE=true
    - CYTHONIZE=false
+   - SETUP=full
+   - SETUP=minimal

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
   - if [[ $SETUP == 'minimal' ]]; then conda create --yes -q -n pyenv python=2.7 numpy=1.9.1 nose=1.3.7 sphinx=1.3; fi
   - source activate pyenv
   - if [[ $SETUP == 'full' ]]; then conda install --yes python=$TRAVIS_PYTHON_VERSION cython biopython matplotlib networkx netcdf4; fi
-  - if [[ $SETUP == 'minimal' ]]; then conda install --yes python=$TRAVIS_PYTHON_VERSION cython biopython networkx; fi
+  - if [[ $SETUP == 'minimal' ]]; then conda install --yes python=$TRAVIS_PYTHON_VERSION biopython networkx; fi
   - if [[ $CYTHONIZE == 'true' ]]; then find . -name '*.pyx' -exec touch '{}' \; ;fi
   - pip install -v package/
   - pip install testsuite/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,15 @@
+env:
+   global:
+      - secure: "HIj3p+p2PV8DBVg/KGUx6n83KwB0ASE5FwOn0SMB9zxnzAqe8sapwdBQdMdq0sXB7xT1spJqRxuxOMVEVn35BNLu7bxMLfa4287C8YXcomnvmv9xruxAsjsIewnNQ80vtPVbQddBPxa4jKbqgPby5QhhAP8KANAqYe44pIV70fY="
+      - GH_DOC_BRANCH: develop
+      - GH_REPOSITORY: github.com/MDAnalysis/mdanalysis.git
+      - GIT_CI_USER: TravisCI
+      - GIT_CI_EMAIL: TravisCI@mdanalysis.org
+      - MDA_DOCDIR: package/doc/html
+   matrix:
+   - SETUP=full CYTHONIZE=true
+   - SETUP=full CYTHONIZE=false
+   - SETUP=minimal CYTHONIZE=false
 language: python
 python:
   - "2.7"
@@ -44,16 +56,3 @@ after_success:
      test ${TRAVIS_BRANCH} == ${GH_DOC_BRANCH} && \
      test "${TRAVIS_BUILD_NUMBER}.1" == "${TRAVIS_JOB_NUMBER}" && \
      bash ./maintainer/deploy_docs.sh
-
-env:
-   global:
-      - secure: "HIj3p+p2PV8DBVg/KGUx6n83KwB0ASE5FwOn0SMB9zxnzAqe8sapwdBQdMdq0sXB7xT1spJqRxuxOMVEVn35BNLu7bxMLfa4287C8YXcomnvmv9xruxAsjsIewnNQ80vtPVbQddBPxa4jKbqgPby5QhhAP8KANAqYe44pIV70fY="
-      - GH_DOC_BRANCH: develop
-      - GH_REPOSITORY: github.com/MDAnalysis/mdanalysis.git
-      - GIT_CI_USER: TravisCI
-      - GIT_CI_EMAIL: TravisCI@mdanalysis.org
-      - MDA_DOCDIR: package/doc/html
-   matrix:
-   - SETUP=full CYTHONIZE=true
-   - SETUP=full CYTHONIZE=false
-   - SETUP=minimal CYTHONIZE=false


### PR DESCRIPTION
This commit asks Travis to run the tests twice: once with all the requirements installed (SETUP=='full'), and once with none of the optional dependencies installed (SETUP=='minimal'). The minimal setup, has to run without the MKL as the conda mkl package pulls scipy with it.

The build fails which is expected. Indeed, until #568 get merged, some tests fail if scipy or netcdf are not installed.

Fix #483 