### PR TITLE
Make xrange and range call python 3 compatible

### DIFF
--- a/package/MDAnalysis/analysis/align.py
+++ b/package/MDAnalysis/analysis/align.py
@@ -1,5 +1,5 @@
 # -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
-# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
 #
 # MDAnalysis --- http://www.MDAnalysis.org
 # Copyright (c) 2006-2015 Naveen Michaud-Agrawal, Elizabeth J. Denning, Oliver Beckstein
@@ -156,6 +156,8 @@ normal users.
 .. autofunction:: fasta2select
 .. autofunction:: get_matching_atoms
 """
+from six.moves import range
+
 import os.path
 import itertools
 
@@ -742,7 +744,7 @@ def fasta2select(fastafilename, is_aligned=False,
     GAP = alignment[0].seq.alphabet.gap_char  # should be the same for both seqs
     if GAP != alignment[1].seq.alphabet.gap_char:
         raise ValueError("Different gap characters in sequence 'target' and 'mobile'.")
-    for ipos in xrange(alignment.get_alignment_length()):
+    for ipos in range(alignment.get_alignment_length()):
         aligned = list(alignment[:, ipos])
         if GAP in aligned:
             continue  # skip residue
@@ -754,7 +756,7 @@ def fasta2select(fastafilename, is_aligned=False,
             template += " and backbone"
         template = "( " + template + " )"
 
-        res_list.append([template % resid(iseq, ipos) for iseq in xrange(nseq)])
+        res_list.append([template % resid(iseq, ipos) for iseq in range(nseq)])
 
     sel = np.array(res_list).transpose()
 

--- a/package/MDAnalysis/analysis/base.py
+++ b/package/MDAnalysis/analysis/base.py
@@ -23,6 +23,8 @@ classes.
 
 
 """
+from six.moves import range
+
 import numpy as np
 import logging
 
@@ -70,7 +72,7 @@ class AnalysisBase(object):
         self.start = start
         self.stop = stop
         self.step = step
-        self.nframes = len(xrange(start, stop, step))
+        self.nframes = len(range(start, stop, step))
 
     def _single_frame(self):
         """Calculate data from a single frame of trajectory

--- a/package/MDAnalysis/analysis/density.py
+++ b/package/MDAnalysis/analysis/density.py
@@ -83,6 +83,8 @@ Classes and Functions
 """
 from __future__ import print_function
 
+from six.moves import range
+
 import numpy as np
 import sys
 import os
@@ -308,7 +310,7 @@ class Density(Grid):
 
         dedges = map(np.diff, self.edges)
         D = len(self.edges)
-        for i in xrange(D):
+        for i in range(D):
             shape = np.ones(D, int)
             shape[i] = len(dedges[i])
             self.grid /= dedges[i].reshape(shape)
@@ -811,7 +813,7 @@ class BfactorDensityCreator(object):
         # rho_smeared = F^-1[ F[g]*F[rho] ]
         g = np.zeros(grid.shape)  # holds the smeared out density
         pos = np.where(grid != 0)  # position in histogram (as bin numbers)
-        for iwat in xrange(len(pos[0])):  # super-ugly loop
+        for iwat in range(len(pos[0])):  # super-ugly loop
             p = tuple([wp[iwat] for wp in pos])
             g += grid[p] * np.fromfunction(self._gaussian, grid.shape, dtype=np.int, p=p, sigma=sigma)
             print("Smearing out atom position {0:4d}/{1:5d} with RMSF {2:4.2f} A\r".format(iwat + 1, len(pos[0]), sigma),)

--- a/package/MDAnalysis/analysis/gnm.py
+++ b/package/MDAnalysis/analysis/gnm.py
@@ -80,6 +80,8 @@ directly needed to perform the analysis.
 
 # import copy #unused
 
+from six.moves import range
+
 import numpy as np
 from numpy import linalg
 

--- a/package/MDAnalysis/analysis/hbonds/hbond_analysis.py
+++ b/package/MDAnalysis/analysis/hbonds/hbond_analysis.py
@@ -310,6 +310,8 @@ Classes
 
 """
 
+from six.moves import range
+
 from collections import defaultdict
 import itertools
 import numpy as np
@@ -1148,8 +1150,8 @@ class HydrogenBondAnalysis(object):
 
         def _make_dict(donors, hydrogens):
             # two steps so that entry for one residue can be UPDATED for multiple donors
-            d = dict((donors[k].resid, {}) for k in xrange(len(donors)) if k in hydrogens)
-            for k in xrange(len(donors)):
+            d = dict((donors[k].resid, {}) for k in range(len(donors)) if k in hydrogens)
+            for k in range(len(donors)):
                 if k in hydrogens:
                     d[donors[k].resid].update(dict((atom.name, donors[k].name) for atom in hydrogens[k]))
             return d
@@ -1192,10 +1194,10 @@ class HydrogenBondAnalysis(object):
         s2h = self._s2_donors_h
 
         def _make_dict(donors, hydrogens):
-            #return dict(flatten_1([(atom.id, donors[k].name) for atom in hydrogens[k]] for k in xrange(len(donors))
+            #return dict(flatten_1([(atom.id, donors[k].name) for atom in hydrogens[k]] for k in range(len(donors))
             # if k in hydrogens))
             x = []
-            for k in xrange(len(donors)):
+            for k in range(len(donors)):
                 if k in hydrogens:
                     x.extend([(atom.index, donors[k].name) for atom in hydrogens[k]])
             return dict(x)

--- a/package/MDAnalysis/analysis/helanal.py
+++ b/package/MDAnalysis/analysis/helanal.py
@@ -110,6 +110,8 @@ Functions
 
 """
 
