### PR TITLE
Ensure HEADER and TITLE occur just once in a PDB file

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -68,6 +68,7 @@ Chronological list of authors
   - Balasubramanian
   - Mattia F. Palermo
   - Utkarsh Saxena
+  - Abhinav Gupta
 
 External code
 -------------

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,7 +13,7 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-??/??/16 jandom
+??/??/16 jandom, abhinavgupta94
 
   * 0.14.1
 
@@ -25,6 +25,7 @@ API Changes
 Fixes
 
   * test_shear_from_matrix doesn't fail for MKL builds anymore (Issue #757)
+  * HEADER and TITLE now appear just once in the PDB. (Issue #741) (PR #761)
 
 Changes
 

--- a/package/MDAnalysis/coordinates/PDB.py
+++ b/package/MDAnalysis/coordinates/PDB.py
@@ -655,7 +655,7 @@ class PrimitivePDBWriter(base.Writer):
     PDB format as used by NAMD/CHARMM: 4-letter resnames and segID are allowed,
     altLoc is written.
 
-    The :class:`PrimitivePDBWriter` can be used to either a dump a coordinate
+    The :class:`PrimitivePDBWriter` can be used to either dump a coordinate
     set to a PDB file (operating as a "single frame writer", selected with the
     constructor keyword *multiframe* = ``False``, the default) or by writing a
     PDB "movie" (multi frame mode, *multiframe* = ``True``), consisting of
@@ -808,6 +808,7 @@ class PrimitivePDBWriter(base.Writer):
 
         self.pdbfile = util.anyopen(self.filename, 'wt')  # open file on init
         self.has_END = False
+        self.first_frame_done = False
 
     def close(self):
         """Close PDB file and write END record"""
@@ -832,10 +833,15 @@ class PrimitivePDBWriter(base.Writer):
         if not self.obj or not hasattr(self.obj, 'universe'):
             self._write_pdb_title(self)
             return
+        if self.first_frame_done == True:
+            return        
 
+        self.first_frame_done = True
         u = self.obj.universe
         self.HEADER(u.trajectory)
+        
         self._write_pdb_title()
+
         self.COMPND(u.trajectory)
         try:
             # currently inconsistent: DCDReader gives a string,

--- a/testsuite/AUTHORS
+++ b/testsuite/AUTHORS
@@ -66,6 +66,7 @@ Chronological list of authors
   - Hai Nguyen
 2016
   - Balasubramanian
+  - Abhinav Gupta
 
 External code
 -------------

--- a/testsuite/MDAnalysisTests/coordinates/test_pdb.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_pdb.py
@@ -243,6 +243,28 @@ class TestPrimitivePDBWriter(TestCase):
         assert_raises(ValueError, u.atoms.write, self.outfile)
         del u
 
+    @attr('issue')
+    def test_check_header_title_multiframe(self):
+        """Check whether HEADER and TITLE are written just once in a multi-
+        frame PDB file (Issue 741)"""
+        u = mda.Universe(PSF,DCD, permissive=True) 
+        pdb = mda.Writer(self.outfile, multiframe=True)
+        protein = u.select_atoms("protein and name CA")
+        for ts in u.trajectory[:5]:
+            pdb.write(protein)
+        pdb.close()
+
+        with open(self.outfile) as f:
+            got_header = 0
+            got_title = 0
+            for line in f:
+                if line.startswith('HEADER'):
+                    got_header += 1
+                    assert_(got_header <= 1, "There should be only one HEADER.")
+                elif line.startswith('TITLE'):
+                    got_title += 1
+                    assert_(got_title <= 1, "There should be only one TITLE.")
+
 
 class TestMultiPDBReader(TestCase):
     def setUp(self):


### PR DESCRIPTION
Fixes #741 

Changes made in this Pull Request:
 - added condition for HEADER and TITLE to be written for the first frame only

PR Checklist
------------
 - [x] Tests?
 - [] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?

