### PR TITLE
Dynamic author list works on python 3

### DIFF
--- a/package/setup.py
+++ b/package/setup.py
@@ -44,6 +44,7 @@ import os
 import sys
 import shutil
 import tempfile
+import warnings
 
 # Make sure I have the right Python version.
 if sys.version_info[:2] < (2, 7):
@@ -423,7 +424,10 @@ def dynamic_author_list():
 
 
 if __name__ == '__main__':
-    dynamic_author_list()
+    try:
+        dynamic_author_list()
+    except (OSError, IOError):
+        warnings.warn('Cannot write the list of authors.')
 
     with open("SUMMARY.txt") as summary:
         LONG_DESCRIPTION = summary.read()

--- a/package/setup.py
+++ b/package/setup.py
@@ -39,6 +39,7 @@ Google groups forbids any name that contains the string `anal'.)
 from __future__ import print_function
 from setuptools import setup, Extension, find_packages
 from distutils.ccompiler import new_compiler
+import codecs
 import os
 import sys
 import shutil
@@ -364,7 +365,7 @@ def dynamic_author_list():
     "Chronological list of authors" title.
     """
     authors = []
-    with open('AUTHORS') as infile:
+    with codecs.open('AUTHORS', encoding='utf-8') as infile:
         # An author is a bullet point under the title "Chronological list of
         # authors". We first want move the cursor down to the title of
         # interest.
@@ -389,7 +390,7 @@ def dynamic_author_list():
                 break
             elif line.strip()[:2] == '- ':
                 # This is a bullet point, so it should be an author name.
-                name = line.strip()[2:].strip().decode('utf-8')
+                name = line.strip()[2:].strip()
                 authors.append(name)
 
     # So far, the list of authors is sorted chronologically. We want it
@@ -403,7 +404,8 @@ def dynamic_author_list():
                + authors + ['Oliver Beckstein'])
 
     # Write the authors.py file.
-    with open('MDAnalysis/authors.py', 'w') as outfile:
+    out_path = 'MDAnalysis/authors.py'
+    with codecs.open(out_path, 'w', encoding='utf-8') as outfile:
         # Write the header
         header = '''\
 #-*- coding:utf-8 -*-
@@ -417,7 +419,7 @@ def dynamic_author_list():
         template = u'__authors__ = [\n{}\n]'
         author_string = u',\n'.join(u'    u"{}"'.format(name)
                                     for name in authors)
-        print(template.format(author_string).encode('utf-8'), file=outfile)
+        print(template.format(author_string), file=outfile)
 
 
 if __name__ == '__main__':

--- a/testsuite/setup.py
+++ b/testsuite/setup.py
@@ -42,6 +42,7 @@ import codecs
 import sys
 import os
 import glob
+import warnings
 
 
 def dynamic_author_list():
@@ -122,7 +123,10 @@ if sys.version_info[:2] < (2, 7):
 
 
 if __name__ == '__main__':
-    dynamic_author_list()
+    try:
+        dynamic_author_list()
+    except (OSError, IOError):
+        warnings.warn('Cannot write the list of authors.')
 
     RELEASE = "0.14.1-dev0"  # this must be in-sync with MDAnalysis
     LONG_DESCRIPTION = \

--- a/testsuite/setup.py
+++ b/testsuite/setup.py
@@ -38,6 +38,7 @@ Google groups forbids any name that contains the string `anal'.)
 from __future__ import print_function
 from setuptools import setup, Extension, find_packages
 
+import codecs
 import sys
 import os
 import glob
@@ -55,7 +56,7 @@ def dynamic_author_list():
     "Chronological list of authors" title.
     """
     authors = []
-    with open('AUTHORS') as infile:
+    with codecs.open('AUTHORS', encoding='utf-8') as infile:
         # An author is a bullet point under the title "Chronological list of
         # authors". We first want move the cursor down to the title of
         # interest.
@@ -80,7 +81,7 @@ def dynamic_author_list():
                 break
             elif line.strip()[:2] == '- ':
                 # This is a bullet point, so it should be an author name.
-                name = line.strip()[2:].strip().decode('utf-8')
+                name = line.strip()[2:].strip()
                 authors.append(name)
 
     # So far, the list of authors is sorted chronologically. We want it
@@ -94,7 +95,8 @@ def dynamic_author_list():
                + authors + ['Oliver Beckstein'])
 
     # Write the authors.py file.
-    with open('MDAnalysisTests/authors.py', 'w') as outfile:
+    out_path = 'MDAnalysisTests/authors.py'
+    with codecs.open(out_path, 'w', encoding='utf-8') as outfile:
         # Write the header
         header = '''\
 #-*- coding:utf-8 -*-
@@ -108,7 +110,7 @@ def dynamic_author_list():
         template = u'__authors__ = [\n{}\n]'
         author_string = u',\n'.join(u'    u"{}"'.format(name)
                                     for name in authors)
-        print(template.format(author_string).encode('utf-8'), file=outfile)
+        print(template.format(author_string), file=outfile)
 
 
 # Make sure I have the right Python version.


### PR DESCRIPTION
Fixes the issue reported by @orbeckst  in [a comment](https://github.com/MDAnalysis/mdanalysis/pull/787#issuecomment-199144565) bellow #787.

The dynamic author list introduced in #787 did not work on python 3
because of the way encoding was handled. This commit fixes the handling
of file encodings by using the codecs library.