### PR TITLE
Fix Merge for issue-363 branch

### DIFF
--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -136,6 +136,28 @@ class GroupBase(object):
 
         return self.__class__(np.concatenate([self._ix, o_ix]), self._u)
 
+    def __radd__(self, other):
+        """Using built-in sum requires supporting 0 + self. If other is
+        anything other 0, an exception will be raised.
+
+        Parameters
+        ----------
+        other : int
+            Other should be 0, or else an exception will be raised.
+
+        Returns
+        -------
+        self
+            Group with elements of `self` reproduced
+
+        """
+        if other == 0:
+            return self.__class__(self._ix, self._u)
+        else:
+            raise TypeError("unsupported operand type(s) for +:"+
+                            " '{}' and '{}'".format(type(self).__name__,
+                                                    type(other).__name__))
+
     def __contains__(self, other):
         if not other.level == self.level:
             # maybe raise TypeError instead?

--- a/package/MDAnalysis/core/topology.py
+++ b/package/MDAnalysis/core/topology.py
@@ -36,7 +36,7 @@ class TransTable(object):
         array must be <= `n_residues`, and the array must be length `n_atoms`;
         giving None defaults to placing all atoms in residue 0
     residue_segindex : 1-D array
-        segindex for each atom in the topology; the number of unique values in this
+        segindex for each residue in the topology; the number of unique values in this
         array must be <= `n_segments`, and the array must be length `n_residues`;
         giving None defaults to placing all residues in segment 0
  

--- a/package/MDAnalysis/core/topology.py
+++ b/package/MDAnalysis/core/topology.py
@@ -315,7 +315,7 @@ class Topology(object):
     """
 
     def __init__(self, n_atoms=1, n_res=1, n_seg=1,
-                 attrs=None,
+                 attrs=[],
                  atom_resindex=None,
                  residue_segindex=None):
         self.n_atoms = n_atoms

--- a/package/MDAnalysis/core/topology.py
+++ b/package/MDAnalysis/core/topology.py
@@ -315,12 +315,14 @@ class Topology(object):
     """
 
     def __init__(self, n_atoms=1, n_res=1, n_seg=1,
-                 attrs=[],
+                 attrs=None,
                  atom_resindex=None,
                  residue_segindex=None):
         self.n_atoms = n_atoms
         self.n_residues = n_res
         self.n_segments = n_seg
+        if attrs is None:
+            attrs = []
         self.tt = TransTable(n_atoms, n_res, n_seg,
                              atom_resindex=atom_resindex,
                              residue_segindex=residue_segindex)

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -265,6 +265,7 @@ class Atomids(AtomAttr):
     """
     attrname = 'ids'
     singular = 'id'
+    per_object = 'atom'
 
 
 #TODO: update docs to property doc
@@ -273,6 +274,7 @@ class Atomnames(AtomAttr):
     """
     attrname = 'names'
     singular = 'name'
+    per_object = 'atom'
     transplants = defaultdict(list)
 
     def getattr__(atomgroup, name):
@@ -321,6 +323,7 @@ class Atomtypes(AtomAttr):
     """Type for each atom"""
     attrname = 'types'
     singular = 'type'
+    per_object = 'atom'
 
 
 #TODO: update docs to property doc
@@ -328,6 +331,7 @@ class Radii(AtomAttr):
     """Radii for each atom"""
     attrname = 'radii'
     singular = 'radius'
+    per_object = 'atom'
 
 
 class ChainIDs(AtomAttr):
