### PR TITLE
Made memleak testing python 3 compliant (closes #662)

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -18,7 +18,7 @@ The rules for this file:
   * 0.14.0
 
 API Changes
-  * Offsets files for Gromcas trajectory formats have been changed to a numpy
+  * Offsets files for Gromacs trajectory formats have been changed to a numpy
     style format '.npz'. Offsets files will be regenerated when you load a
     xtc/trr trajectory again. (Issue #441)
 

--- a/testsuite/CHANGELOG
+++ b/testsuite/CHANGELOG
@@ -13,6 +13,13 @@ Also see https://github.com/MDAnalysis/mdanalysis/wiki/MDAnalysisTests
 and https://github.com/MDAnalysis/mdanalysis/wiki/UnitTests
 
 ------------------------------------------------------------------------------
+??/??/16 manuel.nuno.melo
+
+  * 0.14.0
+
+    - Made memleak testing python 3 compliant (Issue 662). It may be a moot
+      point since python 3.4 now cleverly deals with leaks.
+
 01/16/16 orbeckst
   * 0.13.0
 

--- a/testsuite/MDAnalysisTests/plugins/memleak.py
+++ b/testsuite/MDAnalysisTests/plugins/memleak.py
@@ -14,44 +14,54 @@
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
 
-"""Test plugin that reports memleaks (objects deemed uncollectable by python's garbage collector) on a test-by-test basis.
+"""Test plugin that reports memleaks on a test-by-test basis.
 
 The plugin works by clearing a test's namespace after it has run, and then
 forcing a garbage collection round and checking for uncollectable objects.
 
-Implementation uses the startTest and stopTest hooks. To prevent premature
-success declaration (since the memleak check only runs after the test) the test's
-:class:`nose.proxy.ResultProxy` is monkey-patched with a silent :meth:`addSuccess` method. This
-might seem hackish, but it is how other `:class:nose.plugins.errorclass.ErrorClassPlugins`
-are implemented.
+Implementation uses the startTest hook to register our memory leak check
+as a cleanup to the test.
 """
 
 import gc
 import nose
 from nose.plugins.errorclass import ErrorClass, ErrorClassPlugin
-from nose.pyversion import make_instancemethod
 
 _leakedobjs = set() # We must keep track of seen leaks to avoid raising multiple 
                     # errors for the same ones.
+
+def memleak_check(test, pretest_attrs):
+    """Memory leak check, to be registered as a :class:`unittest.TestCase` cleanup method.
+
+    Registration can be done using :meth:`unittest.TestCase.addCleanup`. The
+    test itself and its `__dict__.keys()` must be registered as arguments.
+
+    This function works by clearing a test's namespace after it has run, and
+    then forcing a garbage collection round and checking for uncollectable
+    objects.
+    """
+    attrs = []
+    for attrname in pretest_attrs:
+        try:
+            attrs.append((attrname, getattr(test, attrname)))
+        except AttributeError:
+            pass
+    test.__dict__.clear()
+    gc.collect()
+    latest_leaks = [ obj for obj in gc.garbage if obj not in _leakedobjs ]
+    _leakedobjs.update(gc.garbage)
+    # Restore the pre-test stuff
+    for name, val in attrs:
+        setattr(test, name, val)
+    if latest_leaks:
+        raise MemleakError("GC failed to collect the following: {0}".format(latest_leaks))
 
 class MemleakError(Exception):
     """Exception raised internally to mark the test as memleaking."""
     pass
 
-class _MemleakResult(nose.proxy.ResultProxy):
-    """Placeholder class where a replacement :meth:`addSuccess` function is defined.
-
-    The :meth:`addSuccess` method will be later monkey-patched onto result objects, saving
-    success declarations for later.
-    """
-    def addSuccess(self, test):
-        self._ml_is_success = True
-
 class Memleak(ErrorClassPlugin):
-    """
-    Report memleaks (objects deemed uncollectable by python's
-    garbage collector) on a test-by-test basis.
-    """
+    """Report memleaks on a test-by-test basis."""
     name = "memleak"
     enabled = False
     memleak = ErrorClass(MemleakError,
@@ -62,43 +72,13 @@ class Memleak(ErrorClassPlugin):
         super(Memleak, self).configure(options, conf)
         self.config = conf # This will let other tests know about config settings.
 
-    def startTest(self, test):
-        # we want to change the ResultProxy object, not just the result,
-        #  therefore we do it here, not in prepareTestResult
-        rp = test.test._resultForDoCleanups
-        # we store the original func
-        rp._ml_add_success = rp.addSuccess
-        # and replace it
-        rp.addSuccess = make_instancemethod(_MemleakResult.addSuccess, rp)
-        # also add a default failure flag
-        rp._ml_is_success = False
-        # Finally, we store with the test the names that it has at birth,
-        #  so that we only wipe stuff created during the test.
-        test._mda_pretest_attrs = test.test.__dict__.keys()
-
-    def stopTest(self, test):
-        rp = test.test._resultForDoCleanups
-        # cleanup of the patched attributes as soon as possible, to minimize potential clashes
-        rp.addSuccess = rp._ml_add_success
-        del rp._ml_add_success
-        attrs = []
-        for attrname in test._mda_pretest_attrs:
-            try:
-                attrs.append((attrname, getattr(test.test, attrname)))
-            except AttributeError:
-                pass
-        test.test.__dict__.clear()
-        gc.collect()
-        latest_leaks = [ obj for obj in gc.garbage if obj not in _leakedobjs ]
-        _leakedobjs.update(gc.garbage)
-        # Restore the pre-test stuff
-        for name, val in attrs:
-            setattr(test.test, name, val)
-        if latest_leaks:
-            raise MemleakError("GC failed to collect the following: {0}".format(latest_leaks))
-        elif rp._ml_is_success:
-            rp.addSuccess(test)
-            del rp._ml_is_success
+    def beforeTest(self, test):
+        # We register our check function and record with it the names that
+        # the test has at birth so that later we only wipe stuff created
+        # during testing.
+        # We really don't want a smart dict_keys object here, as it'd be
+        # changed during testing.
+        test.test.addCleanup(memleak_check, test.test, list(test.test.__dict__.keys()))
 
 plugin_class = Memleak
 

--- a/testsuite/MDAnalysisTests/test_meta.py
+++ b/testsuite/MDAnalysisTests/test_meta.py
@@ -55,9 +55,10 @@ def test_version_at_packagelevel():
     return test_version_format(version)
 
 
-## The following allow testing of the memleak tester plugin.
-## Keep commented out unless you suspect the plugin
-## might be misbehaving."""
+# The following allow testing of the memleak tester plugin.
+# Keep commented out unless you suspect the plugin
+# might be misbehaving. Apparently python3 is immune to these leaks!"""
+#from numpy.testing import TestCase
 #class A():
 #    """This is a small leaky class that won't break anything."""
 #    def __init__(self):

--- a/testsuite/setup.py
+++ b/testsuite/setup.py
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env python
 # -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 fileencoding=utf-8


### PR DESCRIPTION
The memleak testing in python 3.4 may be unneeded anyway since it now cleanly handles leaks from circular references. Perhaps we should disable the memleak test altogether in python 3? (That is, if we decide to only support 3.4+, since previous versions aren't as clever when it comes to leaks).

This PR also fixes an empty line before the setup.py shebang in the testsuite.

Tests in python 3 still fail a lot, but at least no longer due to the memleak testing.