### PR TITLE
Issue 649 docstring

### DIFF
--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -471,8 +471,8 @@ class NamedStream(io.IOBase):
     The class can be used as a context manager.
 
     :class:`NamedStream` is derived from :class:`io.IOBase` (to indicate that
-    it is a stream) *and* :class:`basestring` (that one can use
-    :func:`iterable` in the same way as for strings).
+    it is a stream); some operations that normally expect a string will also
+    work with a :class:`NamedStream`.
 
     .. rubric:: Example
 

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -824,7 +824,8 @@ def guess_format(filename):
 
 
 def iterable(obj):
-    """Returns ``True`` if *obj* can be iterated over and is *not* a  string."""
+    """Returns ``True`` if *obj* can be iterated over and is *not* a  string
+    nor a :class:`NamedStream`"""
     if isinstance(obj, (basestring, NamedStream)):
         return False  # avoid iterating over characters of a string
 


### PR DESCRIPTION
Remove the reference to `NamedStream` inheriting from `basestring` as it
is not true anymore since #652

I went too fast at merging #652 and forgot a docstring had to be updated.