+from six.moves import range
+
 import os
 
 import numpy as np
@@ -612,7 +614,7 @@ def main_loop(positions, ref_axis=None):
     origins = [[0., 0., 0.] for item in positions[:-2]]
     local_helix_axes = []
     location_rotation_vectors = []
-    for i in xrange(len(positions) - 3):
+    for i in range(len(positions) - 3):
         vec12 = positions[i + 1] - positions[i]
         vec23 = positions[i + 2] - positions[i + 1]
         vec34 = positions[i + 3] - positions[i + 2]
@@ -668,7 +670,7 @@ def main_loop(positions, ref_axis=None):
     #local bending angles (eg i > i+3, i+3 > i+6)
 
     bending_angles = [0 for item in range(len(local_helix_axes) - 3)]
-    for axis in xrange(len(local_helix_axes) - 3):
+    for axis in range(len(local_helix_axes) - 3):
         angle = np.arccos(np.dot(local_helix_axes[axis], local_helix_axes[axis + 3]))
         bending_angles[axis] = np.rad2deg(angle)
         #TESTED- angles are correct

--- a/package/MDAnalysis/analysis/leaflet.py
+++ b/package/MDAnalysis/analysis/leaflet.py
@@ -52,6 +52,8 @@ algorithm.
 
 """
 
+from six.moves import range
+
 import numpy as np
 import MDAnalysis
 import networkx as NX
@@ -194,7 +196,7 @@ class LeafletFinder(object):
 
     def groups_iter(self):
         """Iterator over all leaflet :meth:`groups`"""
-        for component_index in xrange(len(self.components)):
+        for component_index in range(len(self.components)):
             yield self.group(component_index)
 
     def write_selection(self, filename, **kwargs):

--- a/package/MDAnalysis/analysis/polymer.py
+++ b/package/MDAnalysis/analysis/polymer.py
@@ -26,6 +26,8 @@ Polymer analysis --- :mod:`MDAnalysis.analysis.polymer`
 This module contains various commonly used tools in analysing polymers.
 
 """
+from six.moves import range
+
 import numpy as np
 import logging
 
@@ -92,7 +94,7 @@ class PersistenceLength(AnalysisBase):
             vecs /= np.sqrt((vecs * vecs).sum(axis=1))[:, None]
 
             inner_pr = np.inner(vecs, vecs)
-            for i in xrange(n-1):
+            for i in range(n-1):
                 self._results[:(n-1)-i] += inner_pr[i, i:]
 
     def _conclude(self):

--- a/package/MDAnalysis/analysis/psa.py
+++ b/package/MDAnalysis/analysis/psa.py
@@ -218,6 +218,8 @@ Classes, methods, and functions
 
 """
 
+from six.moves import range
+
 import numpy as np
 
 import MDAnalysis
@@ -1296,8 +1298,8 @@ class PSAnalysis(object):
         numpaths = self.npaths
         D = np.zeros((numpaths,numpaths))
 
-        for i in xrange(0, numpaths-1):
-            for j in xrange(i+1, numpaths):
+        for i in range(0, numpaths-1):
+            for j in range(i+1, numpaths):
                 P = self.paths[i][start:stop:step]
                 Q = self.paths[j][start:stop:step]
                 D[i,j] = metric_func(P, Q)
@@ -1344,8 +1346,8 @@ class PSAnalysis(object):
         self._HP = [] # list of Hausdorff pairs
         self._psa_pairs = [] # list of PSAPairs
 
-        for i in xrange(0, numpaths-1):
-            for j in xrange(i+1, numpaths):
+        for i in range(0, numpaths-1):
+            for j in range(i+1, numpaths):
                 pp = PSAPair(i, j, numpaths)
                 P = self.paths[i][start:stop:step]
                 Q = self.paths[j][start:stop:step]

--- a/package/MDAnalysis/analysis/waterdynamics.py
+++ b/package/MDAnalysis/analysis/waterdynamics.py
@@ -280,6 +280,8 @@ Classes
 
 """
 
+from six.moves import range
+
 import MDAnalysis.analysis.hbonds
 import numpy as np
 import multiprocessing

--- a/package/MDAnalysis/analysis/x3dna.py
+++ b/package/MDAnalysis/analysis/x3dna.py
@@ -114,6 +114,8 @@ Utilities
 
 """
 
+from six.moves import range
+
 import glob
 import os
 import errno
@@ -346,7 +348,7 @@ class BaseX3DNA(object):
         na_avg, na_std = self.mean_std()
         for k in range(len(na_avg[0])):
             ax = kwargs.pop('ax', plt.subplot(111))
-            x = range(1, len(na_avg[:, k]) + 1)
+            x = list(range(1, len(na_avg[:, k]) + 1))
             ax.errorbar(x, na_avg[:, k], yerr=na_std[:, k], fmt='-o')
             ax.set_xlim(0, len(na_avg[:, k]) + 1)
             ax.set_xlabel(r"Nucleic Acid Number")

--- a/package/MDAnalysis/coordinates/DLPoly.py
+++ b/package/MDAnalysis/coordinates/DLPoly.py
@@ -24,6 +24,8 @@ Read DL Poly_ format coordinate files
 from __future__ import (absolute_import, division,
                         print_function, unicode_literals)
 
+from six.moves import range
+
 import numpy as np
 
 from . import base

--- a/package/MDAnalysis/coordinates/GRO.py
+++ b/package/MDAnalysis/coordinates/GRO.py
@@ -57,6 +57,8 @@ box_triclinic
 .. _GRO format: http://chembytes.wikidot.com/g-grofile
 """
 
