### PR TITLE
Issue 431 registerreaders

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -49,6 +49,8 @@ Enhancement
   * New keywords start, stop, step for density.density_from_Universe()
     to slice a trajectory.
   * MOL2Reader now reads molecule and substructure into ts.data
+  * All subclasses of ProtoReader, Writer and TopologyReader are automatically
+    added to the MDAnalysis directory of I/O (Issue #431)
 
 Changes
 

--- a/package/MDAnalysis/coordinates/DCD.py
+++ b/package/MDAnalysis/coordinates/DCD.py
@@ -192,6 +192,7 @@ class DCDWriter(base.Writer):
     .. _Issue 187: https://github.com/MDAnalysis/mdanalysis/issues/187
     """
     format = 'DCD'
+    multiframe = True
     flavor = 'CHARMM'
     units = {'time': 'AKMA', 'length': 'Angstrom'}
 

--- a/package/MDAnalysis/coordinates/INPCRD.py
+++ b/package/MDAnalysis/coordinates/INPCRD.py
@@ -28,7 +28,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from . import base
 
 class INPReader(base.SingleFrameReader):
-    format = 'INPCRD'
+    format = ['INPCRD', 'RESTRT']
     units = {'length': 'Angstrom'}
 
     def _read_first_frame(self):

--- a/package/MDAnalysis/coordinates/LAMMPS.py
+++ b/package/MDAnalysis/coordinates/LAMMPS.py
@@ -99,7 +99,8 @@ class DCDWriter(DCD.DCDWriter):
     "Angstrom". See :mod:`MDAnalysis.units` for other recognized
     values.
     """
-    format = 'DCD'
+    format = 'LAMMPS'
+    multiframe = True
     flavor = 'LAMMPS'
 
     def __init__(self, *args, **kwargs):
@@ -125,7 +126,7 @@ class DCDReader(DCD.DCDReader):
 
     .. _units style: http://lammps.sandia.gov/doc/units.html
     """
-    format = 'DCD'
+    format = 'LAMMPS'
     flavor = 'LAMMPS'
 
     def __init__(self, dcdfilename, **kwargs):

--- a/package/MDAnalysis/coordinates/MOL2.py
+++ b/package/MDAnalysis/coordinates/MOL2.py
@@ -207,10 +207,11 @@ class MOL2Writer(base.Writer):
 
     """
     format = 'MOL2'
+    multiframe = True
     units = {'time': None, 'length': 'Angstrom'}
 
     def __init__(self, filename, n_atoms=None,
-                 convert_units=None, multiframe=None):
+                 convert_units=None):
         """Create a new MOL2Writer
 
         :Arguments:

--- a/package/MDAnalysis/coordinates/PDB.py
+++ b/package/MDAnalysis/coordinates/PDB.py
@@ -447,7 +447,7 @@ class PrimitivePDBReader(base.Reader):
        * New :attr:`title` (list with all TITLE lines).
 
     """
-    format = 'PDB'
+    format = 'Permissive_PDB'
     units = {'time': None, 'length': 'Angstrom'}
 
     def __init__(self, filename, **kwargs):
@@ -710,7 +710,7 @@ class PrimitivePDBWriter(base.Writer):
     #: wrap comments into REMARK records that are not longer than
     # :attr:`remark_max_length` characters.
     remark_max_length = 66
