### PR TITLE
Activate coverage report for analyses

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,7 +3,6 @@ branch = True
 source = MDAnalysis
 omit =
     */migration/*
-    */analysis/*
     */visualization/*
     */MDAnalysis/tests/*
 


### PR DESCRIPTION
Fixes #804

Changes made in this Pull Request:
 - Coverage is reported for analysis modules

We should expect a large drop in test coverage. The coverall badge will not look as bright.

PR Checklist
------------
 - [ ] ~~Tests?~~
 - [ ] ~~Docs?~~
 - [ ] ~~CHANGELOG updated?~~
 - [x] Issue raised/referenced?

See issue #804.