### PR TITLE
Right align atomtype (#648)

### DIFF
--- a/package/MDAnalysis/coordinates/PDB.py
+++ b/package/MDAnalysis/coordinates/PDB.py
@@ -698,7 +698,7 @@ class PrimitivePDBWriter(base.Writer):
             "ATOM  {serial:5d} {name:<4s}{altLoc:<1s}{resName:<4s}"
             "{chainID:1s}{resSeq:4d}{iCode:1s}"
             "   {pos[0]:8.3f}{pos[1]:8.3f}{pos[2]:8.3f}{occupancy:6.2f}"
-            "{tempFactor:6.2f}      {segID:<4s}{element:2s}{charge:.2f}\n"),
+            "{tempFactor:6.2f}      {segID:<4s}{element:>2s}{charge:.2f}\n"),
         'REMARK': "REMARK     {0}\n",
         'COMPND': "COMPND    {0}\n",
         'HEADER': "HEADER    {0}\n",

--- a/testsuite/MDAnalysisTests/coordinates/test_pdb.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_pdb.py
@@ -723,21 +723,21 @@ class TestPDBWriterOccupancies(object):
 
         assert_(all(u2.atoms.occupancies == 0.12))
 
-def test_writer_alignments():
-    u = mda.Universe(NUCL)
 
-    tmpdir = tempdir.TempDir()
-    outfile = tmpdir.name + '/nucl.pdb'
+class TestWriterAlignments(object):
+    def __init__(self):
+        u = mda.Universe(NUCL)
+        self.tmpdir = tempdir.TempDir()
+        outfile = self.tmpdir.name + '/nucl.pdb'
+        u.atoms.write(outfile)
+        self.writtenstuff = open(outfile, 'r').readlines()
 
-    u.atoms.write(outfile)
+    def test_atomname_alignment(self):
+        # Our PDBWriter adds some stuff up top, so line 1 happens at [4]
+        assert_(self.writtenstuff[4].startswith("ATOM      1  H5T GUA"))
+        assert_(self.writtenstuff[8].startswith("ATOM      5 H5'' GUA"))
 
-    writtenstuff = open(outfile, 'r').readlines()
-
-    # Our PDBWriter adds some stuff up top, so line 1 happens at [4]
-    assert_(writtenstuff[4].startswith(
-        "ATOM      1  H5T GUA"))
-    assert_(writtenstuff[8].startswith(
-        "ATOM      5 H5'' GUA"))
-
-    del tmpdir
-    del outfile
+    def test_atomtype_alignment(self):
+        result_line = ("ATOM      1  H5T GUA R   1       7.974   6.430   9.561"
+                       "  1.00  0.00      RNAA H0.00\n")
+        assert_equal(result_line, self.writtenstuff[4])


### PR DESCRIPTION
Fixes #648 

I'm not sure how this can be tested best.