-    _multiframe = False
+    multiframe = False
 
     def __init__(self, filename, bonds="conect", n_atoms=None, start=0, step=1,
                  remarks="Created by PrimitivePDBWriter",
@@ -764,7 +764,7 @@ class PrimitivePDBWriter(base.Writer):
         if convert_units is None:
             convert_units = flags['convert_lengths']
         self.convert_units = convert_units  # convert length and time to base units
-        self.multiframe = self._multiframe if multiframe is None else multiframe
+        self._multiframe = self.multiframe if multiframe is None else multiframe
         self.bonds = bonds
 
         self.frames_written = 0
@@ -789,7 +789,7 @@ class PrimitivePDBWriter(base.Writer):
         self.pdbfile = None
 
     def _write_pdb_title(self):
-        if self.multiframe:
+        if self._multiframe:
             self.TITLE("MDANALYSIS FRAMES FROM %d, SKIP %d: %s" % (self.start, self.step, self.remarks))
         else:
             self.TITLE("MDANALYSIS FRAME %d: %s" % (self.start, self.remarks))
@@ -978,7 +978,7 @@ class PrimitivePDBWriter(base.Writer):
         self._write_pdb_header()
         # Issue 105: with write() ONLY write a single frame; use write_all_timesteps() to dump
         # everything in one go, or do the traditional loop over frames
-        self.write_next_timestep(self.ts, multiframe=self.multiframe)
+        self.write_next_timestep(self.ts, multiframe=self._multiframe)
         self._write_pdb_bonds()
         # END record is written when file is being close()d
 
@@ -1313,4 +1313,5 @@ class MultiPDBWriter(PrimitivePDBWriter):
     .. versionadded:: 0.7.6
 
     """
-    _multiframe = True
+    format = 'PDB'
+    multiframe = True  # For Writer registration

--- a/package/MDAnalysis/coordinates/TRJ.py
+++ b/package/MDAnalysis/coordinates/TRJ.py
@@ -189,7 +189,7 @@ class TRJReader(base.Reader):
        Frames now 0-based instead of 1-based
        kwarg 'delta' renamed to 'dt', for uniformity with other Readers
     """
-    format = 'TRJ'
+    format = ['TRJ', 'MDCRD']
     units = {'time': 'ps', 'length': 'Angstrom'}
     _Timestep = Timestep
 
@@ -405,7 +405,8 @@ class NCDFReader(base.Reader):
        kwarg 'delta' renamed to 'dt', for uniformity with other Readers
     """
 
-    format = 'NCDF'
+    format = ['NCDF', 'NC']
+    multiframe = True
     version = "1.0"
     units = {'time': 'ps', 'length': 'Angstrom', 'velocity': 'Angstrom/ps',
              'force': 'kcal/(mol*Angstrom)'}

--- a/package/MDAnalysis/coordinates/TRZ.py
+++ b/package/MDAnalysis/coordinates/TRZ.py
@@ -417,6 +417,7 @@ class TRZWriter(base.Writer):
     """
 
     format = 'TRZ'
+    multiframe = True
 
     units = {'time': 'ps', 'length': 'nm', 'velocity': 'nm/ps'}
 

--- a/package/MDAnalysis/coordinates/XYZ.py
+++ b/package/MDAnalysis/coordinates/XYZ.py
@@ -97,6 +97,7 @@ class XYZWriter(base.Writer):
     """
 
     format = 'XYZ'
+    multiframe = True
     # these are assumed!
     units = {'time': 'ps', 'length': 'Angstrom'}
 

--- a/package/MDAnalysis/coordinates/__init__.py
+++ b/package/MDAnalysis/coordinates/__init__.py
@@ -274,17 +274,15 @@ Registry
 
 In various places, MDAnalysis tries to automatically select appropriate formats
 (e.g. by looking at file extensions). In order to allow it to choose the
-correct format, all I/O classes must be registered in one of three dictionaries
-with the format (typically the file extension in upper case):
+correct format, all I/O classes must subclass either 
+:class:`MDAnalysis.coordinates.base.ProtoReader` or
+:class:`MDAnalysis.coordinates.base.Writer` and set the `format` attribute
+with a string defining the expected suffix.
+To assign multiple suffixes to an I/O class, a list of suffixes
+can be given.
 
-- Trajectory reader classes must be added to
-  :data:`MDAnalysis.coordinates._trajectory_readers`.
-
-- Trajectory writer classes must be added to
-  :data:`MDAnalysis.coordinates._trajectory_writers`.
-
-- Single-frame writer classes must be added to to
-  :data:`MDAnalysis.coordinates._frame_writers`.
+To define that a Writer can write multiple trajectory frames, set the
+`multiframe` attribute to True.  The default is False.
 
 
 .. _Timestep API:
@@ -670,28 +668,15 @@ Methods
    manner with the one difference that Frame writers cannot deal with
    raw :class:`~MDAnalysis.coordinates.base.Timestep` objects.
 
-
-Reader/Writer registry
-----------------------
-
-The following data structures connect reader/writer classes to their
-format identifiers. They are documented for programmers who want to
-enhance MDAnalysis; the casual user is unlikely to access them
-directly.
-
-Some formats can either write single frames or trajectories (such as
-PDB). In theses cases, the kind of writer is selected with the
-*multiframe* keyword to :func:`MDAnalysis.coordinates.core.get_writer`
-(or the writer itself).
-
-.. autodata:: _trajectory_readers
-.. autodata:: _compressed_formats
-.. autodata:: _frame_writers
-.. autodata:: _trajectory_writers
-
 """
 
 __all__ = ['reader', 'writer']
+
+# Registry of all Readers & Writers
+# Get filled on class definition by metaclass magic
+_READERS = {}
+_SINGLEFRAME_WRITERS = {}
+_MULTIFRAME_WRITERS = {}
 
 from . import base
 from .core import reader, writer
@@ -712,73 +697,3 @@ from . import TRR
 from . import TRZ
 from . import XTC
 from . import XYZ
-
-#: standard trajectory readers (dict with identifier as key and reader class as value)
-_trajectory_readers = {
-    'DCD': DCD.DCDReader,
-    # 'TRJ': DCD.DCDReader, #commented out because overridden by TRJ.TRJReader
-    'CONFIG': DLPoly.ConfigReader,
-    'HISTORY': DLPoly.HistoryReader,
-    'XTC': XTC.XTCReader,
-    'XYZ': XYZ.XYZReader,
-    'TRR': TRR.TRRReader,
-    'Permissive_PDB': PDB.PrimitivePDBReader,
-    'PDB': PDB.PDBReader,
-    'XPDB': PDB.ExtendedPDBReader,
-    'PDBQT': PDBQT.PDBQTReader,
-    'CRD': CRD.CRDReader,
-    'GRO': GRO.GROReader,
-    'MOL2': MOL2.MOL2Reader,
-    'TRJ': TRJ.TRJReader,  # AMBER text
-    'MDCRD': TRJ.TRJReader,  # AMBER text
-    'NCDF': TRJ.NCDFReader,  # AMBER netcdf
-    'NC': TRJ.NCDFReader,
-    'INPCRD': INPCRD.INPReader,
-    'RESTRT': INPCRD.INPReader,
-    'PQR': PQR.PQRReader,
-    'LAMMPS': LAMMPS.DCDReader,
-    'CHAIN': base.ChainReader,
-    'DMS': DMS.DMSReader,
-    'TRZ': TRZ.TRZReader,
-    'DATA': LAMMPS.DATAReader,
-    'GMS': GMS.GMSReader,
-}
-
-#: formats of readers that can also handle gzip or bzip2 compressed files
-_compressed_formats = ['XYZ', 'TRJ', 'MDCRD', 'PQR', 'PDBQT']
-
-#: frame writers: export to single frame formats such as PDB, gro, crd
-#: Signature::
-#:
-#:   W = FrameWriter(filename)
-#:   W.write(AtomGroup)
-_frame_writers = {
-    'PDBQT': PDBQT.PDBQTWriter,
-    'CRD': CRD.CRDWriter,
-    'GRO': GRO.GROWriter,
-    'PDB': PDB.PrimitivePDBWriter,
-    'PQR': PQR.PQRWriter,
-    'XYZ': XYZ.XYZWriter,
-    'MOL2': MOL2.MOL2Writer,
-}
-
-#: trajectory writers: export frames, typically only saving coordinates
-#: Signature::
-#:
-#:   W = TrajectoryWriter(filename,n_atoms,**kwargs)
-#:   W.write_next_timestep(TimeStep)
-#:   W.write(Timestep)
-#:   W.write(AtomGroup)
-#:   W.write(Universe)
-_trajectory_writers = {
-    'DCD': DCD.DCDWriter,
-    'XTC': XTC.XTCWriter,
-    'TRR': TRR.TRRWriter,
-    'LAMMPS': LAMMPS.DCDWriter,
-    'PDB': PDB.MultiPDBWriter,
-    'NCDF': TRJ.NCDFWriter,
-    'NC': TRJ.NCDFWriter,
-    'TRZ': TRZ.TRZWriter,
-    'XYZ': XYZ.XYZWriter,
-    'MOL2': MOL2.MOL2Writer,
-}

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -1617,7 +1617,6 @@ class Writer(IObase):
             except KeyError:
                 pass
             else:
-                # All multiframe writers work as a singleframe?
                 for f in fmt:
                     _SINGLEFRAME_WRITERS[f] = cls
                 try:

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -123,6 +123,11 @@ import numpy as np
 import copy
 import weakref
 
+from . import (
+    _READERS,
+    _SINGLEFRAME_WRITERS,
+    _MULTIFRAME_WRITERS,
+)
 from ..core import flags
 from .. import units
 from ..lib.util import asiterable
@@ -760,8 +765,6 @@ class IObase(object):
     .. versionchanged:: 0.8
        Added context manager protocol.
     """
-    #: override to define trajectory format of the reader/writer (DCD, XTC, ...)
-    format = None
 
     #: dict with units of of *time* and *length* (and *velocity*, *force*,
     #: ... for formats that support it)
@@ -1006,6 +1009,7 @@ class IObase(object):
         return False  # do not suppress exceptions
 
 
+
 class ProtoReader(IObase):
     """Base class for Readers, without a :meth:`__del__` method.
 
@@ -1027,6 +1031,18 @@ class ProtoReader(IObase):
     #: The appropriate Timestep class, e.g.
     #: :class:`MDAnalysis.coordinates.xdrfile.XTC.Timestep` for XTC.
     _Timestep = Timestep
+
+    class __metaclass__(type):
+        # Auto register upon class creation
+        def __init__(cls, name, bases, classdict):
+            type.__init__(type, name, bases, classdict)
+            try:
+                fmt = asiterable(classdict['format'])
+            except KeyError:
+                pass
+            else:
+                for f in fmt:
+                    _READERS[f] = cls
 
     def __len__(self):
         return self.n_frames
@@ -1577,10 +1593,13 @@ class ChainReader(ProtoReader):
         return filename[0] if isinstance(filename, tuple) else filename
 
     def __repr__(self):
-        return "< %s %r with %d frames of %d atoms>" % \
-               (self.__class__.__name__,
-               [os.path.basename(self.get_flname(fn)) for fn in self.filenames],
-               self.n_frames, self.n_atoms)
+        return ("<{clsname} {fname} with {nframes} frames of {natoms} atoms>"
+                "".format(
+                    clsname=self.__class__.__name__,
+                    fname=[os.path.basename(self.get_flname(fn))
+                           for fn in self.filenames],
+                    nframes=self.n_frames,
+                    natoms=self.n_atoms))
 
 
 class Writer(IObase):
@@ -1589,6 +1608,24 @@ class Writer(IObase):
     See Trajectory API definition in :mod:`MDAnalysis.coordinates.__init__` for
     the required attributes and methods.
     """
+    class __metaclass__(type):
+        # Auto register upon class creation
+        def __init__(cls, name, bases, classdict):
+            type.__init__(type, name, bases, classdict)
+            try:
+                fmt = asiterable(classdict['format'])
+            except KeyError:
+                pass
+            else:
+                # All multiframe writers work as a singleframe?
+                for f in fmt:
+                    _SINGLEFRAME_WRITERS[f] = cls
+                try:
+                    if classdict['multiframe']:
+                        for f in fmt:
+                            _MULTIFRAME_WRITERS[f] = cls
+                except KeyError:
+                    pass
 
     def convert_dimensions_to_unitcell(self, ts, inplace=True):
         """Read dimensions from timestep *ts* and return appropriate unitcell.

--- a/package/MDAnalysis/coordinates/core.py
+++ b/package/MDAnalysis/coordinates/core.py
@@ -53,8 +53,14 @@ def get_reader_for(filename, permissive=False, format=None):
     kwargs
         Keyword arguments for the selected Reader class.
 
-    Automatic detection is disabled when an explicit *format* is
-    provided.
+    Returns
+    -------
+    A Reader object
+
+    Notes
+    -----
+        Automatic detection is disabled when an explicit *format* is
+        provided.
     """
     if format is None:
         format = util.guess_format(filename)
@@ -90,13 +96,17 @@ def reader(filename, **kwargs):
 
     Parameters
     ----------
-    filename : str
-        filename of the input trajectory or coordinate file
+    filename : str or tuple
+        filename (or tuple of filenames) of the input coordinate file
     permissive : bool
         If set to ``True``, a reader is selected that is more tolerant of the
         input (currently only implemented for PDB). [``False``]
     kwargs
         Keyword arguments for the selected Reader class.
+
+    Returns
+    -------
+    A Reader object
 
     .. SeeAlso:: For trajectory formats: :class:`~DCD.DCDReader`,
        :class:`~XTC.XTCReader`, :class:`~TRR.TRRReader`,
@@ -135,6 +145,10 @@ def get_writer_for(filename=None, format='DCD', multiframe=None):
         ``True``: write multiple frames to the trajectory; ``False``: only
         write a single coordinate frame; ``None``: first try trajectory (multi
         frame writers), then the single frame ones. Default is ``None``.
+
+    Returns
+    -------
+    A Writer object
 
     .. versionchanged:: 0.7.6
        Added *multiframe* keyword; the default ``None`` reflects the previous
@@ -198,6 +212,10 @@ def writer(filename, n_atoms=None, **kwargs):
                 length of time between two frames, in ps [1.0]
        Some readers accept additional arguments, which need to be looked
        up in the documentation of the reader.
+
+    Returns
+    -------
+    A Writer object
 
     .. SeeAlso:: :class:`~MDAnalysis.coordinates.DCD.DCDWriter` for DCD
                  trajectories or :class:`~MDAnalysis.coordinates.XTC.XTCWriter`

--- a/package/MDAnalysis/coordinates/core.py
+++ b/package/MDAnalysis/coordinates/core.py
@@ -31,6 +31,11 @@ Helper functions:
 
 """
 
+from . import (
+    _READERS,
+    _SINGLEFRAME_WRITERS,
+    _MULTIFRAME_WRITERS,
+)
 from ..lib import util
 from ..lib.mdamath import triclinic_box, triclinic_vectors, box_volume
 
@@ -38,18 +43,26 @@ from ..lib.mdamath import triclinic_box, triclinic_vectors, box_volume
 def get_reader_for(filename, permissive=False, format=None):
     """Return the appropriate trajectory reader class for *filename*.
 
+    Parameters
+    ----------
+    filename : str
+        filename of the input trajectory or coordinate file
+    permissive : bool
+        If set to ``True``, a reader is selected that is more tolerant of the
+        input (currently only implemented for PDB). [``False``]
+    kwargs
+        Keyword arguments for the selected Reader class.
+
     Automatic detection is disabled when an explicit *format* is
     provided.
     """
-    from . import _trajectory_readers
-
     if format is None:
         format = util.guess_format(filename)
     format = format.upper()
     if permissive and format == 'PDB':
-        return _trajectory_readers['Permissive_PDB']
+        return _READERS['Permissive_PDB']
     try:
-        return _trajectory_readers[format]
+        return _READERS[format]
     except KeyError:
         raise ValueError(
             "Unknown coordinate trajectory format '{0}' for '{1}'. The FORMATs \n"
@@ -59,7 +72,7 @@ def get_reader_for(filename, permissive=False, format=None):
             "           Use the format keyword to explicitly set the format: 'Universe(...,format=FORMAT)'\n"
             "           For missing formats, raise an issue at "
             "http://issues.mdanalysis.org".format(
-                format, filename, _trajectory_readers.keys()))
+                format, filename, _READERS.keys()))
 
 
 def reader(filename, **kwargs):
