### PR TITLE
Xdrlib offset checking, issue (631)

### DIFF
--- a/package/MDAnalysis/coordinates/XDR.py
+++ b/package/MDAnalysis/coordinates/XDR.py
@@ -10,6 +10,8 @@
 # Please cite your use of MDAnalysis in published work:
 #
 # N. Michaud-Agrawal, E. J. Denning, T. B. Woolf, and O. Beckstein.
+
+
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
@@ -113,7 +115,7 @@ class XDRBaseReader(base.Reader):
 
         ctime_ok = getctime(self.filename) == data['ctime']
         size_ok = getsize(self.filename) == data['size']
-        n_atoms_ok = self.n_atoms == data['n_atoms']
+        n_atoms_ok = self._xdr.n_atoms == data['n_atoms']
 
         if not (ctime_ok and size_ok and n_atoms_ok):
             warnings.warn("Reload offsets from trajectory\n "
@@ -131,7 +133,7 @@ class XDRBaseReader(base.Reader):
             try:
                 np.savez(offsets_filename(self.filename),
                          offsets=offsets, size=size, ctime=ctime,
-                         n_atoms=self.n_atoms)
+                         n_atoms=self._xdr.n_atoms)
             except Exception as e:
                 try:
                     warnings.warn("Couldn't save offsets because: {}".format(

--- a/package/MDAnalysis/coordinates/XDR.py
+++ b/package/MDAnalysis/coordinates/XDR.py
@@ -164,7 +164,7 @@ class XDRBaseReader(base.Reader):
             self._xdr.seek(i)
             timestep = self._read_next_timestep()
         except RuntimeError:
-            warnings.warn('seek failed, recalculating offsets and retry')
+            warnings.warn('seek failed, recalculating offsets and retrying')
             offsets = self._xdr.calc_offsets()
             self._xdr.set_offsets(offsets)
             self._read_offsets(store=True)

--- a/package/MDAnalysis/coordinates/XDR.py
+++ b/package/MDAnalysis/coordinates/XDR.py
@@ -43,6 +43,22 @@ def offsets_filename(filename, ending='npz'):
                                                         ending=ending))
 
 
+def read_numpy_offsets(filename):
+    """read offsets into a dictionary
+
+    Parameters
+    ----------
+    filename : str
+        filename of offsets
+
+    Returns
+    -------
+    offsets : dict
+        dictionary of offsets information
+    """
+    return {k: v for k, v in six.iteritems(np.load(filename))}
+
+
 class XDRBaseReader(base.Reader):
     """Base class for xdrlib file formats xtc and trr"""
     def __init__(self, filename, convert_units=True, sub=None,
@@ -93,8 +109,7 @@ class XDRBaseReader(base.Reader):
             self._read_offsets(store=True)
             return
 
-        with open(fname, 'rb') as f:
-            data = {k: v for k, v in six.iteritems(np.load(f))}
+        data = read_numpy_offsets(fname)
 
         ctime_ok = getctime(self.filename) == data['ctime']
         size_ok = getsize(self.filename) == data['size']

--- a/testsuite/MDAnalysisTests/coordinates/test_xdr.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_xdr.py
@@ -789,8 +789,7 @@ class _GromacsReader_offsets(TestCase):
         fname = XDR.offsets_filename(self.traj)
         saved_offsets = XDR.read_numpy_offsets(fname)
         saved_offsets['n_atoms'] += 1
-        with open(fname, 'wb') as f:
-            np.savez(f, **saved_offsets)
+        np.savez(fname, **saved_offsets)
 
         with warnings.catch_warnings(record=True) as warn:
             warnings.simplefilter('always')
@@ -813,7 +812,7 @@ class _GromacsReader_offsets(TestCase):
             reader[idx_frame]
 
         assert_equal(warn[0].message.args[0],
-                     'seek failed, recalculating offsets and retry')
+                     'seek failed, recalculating offsets and retrying')
 
     @dec.slow
     def test_persistent_offsets_readonly(self):