+from six.moves import range
+
 import warnings
 import numpy as np
 
@@ -143,7 +145,7 @@ class GROReader(base.SingleFrameReader):
                     continue
                 if pos < 0:
                     continue
-                for i in xrange(3):
+                for i in range(3):
                     ts._pos[pos, i] = float(line[20 + cs*i: 20 + cs*(i+1)])
 
                 if not has_velocities:

--- a/package/MDAnalysis/coordinates/INPCRD.py
+++ b/package/MDAnalysis/coordinates/INPCRD.py
@@ -25,6 +25,8 @@ Read and write coordinates in Amber_ coordinate/restart file (suffix
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from six.moves import range
+
 from . import base
 
 class INPReader(base.SingleFrameReader):
@@ -47,7 +49,7 @@ class INPReader(base.SingleFrameReader):
                 self.ts.time = time
             self.ts.frame = 0
 
-            for p in xrange(self.n_atoms // 2):
+            for p in range(self.n_atoms // 2):
                 line = inf.readline()
                 # each float is f12.7, 6 floats a line
                 for i, dest in enumerate([(2*p, 0), (2*p, 1), (2*p, 2),

--- a/package/MDAnalysis/coordinates/PDB.py
+++ b/package/MDAnalysis/coordinates/PDB.py
@@ -196,6 +196,8 @@ References
 
 """
 
+from six.moves import range
+
 try:
     # BioPython is overkill but potentially extensible (altLoc etc)
     import Bio.PDB
@@ -591,7 +593,7 @@ class PrimitivePDBReader(base.Reader):
         pos = 0
         occupancy = np.ones(self._n_atoms)
         with util.openany(self.filename, 'r') as f:
-            for i in xrange(line):
+            for i in range(line):
                 f.next()  # forward to frame
             for line in f:
                 if line[:6] == 'ENDMDL':
@@ -1018,7 +1020,7 @@ class PrimitivePDBWriter(base.Writer):
         if not start and traj.n_frames > 1:
             start = traj.frame
 
-        for framenumber in xrange(start, len(traj), step):
+        for framenumber in range(start, len(traj), step):
             traj[framenumber]
             self.write_next_timestep(self.ts, multiframe=True)
 

--- a/package/MDAnalysis/coordinates/TRZ.py
+++ b/package/MDAnalysis/coordinates/TRZ.py
@@ -72,6 +72,8 @@ Reads coordinates, velocities and more (see attributes of the
    :members:
 """
 
+from six.moves import range
+
 from sys import maxint
 import warnings
 import numpy as np

--- a/package/MDAnalysis/coordinates/XYZ.py
+++ b/package/MDAnalysis/coordinates/XYZ.py
@@ -70,6 +70,8 @@ the `VMD xyzplugin`_ from whence the definition was taken)::
 
 """
 
+from six.moves import range
+
 import os
 import errno
 import numpy as np
@@ -358,7 +360,7 @@ class XYZReader(base.Reader):
             # we assume that there are only two header lines per frame
             f.readline()
             f.readline()
-            for i in xrange(self.n_atoms):
+            for i in range(self.n_atoms):
                 self.ts._pos[i] = map(float, f.readline().split()[1:4])
             ts.frame += 1
             return ts

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -115,6 +115,9 @@ module. The derived classes must follow the Trajectory API in
 
 """
 
+from six.moves import range
+import six
+
 import itertools
 import os.path
 import warnings
@@ -122,7 +125,6 @@ import bisect
 import numpy as np
 import copy
 import weakref
-import six
 
 from . import (
     _READERS,
@@ -356,7 +358,7 @@ class Timestep(object):
 
             iterate of the coordinates, atom by atom
         """
-        for i in xrange(self.n_atoms):
+        for i in range(self.n_atoms):
             yield self[i]
 
     def __repr__(self):
@@ -1196,7 +1198,7 @@ class ProtoReader(six.with_metaclass(_Readermeta, IObase)):
         # override with an appropriate implementation e.g. using self[i] might
         # be much slower than skipping steps in a next() loop
         try:
-            for i in xrange(start, stop, step):
+            for i in range(start, stop, step):
                 yield self._read_frame(i)
         except TypeError:  # if _read_frame not implemented
             raise TypeError("{0} does not support slicing."

--- a/package/MDAnalysis/core/AtomGroup.py
+++ b/package/MDAnalysis/core/AtomGroup.py
@@ -407,6 +407,8 @@ Classes and functions
 """
 from __future__ import print_function, absolute_import
 
+from six.moves import range
+
 # Global imports
 import warnings
 import numpy as np
@@ -2058,7 +2060,7 @@ class AtomGroup(object):
         else:
             recenteredpos = self.positions - self.center_of_mass(pbc=False)
         tensor = np.zeros((3, 3))
-        for x in xrange(recenteredpos.shape[0]):
+        for x in range(recenteredpos.shape[0]):
             tensor += masses[x] * np.outer(recenteredpos[x, :],
                                               recenteredpos[x, :])
         tensor /= self.total_mass()
@@ -2091,7 +2093,7 @@ class AtomGroup(object):
         else:
             recenteredpos = self.positions - self.center_of_mass(pbc=False)
         tensor = np.zeros((3, 3))
-        for x in xrange(recenteredpos.shape[0]):
+        for x in range(recenteredpos.shape[0]):
             tensor += masses[x] * np.outer(recenteredpos[x, :],
                                               recenteredpos[x, :])
         tensor /= self.total_mass()

--- a/package/MDAnalysis/lib/distances.py
+++ b/package/MDAnalysis/lib/distances.py
@@ -55,6 +55,8 @@ Functions
 .. autofunction:: transform_StoR(coordinates, box [,backend])
 
 """
+from six.moves import range
+
 import numpy as np
 from numpy.lib.utils import deprecate
 
@@ -305,8 +307,8 @@ def self_distance_array(reference, box=None, result=None, backend="serial"):
              N*(N-1)/2 numpy 1D array with the distances dist[i,j] between ref
              coordinates i and j at position d[k]. Loop through d::
 
-                 for i in xrange(N):
-                     for j in xrange(i+1, N):
+                 for i in range(N):
+                     for j in range(i+1, N):
                          k += 1
                          dist[i,j] = d[k]
 

--- a/package/MDAnalysis/lib/transformations.py
+++ b/package/MDAnalysis/lib/transformations.py
@@ -190,6 +190,8 @@ Functions
 
 from __future__ import division
 
+from six.moves import range
+
 import sys
 import os
 import warnings

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -150,6 +150,8 @@ Class decorators
 
 __docformat__ = "restructuredtext en"
 
+from six.moves import range
+
 import os
 import os.path
 import errno

--- a/package/MDAnalysis/selections/base.py
+++ b/package/MDAnalysis/selections/base.py
@@ -32,6 +32,8 @@ methods.
 """
 from __future__ import absolute_import
 
+from six.moves import range
+
 import os.path
 
 from ..lib import util
@@ -173,7 +175,7 @@ class SelectionWriter(object):
         step = self.numterms or len(selection.atoms)
         with util.openany(self.filename, self._current_mode) as out:
             self._write_head(out, name=name)
-            for iatom in xrange(0, len(selection.atoms), step):
+            for iatom in range(0, len(selection.atoms), step):
                 line = selection_terms[iatom:iatom + step]
                 out.write(" ".join(line))
                 if len(line) == step and not iatom + step == len(selection.atoms):

--- a/package/MDAnalysis/topology/GROParser.py
+++ b/package/MDAnalysis/topology/GROParser.py
@@ -34,6 +34,8 @@ Classes
 """
 from __future__ import absolute_import
 
+from six.moves import range
+
 from ..lib.util import openany
 from ..core.AtomGroup import Atom
 from .core import get_atom_mass, guess_atom_charge, guess_atom_element
@@ -58,7 +60,7 @@ class GROParser(TopologyReader):
         with openany(self.filename, "r") as grofile:
             grofile.readline()
             natoms = int(grofile.readline())
-            for atom_iter in xrange(natoms):
+            for atom_iter in range(natoms):
                 line = grofile.readline()
                 try:
                     resid, resname, name = int(line[0:5]), line[5:10].strip(), line[10:15].strip()

--- a/package/MDAnalysis/topology/HoomdXMLParser.py
+++ b/package/MDAnalysis/topology/HoomdXMLParser.py
@@ -41,6 +41,8 @@ Classes
 """
 from __future__ import absolute_import
 
+from six.moves import range
+
 import xml.etree.ElementTree as ET
 
 from ..lib.util import openany

--- a/package/MDAnalysis/topology/LAMMPSParser.py
+++ b/package/MDAnalysis/topology/LAMMPSParser.py
@@ -38,6 +38,8 @@ Deprecated classes
 """
 from __future__ import absolute_import
 
+from six.moves import range
+
 import numpy as np
 import logging
 import string
@@ -498,7 +500,7 @@ class LAMMPSDataConverter(object):  # pragma: no cover
                         # skip line
                         file_iter.next()
                         data = []
-                        for i in xrange(headers[h]):
+                        for i in range(headers[h]):
                             fields = file_iter.next().strip().split()
                             data.append(tuple(map(conv_float, fields[1:])))
                         sections[line] = data
@@ -514,7 +516,7 @@ class LAMMPSDataConverter(object):  # pragma: no cover
                     elif line == "Atoms":
                         file_iter.next()
                         data = []
-                        for i in xrange(headers["atoms"]):
+                        for i in range(headers["atoms"]):
                             fields = file_iter.next().strip().split()
                             index = int(fields[0]) - 1
                             a = LAMMPSAtom(index=index, name=fields[2], type=int(fields[2]), chain_id=int(fields[1]),
@@ -526,7 +528,7 @@ class LAMMPSDataConverter(object):  # pragma: no cover
                     elif line == "Masses":
                         file_iter.next()
                         data = []
-                        for i in xrange(headers["atom type"]):
+                        for i in range(headers["atom type"]):
                             fields = file_iter.next().strip().split()
                             print "help"
                 self.positions = positions

--- a/package/MDAnalysis/topology/PSFParser.py
+++ b/package/MDAnalysis/topology/PSFParser.py
@@ -36,6 +36,8 @@ Classes
 """
 from __future__ import absolute_import
 
+from six.moves import range
+
 import logging
 from math import ceil
 
@@ -214,7 +216,7 @@ class PSFParser(TopologyReader):
         #   0:8   9:13   14:18   19:23   24:28   29:33   34:48 48:62 62:70 70:84 84:98
 
         atoms = [None, ]*numlines
-        for i in xrange(numlines):
+        for i in range(numlines):
             line = lines()
             try:
                 iatom, segid, resid, resname, atomname, atomtype, charge, mass = set_type(atom_parser(line))
@@ -234,7 +236,7 @@ class PSFParser(TopologyReader):
     def _parsesection(self, lines, atoms_per, numlines):
         section = []  # [None,]*numlines
 
-        for i in xrange(numlines):
+        for i in range(numlines):
             # Subtract 1 from each number to ensure zero-indexing for the atoms
             fields = map(lambda x: int(x) - 1, lines().split())
             for j in range(0, len(fields), atoms_per):

--- a/package/MDAnalysis/topology/TOPParser.py
+++ b/package/MDAnalysis/topology/TOPParser.py
@@ -43,6 +43,8 @@ Classes
 """
 from __future__ import absolute_import
 
+from six.moves import range
+
 from math import ceil
 
 from ..core.AtomGroup import Atom
@@ -152,7 +154,7 @@ class TOPParser(TopologyReader):
                 header = next_line()
             header = next_line()
 
-            topremarks = [next_line().strip() for i in xrange(4)]
+            topremarks = [next_line().strip() for i in range(4)]
             sys_info = [int(k) for i in topremarks for k in i.split()]
 
             structure = {}
@@ -218,7 +220,7 @@ class TOPParser(TopologyReader):
 
     def _parsebond(self, lines, atoms_per, attr, structure, numlines):
         section = []  # [None,]*numlines
-        for i in xrange(numlines):
+        for i in range(numlines):
             l = lines()
             # Subtract 1 from each number to ensure zero-indexing for the atoms
             f = map(int, l.split())
@@ -232,11 +234,11 @@ class TOPParser(TopologyReader):
         y = lines().strip("%FORMAT(")
         y.strip(")")
         x = FORTRANReader(y)
-        for i in xrange(numlines):
+        for i in range(numlines):
             l = lines()
             # Subtract 1 from each number to ensure zero-indexing for the atoms
             try:
-                for j in xrange(len(x.entries)):
+                for j in range(len(x.entries)):
                     section.append(int(l[x.entries[j].start:x.entries[j].stop].strip()))
             except:
                 continue
@@ -247,7 +249,7 @@ class TOPParser(TopologyReader):
         y = lines().strip("%FORMAT(")
         y.strip(")")
         x = FORTRANReader(y)
-        for i in xrange(numlines):
+        for i in range(numlines):
             l = lines()
             # Subtract 1 from each number to ensure zero-indexing for the atoms
             try:
@@ -262,7 +264,7 @@ class TOPParser(TopologyReader):
         y = lines().strip("%FORMAT(")
         y.strip(")")
         x = FORTRANReader(y)
-        for i in xrange(numlines):
+        for i in range(numlines):
             l = lines()
             # Subtract 1 from each number to ensure zero-indexing for the atoms
             for j in range(0, len(x.entries)):

--- a/package/MDAnalysis/topology/XYZParser.py
+++ b/package/MDAnalysis/topology/XYZParser.py
@@ -33,6 +33,8 @@ Classes
 """
 from __future__ import absolute_import
 
+from six.moves import range
+
 from ..core.AtomGroup import Atom
 from ..lib.util import openany
 from .core import get_atom_mass, guess_atom_charge, guess_atom_element

--- a/package/MDAnalysis/topology/tpr/obj.py
+++ b/package/MDAnalysis/topology/tpr/obj.py
@@ -25,6 +25,8 @@ Class definitions for the TPRParser
 
 """
 
+from six.moves import range
+
 from collections import namedtuple
 
 TpxHeader = namedtuple(
@@ -122,8 +124,8 @@ class InteractionKind(object):
     def process(self, atom_ndx):
         while atom_ndx:
             # format for all info: (type, [atom1, atom2, ...])
-            # yield atom_ndx.pop(0), [atom_ndx.pop(0) for i in xrange(self.natoms)]
+            # yield atom_ndx.pop(0), [atom_ndx.pop(0) for i in range(self.natoms)]
 
             # but currently only [atom1, atom2, ...] is interested
             atom_ndx.pop(0)
-            yield [atom_ndx.pop(0) for i in xrange(self.natoms)]
+            yield [atom_ndx.pop(0) for i in range(self.natoms)]

--- a/package/MDAnalysis/topology/tpr/setting.py
+++ b/package/MDAnalysis/topology/tpr/setting.py
@@ -30,6 +30,8 @@ The currently read file format versions are defined in
 
 """
 
+from six.moves import range
+
 #: Gromacs TPR file format versions that can be read by the TPRParser.
 SUPPORTED_VERSIONS = (58, 73, 83, 100, 103)
 
@@ -70,7 +72,7 @@ tpxv_RestrictedBendingAndCombinedAngleTorsionPotentials = 98
     F_ETOT, F_ECONSERVED, F_TEMP, F_VTEMP_NOLONGERUSED,
     F_PDISPCORR, F_PRES, F_DHDL_CON, F_DVDL,
     F_DKDL, F_DVDL_COUL, F_DVDL_VDW, F_DVDL_BONDED,
-    F_DVDL_RESTRAINT, F_DVDL_TEMPERATURE, F_NRE) = range(92)
+    F_DVDL_RESTRAINT, F_DVDL_TEMPERATURE, F_NRE) = list(range(92))
 
 #: Function types from ``<gromacs_dir>/src/gmxlib/tpxio.c``
 ftupd = [

--- a/package/MDAnalysis/topology/tpr/utils.py
+++ b/package/MDAnalysis/topology/tpr/utils.py
@@ -41,18 +41,20 @@ The module also contains the :func:`do_inputrec` to read the TPR header with.
 """
 from __future__ import absolute_import
 
+from six.moves import range
+
 from ...core.AtomGroup import Atom
 from . import obj
 from . import setting as S
 
 def ndo_int(data, n):
     """mimic of gmx_fio_ndo_real in gromacs"""
-    return [data.unpack_int() for i in xrange(n)]
+    return [data.unpack_int() for i in range(n)]
 
 
 def ndo_real(data, n):
     """mimic of gmx_fio_ndo_real in gromacs"""
-    return [data.unpack_real() for i in xrange(n)]
+    return [data.unpack_real() for i in range(n)]
 
 
 def do_rvec(data):
@@ -61,12 +63,12 @@ def do_rvec(data):
 
 def ndo_rvec(data, n):
     """mimic of gmx_fio_ndo_rvec in gromacs"""
-    return [data.unpack_farray(S.DIM, data.unpack_real) for i in xrange(n)]
+    return [data.unpack_farray(S.DIM, data.unpack_real) for i in range(n)]
 
 
 def ndo_ivec(data, n):
     """mimic of gmx_fio_ndo_rvec in gromacs"""
-    return [data.unpack_farray(S.DIM, data.unpack_int) for i in xrange(n)]
+    return [data.unpack_farray(S.DIM, data.unpack_int) for i in range(n)]
 
 
 def fver_err(fver):
@@ -154,7 +156,7 @@ def do_mtop(data, fver, u):
 
     nmoltype = data.unpack_int()
     moltypes = []  # non-gromacs
-    for i in xrange(nmoltype):
+    for i in range(nmoltype):
         moltype = do_moltype(data, symtab, fver)
         moltypes.append(moltype)
 
@@ -162,17 +164,17 @@ def do_mtop(data, fver, u):
 
     mtop = obj.Mtop(nmoltype, moltypes, nmolblock)
 
-    ttop = obj.TPRTopology(*[[] for i in xrange(5)])
+    ttop = obj.TPRTopology(*[[] for i in range(5)])
 
     atom_start_ndx = 0
     res_start_ndx = 0
-    for i in xrange(mtop.nmolblock):
+    for i in range(mtop.nmolblock):
         # molb_type is just an index for moltypes/molecule_types
         mb = do_molblock(data)
         # segment is made to correspond to the molblock as in gromacs, the
         # naming is kind of arbitrary
         segid = "seg_{0}_{1}".format(i, mtop.moltypes[mb.molb_type].name)
-        for j in xrange(mb.molb_nmol):
+        for j in range(mb.molb_nmol):
             mt = mtop.moltypes[mb.molb_type]  # mt: molecule type
             for atomkind in mt.atomkinds:
                 ttop.atoms.append(Atom(atomkind.id + atom_start_ndx,
@@ -213,7 +215,7 @@ def do_symstr(data, symtab):
 def do_symtab(data):
     symtab_nr = data.unpack_int()  # number of symbols
     symtab = []
-    for i in xrange(symtab_nr):
+    for i in range(symtab_nr):
         j = data.unpack_fstring(1)  # strings are separated by void
         j = data.unpack_string()
         symtab.append(j)
@@ -232,7 +234,7 @@ def do_ffparams(data, fver):
 
     # mimicing the c code,
     # remapping the functype due to inconsistency in different versions
-    for i in xrange(len(functype)):
+    for i in range(len(functype)):
         for k in S.ftupd:
             # j[0]: tpx_version, j[1] funtype
             if fver < k[0] and functype[i] >= k[1]:
@@ -555,7 +557,7 @@ def do_atoms(data, symtab, fver):
         fver_err(fver)
 
     atoms = []
-    for i in xrange(nr):
+    for i in range(nr):
         A = do_atom(data, fver)
         atoms.append(A)
 
@@ -580,7 +582,7 @@ def do_resinfo(data, symtab, fver, nres):
         resnames = [symtab[i] for i in ndo_int(data, nres)]
     else:
         resnames = []
-        for i in xrange(nres):
+        for i in range(nres):
             resnames.append(symtab[data.unpack_int()])
             # assume the uchar in gmx is 8 byte, seems right
             data.unpack_fstring(8)
@@ -608,7 +610,7 @@ def do_atom(data, fver):
 def do_ilists(data, fver):
     nr = []  # number of ilist
     iatoms = []  # atoms involved in a particular interaction type
-    for j in xrange(S.F_NRE):  # total number of energies (i.e. interaction types)
+    for j in range(S.F_NRE):  # total number of energies (i.e. interaction types)
         bClear = False
         for k in S.ftupd:
             if fver < k[0] and j == k[1]:
@@ -623,7 +625,7 @@ def do_ilists(data, fver):
             n = data.unpack_int()
             nr.append(n)
             l_ = []
-            for i in xrange(n):
+            for i in range(n):
                 l_.append(data.unpack_int())
             iatoms.append(l_)
 
@@ -665,7 +667,7 @@ def do_blocka(data):
 def do_grps(data):  # pragma: no cover
     grps_nr = []
     myngrps = ngrps = S.egcNR  # remind of version inconsistency
-    for j in xrange(ngrps):
+    for j in range(ngrps):
         if j < myngrps:
             v = data.unpack_int()
             grps_nr.append(v)
@@ -683,14 +685,14 @@ def do_groups(data, symtab):  # pragma: no cover
 
     ngrpnr = []
     grpnr = []
-    for i in xrange(S.egcNR):
+    for i in range(S.egcNR):
         x = data.unpack_int()
         ngrpnr.append(x)
         if x == 0:
             grpnr.append(None)
         else:
             l_ = []
-            for i in xrange(x):
+            for i in range(x):
                 l_.append(data.unpack_uint())
             grpnr.append(l_)
     # print ngrpnr

--- a/package/MDAnalysis/visualization/streamlines_3D.py
+++ b/package/MDAnalysis/visualization/streamlines_3D.py
@@ -27,6 +27,8 @@ Multicore 3D streamplot Python library for MDAnalysis --- :mod:`MDAnalysis.visua
 
 '''
 
+from six.moves import range
+
 import MDAnalysis
 import multiprocessing
 import numpy as np

--- a/testsuite/MDAnalysisTests/analysis/test_base.py
+++ b/testsuite/MDAnalysisTests/analysis/test_base.py
@@ -15,6 +15,8 @@
 #
 from __future__ import division
 
+from six.moves import range
+
 from numpy.testing import (
     assert_,
 )
@@ -53,25 +55,25 @@ class TestAnalysisBase(object):
         assert_(an.nframes == len(self.u.trajectory))
 
         an.run()
-        assert_(an.frames == range(len(self.u.trajectory)))
+        assert_(an.frames == list(range(len(self.u.trajectory))))
 
     def test_start(self):
         an = FrameAnalysis(self.u.trajectory, start=20)
         assert_(an.nframes == len(self.u.trajectory) - 20)
 
         an.run()
-        assert_(an.frames == range(20, len(self.u.trajectory)))
+        assert_(an.frames == list(range(20, len(self.u.trajectory))))
 
     def test_stop(self):
         an = FrameAnalysis(self.u.trajectory, stop=20)
         assert_(an.nframes == 20)
 
         an.run()
-        assert_(an.frames == range(20))
-        
+        assert_(an.frames == list(range(20)))
+
     def test_step(self):
         an = FrameAnalysis(self.u.trajectory, step=20)
         assert_(an.nframes == 5)
 
         an.run()
-        assert_(an.frames == range(98)[::20])
+        assert_(an.frames == list(range(98))[::20])

--- a/testsuite/MDAnalysisTests/analysis/test_hole.py
+++ b/testsuite/MDAnalysisTests/analysis/test_hole.py
@@ -15,6 +15,8 @@
 #
 from __future__ import print_function
 
+from six.moves import range
+
 import MDAnalysis
 import MDAnalysis.analysis.hole
 from MDAnalysis.analysis.hole import HOLEtraj
@@ -83,7 +85,7 @@ class TestHoleModule(TestCase):
             # issue 129 isn't fixed, although this depends on the file descriptor
             # open limit for the machine in question
             try:
-                for i in xrange(2):
+                for i in range(2):
                     # will typically get an OSError for too many files being open after
                     # about 2 seconds if issue 129 isn't resolved
                     H.run()

--- a/testsuite/MDAnalysisTests/analysis/test_rms.py
+++ b/testsuite/MDAnalysisTests/analysis/test_rms.py
@@ -15,6 +15,8 @@
 #
 from __future__ import print_function
 
+from six.moves import range
+
 import MDAnalysis
 import MDAnalysis.analysis.rms
 
@@ -59,7 +61,7 @@ class TestRMSF(TestCase):
     def test_rmsf_identical_frames(self):
         # write a dummy trajectory of all the same frame
         with MDAnalysis.Writer(self.outfile, self.universe.atoms.n_atoms) as W:
-            for i in xrange(self.universe.trajectory.n_frames):
+            for i in range(self.universe.trajectory.n_frames):
                 W.write(self.universe)
 
         self.universe = MDAnalysis.Universe(GRO, self.outfile)

--- a/testsuite/MDAnalysisTests/coordinates/base.py
+++ b/testsuite/MDAnalysisTests/coordinates/base.py
@@ -1,6 +1,6 @@
 import itertools
 import numpy as np
-from six.moves import zip
+from six.moves import zip, range
 from nose.plugins.attrib import attr
 from unittest import TestCase
 import tempdir

--- a/testsuite/MDAnalysisTests/coordinates/test_dcd.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_dcd.py
@@ -1,7 +1,7 @@
 import MDAnalysis as mda
 import numpy as np
 import os
-from six.moves import zip
+from six.moves import zip, range
 
 from nose.plugins.attrib import attr
 from numpy.testing import (assert_equal, assert_array_equal, assert_raises,
@@ -96,7 +96,8 @@ class TestDCDReader(_TestDCD):
 
     def test_reverse_dcd(self):
         frames = [ts.frame for ts in self.dcd[20:5:-1]]
-        assert_equal(frames, range(20, 5, -1), "reversing dcd [20:5:-1]")
+        assert_equal(frames, list(range(20, 5, -1)),
+                     "reversing dcd [20:5:-1]")
 
     def test_n_atoms(self):
         assert_equal(self.universe.trajectory.n_atoms, 3341,

--- a/testsuite/MDAnalysisTests/coordinates/test_gms.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_gms.py
@@ -1,3 +1,5 @@
+from six.moves import range
+
 import MDAnalysis as mda
 import numpy as np
 

--- a/testsuite/MDAnalysisTests/coordinates/test_mol2.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_mol2.py
@@ -13,6 +13,8 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
+from six.moves import range
+
 import tempfile
 import os
 from numpy.testing import *
@@ -116,7 +118,8 @@ class TestMol2_traj(TestCase):
 
     def test_reverse_traj(self):
         frames = [ts.frame for ts in self.traj[20:5:-1]]
-        assert_equal(frames, range(20, 5, -1), "reversing traj [20:5:-1]")
+        assert_equal(frames, list(range(20, 5, -1)),
+                     "reversing traj [20:5:-1]")
 
     def test_n_frames(self):
         assert_equal(self.universe.trajectory.n_frames, 200, "wrong number of frames in traj")

--- a/testsuite/MDAnalysisTests/coordinates/test_xdr.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_xdr.py
@@ -4,7 +4,7 @@ from MDAnalysis.coordinates.base import Timestep
 import numpy as np
 import os
 import shutil
-from six.moves import zip
+from six.moves import zip, range
 import warnings
 
 from nose.plugins.attrib import attr
@@ -133,7 +133,7 @@ class _GromacsReader(TestCase):
     @dec.slow
     def test_reverse_xdrtrj(self):
         frames = [ts.frame for ts in self.trajectory[::-1]]
-        assert_equal(frames, range(9, -1, -1), "slicing xdrtrj [::-1]")
+        assert_equal(frames, list(range(9, -1, -1)), "slicing xdrtrj [::-1]")
 
     @dec.slow
     def test_coordinates(self):

--- a/testsuite/MDAnalysisTests/coordinates/test_xyz.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_xyz.py
@@ -1,3 +1,5 @@
+from six.moves import range
+
 import MDAnalysis as mda
 import numpy as np
 

--- a/testsuite/MDAnalysisTests/test_atomselections.py
+++ b/testsuite/MDAnalysisTests/test_atomselections.py
@@ -14,6 +14,8 @@
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
 
+from six.moves import range
+
 import numpy as np
 from numpy.testing import(
     TestCase,

--- a/testsuite/MDAnalysisTests/test_streamio.py
+++ b/testsuite/MDAnalysisTests/test_streamio.py
@@ -13,6 +13,8 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
+from six.moves import range
+
 import numpy as np
 from numpy.testing import *
 
@@ -43,7 +45,7 @@ class TestIsstream(TestCase):
         assert_equal(util.isstream(obj), False)
 
     def test_iterator(self):
-        obj = (i for i in xrange(3))
+        obj = (i for i in range(3))
         assert_equal(util.isstream(obj), False)
 
     def test_file(self):

--- a/testsuite/MDAnalysisTests/test_topology.py
+++ b/testsuite/MDAnalysisTests/test_topology.py
@@ -13,6 +13,8 @@
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
 
+from six.moves import range
+
 import MDAnalysis
 from MDAnalysis.core.AtomGroup import AtomGroup
 from MDAnalysis.lib.distances import calc_bonds, calc_angles, calc_dihedrals

--- a/testsuite/MDAnalysisTests/test_transformations.py
+++ b/testsuite/MDAnalysisTests/test_transformations.py
@@ -14,6 +14,8 @@
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
 
+from six.moves import range
+
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal, TestCase
 import math

--- a/testsuite/MDAnalysisTests/test_util.py
+++ b/testsuite/MDAnalysisTests/test_util.py
@@ -13,6 +13,8 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
+from six.moves import range
+
 import cStringIO
 import os.path
 import tempfile
@@ -102,7 +104,7 @@ class TestIterable(TestCase):
         assert_equal(util.iterable(()), True)
 
     def test_iterator(self):
-        assert_equal(util.iterable(xrange(3)), True)
+        assert_equal(util.iterable(range(3)), True)
 
     def test_arrays(self):
         assert_equal(util.iterable(np.array([1, 2, 3])), True)


### PR DESCRIPTION
See #632 and #260 

The `xrange` function disapears in Python 3. In the same time, the
meaning of the `range` function changes in python 3 to behave in a
similar fashion as `xrange`. Therefore, in Python 3, `range` produces a
generator and `xrange` does not exist anymore.

This commit replace all calls to `xrange` by calls to `range`. It also
overload the `range` built-in  to use the one provided by `six` that
reproduce the behavior from Python 3.

No Cython file got touched, even though some use xrange, as xrange seems
to keep existing in Cython.

This commit changes the behavior of the `range` built-in!

In the future, `xrange` should not be used anymore. When `range` is
used, it should be overloaded with `from six.moves import range`. When a list
is needed rather than a generator, `list(range(x))` should be used.