@@ -75,26 +88,30 @@ def reader(filename, **kwargs):
     All other keywords are passed on to the underlying Reader classes; see
     their documentation for details.
 
+    Parameters
+    ----------
+    filename : str
+        filename of the input trajectory or coordinate file
+    permissive : bool
+        If set to ``True``, a reader is selected that is more tolerant of the
+        input (currently only implemented for PDB). [``False``]
+    kwargs
+        Keyword arguments for the selected Reader class.
+
     .. SeeAlso:: For trajectory formats: :class:`~DCD.DCDReader`,
        :class:`~XTC.XTCReader`, :class:`~TRR.TRRReader`,
        :class:`~XYZ.XYZReader`.  For single frame formats:
        :class:`~CRD.CRDReader`, :class:`~PDB.PDBReader` and
        :class:`~PDB.PrimitivePDBReader`, :class:`~GRO.GROReader`,
-
-    :Arguments:
-       *filename*
-          filename of the input trajectory or coordinate file
-       *permissive*
-          If set to ``True``, a reader is selected that is more tolerant of the
-          input (currently only implemented for PDB). [``False``]
-       *kwargs*
-           Keyword arguments for the selected Reader class.
     """
     if isinstance(filename, tuple):
-        Reader = get_reader_for(filename[0], permissive=kwargs.pop('permissive', False), format=filename[1])
+        Reader = get_reader_for(filename[0],
+                                permissive=kwargs.pop('permissive', False),
+                                format=filename[1])
         return Reader(filename[0], **kwargs)
     else:
-        Reader = get_reader_for(filename, permissive=kwargs.pop('permissive', False))
+        Reader = get_reader_for(filename,
+                                permissive=kwargs.pop('permissive', False))
         return Reader(filename, **kwargs)
 
 
@@ -107,80 +124,84 @@ def get_writer_for(filename=None, format='DCD', multiframe=None):
     :class:`cStringIO.StringIO` instance then the *format* argument must be
     used.
 
-    :Arguments:
-      *filename*
-         The filename for the trajectory is examined for its extension and
-         the Writer is chosen accordingly.
-      *format*
-         If no *filename* is supplied then the format can be explicitly set;
-         possible values are "DCD", "XTC", "TRR"; "PDB", "CRD", "GRO".
-      *multiframe*
-         ``True``: write multiple frames to the trajectory; ``False``: only
-         write a single coordinate frame; ``None``: first try trajectory (multi
-         frame writers), then the single frame ones. Default is ``None``.
+    Parameters
+    ----------
+    filename : str
+        The filename for the trajectory is examined for its extension and
+        the Writer is chosen accordingly.
+    format : str
+        If no *filename* is supplied then the format can be explicitly set
+    multiframe : bool
+        ``True``: write multiple frames to the trajectory; ``False``: only
+        write a single coordinate frame; ``None``: first try trajectory (multi
+        frame writers), then the single frame ones. Default is ``None``.
 
     .. versionchanged:: 0.7.6
        Added *multiframe* keyword; the default ``None`` reflects the previous
        behaviour.
     """
