### PR TITLE
Small changes to improve python 3 compatibility

### DIFF
--- a/package/MDAnalysis/core/Timeseries.py
+++ b/package/MDAnalysis/core/Timeseries.py
@@ -53,7 +53,7 @@ Timeseries of observables
 
 """
 
-import AtomGroup
+from . import AtomGroup
 
 
 class TimeseriesCollection(object):

--- a/package/MDAnalysis/core/__init__.py
+++ b/package/MDAnalysis/core/__init__.py
@@ -82,6 +82,8 @@ Classes
 
 """
 
+import six
+
 __all__ = ['AtomGroup', 'Selection', 'Timeseries']
 
 
@@ -133,7 +135,7 @@ class Flags(dict):
         self.get_flag(name).set(value)
 
     def _itervalues(self):
-        return super(Flags, self).itervalues()
+        return six.itervalues(super(Flags, self))
 
     def _items(self):
         return super(Flags, self).items()
@@ -443,6 +445,6 @@ class flagsDocs(object):
     __doc__ = flags.doc()
 
 
-import AtomGroup
-import Selection
-import Timeseries
+from . import AtomGroup
+from . import Selection
+from . import Timeseries

--- a/package/MDAnalysis/lib/mdamath.py
+++ b/package/MDAnalysis/lib/mdamath.py
@@ -158,7 +158,7 @@ def triclinic_box(x, y, z):
 
     .. SeeAlso:: Definition of angles: http://en.wikipedia.org/wiki/Lattice_constant
     """
-    A, B, C = [norm(v) for v in x, y, z]
+    A, B, C = [norm(v) for v in (x, y, z)]
     alpha = _angle(y, z)
     beta = _angle(x, z)
     gamma = _angle(x, y)

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -295,7 +295,7 @@ def anyopen(datasource, mode='r', reset=True):
                     stream.reset()
                 except (AttributeError, IOError):
                     try:
-                        stream.seek(0L)
+                        stream.seek(0)
                     except (AttributeError, IOError):
                         warnings.warn("Stream {0}: not guaranteed to be at the beginning."
                                       "".format(filename),
@@ -338,7 +338,7 @@ def anyopen(datasource, mode='r', reset=True):
     return stream
 
 
-def _get_stream(filename, openfunction=file, mode='r'):
+def _get_stream(filename, openfunction=open, mode='r'):
     """Return open stream if *filename* can be opened with *openfunction* or else ``None``."""
     try:
         stream = openfunction(filename, mode=mode)
@@ -554,7 +554,7 @@ class NamedStream(io.IOBase, basestring):
             self.stream.reset()  # e.g. StreamIO
         except (AttributeError, IOError):
             try:
-                self.stream.seek(0L)  # typical file objects
+                self.stream.seek(0)  # typical file objects
             except (AttributeError, IOError):
                 warnings.warn("NamedStream {0}: not guaranteed to be at the beginning."
                               "".format(self.name),


### PR DESCRIPTION
This commit fix few small things that prevented MDAnalysis to be
imported in python 3. MDAnalysis can still not be imported in python 3,
though.