### PR TITLE
dynamic selections for density_from_Universe (issue #584)

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -64,6 +64,8 @@ Chronological list of authors
   - Gorman Stock
   - Jonathan Barnoud
   - Hai Nguyen
+2016
+  - Balasubramanian
 
 External code
 -------------

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -56,6 +56,8 @@ Changes
   * analysis.helanal.helanal_trajectory() and helanal_main() now use a
     logger at level INFO to output all their computed values instead
     of printing to stdout
+  * default offset for ProgressMeter was changed from 0 to 1 (to match
+    the change from 1- to 0-based ts.frame counting)
 
 Fixes
 

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -61,6 +61,9 @@ Changes
     of printing to stdout
   * default offset for ProgressMeter was changed from 0 to 1 (to match
     the change from 1- to 0-based ts.frame counting)
+  * removed superfluous analysis.density.density_from_trajectory();
+    use density_from_Universe(TOPOL, TRAJ) instead.
+  
 
 Fixes
 

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -14,7 +14,7 @@ The rules for this file:
 
 ------------------------------------------------------------------------------
 --/--/16 tyler.je.reddy, kain88-de, richardjgowers, manuel.nuno.melo,
-         orbeckst
+         orbeckst, Balasubra
 
   * 0.13.0
 
@@ -45,6 +45,7 @@ Enhancement
   * Added analysis.rdf, with InterRDF tool. (Issue #460)
   * Made Reader.check_slice_indices a public method (Issue #604)
   * analysis.helanal.helanal_main() now returns results as dict
+  * Added keyword to update selection every frame in density calculation (Issue #584) 
 
 Changes
 

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -46,6 +46,9 @@ Enhancement
   * Made Reader.check_slice_indices a public method (Issue #604)
   * analysis.helanal.helanal_main() now returns results as dict
   * Added keyword to update selection every frame in density calculation (Issue #584) 
+  * New keywords start, stop, step for density.density_from_Universe()
+    to slice a trajectory.
+
 
 Changes
 

--- a/package/MDAnalysis/analysis/density.py
+++ b/package/MDAnalysis/analysis/density.py
@@ -389,9 +389,10 @@ class Density(Grid):
 def density_from_trajectory(*args, **kwargs):
     """Create a density grid from a trajectory.
 
+    ::
          density_from_trajectory(PSF, DCD, delta=1.0, atomselection='name OH2', ...) --> density
 
-    or
+    or ::
 
          density_from_trajectory(PDB, XTC, delta=1.0, atomselection='name OH2', ...) --> density
 
@@ -403,36 +404,33 @@ def density_from_trajectory(*args, **kwargs):
             if reading a single PDB file it is sufficient to just
             provide it once as a single argument
 
-    :Keywords:
-      atomselection
-            selection string (MDAnalysis syntax) for the species to be analyzed
-            ["name OH2"]
-      delta
-            bin size for the density grid in Angstroem (same in x,y,z) [1.0]
-      metadata
-            dictionary of additional data to be saved with the object
-      padding
-            increase histogram dimensions by padding (on top of initial box size)
-            in Angstroem [2.0]
-      soluteselection
-            MDAnalysis selection for the solute, e.g. "protein" [``None``]
-      cutoff
-            With *cutoff*, select '<atomsel> NOT WITHIN <cutoff> OF <soluteselection>'
-            (Special routines that are faster than the standard AROUND selection) [0]
-
     :Returns: :class:`Density`
 
-    .. SeeAlso:: docs for :func:`density_from_Universe` (defaults for kwargs are defined there).
+    .. SeeAlso:: :func:`density_from_Universe` shows all available *kwargs*
     """
     return density_from_Universe(MDAnalysis.Universe(*args), **kwargs)
 
 
 def density_from_Universe(universe, delta=1.0, atomselection='name OH2',
+                          start=None, stop=None, step=None,
                           metadata=None, padding=2.0, cutoff=0, soluteselection=None,
-                          use_kdtree=True, update_selection=False, **kwargs):
-    """Create a density grid from a MDAnalysis.Universe object.
+                          use_kdtree=True, update_selection=False,
+                          quiet=False, interval=1,
+                          **kwargs):
+    """Create a density grid from a :class:`MDAnalysis.Universe` object.
+
+    The trajectory is read, frame by frame, and the atoms selected with *atomselection* are
+    histogrammed on a grid with spacing *delta*::
 
       density_from_Universe(universe, delta=1.0, atomselection='name OH2', ...) --> density
+
+    .. Note:: By default, the *atomselection* is static, i.e., atoms are only
+              selected once at the beginning. If you want dynamically changing
+              selections (such as "name OW and around 4.0 (protein and not name
+              H*)") then set ``update_selection=True``. For the special case of
+              calculating a density of the "bulk" solvent away from a solute
+              use the optimized selections with keywords *cutoff* and
+              *soluteselection*.
 
     :Arguments:
       universe
@@ -444,6 +442,9 @@ def density_from_Universe(universe, delta=1.0, atomselection='name OH2',
             ["name OH2"]
       delta
             bin size for the density grid in Angstroem (same in x,y,z) [1.0]
+      start, stop, step
+            Slice the trajectory as ``trajectory[start"stop:step]``; default
+            is to read the whole trajectory.
       metadata
             dictionary of additional data to be saved with the object
       padding
@@ -452,10 +453,20 @@ def density_from_Universe(universe, delta=1.0, atomselection='name OH2',
       soluteselection
             MDAnalysis selection for the solute, e.g. "protein" [``None``]
       cutoff
-            With *cutoff*, select '<atomsel> NOT WITHIN <cutoff> OF <soluteselection>'
-            (Special routines that are faster than the standard AROUND selection) [0]
+            With *cutoff*, select "<atomsel> NOT WITHIN <cutoff> OF <soluteselection>"
+            (Special routines that are faster than the standard ``AROUND`` selection)
+            [0]
       update_selection
-            True: Atom selection is updated for each frame
+            Should the selection of atoms be updated for every step? [``False``]
+            - ``True``: atom selection is updated for each frame, can be slow
+            - ``False``: atoms are only selected at the beginning
+      quiet
+            Print status update to the screen for every *interval* frame? [``False``]
+            - ``True``: no status updates when a new frame is processed
+            - ``False``: status update every frame (including number of atoms
+              processed, which is interesting with ``update_selection=True``)
+      interval
+           Show status update every *interval* frame [1]
       parameters
             dict with some special parameters for :class:`Density` (see doc)
       kwargs
@@ -464,7 +475,7 @@ def density_from_Universe(universe, delta=1.0, atomselection='name OH2',
     :Returns: :class:`Density`
 
     .. versionchanged:: 0.13.0
-       *update_selection* keyword added
+       *update_selection* and *quite* keywords added
 
     """
     try:
@@ -516,10 +527,10 @@ def density_from_Universe(universe, delta=1.0, atomselection='name OH2',
     grid *= 0.0
     h = grid.copy()
 
-    pm = ProgressMeter(u.trajectory.n_frames, interval=1,
+    pm = ProgressMeter(u.trajectory.n_frames, interval=interval, quiet=quiet,
                        format="Histogramming %(n_atoms)6d atoms in frame "
                        "%(step)5d/%(numsteps)d  [%(percentage)5.1f%%]\r")
-    for ts in u.trajectory:
+    for ts in u.trajectory[start:stop:step]:
         if update_selection:
            group = u.select_atoms(atomselection)
            coord=group.positions

--- a/package/MDAnalysis/analysis/density.py
+++ b/package/MDAnalysis/analysis/density.py
@@ -72,7 +72,6 @@ Classes and Functions
    :inherited-members:
    :show-inheritance:
 .. autofunction:: density_from_Universe
-.. autofunction:: density_from_trajectory
 .. autofunction:: density_from_PDB
 .. autofunction:: Bfactor2RMSF
 .. autoclass:: BfactorDensityCreator
@@ -384,32 +383,6 @@ class Density(Grid):
         else:
             grid_type = 'histogram'
         return '<Density ' + grid_type + ' with ' + str(self.grid.shape) + ' bins>'
-
-
-def density_from_trajectory(*args, **kwargs):
-    """Create a density grid from a trajectory.
-
-    ::
-         density_from_trajectory(PSF, DCD, delta=1.0, atomselection='name OH2', ...) --> density
-
-    or ::
-
-         density_from_trajectory(PDB, XTC, delta=1.0, atomselection='name OH2', ...) --> density
-
-    :Arguments:
-      topology file
-            any topology file understood by MDAnalysis
-      trajectory
-            any trajectory (coordinate) file understood by MDAnalysis;
-            if reading a single PDB file it is sufficient to just
-            provide it once as a single argument
-
-    :Returns: :class:`Density`
-
-    .. SeeAlso:: :func:`density_from_Universe` shows all available *kwargs*
-    """
-    return density_from_Universe(MDAnalysis.Universe(*args), **kwargs)
-
 
 def density_from_Universe(universe, delta=1.0, atomselection='name OH2',
                           start=None, stop=None, step=None,

--- a/package/MDAnalysis/analysis/density.py
+++ b/package/MDAnalysis/analysis/density.py
@@ -425,7 +425,7 @@ def density_from_trajectory(*args, **kwargs):
 
 def density_from_Universe(universe, delta=1.0, atomselection='name OH2',
                           metadata=None, padding=2.0, cutoff=0, soluteselection=None,
-                          use_kdtree=True, **kwargs):
+                          use_kdtree=True, update_selection=False, **kwargs):
     """Create a density grid from a MDAnalysis.Universe object.
 
       density_from_Universe(universe, delta=1.0, atomselection='name OH2', ...) --> density
@@ -450,12 +450,17 @@ def density_from_Universe(universe, delta=1.0, atomselection='name OH2',
       cutoff
             With *cutoff*, select '<atomsel> NOT WITHIN <cutoff> OF <soluteselection>'
             (Special routines that are faster than the standard AROUND selection) [0]
+      update_selection 
+            True: Atom selection is updated for each frame
       parameters
             dict with some special parameters for :class:`Density` (see doc)
       kwargs
             metadata, parameters are modified and passed on to :class:`Density`
 
     :Returns: :class:`Density`
+    
+    .. versionchanged:: 0.13.0
+    *update_selection* keyword added
 
     """
     try:
@@ -511,7 +516,12 @@ def density_from_Universe(universe, delta=1.0, atomselection='name OH2',
     for ts in u.trajectory:
         print("Histograming %6d atoms in frame %5d/%d  [%5.1f%%]\r" % \
               (len(coord), ts.frame, u.trajectory.n_frames, 100.0 * ts.frame / u.trajectory.n_frames),)
-        coord = current_coordinates()
+        if update_selection:
+           group = u.select_atoms(atomselection)
+           coord=group.positions
+        else:
+           coord = current_coordinates()
+           
         if len(coord) == 0:
             continue
         h[:], edges[:] = np.histogramdd(coord, bins=bins, range=arange, normed=False)

--- a/package/MDAnalysis/lib/log.py
+++ b/package/MDAnalysis/lib/log.py
@@ -1,5 +1,5 @@
 # -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
-# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
 #
 # MDAnalysis --- http://www.MDAnalysis.org
 # Copyright (c) 2006-2015 Naveen Michaud-Agrawal, Elizabeth J. Denning, Oliver Beckstein
@@ -209,7 +209,7 @@ class ProgressMeter(object):
 
     """
 
-    def __init__(self, numsteps, format=None, interval=10, offset=0, quiet=False):
+    def __init__(self, numsteps, format=None, interval=10, offset=1, quiet=False):
         """Set up the ProgressMeter
 
         :Arguments:
@@ -233,8 +233,8 @@ class ProgressMeter(object):
               If *format* is ``None`` then the default is used.
               ["Step %(step)5d/%(numsteps)d [%(percentage)5.1f%%]\\r"]
            *offset*
-              number to add to *step*; e.g. if *step* is 0-based then one would
-              set *offset* = 1 [0]
+              number to add to *step*; e.g. if *step* is 0-based (as in MDAnalysis)
+              then one should set *offset* = 1; for 1-based steps, choose 0. [1]
            *quiet*
               If ``True``, disable all output, ``False`` print all messages as
               specified, [``False``]

--- a/package/doc/sphinx/source/conf.py
+++ b/package/doc/sphinx/source/conf.py
@@ -79,14 +79,14 @@ master_doc = 'index'
 # Ordering: (1) Naveen (2) Elizabeth, then all contributors in alphabetical order
 #           (last) Oliver
 authors = u"""Naveen Michaud-Agrawal, Elizabeth J. Denning, Joshua
-    Adelman, Jonathan Barnoud, Christian Beckstein (logo), Alejandro
+    Adelman, Balasubramanian, Jonathan Barnoud, Christian Beckstein (logo), Alejandro
     Bernardin, Sébastien Buchoux, David Caplan, Matthieu Chavent,
     Xavier Deupi, Jan Domański, David L. Dotson, Lennard van der
     Feltz, Philip Fowler, Joseph Goose, Richard J. Gowers, Lukas
     Grossar, Benjamin Hall, Joe Jordan, Max Linke, Jinju Lu, Robert
     McGibbon, Alex Nesterenko, Manuel Nuno Melo, Hai Nguyen,
     Caio S. Souza, Danny Parton, Joshua L. Phillips, Tyler Reddy,
-    Paul Rigor, Sean L. Seyler, Andy Somogyi, Lukas Stelzl, 
+    Paul Rigor, Sean L. Seyler, Andy Somogyi, Lukas Stelzl,
     Gorman Stock, Isaac Virshup, Zhuyi Xue, Carlos Yáñez S.,
     and Oliver Beckstein"""
 project = u'MDAnalysis'

--- a/testsuite/MDAnalysisTests/analysis/test_density.py
+++ b/testsuite/MDAnalysisTests/analysis/test_density.py
@@ -89,6 +89,8 @@ class Test_density_from_Universe(TestCase):
                   }
     references = {'static':
                       {'meandensity': 0.016764271713091212, },
+                  'static_sliced':
+                      {'meandensity': 0.0067057088794023143, },
                   'dynamic':
                       {'meandensity': 0.00062423404854011104, },
                   }
@@ -125,6 +127,13 @@ class Test_density_from_Universe(TestCase):
         self.check_density_from_Universe(
             self.selections['static'],
             self.references['static']['meandensity'])
+
+    def test_density_from_Universe_sliced(self):
+        self.check_density_from_Universe(
+            self.selections['static'],
+            self.references['static_sliced']['meandensity'],
+            start=1, stop=-1, step=2,
+            )
 
     def test_density_from_Universe_update_selection(self):
         self.check_density_from_Universe(

--- a/testsuite/MDAnalysisTests/test_log.py
+++ b/testsuite/MDAnalysisTests/test_log.py
@@ -89,7 +89,7 @@ class TestProgressMeter(TestCase):
     def test_default_ProgressMeter(self, n=101, interval=10):
         format = "Step %(step)5d/%(numsteps)d [%(percentage)5.1f%%]\r"
         with RedirectedStderr(self.buf):
-            pm = MDAnalysis.lib.log.ProgressMeter(n, interval=interval, offset=1)
+            pm = MDAnalysis.lib.log.ProgressMeter(n, interval=interval)
             for frame in range(n):
                 pm.echo(frame)
         self.buf.seek(0L)


### PR DESCRIPTION
I manually merged @Balasubra 's PR #612 that adds dynamic selections to `analysis.density.density_from_Universe()` #584
* rewrote the history to squish commits, follow StyleGuide for commit messages, fixed minor things in docs
* added a test case (just regression test)
* use `ProgressMeter` instead of bare print
* updated the default `offset` parameter for `ProgressMeter` to correspond to new 0-based `ts.frame` counting 

This PR closes PR #612 and issue #584. 