-    from . import _trajectory_writers, _frame_writers
-
     if isinstance(filename, basestring) and filename:
         root, ext = util.get_ext(filename)
         format = util.check_compressed_format(root, ext)
     if multiframe is None:
         try:
-            return _trajectory_writers[format]
+            return _MULTIFRAME_WRITERS[format]
         except KeyError:
             try:
-                return _frame_writers[format]
+                return _SINGLEFRAME_WRITERS[format]
             except KeyError:
-                raise TypeError("No trajectory or frame writer for format %r" % format)
+                raise TypeError(
+                    "No trajectory or frame writer for format {0}"
+                    "".format(format))
     elif multiframe is True:
         try:
-            return _trajectory_writers[format]
+            return _MULTIFRAME_WRITERS[format]
         except KeyError:
-            raise TypeError("No trajectory  writer for format %r" % format)
+            raise TypeError(
+                "No trajectory writer for format {0}"
+                "".format(format))
     elif multiframe is False:
         try:
-            return _frame_writers[format]
+            return _SINGLEFRAME_WRITERS[format]
         except KeyError:
-            raise TypeError("No single frame writer for format %r" % format)
+            raise TypeError(
+                "No single frame writer for format {0}".format(format))
     else:
-        raise ValueError("Unknown value %r for multiframe, only True, False, None allowed" % multiframe)
+        raise ValueError("Unknown value '{0}' for multiframe,"
+                         " only True, False, None allowed"
+                         "".format(multiframe))
 
 
 def writer(filename, n_atoms=None, **kwargs):
     """Initialize a trajectory writer instance for *filename*.
 
-    :Arguments:
-       *filename*
-            Output filename of the trajectory; the extension determines the
-            format.
-       *n_atoms*
-            The number of atoms in the output trajectory; can be ommitted
-            for single-frame writers.
-       *multiframe*
-            ``True``: write a trajectory with multiple frames; ``False``
-            only write a single frame snapshot; ``None`` first try to get
-            a multiframe writer and then fall back to single frame [``None``]
-       *kwargs*
-            Keyword arguments for the writer; all trajectory Writers accept
-            at least
+    Parameters:
+    -----------
+    filename : str
+        Output filename of the trajectory; the extension determines the
+        format.
+    n_atoms : int, optional
+        The number of atoms in the output trajectory; can be ommitted
+        for single-frame writers.
+    multiframe : bool, optional
+        ``True``: write a trajectory with multiple frames; ``False``
+        only write a single frame snapshot; ``None`` first try to get
+        a multiframe writer and then fall back to single frame [``None``]
+    kwargs : optional
+        Keyword arguments for the writer; all trajectory Writers accept
+        at least
+            *start*
+                starting time [0]
+            *step*
+                step size in frames [1]
+            *dt*
+                length of time between two frames, in ps [1.0]
+       Some readers accept additional arguments, which need to be looked
+       up in the documentation of the reader.
 
-               *start*
-                   starting time [0]
-               *step*
-                   step size in frames [1]
-               *dt*
-                   length of time between two frames, in ps [1.0]
-
-            Some readers accept additional arguments, which need to be looked
-            up in the documentation of the reader.
-
-            .. SeeAlso:: :class:`~MDAnalysis.coordinates.DCD.DCDWriter` for DCD
-               trajectories or :class:`~MDAnalysis.coordinates.XTC.XTCWriter`
-               and :class:`~MDAnalysis.coordinates.TRR.TRRWriter` for Gromacs.
+    .. SeeAlso:: :class:`~MDAnalysis.coordinates.DCD.DCDWriter` for DCD
+                 trajectories or :class:`~MDAnalysis.coordinates.XTC.XTCWriter`
+                 and :class:`~MDAnalysis.coordinates.TRR.TRRWriter` for Gromacs.
 
     .. versionchanged:: 0.7.6
        Added *multiframe* keyword. See also :func:`get_writer_for`.

--- a/package/MDAnalysis/coordinates/xdrfile/TRR.py
+++ b/package/MDAnalysis/coordinates/xdrfile/TRR.py
@@ -212,7 +212,11 @@ class TRRWriter(core.TrjWriter):
     .. _Gromacs: http://www.gromacs.org
     """
     format = "TRR"