--- a/testsuite/MDAnalysisTests/coordinates/test_xdr.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_xdr.py
@@ -761,7 +761,7 @@ class _GromacsReader_offsets(TestCase):
             warnings.simplefilter('always')
             self._reader(self.traj)
         assert_equal(warn[0].message.args,
-                     ('Reload offsets from trajectory\n ctime or size did not match', ))
+                     ('Reload offsets from trajectory\n ctime or size or n_atoms did not match', ))
 
     @dec.slow
     def test_persistent_offsets_ctime_mismatch(self):
@@ -777,7 +777,23 @@ class _GromacsReader_offsets(TestCase):
             warnings.simplefilter('always')
             self._reader(self.traj)
         assert_equal(warn[0].message.args,
-                     ('Reload offsets from trajectory\n ctime or size did not match', ))
+                     ('Reload offsets from trajectory\n ctime or size or n_atoms did not match', ))
+
+    @dec.slow
+    def test_persistent_offsets_natoms_mismatch(self):
+        # check that stored offsets are not loaded when trajectory
+        # ctime differs from stored ctime
+        fname = XDR.offsets_filename(self.traj)
+        saved_offsets = XDR.read_numpy_offsets(fname)
+        saved_offsets['n_atoms'] += 1
+        with open(fname, 'wb') as f:
+            np.savez(f, **saved_offsets)
+
+        with warnings.catch_warnings(record=True) as warn:
+            warnings.simplefilter('always')
+            self._reader(self.traj)
+        assert_equal(warn[0].message.args,
+                     ('Reload offsets from trajectory\n ctime or size or n_atoms did not match', ))
 
     # TODO: This doesn't test if the offsets work AT ALL. the old
     # implementation only checked if the offsets were ok to set back to the old

--- a/testsuite/MDAnalysisTests/coordinates/test_xdr.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_xdr.py
@@ -32,6 +32,10 @@ from MDAnalysisTests.coordinates.base import (BaseReaderTest, BaseReference,
 import MDAnalysis.core.AtomGroup
 from MDAnalysis.coordinates import XDR
 
+# I want to catch all warnings in the tests. If this is not set at the start it
+# could cause test that check for warnings to fail.
+warnings.simplefilter('always')
+
 
 class _XDRReader_Sub(TestCase):
 

--- a/testsuite/MDAnalysisTests/coordinates/test_xdr.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_xdr.py
@@ -728,8 +728,7 @@ class _GromacsReader_offsets(TestCase):
                                   err_msg="wrong frame offsets")
 
         outfile_offsets = XDR.offsets_filename(self.traj)
-        with open(outfile_offsets, 'rb') as f:
-            saved_offsets = {k: v for k, v in six.iteritems(np.load(f))}
+        saved_offsets = XDR.read_numpy_offsets(outfile_offsets)
 
         assert_array_almost_equal(self.trajectory._xdr.offsets,
                                   saved_offsets['offsets'],
@@ -753,8 +752,7 @@ class _GromacsReader_offsets(TestCase):
         # check that stored offsets are not loaded when trajectory
         # size differs from stored size
         fname = XDR.offsets_filename(self.traj)
-        with open(fname, 'rb') as f:
-            saved_offsets = {k: v for k, v in six.iteritems(np.load(f))}
+        saved_offsets = XDR.read_numpy_offsets(fname)
         saved_offsets['size'] += 1
         with open(fname, 'wb') as f:
             np.savez(f, **saved_offsets)
@@ -770,8 +768,7 @@ class _GromacsReader_offsets(TestCase):
         # check that stored offsets are not loaded when trajectory
         # ctime differs from stored ctime
         fname = XDR.offsets_filename(self.traj)
-        with open(fname, 'rb') as f:
-            saved_offsets = {k: v for k, v in six.iteritems(np.load(f))}
+        saved_offsets = XDR.read_numpy_offsets(fname)
         saved_offsets['ctime'] += 1
         with open(fname, 'wb') as f:
             np.savez(f, **saved_offsets)


### PR DESCRIPTION
This fixes #631 with the proposed solution.

The only thing missing are more tests. I'm creating a script to generate xtc's with a wrong magic number. That will allow me to test that exceptions are still raised correctly even if we think it was just an error with the magic.