### PR TITLE
Fixes Issue #576

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ addons:
   apt:
     packages:
       - gfortran
+      - libgfortran3
       - libhdf5-serial-dev
       - libnetcdf-dev
       - liblapack-dev
@@ -28,8 +29,8 @@ before_install:
   - export PATH=/home/travis/miniconda/bin:$PATH
   - conda update --yes conda
 install:
-  - if [[ $SETUP == 'full' ]]; then conda create --yes -q -n pyenv mkl python=2.7 numpy=1.9.1 scipy=0.14.0 nose=1.3.7 sphinx=1.3; fi
-  - if [[ $SETUP == 'minimal' ]]; then conda create --yes -q -n pyenv python=2.7 numpy=1.9.1 nose=1.3.7 sphinx=1.3; fi
+  - if [[ $SETUP == 'full' ]]; then conda create --yes -q -n pyenv python=2.7 numpy=1.9.2 scipy=0.16.0 nose=1.3.7 sphinx=1.3; fi
+  - if [[ $SETUP == 'minimal' ]]; then conda create --yes -q -n pyenv python=2.7 numpy=1.9.2 nose=1.3.7 sphinx=1.3; fi
   - source activate pyenv
   - if [[ $SETUP == 'full' ]]; then conda install --yes python=$TRAVIS_PYTHON_VERSION cython biopython matplotlib networkx netcdf4; fi
   - if [[ $SETUP == 'minimal' ]]; then conda install --yes python=$TRAVIS_PYTHON_VERSION biopython networkx; fi
@@ -40,7 +41,7 @@ install:
   - chmod +x testsuite/MDAnalysisTests/mda_nosetests
 # command to run tests
 script:
-  - ./testsuite/MDAnalysisTests/mda_nosetests -v --with-coverage --cover-package MDAnalysis --processes=2 --process-timeout=300 --with-memleak
+  - ./testsuite/MDAnalysisTests/mda_nosetests --with-coverage --cover-package MDAnalysis --processes=2 --process-timeout=300 --with-memleak
   - |
      test ${TRAVIS_PULL_REQUEST} == "false" && \
      test ${TRAVIS_BRANCH} == ${GH_DOC_BRANCH} && \

--- a/testsuite/MDAnalysisTests/analysis/test_persistencelength.py
+++ b/testsuite/MDAnalysisTests/analysis/test_persistencelength.py
@@ -22,9 +22,11 @@ from numpy.testing import (
     assert_,
     assert_almost_equal,
     assert_raises,
+    dec
 )
 
 from MDAnalysisTests.datafiles import Plength
+from MDAnalysisTests import module_not_found
 
 
 class TestPersistenceLength(object):
@@ -52,6 +54,8 @@ class TestPersistenceLength(object):
         assert_(len(p.results) == 280)
         assert_almost_equal(p.lb, 1.485, 3)
 
+    @dec.skipif(module_not_found('scipy'),
+                "Test skipped because scipy is not available.")
     def test_fit(self):
         p = self._make_p()
         p.run()
@@ -72,10 +76,14 @@ class TestFitExponential(object):
         del self.a_ref
         del self.y
 
+    @dec.skipif(module_not_found('scipy'),
+                "Test skipped because scipy is not available.")
     def test_fit_simple(self):
         a = polymer.fit_exponential_decay(self.x, self.y)
         assert_(a == self.a_ref)
 
+    @dec.skipif(module_not_found('scipy'),
+                "Test skipped because scipy is not available.")
     def test_fit_noisy(self):
         y2 = self.y + (np.random.random(len(self.y)) - 0.5) * 0.05
         a = polymer.fit_exponential_decay(self.x, y2)


### PR DESCRIPTION
Added fix for missing libgfortran

Tagged persistencelength scipy tests as optional

Removed verbose from nosetests, caused travis page to be slow to use