-    units = {'time': 'ps', 'length': 'nm', 'velocity': 'nm/ps', 'force': 'kJ/(mol*nm)'}
+    multiframe = True
+    units = {'time': 'ps',
+             'length': 'nm',
+             'velocity': 'nm/ps',
+             'force': 'kJ/(mol*nm)'}
 
 
 class TRRReader(core.TrjReader):
@@ -233,7 +237,10 @@ class TRRReader(core.TrjReader):
     format = "TRR"
     _Timestep = Timestep
     _Writer = TRRWriter
-    units = {'time': 'ps', 'length': 'nm', 'velocity': 'nm/ps', 'force': 'kJ/(mol*nm)'}
+    units = {'time': 'ps',
+             'length': 'nm',
+             'velocity': 'nm/ps',
+             'force': 'kJ/(mol*nm)'}
 
     def _allocate_sub(self, DIM):
         self._pos_buf = np.zeros((self._trr_n_atoms, DIM), dtype=np.float32, order='C')

--- a/package/MDAnalysis/coordinates/xdrfile/XTC.py
+++ b/package/MDAnalysis/coordinates/xdrfile/XTC.py
@@ -59,6 +59,7 @@ class XTCWriter(core.TrjWriter):
     .. _Gromacs: http://www.gromacs.org
     """
     format = "XTC"
+    multiframe = True
 
 
 class XTCReader(core.TrjReader):

--- a/package/MDAnalysis/coordinates/xdrfile/core.py
+++ b/package/MDAnalysis/coordinates/xdrfile/core.py
@@ -128,8 +128,6 @@ class TrjWriter(base.Writer):
     """
     #: units of time (ps) and length (nm) in Gromacs
     units = {'time': 'ps', 'length': 'nm'}