@@ -339,24 +343,28 @@ class ChainIDs(AtomAttr):
     """
     attrname = 'chainIDs'
     singular = 'chainID'
+    per_object = 'atom'
 
 
 class ICodes(AtomAttr):
     """Insertion code for Atoms"""
     attrname = 'icodes'
     singular = 'icode'
+    per_object = 'atom'
 
 
 class Tempfactors(AtomAttr):
     """Tempfactor for atoms"""
     attrname = 'tempfactors'
     singular = 'tempfactor'
+    per_object = 'atom'
 
 
 #TODO: need to add cacheing
 class Masses(AtomAttr):
     attrname = 'masses'
     singular = 'mass'
+    per_object = 'atom'
     target_levels = ['atom', 'residue', 'segment']
     transplants = defaultdict(list)
 
@@ -641,6 +649,7 @@ class Masses(AtomAttr):
 class Charges(AtomAttr):
     attrname = 'charges'
     singular = 'charge'
+    per_object = 'atom'
     target_levels = ['atom', 'residue', 'segment']
     transplants = defaultdict(list)
 
@@ -679,12 +688,14 @@ class Bfactors(AtomAttr):
     """Crystallographic B-factors in A**2 for each atom"""
     attrname = 'bfactors'
     singular = 'bfactor'
+    per_object = 'atom'
 
 
 #TODO: update docs to property doc
 class Occupancies(AtomAttr):
     attrname = 'occupancies'
     singular = 'occupancy'
+    per_object = 'atom'
 
 
 #TODO: update docs to property doc
@@ -692,6 +703,7 @@ class AltLocs(AtomAttr):
     """AltLocs for each atom"""
     attrname = 'altLocs'
     singular = 'altLoc'
+    per_object = 'atom'
 
 
 ## residue attributes
@@ -708,6 +720,7 @@ class ResidueAttr(TopologyAttr):
     attrname = 'residueattrs'
     singular = 'residueattr'
     target_levels = ['residue']
+    per_object = 'residue'
 
     def get_atoms(self, ag):
         rix = self.top.tt.atoms2residues(ag._ix)
@@ -802,6 +815,7 @@ class SegmentAttr(TopologyAttr):
     attrname = 'segmentattrs'
     singular = 'segmentattr'
     target_levels = ['segment']
+    per_object = 'segment'
 
     def get_atoms(self, ag):
         six = self.top.tt.atoms2segments(ag._ix)

--- a/package/MDAnalysis/core/topologyobjects.py
+++ b/package/MDAnalysis/core/topologyobjects.py
@@ -577,6 +577,10 @@ class TopologyGroup(object):
 
         .. versionadded:: 0.9.0
         """
+        # Issue #780 - if self is empty, return self to avoid invalid mask
+        if not self:
+            return self
+
         # Strict requires all items in a row to be seen,
         # otherwise any item in a row
         func = np.all if kwargs.get('strict', False) else np.any


### PR DESCRIPTION
Changes made in this pull request:

- Add `__radd__` method to `GroupBase`, making `0 + ag = ag` which allows `sum(ags)` instead of `ags[0] + ags[1] + ags[2] + ...`
- Fix one-word docstring typo in `TransTable` and set `attrs=[]` if default kwarg `attrs=None` to `Topology()` is unchanged by user.
- Add optional attribute `per_object='atom'|'residue'|'segment'` to TopologyAttrs which causes `Universe._process_attr` on universe generation to check that the length of the value array equals `n_atoms`, `n_residues`, or `n_segments`, respectively, or else it raises `ValueError`.
- Fixes Issue #780 where if an empty bondgroup attempted to create a mask for itself, the resulting mask would be invalid and lead to an error.
- Fixes Merge for the issue-363 branch
  - Merged Universe retains whatever topology attributes are present in **all** of the input universes.
  - Bonds, Angles, Dihedrals, and Impropers are included, if the attributes are present in the input universes.
  - All other attributes not present in an empty `Topology` instance and not in {bonds, angles, dihedrals, impropers} are assumed to be vector-valued topology attributes. Their vector values are concatenated for a new merged TopologyAttr. First a check is made whether the TopologyAttr is subclassed from `AtomAttr`, `ResidueAttr`, or `SegmentAttr` to decide whether `atoms.attr`, `residues.attr`, or `segments.attr` should be concatenated into the new array.
  - Atoms, residues, and segments are re-indexed. Atom index order is the same as the user-given order. Residues and segments from different arguments to `Merge` are given different indices. It's assumed if the user wanted a single residue/segment from the same pre-merge universe to have a single index in the post-merge universe, the user would just add together the atom groups first instead of providing them as separate arguments to `Merge`.

Original text:
This might be premature (I don't know if other planned changes will break this), but I found myself wanting to both use the LAMMPS data writer and mda.Merge for my own work. I have only tested a little bit, but I just thought I'd put it up here.

I also changed the default argument for attrs in core.Topology() beacuse
the default argument of None caused an error, whereas using an empty
list instead will return a blank Topology.

PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?