### PR TITLE
Changed bare except in GROParser to try and fix coverage detection

### DIFF
--- a/package/MDAnalysis/topology/GROParser.py
+++ b/package/MDAnalysis/topology/GROParser.py
@@ -71,7 +71,7 @@ class GROParser(TopologyReader):
                     charge = guess_atom_charge(name)
                     # segid = "SYSTEM"
                     # ignore coords and velocities, they can be read by coordinates.GRO
-                except:
+                except (ValueError, IndexError):
                     raise IOError("Couldn't read the following line of the .gro file:\n"
                                   "{0}".format(line))
                 else:


### PR DESCRIPTION
The coverage fix made in Issue #783 isn't showing up [in coverage](https://coveralls.io/builds/5493830).  The tests seem to get picked up by nose, so I'm not sure why coverage doesn't then mark this as covered.  I've changed the bare except to see if this fixes it...