### PR TITLE
Refining how Components get attribute accessors.

### DIFF
--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -82,7 +82,7 @@ class GroupBase(object):
         setter = lambda self, values: attr.__setitem__(self, values)
 
         setattr(cls, attr.attrname,
-                property(getter, setter, None, attr.__doc__))
+                property(getter, setter, None, attr.groupdoc))
 
     def __len__(self):
         return len(self._ix)
@@ -671,7 +671,6 @@ class ComponentBase(object):
         return self.level.plural(
                 np.concatenate((np.array([self._ix]), o_ix)), self._u)
 
-    # TODO: put in mixin with GroupBase method of same name
     @classmethod
     def _add_prop(cls, attr):
         """Add attr into the namespace for this class
@@ -685,7 +684,7 @@ class ComponentBase(object):
         setter = lambda self, values: attr.__setitem__(self, values)
 
         setattr(cls, attr.singular,
-                property(getter, setter, None, attr.__doc__))
+                property(getter, setter, None, attr.singledoc))
 
     @property
     def universe(self):
@@ -801,12 +800,7 @@ class ResidueBase(ComponentBase):
     @property
     def atoms(self):
         atomsclass = self.level.child.plural
-
-        # we need to pass a fake residue with a numpy array as its self._ix for
-        # downward translation tables to work; this is because they accept
-        # arrays only for performance
-        r_proxy = self.__class__(np.array([self._ix]), self._u)
-        return atomsclass(self._u._topology.indices[r_proxy],
+        return atomsclass(self._u._topology.indices[self],
                           self._u)
 
     @property
@@ -840,21 +834,11 @@ class SegmentBase(ComponentBase):
     @property
     def atoms(self):
         atomsclass = self.level.child.child.plural
-
-        # we need to pass a fake segment with a numpy array as its self._ix for
-        # downward translation tables to work; this is because they accept
-        # arrays only for performance
-        s_proxy = self.__class__(np.array([self._ix]), self._u)
-        return atomsclass(self._u._topology.indices[s_proxy],
+        return atomsclass(self._u._topology.indices[self],
                           self._u)
 
     @property
     def residues(self):
         residuesclass = self.level.child.plural
-
-        # we need to pass a fake residue with a numpy array as its self._ix for
-        # downward translation tables to work; this is because they accept arrays only
-        # for performance
-        s_proxy = self.__class__(np.array([self._ix]), self._u)
-        return residuesclass(self._u._topology.resindices[s_proxy],
+        return residuesclass(self._u._topology.resindices[self],
                              self._u)

--- a/package/MDAnalysis/core/topology.py
+++ b/package/MDAnalysis/core/topology.py
@@ -122,12 +122,12 @@ class TransTable(object):
             indices of atoms present in residues, collectively
 
         """
-        if isinstance(rix, int):
-            x, y = self._res_ptrs[rix]
-            return self._atom_order[x:y]
-        else:
+        try:
             return np.concatenate([self._atom_order[x:y]
                                    for x, y in self._res_ptrs[rix]])
+        except TypeError:
+            x, y = self._res_ptrs[rix]
+            return self._atom_order[x:y]
 
     def r2a_2d(self, rix):
         """Get atom indices represented by each residue index.
@@ -145,11 +145,11 @@ class TransTable(object):
             in that residue
 
         """
-        if isinstance(rix, int):
+        try:
+            return [self._atom_order[x:y] for x, y in self._res_ptrs[rix]]
+        except TypeError:
             x, y = self._res_ptrs[rix]
             return self._atom_order[x:y]
-        else:
-            return (self._atom_order[x:y] for x, y in self._res_ptrs[rix])
 
     def r2s(self, rix):
         """Get segment indices for each residue.
@@ -181,12 +181,12 @@ class TransTable(object):
             sorted indices of residues present in segments, collectively
 
         """
-        if isinstance(six, int):
-            x, y = self._seg_ptrs[six]
-            return self._res_order[x:y]
-        else:
+        try:
             return np.concatenate([self._res_order[x:y]
                                    for x, y in self._seg_ptrs[six]])
+        except TypeError:
+            x, y = self._seg_ptrs[six]
+            return self._res_order[x:y]
 
     def s2r_2d(self, six):
         """Get residue indices represented by each segment index.
@@ -204,11 +204,11 @@ class TransTable(object):
             in that segment
 
         """
-        if isinstance(six, int):
+        try:
+            return [self._res_order[x:y] for x, y in self._seg_ptrs[six]]
+        except TypeError:
             x, y = self._seg_ptrs[six]
             return self._res_order[x:y]
