### PR TITLE
added test for exception raise in GROParser (per issue #597)

### DIFF
--- a/testsuite/AUTHORS
+++ b/testsuite/AUTHORS
@@ -68,7 +68,9 @@ Chronological list of authors
   - Balasubramanian
   - Abhinav Gupta
   - Pedro Reis
-  
+  - Fiona B. Naughton
+
+
 External code
 -------------
 

--- a/testsuite/CHANGELOG
+++ b/testsuite/CHANGELOG
@@ -13,8 +13,7 @@ Also see https://github.com/MDAnalysis/mdanalysis/wiki/MDAnalysisTests
 and https://github.com/MDAnalysis/mdanalysis/wiki/UnitTests
 
 ------------------------------------------------------------------------------
-21/03/16 orbeckst, jbarnoud, pedrishi
-
+??/??/16 orbeckst, jbarnoud, pedrishi, fiona-naughton
   * 0.15.0
 
     - metadata update: link download_url to GitHub releases so that
@@ -23,6 +22,7 @@ and https://github.com/MDAnalysis/mdanalysis/wiki/UnitTests
     - a __version__ variable is now exposed; it is built by setup.py from the
       AUTHORS file (Issue #784)
     - Removed all bare assert (Issue #724)
+    - added tests for GRO format
 
 02/28/16 manuel.nuno.melo
   * 0.14.0

--- a/testsuite/MDAnalysisTests/data/empty_atom.gro
+++ b/testsuite/MDAnalysisTests/data/empty_atom.gro
@@ -1,0 +1,4 @@
+#Empty atom line for testing exception
+    1
+
+  10.00000  10.00000  10.00000

--- a/testsuite/MDAnalysisTests/data/missing_atomname.gro
+++ b/testsuite/MDAnalysisTests/data/missing_atomname.gro
@@ -1,0 +1,4 @@
+#Missing atom name for testing exception raise
+    1
+    1RES          1   0.000  0.000  0.000
+  10.00000  10.00000  10.00000

--- a/testsuite/MDAnalysisTests/datafiles.py
+++ b/testsuite/MDAnalysisTests/datafiles.py
@@ -110,9 +110,13 @@ __all__ = [
     "COORDINATES_TRR",
     "COORDINATES_TOPOLOGY",
     "NUCLsel",
+    "GRO_empty_atom", "GRO_missing_atomname" # for testing GROParser exception raise
 ]
 
 from pkg_resources import resource_filename
+
+GRO_missing_atomname = resource_filename(__name__, 'data/missing_atomname.gro')
+GRO_empty_atom = resource_filename(__name__, 'data/empty_atom.gro')
 
 COORDINATES_XYZ = resource_filename(__name__, 'data/coordinates/test.xyz')
 COORDINATES_XYZ_BZ2 = resource_filename(

--- a/testsuite/MDAnalysisTests/topology/test_gro.py
+++ b/testsuite/MDAnalysisTests/topology/test_gro.py
@@ -14,12 +14,15 @@
 #
 from numpy.testing import (
     assert_,
+    assert_raises,
 )
 
 import MDAnalysis as mda
 
 from MDAnalysisTests.datafiles import (
     two_water_gro_widebox,
+    GRO_empty_atom,
+    GRO_missing_atomname,
 )
 
 
@@ -31,3 +34,14 @@ class TestGROWideBox(object):
         with parser(two_water_gro_widebox) as p:
             s = p.parse()
         assert_(len(s['atoms']) == 6)
+
+def test_parse_empty_atom_IOerror():
+    parser = mda.topology.GROParser.GROParser
+    with parser(GRO_empty_atom) as p:
+      assert_raises(IOError, p.parse)
+
+def test_parse_missing_atomname_IOerror():
+    parser = mda.topology.GROParser.GROParser
+    with parser(GRO_missing_atomname) as p:
+      assert_raises(IOError, p.parse)
+


### PR DESCRIPTION
Part of #597 ; specifically checking the GROParser raises IOError when it can't parse atom lines in a .gro file.

Changes made in this Pull Request:
 - added test .gro file with blank atom line
 - added the test for the exception

