### PR TITLE
Only use python 2/3 compatible exception printing

### DIFF
--- a/package/MDAnalysis/coordinates/XDR.py
+++ b/package/MDAnalysis/coordinates/XDR.py
@@ -140,11 +140,7 @@ class XDRBaseReader(base.Reader):
                          offsets=offsets, size=size, ctime=ctime,
                          n_atoms=self._xdr.n_atoms)
             except Exception as e:
-                try:
-                    warnings.warn("Couldn't save offsets because: {}".format(
-                        e.message))
-                except AttributeError:
-                    warnings.warn("Couldn't save offsets because: {}".format(e))
+                warnings.warn("Couldn't save offsets because: {}".format(e))
 
     def rewind(self):
         """Read the first frame again"""


### PR DESCRIPTION
The old `e.message` seems to be from older python versions and has been
removed in python 3. For python 2.7 and later just printing the
Exception works fine.

This brings coverage for the XDR class to 100% again.