### PR TITLE
Don't fail when loading old offset formats. (fixes #736)

### DIFF
--- a/package/MDAnalysis/coordinates/XDR.py
+++ b/package/MDAnalysis/coordinates/XDR.py
@@ -112,10 +112,15 @@ class XDRBaseReader(base.Reader):
             return
 
         data = read_numpy_offsets(fname)
+        ctime_ok = size_ok = n_atoms_ok = False
 
-        ctime_ok = getctime(self.filename) == data['ctime']
-        size_ok = getsize(self.filename) == data['size']
-        n_atoms_ok = self._xdr.n_atoms == data['n_atoms']
+        try:
+            ctime_ok = getctime(self.filename) == data['ctime']
+            size_ok = getsize(self.filename) == data['size']
+            n_atoms_ok = self._xdr.n_atoms == data['n_atoms']
+        except KeyError:
+            # we tripped over some old offset formated file
+            pass
 
         if not (ctime_ok and size_ok and n_atoms_ok):
             warnings.warn("Reload offsets from trajectory\n "

--- a/testsuite/MDAnalysisTests/coordinates/test_xdr.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_xdr.py
@@ -815,6 +815,19 @@ class _GromacsReader_offsets(TestCase):
                      'seek failed, recalculating offsets and retrying')
 
     @dec.slow
+    def test_unsupported_format(self):
+        fname = XDR.offsets_filename(self.traj)
+        saved_offsets = XDR.read_numpy_offsets(fname)
+
+        idx_frame = 3
+        saved_offsets.pop('n_atoms')
+        np.savez(fname, **saved_offsets)
+
+        # ok as long as this doesn't throw
+        reader = self._reader(self.traj)
+        reader[idx_frame]
+
+    @dec.slow
     def test_persistent_offsets_readonly(self):
         os.remove(XDR.offsets_filename(self.traj))
         assert_equal(os.path.exists(


### PR DESCRIPTION
In case we change the format again in the future it won't bother users.

See #736