-    #: override to define trajectory format of the reader (XTC or TRR)
-    format = None
 
     def __init__(self, filename, n_atoms, start=0, step=1, dt=None, precision=1000.0, remarks=None,
                  convert_units=None):
@@ -323,8 +321,7 @@ class TrjReader(base.Reader):
     """
     #: units of time (ps) and length (nm) in Gromacs
     units = {'time': 'ps', 'length': 'nm'}
-    #: override to define trajectory format of the reader (XTC or TRR)
-    format = None
+
     #: supply the appropriate Timestep class, e.g.
     #: :class:`MDAnalysis.coordinates.xdrfile.XTC.Timestep` for XTC
     _Timestep = Timestep

--- a/package/MDAnalysis/core/AtomGroup.py
+++ b/package/MDAnalysis/core/AtomGroup.py
@@ -3756,8 +3756,8 @@ class Universe(object):
                 # or if file is known as a topology & coordinate file, use that
                 if fmt is None:
                     fmt = util.guess_format(self.filename)
-                if (fmt in MDAnalysis.coordinates._trajectory_readers
-                    and fmt in MDAnalysis.topology._topology_parsers):
+                if (fmt in MDAnalysis.coordinates._READERS
+                    and fmt in MDAnalysis.topology._PARSERS):
                     coordinatefile = self.filename
             # Fix by SB: make sure coordinatefile is never an empty tuple
             if len(coordinatefile) == 0:

--- a/package/MDAnalysis/topology/CRDParser.py
+++ b/package/MDAnalysis/topology/CRDParser.py
@@ -39,6 +39,7 @@ from .base import TopologyReader
 
 class CRDParser(TopologyReader):
     """Parse a CHARMM CARD coordinate file for topology information."""
+    format = 'CRD'
 
     def parse(self):
         """Parse CRD file *filename* and return the dict `structure`.

--- a/package/MDAnalysis/topology/DLPolyParser.py
+++ b/package/MDAnalysis/topology/DLPolyParser.py
@@ -38,6 +38,8 @@ class ConfigParser(base.TopologyReader):
 
     .. versionadded:: 0.10.1
     """
+    format = 'CONFIG'
+
     def parse(self):
         with openany(self.filename, 'r') as inf:
             inf.readline()
@@ -101,6 +103,8 @@ class HistoryParser(base.TopologyReader):
 
     .. versionadded:: 0.10.1
     """
+    format = 'HISTORY'
+
     def parse(self):
         with openany(self.filename, 'r') as inf:
             inf.readline()

--- a/package/MDAnalysis/topology/DMSParser.py
+++ b/package/MDAnalysis/topology/DMSParser.py
@@ -51,6 +51,7 @@ class DMSParser(TopologyReader):
     .. _Desmond: http://www.deshawresearch.com/resources_desmond.html
     .. _DMS: http://www.deshawresearch.com/Desmond_Users_Guide-0.7.pdf
     """
+    format = 'DMS'
 
     def parse(self):
         """Parse DMS file *filename* and return the dict `structure`.

--- a/package/MDAnalysis/topology/GMSParser.py
+++ b/package/MDAnalysis/topology/GMSParser.py
@@ -52,6 +52,8 @@ class GMSParser(TopologyReader):
 
     .. versionadded:: 0.9.1
     """
+    format = 'GMS'
+
     def parse(self):
         """Read list of atoms from a GAMESS file."""
 

--- a/package/MDAnalysis/topology/GROParser.py
+++ b/package/MDAnalysis/topology/GROParser.py
@@ -41,6 +41,8 @@ from .base import TopologyReader
 
 
 class GROParser(TopologyReader):
+    format = 'GRO'
+
     def parse(self):
         """Parse GRO file *filename* and return the dict `structure`.
 

--- a/package/MDAnalysis/topology/HoomdXMLParser.py
+++ b/package/MDAnalysis/topology/HoomdXMLParser.py
@@ -40,13 +40,17 @@ Classes
 
 """
 from __future__ import absolute_import
+
+import xml.etree.ElementTree as ET
+
 from ..lib.util import openany
 from ..core.AtomGroup import Atom
 from .core import guess_atom_element
 from .base import TopologyReader
-import xml.etree.ElementTree as ET
 
 class HoomdXMLParser(TopologyReader):
+    format = 'XML'
+
     def parse(self):
         """Parse Hoomd XML file *filename* and return the dict `structure`.
 

