### PR TITLE
Replace `basestring` by `six.string_types`

### DIFF
--- a/package/MDAnalysis/analysis/hole.py
+++ b/package/MDAnalysis/analysis/hole.py
@@ -1,5 +1,5 @@
 # -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
-# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
 #
 # MDAnalysis --- http://www.MDAnalysis.org
 # Copyright (c) 2006-2015 Naveen Michaud-Agrawal, Elizabeth J. Denning, Oliver Beckstein
@@ -172,8 +172,10 @@ Utilities
 
 """
 
-import numpy as np
 from six.moves import zip, cPickle
+import six
+
+import numpy as np
 import glob
 import os
 import errno
@@ -1069,7 +1071,7 @@ class HOLEtraj(BaseHOLE):
         * If data is a array/list: use as is
         * If ``None``: assign frame numbers from trajectory
         """
-        if isinstance(data, basestring):
+        if isinstance(data, six.string_types):
             q = np.loadtxt(data)
         elif data is None:
             # frame numbers

--- a/package/MDAnalysis/coordinates/core.py
+++ b/package/MDAnalysis/coordinates/core.py
@@ -1,5 +1,5 @@
 # -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
-# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
 #
 # MDAnalysis --- http://www.MDAnalysis.org
 # Copyright (c) 2006-2015 Naveen Michaud-Agrawal, Elizabeth J. Denning, Oliver Beckstein
@@ -30,6 +30,8 @@ Helper functions:
 .. autofunction:: get_writer_for
 
 """
+
+import six
 
 from . import (
     _READERS,
@@ -154,7 +156,7 @@ def get_writer_for(filename=None, format='DCD', multiframe=None):
        Added *multiframe* keyword; the default ``None`` reflects the previous
        behaviour.
     """
-    if isinstance(filename, basestring) and filename:
+    if isinstance(filename, six.string_types) and filename:
         root, ext = util.get_ext(filename)
         format = util.check_compressed_format(root, ext)
     if multiframe is None:

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -151,6 +151,7 @@ Class decorators
 __docformat__ = "restructuredtext en"
 
 from six.moves import range
+import six
 
 import os
 import os.path
@@ -826,7 +827,7 @@ def guess_format(filename):
 def iterable(obj):
     """Returns ``True`` if *obj* can be iterated over and is *not* a  string
     nor a :class:`NamedStream`"""
-    if isinstance(obj, (basestring, NamedStream)):
+    if isinstance(obj, (six.string_types, NamedStream)):
         return False  # avoid iterating over characters of a string
 
     if hasattr(obj, 'next'):


### PR DESCRIPTION
`basestring` got removed from Python 3. This commit replaces all its
occurrences by `six.string_types`.

See #643 and #260