### PR TITLE
WIP: Contact improvements

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -45,7 +45,7 @@ Fixes
 
 Changes
 
-  * Generalized contact analysis class added. (Issue #702)
+  * Generalized contact analysis class `Contacts` added. (Issue #702)
 
 Deprecations (Issue #599)
 
@@ -63,6 +63,7 @@ Deprecations (Issue #599)
   * Deprecated Residue name, id
   * Deprecated Segment id, name
   * Deprecated as_Universe function; not needed
+  * Deprecated ContactAnalysis and ContactAnalysis1 classes
 
 02/28/16 tyler.je.reddy, kain88-de, jbarnoud, richardjgowers, orbeckst
          manuel.nuno.melo, Balasubra, Saxenauts, mattihappy

--- a/package/MDAnalysis/analysis/contacts.py
+++ b/package/MDAnalysis/analysis/contacts.py
@@ -2,8 +2,8 @@
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
 #
 # MDAnalysis --- http://www.MDAnalysis.org
-# Copyright (c) 2006-2015 Naveen Michaud-Agrawal, Elizabeth J. Denning, Oliver Beckstein
-# and contributors (see AUTHORS for the full list)
+# Copyright (c) 2006-2015 Naveen Michaud-Agrawal, Elizabeth J. Denning, Oliver
+# Beckstein and contributors (see AUTHORS for the full list)
 #
 # Released under the GNU Public Licence, v2 or any higher version
 #
@@ -14,45 +14,31 @@
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
 
-"""
-Native contacts analysis --- :mod:`MDAnalysis.analysis.contacts`
+"""Native contacts analysis --- :mod:`MDAnalysis.analysis.contacts`
 ================================================================
 
-Analysis of native contacts *q* over a trajectory.
 
-* a "contact" exists between two atoms *i* and *j* if the distance between them is
-  smaller than a given *radius*
+Analysis of native contacts *Q* over a trajectory. Native contacts of a
+conformation are contacts that exist in a reference structure and in the
+conformation. Contacts in the reference structure are always defined as being
+closer then a distance `radius`. The fraction of native contacts for a
+conformation can be calculated in different ways. This module supports 3
+different metrics liseted below, as wel as custom metrics.
 
-* a "native contact" exists between *i* and *j* if a contact exists and if the
-  contact also exists between the equivalent atoms in a reference structure or
-  conformation
+1. *Hard Cut*: To count as a contact the atoms *i* and *j* have to be at least
+   as close as in the reference structure.
 
-The "fraction of native contacts" *q(t)* is a number between 0 and 1 and
+2. *Soft Cut*: The atom pair *i* and *j* is assigned based on a soft potential
+   that is 1 for if the distance is 0, 1./2 if the distance is the same as in
+   the reference and 0 for large distances. For the exact definition of the
+   potential and parameters have a look at `soft_cut_q`.
+
+3. *Radius Cut*: To count as a contact the atoms *i* and *j* cannot be further
+   apart then some distance `radius`.
+
+The "fraction of native contacts" *Q(t)* is a number between 0 and 1 and
 calculated as the total number of native contacts for a given time frame
 divided by the total number of contacts in the reference structure.
-
-Classes are available for two somewhat different ways to perform a contact
-analysis:
-
-1. Contacts between two groups of atoms are defined with
-   :class:`ContactAnalysis1`), which allows one to calculate *q(t)* over
-   time. This is especially useful in order to look at native contacts during
-   an equilibrium simulation where one can also look at the average matrix of
-   native contacts (see :meth:`ContactAnalysis1.plot_qavg`).
-
-2. Contacts are defined within one group in a protein (e.g. all C-alpha atoms)
-   but relative to *two different conformations* 1 and 2, using
-   :class:`ContactAnalysis`. This allows one to do a *q1-q2* analysis that
-   shows how native contacts of state 1 change in comparison to native contacts
-   of state 2.  Transition pathways have been analyzed in terms of these two
-   variables q1 and q2 that relate to the native contacts in the end states of
-   the transition.
-
-.. SeeAlso:: See http://lorentz.dynstr.pasteur.fr/joel/adenylate.php for an
-   example of contact analysis applied to MinActionPath trajectories of AdK
-   (although this was *not* performed with MDAnalysis --- it's provided as a
-   very good illustrative example).
-
 
 Examples
 --------
@@ -64,52 +50,51 @@ As an example we analyze the opening ("unzipping") of salt bridges
 when the AdK enzyme opens up; this is one of the example trajectories
 in MDAnalysis. ::
 
-    import MDAnalysis
-    import MDAnalysis.analysis.contacts
-    from MDAnalysis.tests.datafiles import PSF,DCD
+>>> import MDAnalysis as mda
+>>> from MDAnalysis.analysis import contacts
+>>> from MDAnalysis.tests.datafiles import PSF,DCD
+>>> import matplotlib.pyplot as plt
+>>> # example trajectory (transition of AdK from closed to open)
+>>> u = mda.Universe(PSF,DCD)
+>>> # crude definition of salt bridges as contacts between NH/NZ in ARG/LYS and
+>>> # OE*/OD* in ASP/GLU. You might want to think a little bit harder about the
+>>> # problem before using this for real work.
+>>> sel_basic = "(resname ARG LYS) and (name NH* NZ)"
+>>> sel_acidic = "(resname ASP GLU) and (name OE* OD*)"
+>>> # reference groups (first frame of the trajectory, but you could also use a
+>>> # separate PDB, eg crystal structure)
+>>> acidic = u.select_atoms(sel_acidic)
+>>> basic = u.select_atoms(sel_basic)
+>>> # set up analysis of native contacts ("salt bridges"); salt bridges have a
+>>> # distance <6 A
+>>> ca1 = contacts.Contacts(u, selection=(sel_acidic, sel_basic),
+>>>                         refgroup=(acidic, basic), radius=6.0)
+>>> # iterate through trajectory and perform analysis of "native contacts" Q
+>>> ca1.run()
+>>> # print number of averave contacts
+>>> average_contacts = np.mean(ca1.timeseries[:, 1])
+>>> print('average contacts = {}'.format(average_contacts))
+>>> # plot time series q(t)
+>>> f, ax = plt.subplots()
+>>> ax.plot(ca1.timeseries[:, 0], ca1.timeseries[:, 1])
+>>> ax.set(xlabel='frame', ylabel='fraction of native contacts',
+           title='Native Contacts, average = {:.2f}'.format(average_contacts))
+>>> fig.show()
 
-    # example trajectory (transition of AdK from closed to open)
-    u = MDAnalysis.Universe(PSF,DCD)
-
-    # crude definition of salt bridges as contacts between NH/NZ in ARG/LYS and OE*/OD* in ASP/GLU.
-    # You might want to think a little bit harder about the problem before using this for real work.
-    sel_basic = "(resname ARG or resname LYS) and (name NH* or name NZ)"
-    sel_acidic = "(resname ASP or resname GLU) and (name OE* or name OD*)"
-
-    # reference groups (first frame of the trajectory, but you could also use a separate PDB, eg crystal structure)
-    acidic = u.select_atoms(sel_acidic)
-    basic = u.select_atoms(sel_basic)
-
-    # set up analysis of native contacts ("salt bridges"); salt bridges have a distance <6 A
-    CA1 = MDAnalysis.analysis.contacts.ContactAnalysis1(u, selection=(sel_acidic, sel_basic), refgroup=(acidic,
-    basic), radius=6.0, outfile="qsalt.dat")
-
-    # iterate through trajectory and perform analysis of "native contacts" q
-    # (force=True ignores any previous results, force=True is useful when testing)
-    CA1.run(force=True)
-
-    # plot time series q(t) [possibly do "import pylab; pylab.clf()" do clear the figure first...]
-    CA1.plot(filename="adk_saltbridge_contact_analysis1.pdf", linewidth=3, color="blue")
-
-    # or plot the data in qsalt.dat yourself.
-    CA1.plot_qavg(filename="adk_saltbridge_contact_analysis1_matrix.pdf")
 
 The first graph shows that when AdK opens, about 20% of the salt
 bridges that existed in the closed state disappear when the enzyme
 opens. They open in a step-wise fashion (made more clear by the movie
 `AdK_zipper_cartoon.avi`_).
 
-The output graphs can be made prettier but if you look at the code
-itself then you'll quickly figure out what to do. The qavg plot is the
-matrix of all contacts, averaged over the trajectory. This plot makes
-more sense for an equilibrium trajectory than for the example above
-but is is included for illustration.
-
-See the docs for :class:`ContactAnalysis1` for another example.
-
-
 .. AdK_zipper_cartoon.avi:
    http://www.ncbi.nlm.nih.gov/pmc/articles/PMC2803350/bin/NIHMS150766-supplement-03.avi
+
+Notes
+-----
+Suggested cutoff distances for different simulations
+* For all-atom simulations, cutoff = 4.5 A
+* For coarse-grained simulations, cutoff = 6.0 A
 
 Two-dimensional contact analysis (q1-q2)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -117,23 +102,85 @@ Two-dimensional contact analysis (q1-q2)
 Analyze a single DIMS transition of AdK between its closed and open
 conformation and plot the trajectory projected on q1-q2::
 
-  import MDAnalysis.analysis.contacts
-  from MDAnalysis.tests.datafiles import PSF, DCD
-  C = MDAnalysis.analysis.contacts.ContactAnalysis(PSF, DCD)
-  C.run()
-  C.plot()
+
+>>> import MDAnalysis as mda
+>>> from MDAnalysis.analysis import contacts
+>>> from MDAnalysisTests.datafiles import PSF, DCD
+>>> u = mda.Universe(PSF, DCD)
+>>> q1q2 = contacts.q1q2(u, 'name CA', radius=8)
+>>> q1q2.run()
+>>>
+>>> f, ax = plt.subplots(1, 2, figsize=plt.figaspect(0.5))
+>>> ax[0].plot(q1q2.timeseries[:, 0], q1q2.timeseries[:, 1], label='q1')
+>>> ax[0].plot(q1q2.timeseries[:, 0], q1q2.timeseries[:, 2], label='q2')
+>>> ax[0].legend(loc='best')
+>>> ax[1].plot(q1q2.timeseries[:, 1], q1q2.timeseries[:, 2], '.-')
+>>> f.show()
 
 Compare the resulting pathway to the `MinActionPath result for AdK`_.
 
 .. _MinActionPath result for AdK:
    http://lorentz.dynstr.pasteur.fr/joel/adenylate.php
 
+Writing your own contact analysis
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ..class:`Contacts` has been designed to be extensible for your own
+analysis. As an example we will analysis when the acidic and basic groups of
+are in contact which each other, this means that at least one of the contacts
+formed in the reference is closer then 2.5 Angstrom. For this we define a new
+method to determine if any contact is closer then 2.5 Angström that implements
+the API ..class:`Contacts` except.
+
+The first to parameters `r` and `r0` are provided by ..class:`Contacts` the
+others can be passed as keyword args using the `kwargs` parameter in
+..class:`Contacts`.
+
+>>> def is_any_closer(r, r0, dist=2.5):
+>>>     return np.any(r < dist)
+
+Next we are creating an instance of the Constants class and use the
+`is_any_closer` function as an argument to `method` and run the analysus
+
+>>> # crude definition of salt bridges as contacts between NH/NZ in ARG/LYS and
+>>> # OE*/OD* in ASP/GLU. You might want to think a little bit harder about the
+>>> # problem before using this for real work.
+>>> sel_basic = "(resname ARG LYS) and (name NH* NZ)"
+>>> sel_acidic = "(resname ASP GLU) and (name OE* OD*)"
+>>> # reference groups (first frame of the trajectory, but you could also use a
+>>> # separate PDB, eg crystal structure)
+>>> acidic = u.select_atoms(sel_acidic)
+>>> basic = u.select_atoms(sel_basic)
+>>> nc = contacts.Contacts(u, selection=(sel_acidic, sel_basic),
+>>>                        method=is_any_closer,
+>>>                        refgroup=(acidic, basic), kwargs={'dist': 2.5})
+>>>
+>>> nc.run()
+>>>
+>>> bound = nc.timeseries[:, 1]
+>>> frames = nc.timeseries[:, 0]
+>>>
+>>> f, ax = plt.subplots()
+>>>
+>>> ax.plot(frames, bound, '.')
+>>> ax.set(xlabel='frame', ylabel='is Bound',
+>>>        ylim=(-0.1, 1.1))
+>>>
+>>> f.show()
+
+Functions
+---------
+
+.. autofunction:: hard_cut_q
+.. autofunction:: soft_cut_q
+.. autofunction:: radius_cut_q
+.. autofunction:: contact_matrix
+.. autofunction:: q1q2
+
 Classes
 -------
 
 .. autoclass:: Contacts
-   :members:
-.. autoclass:: ContactAnalysis
    :members:
 
 
@@ -142,8 +189,11 @@ Deprecated
 
 .. autoclass:: ContactAnalysis1
    :members:
+.. autoclass:: ContactAnalysis
+   :members:
 
 """
+from __future__ import division
 
 import os
 import errno
@@ -152,6 +202,7 @@ import bz2
 from six.moves import zip
 
 import numpy as np
+from numpy.lib.utils import deprecate
 
 import logging
 
@@ -159,15 +210,302 @@ import MDAnalysis
 import MDAnalysis.lib.distances
 from MDAnalysis.lib.util import openany
 from MDAnalysis.analysis.distances import distance_array
+from MDAnalysis.core.AtomGroup import AtomGroup
 from .base import AnalysisBase
 
 logger = logging.getLogger("MDAnalysis.analysis.contacts")
+
+
+def soft_cut_q(r, r0, beta=5.0, lambda_constant=1.8):
+    r"""Calculate fraction of native contacts *Q* for a soft cut off
+
+    ..math::
+        Q(r, r_0) = \frac{1}{1 + e^{\beta (r - \lambda r_0)}}
+
+    Reasonable values for different simulation types are
+
+    *All Atom*: lambda_constant = 1.8 (unitless)
+    *Coarse Grained*: lambda_constant = 1.5 (unitless)
+
+    Parameters
+    ----------
+    r: array
+      Contact distances at time t
+    r0: array
+      Contact distances at time t=0, reference distances
+    beta: float (default 5.0 Angstrom)
+      Softness of the switching function
+    lambda_constant: float (default 1.8, unitless)
+      Reference distance tolerance
+
+    Returns
+    -------
+    Q : float
+      fraction of native contacts
+
+    References
+    ----------
+    .. [1] RB Best, G Hummer, and WA Eaton, "Native contacts determine protein
+       folding mechanisms in atomistic simulations" _PNAS_ **110** (2013),
+       17874–17879. `10.1073/pnas.1311599110
+       <http://doi.org/10.1073/pnas.1311599110>`_.
+
+    """
+    r = np.asarray(r)
+    r0 = np.asarray(r0)
+    result = 1/(1 + np.exp(beta*(r - lambda_constant * r0)))
+
+    return result.sum() / len(r0)
+
+
+def hard_cut_q(r, cutoff):
+    """Calculate fraction of native contacts *Q* for a hard cut off. The cutoff
+    can either be a float a ndarray the same shape as `r`
+
+    Parameters
+    ----------
+    r : ndarray
+        distance matrix
+    cutoff : ndarray | float
+        cut off value to count distances. Can either be a float of a ndarray of
+        the same size as distances
+
+    Returns
+    -------
+    Q : float
+        fraction of contacts
+
+    """
+    r = np.asarray(r)
+    cutoff = np.asarray(cutoff)
+    y = r <= cutoff
+    return y.sum() / r.size
+
+
+def radius_cut_q(r, r0, radius):
+    """calculate native contacts *Q* based on the single sistance radius
+
+    Parameters
+    ----------
+    r : ndarray
+        distance array between atoms
+    r0 : ndarray
+        unused to fullfill Contacts API
+    radius : float
+        Distance between atoms at which a contact is formed
+
+    Returns
+    -------
+    Q : float
+        fraction of contacts
+
+    References
+    ----------
+    .. [1] Franklin, J., Koehl, P., Doniach, S., & Delarue, M. (2007).
+       MinActionPath: Maximum likelihood trajectory for large-scale structural
+       transitions in a coarse-grained locally harmonic energy landscape.
+       Nucleic Acids Research, 35(SUPPL.2), 477–482.
+       http://doi.org/10.1093/nar/gkm342
+
+    """
+    return hard_cut_q(r, radius)
+
+
+def contact_matrix(d, radius, out=None):
+    """calculate contacts from distance matrix
+
+    Parameters
+    ----------
+    d : array-like
+        distance matrix
+    radius : float
+        distance below which a contact is formed.
+    out: array (optional)
+        If `out` is supplied as a pre-allocated array of the correct
+        shape then it is filled instead of allocating a new one in
+        order to increase performance.
+
+    Returns
+    -------
+    contacts : ndarray
+        boolean array of formed contacts
+    """
+    if out is not None:
+        out[:] = d <= radius
+    else:
+        out = d <= radius
+    return out
+
+
+class Contacts(AnalysisBase):
+    """Calculate contacts based observables.
+
+    The standard methods used in this class calculate the fraction of native
+    contacts *Q* from a trajectory. By defining your own method it is possible
+    to calculate other observables that only depend on the distances and a
+    possible reference distance.
+
+    Attributes
+    ----------
+    timeseries : list
+        list containing *Q* for all refgroup pairs and analyzed frames
+
+    """
+    def __init__(self, u, selection, refgroup, method="hard_cut", radius=4.5,
+                 kwargs=None, start=None, stop=None, step=None,):
+        """Initialization
+
+        Parameters
+        ----------
+        u : Universe
+            trajectory
+        selection : tuple(string, string)
+            two contacting groups that change over time
+        refgroup : tuple(AtomGroup, AtomGroup)
+            two contacting atomgroups in their reference conformation. This
+            can also be a list of tuples containing different atom groups
+        radius : float, optional (4.5 Angstroms)
+            radius within which contacts exist in refgroup
+        method : string | callable (optional)
+            Can either be one of ['hard_cut' , 'soft_cut'] or a callable that
+            implements a API (r, r0, **kwargs).
+        kwargs : dict, optional
+            dictionary of additional kwargs passed to `method`. Check
+            respective functions for reasonable values.
+        start : int, optional
+            First frame of trajectory to analyse, Default: 0
+        stop : int, optional
+            Last frame of trajectory to analyse, Default: -1
+        step : int, optional
+            Step between frames to analyse, Default: 1
+
+        """
+        if method == 'hard_cut':
+            self.fraction_contacts = hard_cut_q
+        elif method == 'soft_cut':
+            self.fraction_contacts = soft_cut_q
+        else:
+            if not callable(method):
+                raise ValueError("method has to be callable")
+            self.fraction_contacts = method
+
+        # setup boilerplate
+        self.u = u
+        self._setup_frames(self.u.trajectory, start, stop, step)
+
+        self.selection = selection
+        self.grA = u.select_atoms(selection[0])
+        self.grB = u.select_atoms(selection[1])
+
+        # contacts formed in reference
+        self.r0 = []
+        self.initial_contacts = []
+
+        if isinstance(refgroup[0], AtomGroup):
+            refA, refB = refgroup
+            self.r0.append(distance_array(refA.positions, refB.positions))
+            self.initial_contacts.append(contact_matrix(self.r0[-1], radius))
+        else:
+            for refA, refB in refgroup:
+                self.r0.append(distance_array(refA.positions, refB.positions))
+                self.initial_contacts.append(contact_matrix(self.r0[-1],
+                                                            radius))
+
+        self.fraction_kwargs = kwargs if kwargs is not None else {}
+        self.timeseries = []
+
+    def _single_frame(self):
+        # compute distance array for a frame
+        d = distance_array(self.grA.positions, self.grB.positions)
+
+        y = np.empty(len(self.r0) + 1)
+        y[0] = self._ts.frame
+        for i, (initial_contacts, r0) in enumerate(zip(self.initial_contacts,
+                                                       self.r0)):
+            # select only the contacts that were formed in the reference state
+            r = d[initial_contacts]
+            r0 = r0[initial_contacts]
+            y[i + 1] = self.fraction_contacts(r, r0, **self.fraction_kwargs)
+
+        if len(y) == 1:
+            y = y[0]
+        self.timeseries.append(y)
+
+    def _conclude(self):
+        self.timeseries = np.array(self.timeseries, dtype=float)
+
+    def save(self, outfile):
+        """save contacts timeseries
+
+        Parameter
+        ---------
+        outfile : str
+            file to save contacts
+
+        """
+        with open(outfile, "w") as f:
+            f.write("# q1 analysis\n")
+            np.savetxt(f, self.timeseries)
+
+
+def _new_selections(u_orig, selections, frame):
+    """create stand alone AGs from selections at frame"""
+    u = MDAnalysis.Universe(u_orig.filename, u_orig.trajectory.filename)
+    u.trajectory[frame]
+    return [u.select_atoms(s) for s in selections]
+
+
+def q1q2(u, selection='all', radius=4.5,
+         start=None, stop=None, step=None):
+    """Do a q1-q2 analysis to compare native contacts between the starting
+    structure and final structure of a trajectory.
+
+    Parameters
+    ----------
+    u : Universe
+        Universe with a trajectory
+    selection : string, optional
+        atoms to do analysis on
+    radius : float, optional
+        distance at which contact is formed
+    start : int, optional
+        First frame of trajectory to analyse, Default: 0
+    stop : int, optional
+        Last frame of trajectory to analyse, Default: -1
+    step : int, optional
+        Step between frames to analyse, Default: 1
+
+    Returns
+    -------
+    contacts
+        Contact Analysis setup for a q1-q2 analysis
+
+    """
+    selection = (selection, selection)
+    first_frame_refs = _new_selections(u, selection, 0)
+    last_frame_refs = _new_selections(u, selection, -1)
+    return Contacts(u, selection,
+                    (first_frame_refs, last_frame_refs),
+                    radius=radius, method=radius_cut_q,
+                    start=start, stop=stop, step=step,
+                    kwargs={'radius': radius})
+
+################################################################################
+################################################################################
+################################################################################
+################################################################################
+################################################################################
+################################################################################
+
+
+# What comes now are old deprecated contact Analysis classes
 
 
 # ContactAnalysis needs to be cleaned up and possibly renamed but
 # until then it remains because we don't have the functionality
 # elsewhere.
 
+@deprecate(new_name="Contacts", message="This class will be removed in 0.17")
 class ContactAnalysis(object):
     """Perform a native contact analysis ("q1-q2").
 
@@ -209,18 +547,18 @@ class ContactAnalysis(object):
         trajectory : filename
             trajectory
         ref1 : filename or ``None``, optional
-            structure of the reference conformation 1 (pdb); if ``None`` the *first*
-            frame of the trajectory is chosen
+            structure of the reference conformation 1 (pdb); if ``None`` the
+            *first* frame of the trajectory is chosen
         ref2 : filename or ``None``, optional
-            structure of the reference conformation 2 (pdb); if ``None`` the *last*
-            frame of the trajectory is chosen
+            structure of the reference conformation 2 (pdb); if ``None`` the
+            *last* frame of the trajectory is chosen
         radius : float, optional, default 8 A
             contacts are deemed any Ca within radius
         targetdir : path, optional, default ``.``
             output files are saved in this directory
         infix : string, optional
-            additional tag string that is inserted into the output filename of the
-            data file
+            additional tag string that is inserted into the output filename of
+            the data file
          selection : string, optional, default ``"name CA"``
             MDAnalysis selection string that selects the particles of
             interest; the default is to only select the C-alpha atoms
@@ -234,6 +572,7 @@ class ContactAnalysis(object):
             per-residue basis to compute contacts. This allows, for instance
             defining the sidechains as `selection` and then computing distances
             between sidechain centroids.
+
         """
 
         self.topology = topology
@@ -254,11 +593,15 @@ class ContactAnalysis(object):
         # short circuit if output file already exists: skip everything
         if self.output_exists():
             self._skip = True
-            return  # do not bother reading any data or initializing arrays... !!
-        # don't bother if trajectory is empty (can lead to segfaults so better catch it)
+            # do not bother reading any data or initializing arrays... !!
+            return
+
+        # don't bother if trajectory is empty (can lead to segfaults so better
+        # catch it)
         stats = os.stat(trajectory)
         if stats.st_size == 0:
-            warnings.warn('trajectory = {trajectory!s} is empty, skipping...'.format(**vars()))
+            warnings.warn('trajectory = {trajectory!s} is empty, '
+                          'skipping...'.format(**vars()))
             self._skip = True
             return
         # under normal circumstances we do not skip
@@ -308,9 +651,9 @@ class ContactAnalysis(object):
               passed on to :func:`MDAnalysis.lib.distances.self_distance_array`
               as a preallocated array
         centroids : bool, optional, default ``None``
-              ``True``: calculate per-residue centroids from the selected atoms;
-              ``False``: consider each atom separately; ``None``: use the class
-              default for *centroids* [``None``]
+              ``True``: calculate per-residue centroids from the selected
+              atoms; ``False``: consider each atom separately; ``None``: use
+              the class default for *centroids* [``None``]
 
         """
         centroids = kwargs.pop("centroids", None)
@@ -319,15 +662,18 @@ class ContactAnalysis(object):
             coordinates = g.positions
         else:
             # centroids per residue (but only including the selected atoms)
-            coordinates = np.array([residue.centroid() for residue in g.split("residue")])
-        return MDAnalysis.lib.distances.self_distance_array(coordinates, **kwargs)
+            coordinates = np.array([residue.centroid()
+                                    for residue in g.split("residue")])
+        return MDAnalysis.lib.distances.self_distance_array(coordinates,
+                                                            **kwargs)
 
     def output_exists(self, force=False):
         """Return True if default output file already exists.
 
         Disable with force=True (will always return False)
         """
-        return (os.path.isfile(self.output) or os.path.isfile(self.output_bz2)) and not (self.force or force)
+        return (os.path.isfile(self.output) or
+                os.path.isfile(self.output_bz2)) and not (self.force or force)
 
     def run(self, store=True, force=False):
         """Analyze trajectory and produce timeseries.
@@ -336,7 +682,8 @@ class ContactAnalysis(object):
         store=True) and writes them to a bzip2-compressed data file.
         """
         if self._skip or self.output_exists(force=force):
-            warnings.warn("File {output!r} or {output_bz2!r} already exists, loading {trajectory!r}.".format(**vars(self)))
+            warnings.warn("File {output!r} or {output_bz2!r} already exists, "
+                          "loading {trajectory!r}.".format(**vars(self)))
             try:
                 self.load(self.output)
             except IOError:
@@ -345,7 +692,10 @@ class ContactAnalysis(object):
 
         outbz2 = bz2.BZ2File(self.output_bz2, mode='w', buffering=8192)
         try:
-            outbz2.write("# q1-q2 analysis\n# nref1 = {0:d}\n# nref2 = {1:d}\n".format(self.nref[0], self.nref[1]))
+            outbz2.write("# q1-q2 analysis\n"
+                         "# nref1 = {0:d}\n"
+                         "# nref2 = {1:d}\n".format(self.nref[0],
+                                                    self.nref[1]))
             outbz2.write("# frame  q1  q2   n1  n2\n")
             records = []
             for ts in self.u.trajectory:
@@ -444,28 +794,26 @@ class ContactAnalysis(object):
 
         kwargs.setdefault('color', 'black')
         if self.timeseries is None:
-            raise ValueError("No timeseries data; do 'ContactAnalysis.run(store=True)' first.")
+            raise ValueError("No timeseries data; do "
+                             "'ContactAnalysis.run(store=True)' first.")
         t = self.timeseries
         plot(t[1], t[2], **kwargs)
         xlabel(r"$q_1$")
         ylabel(r"$q_2$")
 
 
-# ContactAnalysis1 is a (hopefully) temporary hack. It should be unified with ContactAnalysis
-# or either should be derived from a base class because many methods are copy&paste with
-# minor changes (mostly for going from q1q2 -> q1 only).
-# If ContactAnalysis is enhanced to accept two references then this should be even easier.
-# It might also be worthwhile making a simpler class that just does the q calculation
-# and use it for both reference and trajectory data.
+@deprecate(new_name="Contacts", message="This class will be removed in 0.17")
 class ContactAnalysis1(object):
-    """Perform a very flexible native contact analysis with respect to a single reference.
+    """Perform a very flexible native contact analysis with respect to a single
+    reference.
 
     This analysis class allows one to calculate the fraction of native contacts
     *q* between two arbitrary groups of atoms with respect to an arbitrary
     reference structure. For instance, as a reference one could take a crystal
     structure of a complex, and as the two groups atoms one selects two
     molecules A and B in the complex. Then the question to be answered by *q*
-    is, is which percentage of the contacts between A and B persist during the simulation.
+    is, is which percentage of the contacts between A and B persist during the
+    simulation.
 
     First prepare :class:`~MDAnalysis.core.AtomGroup.AtomGroup` selections for
     the reference atoms; this example uses some arbitrary selections::
@@ -494,7 +842,8 @@ class ContactAnalysis1(object):
 
     Now we are ready to set up the analysis::
 
-      CA1 = ContactAnalysis1(u, selection=(selA,selB), refgroup=(refA,refB), radius=8.0, outfile="q.dat")
+      CA1 = ContactAnalysis1(u, selection=(selA,selB), refgroup=(refA,refB),
+                             radius=8.0, outfile="q.dat")
 
     If the groups do not match in length then a :exc:`ValueError` is raised.
 
@@ -532,14 +881,16 @@ class ContactAnalysis1(object):
 
         :Keywords:
           *selection*
-            selection string that determines which distances are calculated; if this
-            is a tuple or list with two entries then distances are calculated between
-            these two different groups ["name CA or name B*"]
+            selection string that determines which distances are calculated; if
+            this is a tuple or list with two entries then distances are
+            calculated between these two different groups ["name CA or name
+            B*"]
           *refgroup*
-            reference group, either a single :class:`~MDAnalysis.core.AtomGroup.AtomGroup`
-            (if there is only a single *selection*) or a list of two such groups.
-            The reference contacts are directly computed from *refgroup* and hence
-            the atoms in the reference group(s) must be equivalent to the ones produced
+            reference group, either a single
+            :class:`~MDAnalysis.core.AtomGroup.AtomGroup` (if there is only a
+            single *selection*) or a list of two such groups. The reference
+            contacts are directly computed from *refgroup* and hence the atoms
+            in the reference group(s) must be equivalent to the ones produced
             by the *selection* on the input trajectory.
           *radius*
             contacts are deemed any atoms within radius [8.0 A]
@@ -562,6 +913,7 @@ class ContactAnalysis1(object):
         the attribute :attr:`ContactAnalysis1.timeseries`.
 
         .. deprecated: 0.14.0
+
         """
 
         # XX or should I use as input
@@ -574,8 +926,9 @@ class ContactAnalysis1(object):
         # - make this selection based on qavg
         from os.path import splitext
 
-        warnings.warn("ContactAnalysis1 is deprecated and will be removed in 1.0. "
-                      "Use Contacts instead.", category=DeprecationWarning)
+        warnings.warn("ContactAnalysis1 is deprecated and will be removed "
+                      "in 1.0. Use Contacts instead.",
+                      category=DeprecationWarning)
 
         self.selection_strings = self._return_tuple2(kwargs.pop(
             'selection', "name CA or name B*"), "selection")
@@ -592,16 +945,19 @@ class ContactAnalysis1(object):
         self.filenames = args
         self.universe = MDAnalysis.as_Universe(*args, **kwargs)
 
-        self.selections = [self.universe.select_atoms(s) for s in self.selection_strings]
+        self.selections = [self.universe.select_atoms(s)
+                           for s in self.selection_strings]
 
         # sanity checkes
         for x in self.references:
             if x is None:
                 raise ValueError("a reference AtomGroup must be supplied")
-        for ref, sel, s in zip(self.references, self.selections, self.selection_strings):
+        for ref, sel, s in zip(self.references,
+                               self.selections,
+                               self.selection_strings):
             if ref.atoms.n_atoms != sel.atoms.n_atoms:
-                raise ValueError("selection=%r: Number of atoms differ between "
-                                 "reference (%d) and trajectory (%d)" %
+                raise ValueError("selection=%r: Number of atoms differ "
+                                 "between reference (%d) and trajectory (%d)" %
                                  (s, ref.atoms.n_atoms, sel.atoms.n_atoms))
 
         # compute reference contacts
@@ -627,8 +983,8 @@ class ContactAnalysis1(object):
         elif len(t) == 1:
             return (x, x)
         else:
-            raise ValueError("%(name)s must be a single object or a tuple/list with two objects "
-                             "and not %(x)r" % vars())
+            raise ValueError("%(name)s must be a single object or a "
+                             "tuple/list with two objects and not %(x)r" % vars())
 
     def output_exists(self, force=False):
         """Return True if default output file already exists.
@@ -637,38 +993,47 @@ class ContactAnalysis1(object):
         """
         return os.path.isfile(self.output) and not (self.force or force)
 
-    def run(self, store=True, force=False, start=0, stop=None, step=1, **kwargs):
+    def run(self, store=True, force=False, start=0, stop=None, step=1,
+            **kwargs):
         """Analyze trajectory and produce timeseries.
 
         Stores results in :attr:`ContactAnalysis1.timeseries` (if store=True)
         and writes them to a data file. The average q is written to a second
         data file.
         *start*
-            The value of the first frame index in the trajectory to be used (default: index 0)
+            The value of the first frame index in the trajectory to be used
+            (default: index 0)
         *stop*
-            The value of the last frame index in the trajectory to be used (default: None -- use all frames)
+            The value of the last frame index in the trajectory to be used
+            (default: None -- use all frames)
         *step*
-            The number of frames to skip during trajectory iteration (default: use every frame)
+            The number of frames to skip during trajectory iteration (default:
+            use every frame)
+
         """
 
         if 'start_frame' in kwargs:
-            warnings.warn("start_frame argument has been deprecated, use start instead --"
-                           "removal targeted for version 0.15.0", DeprecationWarning)
+            warnings.warn("start_frame argument has been deprecated, use "
+                          "start instead -- removal targeted for version "
+                          "0.15.0", DeprecationWarning)
             start = kwargs.pop('start_frame')
 
         if 'end_frame' in kwargs:
-            warnings.warn("end_frame argument has been deprecated, use stop instead --"
-                           "removal targeted for version 0.15.0", DeprecationWarning)
+            warnings.warn("end_frame argument has been deprecated, use "
+                          "stop instead -- removal targeted for version "
+                          "0.15.0", DeprecationWarning)
             stop = kwargs.pop('end_frame')
 
         if 'step_value' in kwargs:
-            warnings.warn("step_value argument has been deprecated, use step instead --"
-                           "removal targeted for version 0.15.0", DeprecationWarning)
+            warnings.warn("step_value argument has been deprecated, use "
+                          "step instead -- removal targeted for version "
+                          "0.15.0", DeprecationWarning)
             step = kwargs.pop('step_value')
 
         if self.output_exists(force=force):
-            warnings.warn("File %r already exists, loading it INSTEAD of trajectory %r. "
-                          "Use force=True to overwrite the output file. " %
+            warnings.warn("File %r already exists, loading it INSTEAD of "
+                          "trajectory %r. Use force=True to overwrite "
+                          "the output file. " %
                           (self.output, self.universe.trajectory.filename))
             self.load(self.output)
             return None
@@ -682,7 +1047,9 @@ class ContactAnalysis1(object):
             for ts in self.universe.trajectory[start:stop:step]:
                 frame = ts.frame
                 # use pre-allocated distance array to save a little bit of time
-                MDAnalysis.lib.distances.distance_array(A.coordinates(), B.coordinates(), result=self.d)
+                MDAnalysis.lib.distances.distance_array(A.coordinates(),
+                                                        B.coordinates(),
+                                                        result=self.d)
                 self.qarray(self.d, out=self.q)
                 n1, q1 = self.qN(self.q, out=self._qtmp)
                 self.qavg += self.q
@@ -696,7 +1063,8 @@ class ContactAnalysis1(object):
         if n_frames > 0:
             self.qavg /= n_frames
         else:
-            logger.warn("No frames were analyzed. Check values of start, stop, step.")
+            logger.warn("No frames were analyzed. "
+                        "Check values of start, stop, step.")
             logger.debug("start={start} stop={stop} step={step}".format(**vars()))
         np.savetxt(self.outarray, self.qavg, fmt="%8.6f")
         return self.output
@@ -767,7 +1135,8 @@ class ContactAnalysis1(object):
         kwargs.setdefault('color', 'black')
         kwargs.setdefault('linewidth', 2)
         if self.timeseries is None:
-            raise ValueError("No timeseries data; do 'ContactAnalysis.run(store=True)' first.")
+            raise ValueError("No timeseries data; "
+                             "do 'ContactAnalysis.run(store=True)' first.")
         t = self.timeseries
         plot(t[0], t[1], **kwargs)
         xlabel(r"frame number $t$")
@@ -777,8 +1146,10 @@ class ContactAnalysis1(object):
             savefig(filename)
 
     def _plot_qavg_pcolor(self, filename=None, **kwargs):
-        """Plot :attr:`ContactAnalysis1.qavg`, the matrix of average native contacts."""
-        from pylab import pcolor, gca, meshgrid, xlabel, ylabel, xlim, ylim, colorbar, savefig
+        """Plot :attr:`ContactAnalysis1.qavg`, the matrix of average native
+        contacts."""
+        from pylab import (pcolor, gca, meshgrid, xlabel, ylabel, xlim, ylim,
+                           colorbar, savefig)
 
         x, y = self.selections[0].resids, self.selections[1].resids
         X, Y = meshgrid(x, y)
@@ -806,7 +1177,8 @@ class ContactAnalysis1(object):
         suffix determines the file type, e.g. pdf, png, eps, ...). All other
         keyword arguments are passed on to :func:`pylab.imshow`.
         """
-        from pylab import imshow, xlabel, ylabel, xlim, ylim, colorbar, cm, clf, savefig
+        from pylab import (imshow, xlabel, ylabel, xlim, ylim, colorbar, cm,
+                           clf, savefig)
 
         x, y = self.selections[0].resids, self.selections[1].resids
 
@@ -831,370 +1203,3 @@ class ContactAnalysis1(object):
 
         if filename is not None:
             savefig(filename)
-
-
-def best_hummer_q(r, r0, beta=5.0, lambda_constant=1.8):
-    """Calculate the Best-Hummer fraction of native contacts (Q)
-
-    A soft-cutoff contacts analysis
-
-    Parameters
-    ----------
-    r: array
-      Contact distances at time t
-    r0: array
-      Contact distances at time t=0, reference distances
-    beta: float (default 5.0 Angstrom)
-      Softness of the switching function
-    lambda_constant: float (default 1.8, unitless)
-      Reference distance tolerance
-
-    Returns
-    -------
-    Q : float
-      Fraction of native contacts
-    result : array
-      Intermediate, r-r0 array transformed by the switching function
-    """
-    result = 1/(1 + np.exp(beta*(r - lambda_constant * r0)))
-
-    return result.sum() / len(r0), result
-
-
-class Contacts(AnalysisBase):
-    """Calculate fraction of native contacts (Q) from a trajectory
-
-    Inputs
-    ------
-    Two string selections for the contacting AtomGroups,
-    the groups could be protein-lipid or protein-protein.
-
-    Use two reference AtomGroups to obtain reference distances (r0)
-    for the cotacts.
-
-    Methods available
-    -----------------
-    Supports either hard-cutoff or soft-cutoff (Best-Hummer like [1]_)
-    contacts.
-
-    Returns
-    -------
-    list
-        Returns a list of following structure::
-            {
-                [[t1, q1], [t2, q2], ... [tn, qn]]
-            }
-        where t is time in ps and q is the fraction of native contacts
-
-    Examples
-    --------
-
-    1. Protein folding::
-
-        ref = Universe("villin.gro")
-        u = Universe("conf_protein.gro", "traj_protein.xtc")
-        Q = calculate_contacts(u, ref, "protein and not name H*", "protein and not name H*")
-
-    2. A pair of helices::
-
-        ref = Universe("glycophorin_dimer.pdb")
-        u = Universe("conf_protein.gro", "traj_protein.xtc")
-        Q = calculate_contacts(u, ref, \
-            "protein and resid 75-92 and not name H* and segid A", \
-            "protein and resid 75-92 and not name H* and segid B")
-
-    Parameter choices
-    -----------------
-    There are recommendations and not strict orders.
-    These parameters should be insensitive to small changes.
-    * For all-atom simulations, radius = 4.5 A and lambda_constant = 1.8 (unitless)
-    * For coarse-grained simulations, radius = 6.0 A and lambda_constant = 1.5 (unitless)
-
-    Additional
-    ----------
-    Supports writing and reading the analysis results to and from a text file.
-    Supports simple plotting operations, for exploratory data analysis.
-
-    Notes
-    -----
-    We use the definition of Best et al [1]_, namely Eq. (1) of the SI
-    defines the expression for the fraction of native contacts,
-    $Q(X)$:
-
-    .. math::
-
-        Q(X) = \frac{1}{|S|} \sum_{(i,j) \in S}
-               \frac{1}{1 + \exp[\beta(r_{ij}(X) - \lambda r_{ij}^0)]}
-
-    where:
-
-    * :math:`X` is a conformation,
-    * :math:`r_{ij}(X)` is the distance between atoms $i$ and $j$ in
-      conformation $X$,
-    * :math:`r^0_{ij}` is the distance from heavy atom i to j in the
-      native state conformation,
-    * :math:`S` is the set of all pairs of heavy atoms $(i,j)$
-      belonging to residues $\theta_i$ and $\theta_j$ such that
-      $|\theta_i - \theta_j| > 3$ and $r^0_{i,} < 4.5
-      \unicode{x212B}$,
-    * :math:`\beta=5 \unicode{x212B}^{-1},
-    * :math:`\lambda=1.8` for all-atom simulations
-
-    References
-    ----------
-
-    .. [1] RB Best, G Hummer, and WA Eaton, "Native contacts determine
-       protein folding mechanisms in atomistic simulations" _PNAS_
-       **110** (2013), 17874–17879.  `10.1073/pnas.1311599110
-       <http://doi.org/10.1073/pnas.1311599110>`_.
-
-    """
-    def __init__(self, u, selection, refgroup, method="cutoff", radius=4.5, outfile=None,
-                 start=None, stop=None, step=None, **kwargs):
-        """Calculate the persistence length for polymer chains
-
-        Parameters
-        ----------
-        u: Universe
-            trajectory
-        selection: tuple(string, string)
-            two contacting groups that change over time
-        refgroup: tuple(AtomGroup, AtomGroup)
-            two contacting groups in their reference conformation
-        radius: float, optional (4.5 Angstroms)
-            radius within which contacts exist
-        method: string
-            either 'cutoff' or 'best-hummer'
-
-        start : int, optional
-            First frame of trajectory to analyse, Default: 0
-        stop : int, optional
-            Last frame of trajectory to analyse, Default: -1
-        step : int, optional
-            Step between frames to analyse, Default: 1
-
-        Parameters for 'best-hummer' method
-        -----------------------------------
-        lambda_constant: float, optional (1.8 unitless)
-            contact is considered formed between (lambda*r0,r0)
-        beta: float, optional (5 Angstroms^-1)
-            softness of the switching function, the lower the softer
-
-        Attributes
-        ----------
-        results: list
-            Fraction of native contacts for each frame
-        """
-
-        # check method
-        if not method in ("cutoff", "best-hummer"):
-            raise ValueError("method has to be 'cutoff' or 'best-hummer'")
-        self._method = method
-
-        # method-specific parameters
-        if method == "best-hummer":
-            self.beta = kwargs.get('beta', 5.0)
-            self.lambda_constant  = kwargs.get('lambda_constant', 1.8)
-
-        # steup boilerplate
-        self.u = u
-        self._setup_frames(self.u.trajectory,
-                           start=start,
-                           stop=stop,
-                           step=step)
-
-        self.selection = selection
-        grA, grB = u.select_atoms(selection[0]), u.select_atoms(selection[1])
-        self.grA, self.grB = grA, grB
-        refA, refB = refgroup
-
-        # contacts formed in reference
-        r0 = distance_array(refA.positions, refB.positions)
-        self.r0 = r0
-        self.mask = r0 < radius
-
-        self.contact_matrix = []
-        self.timeseries = []
-        self.outfile = outfile
-
-    def load(self, filename):
-        """Load the data file.
-
-        Arguments
-        ---------
-        filename : string
-            name of the data file to be read (can be compressed
-            or a stream, see :func:`~MDAnalysis.lib.util.openany`
-            for what is possible)
-        """
-        records = []
-        with openany(filename) as data:
-            for line in data:
-                if line.startswith('#'): continue
-                records.append(map(float, line.split()))
-        return np.array(records)
-
-    def _single_frame(self):
-        grA, grB, r0, mask = self.grA, self.grB, self.r0, self.mask
-
-        # compute distance array for a frame
-        d = distance_array(grA.positions, grB.positions)
-
-        # select only the contacts that were formed in the reference state
-        # r, r0 are 1D array
-        r, r0 = d[mask], r0[mask]
-
-        if self._method == "cutoff":
-            y = r <= r0
-            y = float(y.sum())/mask.sum()
-        elif self._method == "best-hummer":
-            y, _ = best_hummer_q(r, r0, self.beta, self.lambda_constant)
-        else:
-            raise ValueError("Unknown method type, has to be 'cutoff' or 'best-hummer'")
-
-        cm = np.zeros((grA.positions.shape[0], grB.positions.shape[0]))
-        cm[mask] = y
-        self.contact_matrix.append(cm)
-        self.timeseries.append((self._ts.frame , y, mask.sum()))
-
-    def _conclude(self):
-        """Finalise the timeseries you've gathered.
-
-        Called at the end of the run() method to finish everything up.
-        """
-        # write output
-        if not self.outfile: return
-        with open(self.outfile, "w") as f:
-            f.write("# q1 analysis\n# nref = {0:d}\n".format(self.mask.sum()))
-            f.write("# frame  q1  n1\n")
-            for frame, q1, n1 in self.timeseries:
-                f.write("{frame:4d}  {q1:8.6f} {n1:5d}\n".format(**vars()))
-
-    def contact_matrix(self, d, out=None):
-        """Return distance array with True for contacts.
-
-        Parameters
-        ----------
-        d : array
-            is the matrix of distances. The method uses the value of
-            `ContactAnalysis1.radius` to determine if a ``distance < radius``
-            is considered a contact.
-        out: array (optional)
-            If `out` is supplied as a pre-allocated array of the correct
-            shape then it is filled instead of allocating a new one in
-            order to increase performance.
-
-        Returns
-        -------
-        array
-            boolean array of which contacts are formed
-
-        Note
-        ----
-        This method is typically only used internally.
-        """
-        if out:
-            out[:] = (d <= self.radius)
-        else:
-            out = (d <= self.radius)
-        return out
-
-    def fraction_native(q, out=None):
-        """Calculate native contacts relative to reference state.
-
-        Parameters
-        ----------
-        q: array
-            is the matrix of contacts (e.g. `ContactAnalysis1.q`).
-        out: array
-            If *out* is supplied as a pre-allocated array of the correct
-            shape then it is filled instead of allocating a new one in
-            order to increase performance.
-
-        Returns
-        -------
-        contacts : integer
-           total number of contacts
-        fraction : float
-           Fraction of native contacts (Q) calculated from a contact matrix
-
-        Note
-        ----
-        This method is typically only used internally.
-        """
-        if out:
-            np.logical_and(q, self.mask, out)
-        else:
-            out = np.logical_and(q, self.mask)
-        contacts = out.sum()
-        return contacts, float(contacts) / self.mask.sum()
-
-    def plot(self, filename=None, **kwargs):
-        """Plot q(t).
-
-        Parameters
-        ----------
-        filename : str
-            If `filename` is supplied then the figure is also written to file (the
-            suffix determines the file type, e.g. pdf, png, eps, ...). All other
-            keyword arguments are passed on to `pylab.plot`.
-        **kwargs
-            Arbitrary keyword arguments for the plotting function
-        """
-        if not self.timeseries :
-            raise ValueError("No timeseries data; do 'Contacts.run()' first.")
-        x, y, _ = zip(*self.timeseries)
-
-        import matplotlib.pyplot as plt
-        kwargs.setdefault('color', 'black')
-        kwargs.setdefault('linewidth', 2)
-
-        fig = plt.figure()
-        ax = fig.add_subplot(111)
-        ax.plot(x, y, **kwargs)
-        ax.set_xlabel(r"frame number $t$")
-        ax.set_ylabel(r"contacts $q_1$")
-
-        if filename:
-            fig.savefig(filename)
-        else:
-            fig.show()
-
-    def plot_qavg(self, filename=None, **kwargs):
-        """Plot `Contacts.qavg`, the matrix of average contacts.
-
-        Parameters
-        ----------
-        filename : str
-            If `filename` is supplied then the figure is also written to file (the
-            suffix determines the file type, e.g. pdf, png, eps, ...). All other
-            keyword arguments are passed on to `pylab.imshow`.
-        **kwargs
-            Arbitrary keyword arguments for the plotting function
-        """
-        if not self.contact_matrix :
-            raise ValueError("No timeseries data; do 'Contacts.run()' first.")
-        # collapse on the time-axis
-        data = np.array(self.contact_matrix)
-        data = data.mean(axis=0)
-
-        import matplotlib.pyplot as plt
-        import matplotlib.cm as cm
-
-        kwargs['origin'] = 'lower'
-        kwargs.setdefault('aspect', 'equal')
-        kwargs.setdefault('interpolation', 'nearest')
-        kwargs.setdefault('vmin', 0)
-        kwargs.setdefault('vmax', 1)
-        kwargs.setdefault('cmap', cm.hot)
-
-        fig = plt.figure()
-        ax = fig.add_subplot(111)
-        cax = ax.imshow(data, **kwargs)
-
-        cbar = fig.colorbar(cax)
-
-        if filename:
-            fig.savefig(filename)
-        else:
-            fig.show()

--- a/testsuite/MDAnalysisTests/analysis/test_contacts.py
+++ b/testsuite/MDAnalysisTests/analysis/test_contacts.py
@@ -2,8 +2,8 @@
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 fileencoding=utf-8
 #
 # MDAnalysis --- http://www.MDAnalysis.org
-# Copyright (c) 2006-2015 Naveen Michaud-Agrawal, Elizabeth J. Denning, Oliver Beckstein
-# and contributors (see AUTHORS for the full list)
+# Copyright (c) 2006-2015 Naveen Michaud-Agrawal, Elizabeth J. Denning, Oliver
+# Beckstein and contributors (see AUTHORS for the full list)
 #
 # Released under the GNU Public Licence, v2 or any higher version
 #
@@ -15,186 +15,323 @@
 #
 from __future__ import print_function
 
-import MDAnalysis
-import MDAnalysis.analysis.contacts
+import MDAnalysis as mda
+from MDAnalysis.analysis import contacts
 from MDAnalysis.analysis.distances import distance_array
-from MDAnalysis import SelectionError
 
-from numpy.testing import (TestCase, dec,
-                           assert_almost_equal, assert_raises, assert_equal)
+from numpy.testing import (dec, assert_almost_equal, assert_equal, raises,
+                           assert_array_equal, assert_array_almost_equal)
 import numpy as np
-import nose
-from nose.plugins.attrib import attr
 
-import os
 import tempdir
 
-from MDAnalysisTests.datafiles import (
-    PSF, 
-    DCD, 
-    contacts_villin_folded, 
-    contacts_villin_unfolded,
-    contacts_file,
-)
-
-from MDAnalysisTests import executable_not_found, parser_not_found
+from MDAnalysisTests.datafiles import (PSF,
+                                       DCD,
+                                       contacts_villin_folded,
+                                       contacts_villin_unfolded,
+                                       contacts_file, )
+from MDAnalysisTests import parser_not_found
 
 
+def test_soft_cut_q():
+    # just check some of the extremal points
+    assert_equal(contacts.soft_cut_q([0], [0]), .5)
+    assert_almost_equal(contacts.soft_cut_q([100], [0]), 0)
+    assert_almost_equal(contacts.soft_cut_q([-100], [0]), 1)
 
-def best_hummer_q(ref, u, selA, selB, radius=4.5, beta=5.0, lambda_constant=1.8):
+
+def test_soft_cut_q_folded():
+    u = mda.Universe(contacts_villin_folded)
+
+    contacts_data = np.genfromtxt(contacts_file)
+    # indices have been stored 1 indexed
+    indices = contacts_data[:, :2].astype(int) - 1
+
+    r = np.linalg.norm(u.atoms.positions[indices[:, 0]] -
+                       u.atoms.positions[indices[:, 1]], axis=1)
+    r0 = contacts_data[:, 2]
+
+    beta = 5.0
+    lambda_constant = 1.8
+    Q = 1 / (1 + np.exp(beta * (r - lambda_constant * r0)))
+
+    assert_almost_equal(Q.mean(), 1.0, decimal=3)
+
+
+def test_soft_cut_q_unfolded():
+    u = mda.Universe(contacts_villin_unfolded)
+
+    contacts_data = np.genfromtxt(contacts_file)
+    # indices have been stored 1 indexed
+    indices = contacts_data[:, :2].astype(int) - 1
+
+    r = np.linalg.norm(u.atoms.positions[indices[:, 0]] -
+                       u.atoms.positions[indices[:, 1]], axis=1)
+    r0 = contacts_data[:, 2]
+
+    beta = 5.0
+    lambda_constant = 1.8
+    Q = 1 / (1 + np.exp(beta * (r - lambda_constant * r0)))
+
+    assert_almost_equal(Q.mean(), 0.0, decimal=1)
+
+
+def test_hard_cut_q():
+    # just check some extremal points
+    assert_equal(contacts.hard_cut_q([1], 2), 1)
+    assert_equal(contacts.hard_cut_q([2], 1), 0)
+    assert_equal(contacts.hard_cut_q([2, 0.5], 1), 0.5)
+    assert_equal(contacts.hard_cut_q([2, 3], [3, 4]), 1)
+    assert_equal(contacts.hard_cut_q([4, 5], [3, 4]), 0)
+
+
+def test_radius_cut_q():
+    # check some extremal points
+    assert_equal(contacts.radius_cut_q([1], None, 2), 1)
+    assert_equal(contacts.radius_cut_q([2], None, 1), 0)
+    assert_equal(contacts.radius_cut_q([2, 0.5], None, 1), 0.5)
+
+
+def test_contact_matrix():
+    d = np.arange(5)
+    radius = np.ones(5) * 2.5
+
+    out = contacts.contact_matrix(d, radius)
+    assert_array_equal(out, [True, True, True, False, False])
+
+    # check in-place update
+    out = np.empty(out.shape)
+    contacts.contact_matrix(d, radius, out=out)
+    assert_array_equal(out, [True, True, True, False, False])
+
+
+def test_new_selection():
+    u = mda.Universe(PSF, DCD)
+    selections = ('all', )
+    sel = contacts._new_selections(u, selections, -1)[0]
+    u.trajectory[-1]
+    assert_array_equal(sel.positions, u.atoms.positions)
+
+
+def soft_cut(ref, u, selA, selB, radius=4.5, beta=5.0, lambda_constant=1.8):
     """
         Reference implementation for testing
-    """    
+    """
     # reference groups A and B from selection strings
     refA, refB = ref.select_atoms(selA), ref.select_atoms(selB)
 
     # 2D float array, reference distances (r0)
     dref = distance_array(refA.positions, refB.positions)
 
-    # 2D bool array, select reference distances that are less than the cutoff radius
+    # 2D bool array, select reference distances that are less than the cutoff
+    # radius
     mask = dref < radius
-    #print("ref has {:d} contacts within {:.2f}".format(mask.sum(), radius))
 
     # group A and B in a trajectory
     grA, grB = u.select_atoms(selA), u.select_atoms(selB)
     results = []
 
-
     for ts in u.trajectory:
         d = distance_array(grA.positions, grB.positions)
         r, r0 = d[mask], dref[mask]
-        x = 1/(1 + np.exp(beta*(r - lambda_constant * r0)))
+        x = 1 / (1 + np.exp(beta * (r - lambda_constant * r0)))
 
         # average/normalize and append to results
-        results.append(( ts.time, x.sum()/mask.sum() ))
+        results.append((ts.time, x.sum() / mask.sum()))
 
-    #results = pd.DataFrame(results, columns=["Time (ps)", "Q"])
-    return results
+    return np.asarray(results)
 
-class TestContactAnalysis1(TestCase):
-    @dec.skipif(parser_not_found('DCD'),
-                'DCD parser not available. Are you using python 3?')
-    def setUp(self):
-        self.universe = MDAnalysis.Universe(PSF, DCD)
+
+class TestContacts():
+    @dec.skipif(
+        parser_not_found('DCD'),
+        'DCD parser not available. Are you using python 3?')
+    def __init__(self):
+        self.universe = mda.Universe(PSF, DCD)
         self.trajectory = self.universe.trajectory
 
-        self.folded = MDAnalysis.Universe(contacts_villin_folded)
-        self.unfolded = MDAnalysis.Universe(contacts_villin_unfolded)
+        self.sel_basic = "(resname ARG LYS) and (name NH* NZ)"
+        self.sel_acidic = "(resname ASP GLU) and (name OE* OD*)"
 
     def tearDown(self):
-        del self.universe, self.trajectory
-        del self.folded, self.unfolded  
+        # reset trajectory
+        self.universe.trajectory[0]
 
-    def _run_ContactAnalysis1(self, **runkwargs):
-        sel_basic = "(resname ARG or resname LYS) and (name NH* or name NZ)"
-        sel_acidic = "(resname ASP or resname GLU) and (name OE* or name OD*)"
-        acidic = self.universe.select_atoms(sel_acidic)
-        basic = self.universe.select_atoms(sel_basic)
-        outfile = 'qsalt.dat'
-        CA1 = MDAnalysis.analysis.contacts.Contacts(
+    def _run_Contacts(self, **kwargs):
+        acidic = self.universe.select_atoms(self.sel_acidic)
+        basic = self.universe.select_atoms(self.sel_basic)
+        Contacts = contacts.Contacts(
             self.universe,
-            selection=(sel_acidic, sel_basic), refgroup=(acidic, basic),
-            radius=6.0, outfile=outfile, **runkwargs)
-        kwargs = runkwargs.copy()
-        kwargs['force'] = True
-        CA1.run(**kwargs)
-        return CA1
+            selection=(self.sel_acidic, self.sel_basic),
+            refgroup=(acidic, basic),
+            radius=6.0,
+            **kwargs)
+        Contacts.run()
+        return Contacts
 
     def test_startframe(self):
-        """test_startframe: TestContactAnalysis1: start frame set to 0 (resolution of Issue #624)"""
-        with tempdir.in_tempdir():
-            CA1 = self._run_ContactAnalysis1()
-            self.assertEqual(len(CA1.timeseries), self.universe.trajectory.n_frames)
+        """test_startframe: TestContactAnalysis1: start frame set to 0 (resolution of
+        Issue #624)
+
+        """
+        CA1 = self._run_Contacts()
+        assert_equal(len(CA1.timeseries), self.universe.trajectory.n_frames)
 
     def test_end_zero(self):
         """test_end_zero: TestContactAnalysis1: stop frame 0 is not ignored"""
-        with tempdir.in_tempdir():
-            CA1 = self._run_ContactAnalysis1(stop=0)
-            self.assertEqual(len(CA1.timeseries), 0)
+        CA1 = self._run_Contacts(stop=0)
+        assert_equal(len(CA1.timeseries), 0)
 
     def test_slicing(self):
         start, stop, step = 10, 30, 5
-        with tempdir.in_tempdir():
-            CA1 = self._run_ContactAnalysis1(start=start, stop=stop, step=step)
-            frames = np.arange(self.universe.trajectory.n_frames)[start:stop:step]
-            self.assertEqual(len(CA1.timeseries), len(frames))
-
-
-    def test_math_folded(self):
-
-        u = self.folded
-
-        # read the text files
-        data = [l.split() for l in open(contacts_file).readlines()]
-        # convert to 0-based indexing
-        data = [ (int(i)-1, int(j)-1, float(d))  for i, j, d in data]
-        # get r and r0
-        data = [ (np.linalg.norm(u.atoms[i].pos - u.atoms[j].pos), d)  for i, j, d in data]
-        data = np.array(data)
-
-        r = data[:,0]
-        r0 = data[:,1]
-
-        beta = 5.0
-        lambda_constant = 1.8
-
-        Q = 1/(1 + np.exp(beta*(r - lambda_constant * r0)))
-
-        assert_almost_equal(Q.mean(),  1.0, decimal=3)
-
-    def test_math_unfolded(self):
-
-        u = self.unfolded
-
-        # read the text files
-        data = [l.split() for l in open(contacts_file).readlines()]
-        # convert to 0-based indexing
-        data = [ (int(i)-1, int(j)-1, float(d))  for i, j, d in data]
-        # get r and r0
-        data = [ (np.linalg.norm(u.atoms[i].pos - u.atoms[j].pos), d)  for i, j, d in data]
-        data = np.array(data)
-
-        r = data[:,0]
-        r0 = data[:,1]
-
-        beta = 5.0
-        lambda_constant = 1.8
-
-        Q = 1/(1 + np.exp(beta*(r - lambda_constant * r0)))
-
-        assert_almost_equal(Q.mean(),  0.0, decimal=1)
+        CA1 = self._run_Contacts(start=start, stop=stop, step=step)
+        frames = np.arange(self.universe.trajectory.n_frames)[start:stop:step]
+        assert_equal(len(CA1.timeseries), len(frames))
 
     @staticmethod
     def test_villin_folded():
-
         # one folded, one unfolded
-        f = MDAnalysis.Universe(contacts_villin_folded)
-        u = MDAnalysis.Universe(contacts_villin_unfolded)
+        f = mda.Universe(contacts_villin_folded)
+        u = mda.Universe(contacts_villin_unfolded)
         sel = "protein and not name H*"
 
         grF = f.select_atoms(sel)
-        grU = u.select_atoms(sel)
 
-        q = MDAnalysis.analysis.contacts.Contacts(u, selection=(sel, sel), refgroup=(grF, grF), method="best-hummer")
+        q = contacts.Contacts(u,
+                              selection=(sel, sel),
+                              refgroup=(grF, grF),
+                              method="soft_cut")
         q.run()
-        
-        results = zip(*best_hummer_q(f, u, sel, sel))[1]
 
-        assert_almost_equal(zip(*q.timeseries)[1], results)
+        results = soft_cut(f, u, sel, sel)
+        assert_almost_equal(q.timeseries[:, 1], results[:, 1])
 
     @staticmethod
     def test_villin_unfolded():
 
         # both folded
-        f = MDAnalysis.Universe(contacts_villin_folded)
-        u = MDAnalysis.Universe(contacts_villin_folded)
+        f = mda.Universe(contacts_villin_folded)
+        u = mda.Universe(contacts_villin_folded)
         sel = "protein and not name H*"
 
         grF = f.select_atoms(sel)
-        grU = u.select_atoms(sel)
 
-        q = MDAnalysis.analysis.contacts.Contacts(u, selection=(sel, sel), refgroup=(grF, grF), method="best-hummer")
+        q = contacts.Contacts(u,
+                              selection=(sel, sel),
+                              refgroup=(grF, grF),
+                              method="soft_cut")
         q.run()
-        
-        results = zip(*best_hummer_q(f, u, sel, sel)) [1]
-        assert_almost_equal(zip(*q.timeseries)[1], results)        
+
+        results = soft_cut(f, u, sel, sel)
+        assert_almost_equal(q.timeseries[:, 1], results[:, 1])
+
+    def test_hard_cut_method(self):
+        ca = self._run_Contacts()
+        expected = [1., 0.58252427, 0.52427184, 0.55339806, 0.54368932,
+                    0.54368932, 0.51456311, 0.46601942, 0.48543689, 0.52427184,
+                    0.46601942, 0.58252427, 0.51456311, 0.48543689, 0.48543689,
+                    0.48543689, 0.46601942, 0.51456311, 0.49514563, 0.49514563,
+                    0.45631068, 0.47572816, 0.49514563, 0.50485437, 0.53398058,
+                    0.50485437, 0.51456311, 0.51456311, 0.49514563, 0.49514563,
+                    0.54368932, 0.50485437, 0.48543689, 0.55339806, 0.45631068,
+                    0.46601942, 0.53398058, 0.53398058, 0.46601942, 0.52427184,
+                    0.45631068, 0.46601942, 0.47572816, 0.46601942, 0.45631068,
+                    0.47572816, 0.45631068, 0.48543689, 0.4368932, 0.4368932,
+                    0.45631068, 0.50485437, 0.41747573, 0.4368932, 0.51456311,
+                    0.47572816, 0.46601942, 0.46601942, 0.47572816, 0.47572816,
+                    0.46601942, 0.45631068, 0.44660194, 0.47572816, 0.48543689,
+                    0.47572816, 0.42718447, 0.40776699, 0.37864078, 0.42718447,
+                    0.45631068, 0.4368932, 0.4368932, 0.45631068, 0.4368932,
+                    0.46601942, 0.45631068, 0.48543689, 0.44660194, 0.44660194,
+                    0.44660194, 0.42718447, 0.45631068, 0.44660194, 0.48543689,
+                    0.48543689, 0.44660194, 0.4368932, 0.40776699, 0.41747573,
+                    0.48543689, 0.45631068, 0.46601942, 0.47572816, 0.51456311,
+                    0.45631068, 0.37864078, 0.42718447]
+        assert_equal(len(ca.timeseries), len(expected))
+        assert_array_almost_equal(ca.timeseries[:, 1], expected)
+
+    @staticmethod
+    def _is_any_closer(r, r0, dist=2.5):
+        return np.any(r < dist)
+
+    def test_own_method(self):
+        ca = self._run_Contacts(method=self._is_any_closer)
+
+        bound_expected = [1., 1., 0., 1., 1., 0., 0., 1., 0., 1., 1., 0., 0.,
+                          1., 0., 0., 0., 0., 1., 1., 0., 0., 0., 1., 0., 1.,
+                          0., 1., 1., 0., 1., 1., 1., 0., 0., 0., 0., 1., 0.,
+                          0., 1., 0., 1., 1., 1., 0., 1., 0., 0., 1., 1., 1.,
+                          0., 1., 0., 1., 1., 0., 0., 0., 1., 1., 1., 0., 0.,
+                          1., 0., 1., 1., 1., 1., 1., 1., 0., 1., 1., 0., 1.,
+                          0., 0., 1., 1., 0., 0., 1., 1., 1., 0., 1., 0., 0.,
+                          1., 0., 1., 1., 1., 1., 1.]
+        assert_array_equal(ca.timeseries[:, 1], bound_expected)
+
+    @staticmethod
+    def _weird_own_method(r, r0):
+        return 'aaa'
+
+    @raises(ValueError)
+    def test_own_method_no_array_cast(self):
+        self._run_Contacts(method=self._weird_own_method, stop=2)
+
+    @raises(ValueError)
+    def test_non_callable_method(self):
+        self._run_Contacts(method=2, stop=2)
+
+    def test_save(self):
+        with tempdir.in_tempdir():
+            ca = self._run_Contacts()
+            ca.save('testfile.npy')
+            saved = np.genfromtxt('testfile.npy')
+            assert_array_almost_equal(ca.timeseries, saved)
+
+
+def test_q1q2():
+    u = mda.Universe(PSF, DCD)
+    q1q2 = contacts.q1q2(u, 'name CA', radius=8)
+    q1q2.run()
+
+    q1_expected = [1., 0.98092643, 0.97366031, 0.97275204, 0.97002725,
+                   0.97275204, 0.96276113, 0.96730245, 0.9582198, 0.96185286,
+                   0.95367847, 0.96276113, 0.9582198, 0.95186194, 0.95367847,
+                   0.95095368, 0.94187103, 0.95186194, 0.94277929, 0.94187103,
+                   0.9373297, 0.93642144, 0.93097184, 0.93914623, 0.93278837,
+                   0.93188011, 0.9373297, 0.93097184, 0.93188011, 0.92643052,
+                   0.92824705, 0.92915531, 0.92643052, 0.92461399, 0.92279746,
+                   0.92643052, 0.93278837, 0.93188011, 0.93369664, 0.9346049,
+                   0.9373297, 0.94096276, 0.9400545, 0.93642144, 0.9373297,
+                   0.9373297, 0.9400545, 0.93006358, 0.9400545, 0.93823797,
+                   0.93914623, 0.93278837, 0.93097184, 0.93097184, 0.92733878,
+                   0.92824705, 0.92279746, 0.92824705, 0.91825613, 0.92733878,
+                   0.92643052, 0.92733878, 0.93278837, 0.92733878, 0.92824705,
+                   0.93097184, 0.93278837, 0.93914623, 0.93097184, 0.9373297,
+                   0.92915531, 0.93188011, 0.93551317, 0.94096276, 0.93642144,
+                   0.93642144, 0.9346049, 0.93369664, 0.93369664, 0.93278837,
+                   0.93006358, 0.93278837, 0.93006358, 0.9346049, 0.92824705,
+                   0.93097184, 0.93006358, 0.93188011, 0.93278837, 0.93006358,
+                   0.92915531, 0.92824705, 0.92733878, 0.92643052, 0.93188011,
+                   0.93006358, 0.9346049, 0.93188011]
+    assert_array_almost_equal(q1q2.timeseries[:, 1], q1_expected)
+
+    q2_expected = [0.94649446, 0.94926199, 0.95295203, 0.95110701, 0.94833948,
+                   0.95479705, 0.94926199, 0.9501845, 0.94926199, 0.95387454,
+                   0.95202952, 0.95110701, 0.94649446, 0.94095941, 0.94649446,
+                   0.9400369, 0.94464945, 0.95202952, 0.94741697, 0.94649446,
+                   0.94188192, 0.94188192, 0.93911439, 0.94464945, 0.9400369,
+                   0.94095941, 0.94372694, 0.93726937, 0.93819188, 0.93357934,
+                   0.93726937, 0.93911439, 0.93911439, 0.93450185, 0.93357934,
+                   0.93265683, 0.93911439, 0.94372694, 0.93911439, 0.94649446,
+                   0.94833948, 0.95110701, 0.95110701, 0.95295203, 0.94926199,
+                   0.95110701, 0.94926199, 0.94741697, 0.95202952, 0.95202952,
+                   0.95202952, 0.94741697, 0.94741697, 0.94926199, 0.94280443,
+                   0.94741697, 0.94833948, 0.94833948, 0.9400369, 0.94649446,
+                   0.94741697, 0.94926199, 0.95295203, 0.94926199, 0.9501845,
+                   0.95664207, 0.95756458, 0.96309963, 0.95756458, 0.96217712,
+                   0.95756458, 0.96217712, 0.96586716, 0.96863469, 0.96494465,
+                   0.97232472, 0.97140221, 0.9695572, 0.97416974, 0.9695572,
+                   0.96217712, 0.96771218, 0.9704797, 0.96771218, 0.9695572,
+                   0.97140221, 0.97601476, 0.97693727, 0.98154982, 0.98431734,
+                   0.97601476, 0.9797048, 0.98154982, 0.98062731, 0.98431734,
+                   0.98616236, 0.9898524, 1.]
+    assert_array_almost_equal(q1q2.timeseries[:, 2], q2_expected)


### PR DESCRIPTION
This continues the work in #708.  I have stripped down `Contacts` to the absolute bare essential (besides `single_frame` everything is gone, renamed or moved to it's own function). I think this results in a cleaner implementation in the end and also one that is more flexible. I'm aware that I might have removed useful functionality but I'm happy to add that again if someone explains to me why they need it.

I've created a ipython notebook in the root-directory where I outlined the normal fraction of native contacts analysis and a new analysis for an easy binary decision algorithm if a protein is folded or two partners are bound. I plan to keep this notebook always at the top comment and remove it before I merge. I would like some help if this is all the usage that people want and what use cases are currently missing as example, or if they can't be done with the class right now)

The plots are now removed as well because I don't think the `plot_qavg` contained a lot of content (basically only a complicated way to visualize `np.mean(q)`). The timeseries plot is removed because with arbitrary functions allowed as methods it might now represent accurately the data that is plotted. 

Changes made in this Pull Request:
 -  removed all untested code from `Contacts`
 -  Contacts now accepts arbitrary functions as method kwarg
 -  old contact analysis classes are moved to be deprecated soon

PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - ~~[ ] Issue raised/referenced?~~
 - [x] deprecate old contact classes
 - ~~[ ] pbc keyword~~
