### PR TITLE
Fix missing datafiles in __all__

### DIFF
--- a/testsuite/MDAnalysisTests/datafiles.py
+++ b/testsuite/MDAnalysisTests/datafiles.py
@@ -62,6 +62,7 @@ __all__ = [
     "PRM", "TRJ", "TRJ_bz2",  # Amber (no periodic box)
     "INPCRD",
     "PRMpbc", "TRJpbc_bz2",  # Amber (periodic box)
+    "PRM7", "NCDFtruncoct",  # Amber (cpptrj test trajectory, see Issue 488)
     "PRM12", "TRJ12_bz2",  # Amber (v12 format, Issue 100)
     "PRMncdf", "TRJncdf", "NCDF",  # Amber (netcdf)
     "PFncdf_Top", "PFncdf_Trj", # Amber ncdf with Positions and Forces
@@ -298,3 +299,8 @@ Martini_membrane_gro = resource_filename(__name__, 'data/martini_dppc_chol_bilay
 
 # Contains one of each residue in 'nucleic' selections
 NUCLsel = resource_filename(__name__, 'data/nucl_res.pdb')
+
+
+#------------------------------------------------------------
+# This should be the last line: clean up namespace
+del resource_filename

--- a/testsuite/MDAnalysisTests/datafiles.py
+++ b/testsuite/MDAnalysisTests/datafiles.py
@@ -301,6 +301,5 @@ Martini_membrane_gro = resource_filename(__name__, 'data/martini_dppc_chol_bilay
 NUCLsel = resource_filename(__name__, 'data/nucl_res.pdb')
 
 
-#------------------------------------------------------------
 # This should be the last line: clean up namespace
 del resource_filename

--- a/testsuite/MDAnalysisTests/test_datafiles.py
+++ b/testsuite/MDAnalysisTests/test_datafiles.py
@@ -1,0 +1,38 @@
+# -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 fileencoding=utf-8
+#
+# MDAnalysis --- http://www.MDAnalysis.org
+# Copyright (c) 2006-2015 Naveen Michaud-Agrawal, Elizabeth J. Denning, Oliver Beckstein
+# and contributors (see AUTHORS for the full list)
+#
+# Released under the GNU Public Licence, v2 or any higher version
+#
+# Please cite your use of MDAnalysis in published work:
+#
+# N. Michaud-Agrawal, E. J. Denning, T. B. Woolf, and O. Beckstein.
+# MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
+# J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
+#
+
+from numpy.testing import assert_array_equal
+
+
+class TestDatafiles(object):
+    def test_import(self):
+        try:
+            import MDAnalysis.tests.datafiles
+        except ImportError:
+            raise AssertionError("Failed to 'import MDAnalysis.tests.datafiles --- install MDAnalysisTests")
+
+    def test_all_exports(self):
+        import MDAnalysisTests.datafiles
+        missing = [name for name in dir(MDAnalysisTests.datafiles)
+                   if not name.startswith('_') and name not in MDAnalysisTests.datafiles.__all__]
+        assert_array_equal(missing, [], err_msg="Variables need to be added to __all__.")
+
+    def test_export_variables(self):
+        import MDAnalysisTests.datafiles
+        import MDAnalysis.tests.datafiles
+        missing = [name for name in MDAnalysisTests.datafiles.__all__
+                   if name not in dir(MDAnalysis.tests.datafiles)]
+        assert_array_equal(missing, [], err_msg="Variables not exported to MDAnalysis.tests.datafiles")


### PR DESCRIPTION
* some data file variables were not included in the `__all__` export and thus did not show up in `MDAnalysis.tests.datafiles`.
* added a test for `MDAnalysis.tests.datafiles` (a bit of a meta test...)