### PR TITLE
Mass COM calculation

### DIFF
--- a/package/MDAnalysis/lib/trans.pyx
+++ b/package/MDAnalysis/lib/trans.pyx
@@ -6,16 +6,15 @@ cimport numpy as np
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def residue_positions(
-        np.ndarray[np.float32_t, ndim=2] coords,
-        np.ndarray[np.int64_t, ndim=1] indices):
+        float[:, :] coords not None,
+        long[:] indices not None):
     cdef Py_ssize_t i, j, k
 
     cdef int n_items = indices.shape[0]
     cdef int n_res = np.unique(indices).shape[0]
 
-    cdef np.ndarray[np.int64_t] counter = np.zeros(n_res, dtype=np.int64)
-    cdef np.ndarray[np.float32_t, ndim=2] output = np.zeros((n_res, 3),
-                                                            dtype=np.float32)
+    cdef long[:] counter = np.zeros(n_res, dtype=np.int64)
+    cdef float[:, :] output = np.zeros((n_res, 3), dtype=np.float32)
 
     for i in range(n_items):
         j = indices[i]
@@ -27,4 +26,4 @@ def residue_positions(
         for k in range(3):
             output[i, k] /= counter[i]
 
-    return output
+    return np.asarray(output)

--- a/package/MDAnalysis/lib/trans.pyx
+++ b/package/MDAnalysis/lib/trans.pyx
@@ -1,0 +1,30 @@
+import numpy as np
+cimport cython
+cimport numpy as np
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def residue_positions(
+        np.ndarray[np.float32_t, ndim=2] coords,
+        np.ndarray[np.int64_t, ndim=1] indices):
+    cdef Py_ssize_t i, j, k
+
+    cdef int n_items = indices.shape[0]
+    cdef int n_res = np.unique(indices).shape[0]
+
+    cdef np.ndarray[np.int64_t] counter = np.zeros(n_res, dtype=np.int64)
+    cdef np.ndarray[np.float32_t, ndim=2] output = np.zeros((n_res, 3),
+                                                            dtype=np.float32)
+
+    for i in range(n_items):
+        j = indices[i]
+        for k in range(3):
+            output[j, k] += coords[i, k]
+        counter[j] += 1
+
+    for i in range(n_res):
+        for k in range(3):
+            output[i, k] /= counter[i]
+
+    return output

--- a/package/setup.py
+++ b/package/setup.py
@@ -310,9 +310,12 @@ def extensions(config):
     util = MDAExtension('lib.formats.cython_util',
                         sources=['MDAnalysis/lib/formats/cython_util.pyx'],
                         include_dirs=include_dirs)
+    trans = MDAExtension('lib.trans',
+                         sources=['MDAnalysis/lib/trans.pyx'],
+                         include_dirs=include_dirs)
 
     extensions = [dcd, dcd_time, distances, distances_omp, qcprot,
-                  transformation, xdrlib, util]
+                  transformation, xdrlib, util, trans]
     if use_cython:
         extensions = cythonize(extensions)
     return extensions


### PR DESCRIPTION
So over in #670 we mooted having a mass COM method, so I mocked this up quickly in Cython. (it's roughly 30x faster than previous)

Basically, given a list of 0 based resids, returns the center of geometry for each resid. So is the equivalent of:
`np.array([r.center_of_geometry() for r in u.residues])`

So there's lots of rough edges as to how the function works, including adding a mass (and charge?) weighting option so it returns CoM.

So my question is, is this as good as cython as we can write? (maybe @kain88-de or anyone better at cython than me can say)

I did a numpy typed version:
https://github.com/MDAnalysis/mdanalysis/commit/12060928efe53d6f48454d8ab8a197488664682c

And a memory view version:
https://github.com/MDAnalysis/mdanalysis/commit/62fdf9927f3a9187df5670703b5a027f9c726338

And couldn't see any difference in the performance