### PR TITLE
Fix DATA type parsing and add explicit bond types

### DIFF
--- a/package/MDAnalysis/core/topologyobjects.py
+++ b/package/MDAnalysis/core/topologyobjects.py
@@ -511,14 +511,19 @@ class TopologyGroup(object):
         if type is None:
             type = np.array([None for x in bondidx]).reshape(len(bondidx), 1)
         split_index = {'bond':2, 'angle':3, 'dihedral':4, 'improper':4}[self.btype]
-        unique_records = np.unique((np.rec.fromarrays([bondidx[:, i] for i in xrange(split_index)] + [type])))
-        self._bix = np.vstack([unique_records[unique_records.dtype.names[i]] for i in xrange(split_index)]).T
-        self._bondtypes = unique_records[unique_records.dtype.names[bondidx.shape[1]]]
+        if len(bondidx) > 0:
+            unique_records = np.unique((np.rec.fromarrays([bondidx[:, i] for i in xrange(split_index)] + [type])))
+            self._bix = np.vstack([unique_records[unique_records.dtype.names[i]] for i in xrange(split_index)]).T
+            self._bondtypes = unique_records[unique_records.dtype.names[bondidx.shape[1]]]
+            # Create vertical AtomGroups
+            self._ags = [universe.atoms[bondidx[:,i]]
+                         for i in xrange(bondidx.shape[1])]
+        else:
+            self._bix = np.array([])
+            self._bondtypes = np.array([])
+            self._ags = []
         self._u = universe
 
-        # Create vertical AtomGroups
-        self._ags = [universe.atoms[bondidx[:,i]]
-                     for i in xrange(bondidx.shape[1])]
 
         self._cache = dict()  # used for topdict saving
 

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -1164,32 +1164,3 @@ def cached(key):
         return wrapper
 
     return cached_lookup
-
-
-def unique_rows(arr):
-    """Return the unique rows from an array
-
-    Arguments
-    ---------
-    arr - np.array of shape (n1, m)
-
-    Returns
-    -------
-    unique_rows (n2, m)
-
-    Examples
-    --------
-    Remove dupicate rows from an array:
-    >>> a = np.array([[0, 1], [1, 2], [1, 2], [0, 1], [2, 3]])
-    >>> b = unique_rows(a)
-    >>> b
-    array([[0, 1], [1, 2], [2, 3]])
-    """
-    # From here, but adapted to handle any size rows
-    # https://mail.scipy.org/pipermail/scipy-user/2011-December/031200.html
-    m = arr.shape[1]
-
-    u = np.unique(arr.view(
-        dtype=np.dtype([(str(i), arr.dtype) for i in xrange(m)])
-    ))
-    return u.view(arr.dtype).reshape(-1, m)

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -1164,3 +1164,32 @@ def cached(key):
         return wrapper
 
     return cached_lookup
+
+
+def unique_rows(arr):
+    """Return the unique rows from an array
+
+    Arguments
+    ---------
+    arr - np.array of shape (n1, m)
+
+    Returns
+    -------
+    unique_rows (n2, m)
+
+    Examples
+    --------
+    Remove dupicate rows from an array:
+    >>> a = np.array([[0, 1], [1, 2], [1, 2], [0, 1], [2, 3]])
+    >>> b = unique_rows(a)
+    >>> b
+    array([[0, 1], [1, 2], [2, 3]])
+    """
+    # From here, but adapted to handle any size rows
+    # https://mail.scipy.org/pipermail/scipy-user/2011-December/031200.html
+    m = arr.shape[1]
+
+    u = np.unique(arr.view(
+        dtype=np.dtype([(str(i), arr.dtype) for i in xrange(m)])
+    ))
+    return u.view(arr.dtype).reshape(-1, m)

--- a/package/MDAnalysis/topology/LAMMPSParser.py
+++ b/package/MDAnalysis/topology/LAMMPSParser.py
@@ -204,11 +204,11 @@ class DATAParser(TopologyReader):
                 (Impropers, 'Impropers', 4)
         ]:
             try:
-                sect = self._parse_bond_section(sects[L], nentries)
+                type, sect = self._parse_bond_section(sects[L], nentries)
             except KeyError:
                 pass
             else:
-                top.add_TopologyAttr(attr(sect))
+                top.add_TopologyAttr(attr(sect, type))
 
         return top
 
@@ -273,12 +273,14 @@ class DATAParser(TopologyReader):
         nentries - number of integers per line
         """
         section = []
+        type = []
         for line in datalines:
             line = line.split()
             # map to 0 based int
             section.append(tuple(map(lambda x: int(x) - 1, 
                                      line[2:2 + nentries])))
-        return tuple(section)
+            type.append(line[1])
+        return tuple(type), tuple(section)
 
     def _parse_atoms(self, datalines, massdict=None):
         """Creates a Topology object
@@ -315,14 +317,15 @@ class DATAParser(TopologyReader):
         n = len(datalines[0].split())
         has_charge = True if n in [7, 10] else False
 
-        types = np.zeros(n_atoms, dtype=np.int32)
+        types = np.zeros(n_atoms, dtype='|S1')
         resids = np.zeros(n_atoms, dtype=np.int32)
         if has_charge:
             charges = np.zeros(n_atoms, dtype=np.float32)
 
         for line in datalines:
             line = line.split()
-            idx, resid, atype = map(int, line[:3])
+            idx, resid = map(int, line[:2])
+            atype = line[2]
             idx -= 1
             resids[idx] = resid
             types[idx] = atype
@@ -360,7 +363,7 @@ class DATAParser(TopologyReader):
         masses = {}
         for line in datalines:
             line = line.split()
-            masses[int(line[0])] = float(line[1])
+            masses[line[0]] = float(line[1])
 
         return masses
 


### PR DESCRIPTION
Regarding #763 

Changes made in this Pull Request:

**NOTE:** `atoms.bonds` is broken for atom groups without explicit bond typing
in this commit.

In order to write a LAMMPS.DATAWriter, I first need explicit typing of bonds,
angles, dihedrals, and impropers beyond the tupling of atoms types done now.
To hack bond types into the topology, I branched issue-363 and tried the
following:

1. Add optional `types` keyword to `topologyattrs.Bonds`. This is stored
in the class instance a `self._bondtypes`. A topology parser can pass `types`
to the Bonds topologyattr.
2. When `topologyattrs.Bonds` is called upon to generate a TopologyGroup,
these values are passed on via a new keyword in `TopologyGroup.__init__()`.
They are stored in the TopologyGroup instance as `self._bondtypes`.
3. I modified `TopologyGroup.__getitem__` to yield a Bond with attribute
`_bondtype`. If `_bondtype is not None` then it overrides the default behavior
of `bond.type`.
4. I modified `TopologyGroup()` calls wherever I could find them to pass on
`_bondtype` in the instantiation.

I found that the DATAParser in branch #363 is slightly broken, because
the atom types are saved as integers which breaks `select_atoms` (I think it
expects strings, and typing the types as strings on parsing fixes this issue).
It seems there is currently no test for atom selection from LAMMPS DATA files,
so this might have gone undetected.

An error is raised for `ag.bonds` for an atom group that doesn't have bonds,
but this seems to also be the case for branch issue-363 right now, so I didn't
try to fix this.

An especially ugly place is where I tried to hack `_bondtypes`
into the existing code to remove duplicate bonds. This is also where
the code seems to be broken for non-explicit bond types. In this case,
I set `_bondtypes` to be a numpy array full of `None` with `dtype=object`.
It seems that `unique_rows` fails for this case, although it works fine
when `_bondtypes.dtype == "|S1"`.

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
