### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/package/MDAnalysis/coordinates/GMS.py
+++ b/package/MDAnalysis/coordinates/GMS.py
@@ -106,7 +106,7 @@ class GMSReader(base.Reader):
         counter = 0
         for line in self.outfile:
             m = re.match(r'^.*RUNTYP=([A-Z]+)\s+.*', line)
-            if (m != None):
+            if (m is not None):
                 self.close()
                 return m.group(1).lower()
 
@@ -130,7 +130,7 @@ class GMSReader(base.Reader):
         # this assumes that this is only called once at startup and that the filestream is already open
         for line in self.outfile:           
             m = re.match(r'\s*TOTAL NUMBER OF ATOMS\s*=\s*([0-9]+)\s*',line)
-            if m == None:
+            if m is None:
                 continue
             self.close()
             return int(m.group(1))
@@ -180,14 +180,14 @@ class GMSReader(base.Reader):
 
         for line in self.outfile:
             if self.runtyp == 'optimize': 
-                if (flag == 0) and (re.match(r'^.NSERCH=.*', line) != None):
+                if (flag == 0) and (re.match(r'^.NSERCH=.*', line) is not None):
                     flag = 1
                     continue
                 if (flag == 1) and (re.match(r'^ COORDINATES OF ALL ATOMS ARE ',\
-                    line) != None):
+                    line) is not None):
                     flag = 2
                     continue
-                if (flag == 2) and (re.match(r'^\s*[-]+\s*', line) != None):
+                if (flag == 2) and (re.match(r'^\s*[-]+\s*', line) is not None):
                     flag = 3
                     continue
                 if flag == 3 and counter < self.n_atoms:
@@ -199,11 +199,11 @@ class GMSReader(base.Reader):
 
             elif self.runtyp == 'surface':
                 if (flag == 0) and (re.match(\
-                        r'^.COORD 1=\s*([-]?[0-9]+\.[0-9]+).*', line) != None):
+                        r'^.COORD 1=\s*([-]?[0-9]+\.[0-9]+).*', line) is not None):
                     flag = 1
                     continue
                 if (flag == 1) and (re.match(\
-                        r'^\s*HAS ENERGY VALUE\s*([-]?[0-9]+\.[0-9]+)\s*', line) != None):
+                        r'^\s*HAS ENERGY VALUE\s*([-]?[0-9]+\.[0-9]+)\s*', line) is not None):
                     flag = 3
                     continue
                 if flag == 3 and counter < self.n_atoms:

--- a/package/MDAnalysis/topology/GMSParser.py
+++ b/package/MDAnalysis/topology/GMSParser.py
@@ -75,7 +75,7 @@ class GMSParser(TopologyReader):
                 _m = re.match(\
 r'^\s*([A-Za-z_][A-Za-z_0-9]*)\s+([0-9]+\.[0-9]+)\s+(\-?[0-9]+\.[0-9]+)\s+(\-?[0-9]+\.[0-9]+)\s+(\-?[0-9]+\.[0-9]+).*',
                         line)
-                if _m == None:
+                if _m is None:
                     break
                 name = _m.group(1)
                 elem = int(float(_m.group(2)))


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:MDAnalysis:mdanalysis?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:MDAnalysis:mdanalysis?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)