--- a/package/MDAnalysis/topology/LAMMPSParser.py
+++ b/package/MDAnalysis/topology/LAMMPSParser.py
@@ -134,6 +134,8 @@ class DATAParser(TopologyReader):
 
     .. versionadded:: 0.9.0
     """
+    format = 'DATA'
+
     def iterdata(self):
         with anyopen(self.filename, 'r') as f:
             for line in f:

--- a/package/MDAnalysis/topology/MOL2Parser.py
+++ b/package/MDAnalysis/topology/MOL2Parser.py
@@ -49,6 +49,7 @@ class MOL2Parser(TopologyReader):
     .. versionchanged:: 0.9
        Now subclasses TopologyReader
     """
+    format = 'MOL2'
 
     def parse(self, filename=None):
         """Parse MOL2 file *filename* and return the dict `structure`.

--- a/package/MDAnalysis/topology/PDBParser.py
+++ b/package/MDAnalysis/topology/PDBParser.py
@@ -54,6 +54,7 @@ from .core import guess_atom_type, guess_atom_mass, guess_atom_charge
 
 class PDBParser(TopologyReader):
     """Read minimum topology information from a PDB file."""
+    format = 'PDB'
 
     def parse(self):
         """Parse atom information from PDB file *pdbfile*.

--- a/package/MDAnalysis/topology/PDBQTParser.py
+++ b/package/MDAnalysis/topology/PDBQTParser.py
@@ -51,6 +51,7 @@ from .base import TopologyReader
 
 class PDBQTParser(TopologyReader):
     """Read topology from a PDBQT file."""
+    format = 'PDBQT'
 
     def parse(self):
         """Parse atom information from PDBQT file *filename*.

--- a/package/MDAnalysis/topology/PQRParser.py
+++ b/package/MDAnalysis/topology/PQRParser.py
@@ -54,6 +54,8 @@ class PQRParser(TopologyReader):
        Read chainID from a PQR file and use it as segid (before we always used
        'SYSTEM' as the new segid).
     """
+    format = 'PQR'
+
     def parse(self):
         """Parse atom information from PQR file *filename*.
 

--- a/package/MDAnalysis/topology/PSFParser.py
+++ b/package/MDAnalysis/topology/PSFParser.py
@@ -51,6 +51,7 @@ class PSFParser(TopologyReader):
 
     .. _PSF: http://www.charmm.org/documentation/c35b1/struct.html
     """
+    format = 'PSF'
 
     def parse(self):
         """Parse PSF file *filename*.

--- a/package/MDAnalysis/topology/PrimitivePDBParser.py
+++ b/package/MDAnalysis/topology/PrimitivePDBParser.py
@@ -63,7 +63,7 @@ class PrimitivePDBParser(TopologyReader):
 
     .. versionadded:: 0.8
     """
-    format = 'PDB'
+    format = 'Permissive_PDB'
 
     def parse(self):
         """Parse atom information from PDB file *filename*.

--- a/package/MDAnalysis/topology/TOPParser.py
+++ b/package/MDAnalysis/topology/TOPParser.py
@@ -69,6 +69,7 @@ class TOPParser(TopologyReader):
       parses both amber10 and amber12 formats
 
     """
+    format = ['TOP', 'PRMTOP', 'PARM7']
 
     def parse(self):
         """Parse Amber PRMTOP topology file *filename*.

--- a/package/MDAnalysis/topology/TPRParser.py
+++ b/package/MDAnalysis/topology/TPRParser.py
@@ -147,6 +147,8 @@ class TPRParser(TopologyReader):
     .. _Gromacs: http://www.gromacs.org
     .. _TPR file: http://manual.gromacs.org/current/online/tpr.html
     """
+    format = 'TPR'
+
     def parse(self):
         """Parse a Gromacs TPR file into a MDAnalysis internal topology structure.
 

--- a/package/MDAnalysis/topology/XYZParser.py
+++ b/package/MDAnalysis/topology/XYZParser.py
@@ -44,6 +44,7 @@ class XYZParser(TopologyReader):
 
     .. versionadded:: 0.9.1
     """
+    format = 'XYZ'
 
     def parse(self):
         """Read the file and return the structure.

--- a/package/MDAnalysis/topology/__init__.py
+++ b/package/MDAnalysis/topology/__init__.py
@@ -239,6 +239,9 @@ __all__ = ['core', 'PSFParser', 'PDBParser', 'PQRParser', 'GROParser',
            'CRDParser', 'TOPParser', 'PDBQTParser', 'TPRParser',
            'LAMMPSParser', 'XYZParser', 'GMSParser', 'DLPolyParser',
            'HoomdXMLParser']
+# Registry of all Parsers in MDAnalysis
+# Gets filled on class definition by metaclass magic
+_PARSERS = {}
 
 from . import core
 from . import PSFParser
@@ -258,30 +261,3 @@ from . import XYZParser
 from . import GMSParser
 from . import DLPolyParser
 from . import HoomdXMLParser
-
-
-# dictionary of known file formats and the corresponding file parser
-# (all parser should essentially do the same thing; the PSFParser is
-# the reference implementation). The keys in :data:`_topology_parsers`
-# are the known topology formats.
-_topology_parsers = {'PSF': PSFParser.PSFParser,
-                     'PDB': PDBParser.PDBParser,
-                     'Permissive_PDB': PrimitivePDBParser.PrimitivePDBParser,
-                     'XPDB': ExtendedPDBParser.ExtendedPDBParser,
-                     'PQR': PQRParser.PQRParser,
-                     'GRO': GROParser.GROParser,
-                     'CRD': CRDParser.CRDParser,
-                     'TOP': TOPParser.TOPParser,
-                     'PRMTOP': TOPParser.TOPParser,
-                     'PARM7': TOPParser.TOPParser,                     
-                     'PDBQT': PDBQTParser.PDBQTParser,
-                     'TPR': TPRParser.TPRParser,
-                     'DMS': DMSParser.DMSParser,
-                     'MOL2': MOL2Parser.MOL2Parser,
-                     'DATA': LAMMPSParser.DATAParser,
-                     'XYZ': XYZParser.XYZParser,
-                     'GMS': GMSParser.GMSParser,
-                     'CONFIG': DLPolyParser.ConfigParser,
-                     'HISTORY': DLPolyParser.HistoryParser,
-                     'XML': HoomdXMLParser.HoomdXMLParser,
-                     }

--- a/package/MDAnalysis/topology/base.py
+++ b/package/MDAnalysis/topology/base.py
@@ -37,9 +37,19 @@ from ..lib import util
 class TopologyReader(IObase):
     """Base class for topology readers
 