-        else:
-            return (self._res_order[x:y] for x, y in self._seg_ptrs[six])
 
     # Compound moves, does 2 translations
     def a2s(self, aix):
@@ -271,7 +271,7 @@ class TransTable(object):
         if isinstance(rixs, np.ndarray):
             return self.r2a_1d(rixs)
         else:
-            return (self.r2a_1d(rix) for rix in rixs)
+            return [self.r2a_1d(rix) for rix in rixs]
 
 
 #TODO: movers and resizers

--- a/package/MDAnalysis/core/topology.py
+++ b/package/MDAnalysis/core/topology.py
@@ -122,8 +122,12 @@ class TransTable(object):
             indices of atoms present in residues, collectively
 
         """
-        return np.concatenate([self._atom_order[x:y]
-                               for x, y in self._res_ptrs[rix]])
+        if isinstance(rix, int):
+            x, y = self._res_ptrs[rix]
+            return self._atom_order[x:y]
+        else:
+            return np.concatenate([self._atom_order[x:y]
+                                   for x, y in self._res_ptrs[rix]])
 
     def r2a_2d(self, rix):
         """Get atom indices represented by each residue index.
@@ -141,7 +145,11 @@ class TransTable(object):
             in that residue
 
         """
-        return (self._atom_order[x:y] for x, y in self._res_ptrs[rix])
+        if isinstance(rix, int):
+            x, y = self._res_ptrs[rix]
+            return self._atom_order[x:y]
+        else:
+            return (self._atom_order[x:y] for x, y in self._res_ptrs[rix])
 
     def r2s(self, rix):
         """Get segment indices for each residue.
@@ -173,8 +181,12 @@ class TransTable(object):
             sorted indices of residues present in segments, collectively
 
         """
-        return np.concatenate([self._res_order[x:y]
-                               for x, y in self._seg_ptrs[six]])
+        if isinstance(six, int):
+            x, y = self._seg_ptrs[six]
+            return self._res_order[x:y]
+        else:
+            return np.concatenate([self._res_order[x:y]
+                                   for x, y in self._seg_ptrs[six]])
 
     def s2r_2d(self, six):
         """Get residue indices represented by each segment index.
@@ -192,7 +204,11 @@ class TransTable(object):
             in that segment
 
         """
-        return (self._res_order[x:y] for x, y in self._seg_ptrs[six])
+        if isinstance(six, int):
+            x, y = self._seg_ptrs[six]
+            return self._res_order[x:y]
+        else:
+            return (self._res_order[x:y] for x, y in self._seg_ptrs[six])
 
     # Compound moves, does 2 translations
     def a2s(self, aix):
@@ -226,8 +242,13 @@ class TransTable(object):
             sorted indices of atoms present in segments, collectively
 
         """
+
         rixs = self.s2r_2d(six)
-        return np.concatenate([self.r2a_1d(rix) for rix in rixs])
+
+        if isinstance(rixs, np.ndarray):
+            return self.r2a_1d(rixs)
+        else:
+            return np.concatenate([self.r2a_1d(rix) for rix in rixs])
 
     def s2a_2d(self, six):
         """Get atom indices represented by each segment index.
@@ -246,7 +267,11 @@ class TransTable(object):
 
         """
         rixs = self.s2r_2d(six)
-        return (self.r2a_1d(rix) for rix in rixs)
+
+        if isinstance(rixs, np.ndarray):
+            return self.r2a_1d(rixs)
+        else:
+            return (self.r2a_1d(rix) for rix in rixs)
 
 
 #TODO: movers and resizers
@@ -318,7 +343,3 @@ class Topology(object):
         self.attrs.append(topologyattr)
         topologyattr.top = self
         self.__setattr__(topologyattr.attrname, topologyattr)
-
-        ## TODO: add checking that TopologyAttr len gives right length for
-        # its level
-

--- a/package/MDAnalysis/core/topology.py
+++ b/package/MDAnalysis/core/topology.py
@@ -248,7 +248,7 @@ class TransTable(object):
         if isinstance(rixs, np.ndarray):
             return self.r2a_1d(rixs)
         else:
-            return np.concatenate([self.r2a_1d(rix) for rix in rixs])
+            return np.concatenate((self.r2a_1d(rix) for rix in rixs))
 
     def s2a_2d(self, six):
         """Get atom indices represented by each segment index.
@@ -271,7 +271,7 @@ class TransTable(object):
         if isinstance(rixs, np.ndarray):
             return self.r2a_1d(rixs)
         else:
-            return [self.r2a_1d(rix) for rix in rixs]
+            return (self.r2a_1d(rix) for rix in rixs)
 
 
 #TODO: movers and resizers

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -119,7 +119,7 @@ class Atomindices(TopologyAttr):
     """
     attrname = 'indices'
     singular = 'index'
