### PR TITLE
NamedStream cleanup

### DIFF
--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -730,6 +730,17 @@ class NamedStream(io.IOBase):
     def __len__(self):
         return len(self.name)
 
+    def __add__(self, x):
+        return self.name + x
+
+    def __radd__(self, x):
+        return x + self.name
+
+    def __mul__(self, x):
+        return self.name * x
+
+    __rmul__ = __mul__
+
     def __format__(self, format_spec):
         return self.name.format(format_spec)
 

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -472,8 +472,11 @@ class NamedStream(io.IOBase):
     The class can be used as a context manager.
 
     :class:`NamedStream` is derived from :class:`io.IOBase` (to indicate that
-    it is a stream); some operations that normally expect a string will also
-    work with a :class:`NamedStream`.
+    it is a stream). Many operations that normally expect a string will also
+    work with a :class:`NamedStream`; for instance, most of the functions in
+    :mod:`os.path` will work with the exception of :func:`os.path.expandvars`
+    and :func:`os.path.expanduser`, which will return the :class:`NamedStream`
+    itself instead of a string if no substitutions were made.
 
     .. rubric:: Example
 
@@ -527,22 +530,22 @@ class NamedStream(io.IOBase):
            :meth:`close` (see there) unless the *close* keyword is set to
            ``True``.
 
-        :Arguments:
-
-           *stream*
-               open stream (e.g. :class:`file` or :func:`cStringIO.StringIO`)
-           *filename*
+        Arguments
+        ---------
+        stream : stream
+               an open stream (e.g. :class:`file` or :func:`cStringIO.StringIO`)
+        filename : str
                the filename that should be associated with the stream
 
-        :Keywords:
-
-           *reset*
+        Keywords
+        --------
+        reset : boolean, default ``True``
                start the stream from the beginning (either :meth:`reset` or :meth:`seek`)
-               when the class instance is constructed [``True``]
-           *close*
+               when the class instance is constructed
+        close : booelan, default ``True``
                close the stream when a :keyword:`with` block exits or when
                :meth:`close` is called; note that the default is **not to close
-               the stream** [``False``]
+               the stream**
 
         .. versionadded:: 0.9.0
         """
@@ -576,7 +579,7 @@ class NamedStream(io.IOBase):
         return iter(self.stream)
 
     def __enter__(self):
-        # do not call the stream __enter__ because the stream is already open
+        # do not call the stream's __enter__ because the stream is already open
         return self
 
     def __exit__(self, *args):

--- a/testsuite/MDAnalysisTests/test_streamio.py
+++ b/testsuite/MDAnalysisTests/test_streamio.py
@@ -160,9 +160,12 @@ class TestNamedStream_filename_behavior(object):
     # note: no setUp() because classes with generators would run it
     #       *for each generated test* and we need it for the generator method
 
-    def test_ospath_funcs(self):
+    def create_NamedStream(self):
         obj = cStringIO.StringIO()
-        ns = util.NamedStream(obj, self.textname)
+        return util.NamedStream(obj, self.textname)
+
+    def test_ospath_funcs(self):
+        ns = self.create_NamedStream()
 
         funcs = ("abspath", "basename", "dirname", "normpath",
                  "relpath", "split", "splitext")
@@ -174,7 +177,7 @@ class TestNamedStream_filename_behavior(object):
                          err_msg=("os.path.{0}() does not work with "
                                   "NamedStream").format(funcname))
         # join not included because of different call signature
-        def _test_join(func="join", fn=self.textname, ns=ns, path="/tmp/MDAnalysisTests"):
+        def _test_join(funcname="join", fn=self.textname, ns=ns, path="/tmp/MDAnalysisTests"):
             reference = os.path.join(path, fn)
             value = os.path.join(path, ns)
             assert_equal(value, reference,
@@ -183,6 +186,22 @@ class TestNamedStream_filename_behavior(object):
         for func in funcs:
             yield _test_func, func
         yield _test_join, "join"
+
+    def test_add(self):
+        ns = self.create_NamedStream()
+        try:
+            assert_equal(ns + "foo", self.textname + "foo")
+        except TypeError:
+            raise AssertionError("NamedStream does not support  "
+                                 "string concatenation, NamedStream + str")
+
+    def test_radd(self):
+        ns = self.create_NamedStream()
+        try:
+            assert_equal("foo" + ns, "foo" + self.textname)
+        except TypeError:
+            raise AssertionError("NamedStream does not support right "
+                                 "string concatenation, str + NamedStream")
 
 
 class _StreamData(object):


### PR DESCRIPTION
As discussed in #649 and PR #652, `NamedStream` is a bit of a hack... not necessarily in the best sense of the word. This PR builds on #652 (towards Py3 compatibility) and tries to make `NamedStream` work as seamlessly as advertised or at least document its failures.

I added tests that explore the limitations of using a `NamedStream` instance as a filename under the new scheme where the class is *not* derived from either `basestring` or `str`. I apply most of the filename-related tests in `os.path`. 

The tests partially fail on those that have to do a string concatenation with `NamedString` as the argument, i.e.

      str + NamedStream

which is

     str.__add__(NamedStream)

That seems to be a problem that can only be resolved by properly inheriting from something that `str.__add__` is willing to consume.

UPDATE: Below @richardjgowers rightly points out that `NamedStream.__radd__` will solve the problem.