### PR TITLE
Remove relative imports introduced in #787

### DIFF
--- a/testsuite/MDAnalysisTests/__init__.py
+++ b/testsuite/MDAnalysisTests/__init__.py
@@ -111,7 +111,7 @@ logger = logging.getLogger("MDAnalysisTests.__init__")
 
 __version__ = "0.14.1-dev0"  # keep in sync with RELEASE in setup.py
 try:
-    from .authors import __authors__
+    from MDAnalysisTests.authors import __authors__
 except ImportError:
     logger.info('Could not find authors.py, __authors__ will be empty.')
     __authors__ = []

--- a/testsuite/MDAnalysisTests/test_authors.py
+++ b/testsuite/MDAnalysisTests/test_authors.py
@@ -23,6 +23,6 @@ def test_package_authors():
 
 
 def test_testsuite_authors():
-    from . import __authors__
+    from MDAnalysisTests import __authors__
     assert_(len(__authors__) > 0,
             'Could not find the list of authors')


### PR DESCRIPTION
We prohibit relative imports in the tests (see #189). When adding tests
for the dynamic author list (#787), I introduced some such relative
imports.

Closes #784 