### PR TITLE
Remove some bangs from formated string

### DIFF
--- a/package/MDAnalysis/analysis/align.py
+++ b/package/MDAnalysis/analysis/align.py
@@ -922,7 +922,7 @@ def get_matching_atoms(ag1, ag2, tol_mass=0.1, strict=False):
 
         logger.error("Atoms: reference | trajectory")
         for ar, at in itertools.izip(ag1[mismatch_atomindex], ag2[mismatch_atomindex]):
-            logger.error("{0:4!s} {1:3d} {2:3!s} {3:3!s} {4:6.3f}  |  {5:4!s} {6:3d} {7:3!s} {8:3!s} {9:6.3f}".format(ar.segid, ar.resid, ar.resname, ar.name, ar.mass,
+            logger.error("{0:4s} {1:3d} {2:3s} {3:3s} {4:6.3f}  |  {5:4s} {6:3d} {7:3s} {8:3s} {9:6.3f}".format(ar.segid, ar.resid, ar.resname, ar.name, ar.mass,
                           at.segid, at.resid, at.resname, at.name, at.mass))
         errmsg = ("Inconsistent selections, masses differ by more than {0}; " + \
             "mis-matching atoms are shown above.").format(tol_mass)

--- a/package/MDAnalysis/coordinates/XYZ.py
+++ b/package/MDAnalysis/coordinates/XYZ.py
@@ -246,7 +246,7 @@ class XYZWriter(base.Writer):
         self._xyz.write("{0:d}\n".format(ts.n_atoms))
         self._xyz.write("frame {0}\n".format(ts.frame))
         for atom, (x, y, z) in itertools.izip(self.atomnames, coordinates):
-            self._xyz.write("{0:8!s}  {1:10.5f} {2:10.5f} {3:10.5f}\n".format(atom, x, y, z))
+            self._xyz.write("{0:8s}  {1:10.5f} {2:10.5f} {3:10.5f}\n".format(atom, x, y, z))
 
 
 class XYZReader(base.Reader):


### PR DESCRIPTION
Cody (quantifiedcode) uses exclamation marks in its format strings.
Some appear to cause error.

Note that the same problem could appear in part of the code that are not covered by tests (e.g. the examples).

This PR targets the autofix/wrapped2_to3_fix-3 branch to makes PR #592 pass the tests.