-    All topology readers must:
-      * Be initialised with a filename
-      * Return a struct dict by calling their parse function
+    Parameters
+    ----------
+    filename : str
+        name of the topology file
+    universe : Universe, optional
+        Supply a Universe to the Parser.  This then passes it to the
+        atom instances that are created within parsers.
+    kwargs : optional
+        Other keyword arguments that can vary with the specific format.
+        These are stored as self.kwargs
+
+    All topology readers must define a `parse` method which
+    returns a topology dict.
 
     Raises
     ------
@@ -62,19 +72,6 @@ class TopologyReader(IObase):
                     _PARSERS[f] = cls
 
     def __init__(self, filename, universe=None, **kwargs):
-        """Standard arguments for a TopologyReader:
-
-        Parameters
-        ----------
-        filename : str
-            name of the topology file
-        universe : Universe, optional
-            Supply a Universe to the Parser.  This then passes it to the
-            atom instances that are created within parsers.
-        kwargs : optional
-            Other keyword arguments that can vary with the specific format.
-            These are stored as self.kwargs
-        """
         self.filename = filename
         self._u = universe
         self.kwargs = kwargs

--- a/package/MDAnalysis/topology/base.py
+++ b/package/MDAnalysis/topology/base.py
@@ -29,7 +29,9 @@ Classes
 
 """
 
+from . import _PARSERS
 from ..coordinates.base import IObase
+from ..lib import util
 
 
 class TopologyReader(IObase):
@@ -39,30 +41,39 @@ class TopologyReader(IObase):
       * Be initialised with a filename
       * Return a struct dict by calling their parse function
 
-    :Raises:
-       * :exc:`IOError` upon failing to read a topology file
-       * :exc:`ValueError` upon failing to make sense of the read data
+    Raises
+    ------
+    * :exc:`IOError` upon failing to read a topology file
+    * :exc:`ValueError` upon failing to make sense of the read data
 
     .. versionadded:: 0.9.0
     .. versionchanged:: 0.9.2
        Added keyword 'universe' to pass to Atom creation.
     """
+    class __metaclass__(type):
+        def __init__(cls, name, bases, classdict):
+            type.__init__(type, name, bases, classdict)
+            try:
+                fmt = util.asiterable(classdict['format'])
+            except KeyError:
+                pass
+            else:
+                for f in fmt:
+                    _PARSERS[f] = cls
+
     def __init__(self, filename, universe=None, **kwargs):
         """Standard arguments for a TopologyReader:
 
-        :Arguments:
-
-           *filename*
-               name of the topology file
-
-        :Keywords:
-           *universe*
-               Supply a Universe to the Parser.  This then passes it to the
-               atom instances that are created within parsers.
-           *kwargs*
-               Other keyword arguments that can vary with the specific format.
-               These are stored as self.kwargs
-
+        Parameters
+        ----------
+        filename : str
+            name of the topology file
+        universe : Universe, optional
+            Supply a Universe to the Parser.  This then passes it to the
+            atom instances that are created within parsers.
+        kwargs : optional
+            Other keyword arguments that can vary with the specific format.
+            These are stored as self.kwargs
         """
         self.filename = filename
         self._u = universe

--- a/package/MDAnalysis/topology/core.py
+++ b/package/MDAnalysis/topology/core.py
@@ -33,6 +33,7 @@ from collections import defaultdict
 from itertools import izip
 
 # Local imports
+from . import _PARSERS
 from . import tables
 from ..lib import distances
 from ..lib.util import cached
@@ -120,16 +121,14 @@ def get_parser_for(filename, permissive=False, format=None):
       *ValueError*
         If no appropriate parser could be found.
     """
-    from . import _topology_parsers
-
     if format is None:
         format = util.guess_format(filename)
     format = format.upper()
     if format == 'PDB' and permissive:
-        return _topology_parsers['Permissive_PDB']
+        return _PARSERS['Permissive_PDB']
 
     try:
-        return _topology_parsers[format]
+        return _PARSERS[format]
     except KeyError:
         raise ValueError(
             "Cannot autodetect topology type for file '{0}' "
@@ -140,7 +139,7 @@ def get_parser_for(filename, permissive=False, format=None):
             "           {1}\n"
             "           See http://docs.mdanalysis.org/documentation_pages/topology/init.html#supported-topology-formats\n"
             "           For missing formats, raise an issue at "
-            "http://issues.mdanalysis.org".format(filename, _topology_parsers.keys()))
+            "http://issues.mdanalysis.org".format(filename, _PARSERS.keys()))
 
 
 # following guess_* used by PDB parser


### PR DESCRIPTION
Closes Issue #431 

Creating a subclass of `ProtoReader`, `Writer` or `TopologyReader` creates an entry in the dictionary that keeps track of formats: classes.