### PR TITLE
Fix get_writer_for with NamedStream #712

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -45,6 +45,8 @@ Changes
     message is raised when the TRZ writer is asked to write a title longer
     than 80 characters. (Issue #689)
   * PDB doesn't save charge information anymore
+  * coordinates.core.get_writer_for uses the user defined format if provided
+    before trying to deduce the format from file extension. (Issue #712)
 
 Fixes
 

--- a/testsuite/MDAnalysisTests/test_util.py
+++ b/testsuite/MDAnalysisTests/test_util.py
@@ -600,7 +600,7 @@ class TestGuessFormat(object):
     compressed_extensions = ['.bz2', '.gz']
 
     def _check_get_ext(self, f, fn):
-        """Check that get ext works"""
+        """Check that get_ext works"""
         a, b = util.get_ext(fn)
 
         assert a == 'file'
@@ -677,6 +677,47 @@ class TestGuessFormat(object):
         s = StringIO('this is a very fun file')
 
         assert_raises(ValueError, util.guess_format, s)
+
+
+class TestGetWritterFor(TestCase):
+    def test_no_arguments(self):
+        """Does ``get_writer_for`` fails as expected when provided no
+        arguments
+        """
+        assert_raises(TypeError, mda.coordinates.core.get_writer_for)
+
+    def test_precedence(self):
+        """Make sure ``get_writer_for`` uses *format* if provided"""
+        writter = mda.coordinates.core.get_writer_for('test.pdb', 'GRO')
+        assert_equal(writter, mda.coordinates.GRO.GROWriter)
+
+    def test_missing_extension(self):
+        """Make sure ``get_writer_for`` behave as expected if *filename*
+        has no extension
+        """
+        assert_raises(TypeError, mda.coordinates.core.get_writer_for,
+                      filename='test', format=None)
+
+    def test_wrong_format(self):
+        """Make sure ``get_writer_for`` fails if the format is unknown"""
+        assert_raises(TypeError, mda.coordinates.core.get_writer_for,
+                      format='UNK')
+
+    def test_compressed_extension(self):
+        """Make sure ``get_writer_for`` works with compressed file file names
+        """
+        for ext in ('.gz', '.bz2'):
+            fn = 'test.gro' + ext
+            writter = mda.coordinates.core.get_writer_for(filename=fn)
+            assert_equal(writter, mda.coordinates.GRO.GROWriter)
+
+    def test_compressed_extension_fail(self):
+        """Make sure ``get_writer_for`` fails if an unknown format is compressed
+        """
+        for ext in ('.gz', '.bz2'):
+            fn = 'test.unk' + ext
+            assert_raises(TypeError, mda.coordinates.core.get_writer_for,
+                          filename=fn)
 
 
 class TestBlocksOf(object):


### PR DESCRIPTION
Also change the default behavior of the function. Now,
MDAnalysis.coordinates.core.get_writer_for uses the format given via the
*format* argument in priority. If *format* is not provided, then the
function try to deduce the format from the file extension of the file
name given via *filename*.

Fixes #712