-    levels = ['atom']
+    target_levels = ['atom']
 
     def __init__(self):
         pass
@@ -155,7 +155,7 @@ class Resindices(TopologyAttr):
     """
     attrname = 'resindices'
     singular = 'resindex'
-    levels = ['residue']
+    target_levels = ['residue']
 
     def __init__(self):
         pass
@@ -199,7 +199,7 @@ class Segindices(TopologyAttr):
     """
     attrname = 'segindices'
     singular = 'segindex'
-    levels = ['segment']
+    target_levels = ['segment']
 
     def __init__(self):
         pass
@@ -229,7 +229,7 @@ class AtomAttr(TopologyAttr):
     """
     attrname = 'atomattrs'
     singular = 'atomattr'
-    levels = ['atom']
+    target_levels = ['atom']
 
     def get_atoms(self, ag):
         return self.values[ag._ix]
@@ -314,7 +314,7 @@ class Tempfactors(AtomAttr):
 class Masses(AtomAttr):
     attrname = 'masses'
     singular = 'mass'
-    levels = ['atom', 'residue', 'segment']
+    target_levels = ['atom', 'residue', 'segment']
     transplants = defaultdict(list)
 
     groupdoc = """Mass of each component in the Group.
@@ -503,7 +503,7 @@ class ResidueAttr(TopologyAttr):
     """
     attrname = 'residueattrs'
     singular = 'residueattr'
-    levels = ['residue']
+    target_levels = ['residue']
 
     def get_atoms(self, ag):
         rix = self.top.tt.a2r(ag._ix)
@@ -530,21 +530,21 @@ class Resids(ResidueAttr):
     """Residue ID"""
     attrname = 'resids'
     singular = 'resid'
-    levels = ['atom', 'residue']
+    target_levels = ['atom', 'residue']
 
 
 #TODO: update docs to property doc
 class Resnames(ResidueAttr):
     attrname = 'resnames'
     singular = 'resname'
-    levels = ['atom', 'residue']
+    target_levels = ['atom', 'residue']
 
 
 #TODO: update docs to property doc
 class Resnums(ResidueAttr):
     attrname = 'resnums'
     singular = 'resnum'
-    levels = ['atom', 'residue']
+    target_levels = ['atom', 'residue']
 
 
 ## segment attributes
@@ -555,7 +555,7 @@ class SegmentAttr(TopologyAttr):
     """
     attrname = 'segmentattrs'
     singular = 'segmentattr'
-    levels = ['segment']
+    target_levels = ['segment']
 
     def get_atoms(self, ag):
         six = self.top.tt.a2s(ag._ix)
@@ -576,7 +576,7 @@ class SegmentAttr(TopologyAttr):
 class Segids(SegmentAttr):
     attrname = 'segids'
     singular = 'segid'
-    levels = ['atom', 'residue', 'segment']
+    target_levels = ['atom', 'residue', 'segment']
 
 
 #TODO: update docs to property doc

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -377,7 +377,7 @@ class Universe(object):
         """
         self._classes['group']._add_prop(attr)
 
-        for level in attr.levels:
+        for level in attr.target_levels:
             try:
                 self._classes[level]._add_prop(attr)
             except (KeyError, AttributeError):

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -377,10 +377,11 @@ class Universe(object):
         """
         self._classes['group']._add_prop(attr)
 
-        try:
-            self._classes[attr.level]._add_prop(attr)
-        except (KeyError, AttributeError):
-            pass
+        for level in attr.levels:
+            try:
+                self._classes[level]._add_prop(attr)
+            except (KeyError, AttributeError):
+                pass
 
         for dest in ['atom', 'residue', 'segment', 'group',
                      'atomgroup', 'residuegroup', 'segmentgroup']:


### PR DESCRIPTION
Taking Masses as an example, since we already define how
`ResidueGroup.masses` and `SegmentGroup.masses` work (automatic
aggregation of components), there's no need to define the same
thing twice to make there be a `Residue.mass` and `Segment.mass`
property that gives the value for a single one of these components.

This required making TransTable methods handle single integers, which
adds only a single if statement to methods that already had list
comprehensions anyway, so shouldn't see a performance hit. This means we
don't have to do backflips for Residues and Segments to make downward
translations work, either.

Also mixed in here are some work on docstrings that are not yet
complete. Sorry.