### PR TITLE
Test travis build with travis_wait

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ install:
   - chmod +x testsuite/MDAnalysisTests/mda_nosetests
 # command to run tests
 script:
-  - ./testsuite/MDAnalysisTests/mda_nosetests --with-coverage --cover-package MDAnalysis --processes=2 --process-timeout=300 --with-memleak
+  - travis_wait ./testsuite/MDAnalysisTests/mda_nosetests --with-coverage --cover-package MDAnalysis --processes=2 --process-timeout=300 --with-memleak
   - |
      test ${TRAVIS_PULL_REQUEST} == "false" && \
      test ${TRAVIS_BRANCH} == ${GH_DOC_BRANCH} && \


### PR DESCRIPTION
The python 3 build on python 3 often fails because it spend more than 10 minutes without an output. Eventually, the tests ends as expected.

Here we prefix the build with the `travis_wait` command that allows to bypass the time out. This way, we the tests ends normally despite the 10 minutes time out.