### PR TITLE
Add `six` to the requirements

### DIFF
--- a/package/setup.py
+++ b/package/setup.py
@@ -363,6 +363,7 @@ if __name__ == '__main__':
               'biopython>=1.59',
               'networkx>=1.0',
               'GridDataFormats>=0.3.2',
+              'six>=1.4.0',
           ],
           # extras can be difficult to install through setuptools and/or
           # you might prefer to use the version available through your


### PR DESCRIPTION
Part of the code already use the `six` module in prevision for python 3
support. Yet, `six` was not declared as a requirement in setup.py.

This commit declares six>=1.4.0 in setup.py. Not all test pass with
older version of six.