### PR TITLE
A Universe now holds onto its initialization kwargs.

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,7 +13,8 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-??/??/16 jandom, abhinavgupta94, orbeckst, kain88-de, hainm, jdetle, jbarnoud
+??/??/16 jandom, abhinavgupta94, orbeckst, kain88-de, hainm, jdetle, jbarnoud,
+         dotsdl
 
   * 0.15.0
 
@@ -32,6 +33,7 @@ API Changes
 Enhancements
 
   * Add conda build scripts (Issue #608)
+  * Added read-only property giving Universe init kwargs (Issue #292)
 
 Fixes
   

--- a/package/MDAnalysis/core/AtomGroup.py
+++ b/package/MDAnalysis/core/AtomGroup.py
@@ -3966,6 +3966,10 @@ class Universe(object):
         from ..topology.base import TopologyReader
         from ..coordinates.base import ProtoReader
 
+        # hold on to copy of kwargs; used by external libraries that
+        # reinitialize universes
+        self._kwargs = copy.deepcopy(kwargs)
+
         # managed attribute holding Reader
         self._trajectory = None
 

--- a/package/MDAnalysis/core/AtomGroup.py
+++ b/package/MDAnalysis/core/AtomGroup.py
@@ -4267,6 +4267,13 @@ class Universe(object):
         return self
 
     @property
+    def kwargs(self):
+        """Keyword arguments used to initialize this universe (read-only).
+
+        """
+        return copy.deepcopy(self._kwargs)
+
+    @property
     @cached('fragments')
     def fragments(self):
         """Read only tuple of fragments in the Universe

--- a/testsuite/MDAnalysisTests/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/test_atomgroup.py
@@ -1725,7 +1725,7 @@ class TestUniverse(TestCase):
         assert_allclose(u.dimensions, box)
 
     @staticmethod
-    def test_universe_kwargs(self):
+    def test_universe_kwargs():
         u = MDAnalysis.Universe(PSF, PDB_small, fake_kwarg=True)
         assert_equal(len(u.atoms), 3341, "Loading universe failed somehow")
 

--- a/testsuite/MDAnalysisTests/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/test_atomgroup.py
@@ -2150,7 +2150,7 @@ class TestGuessBonds(TestCase):
         u = MDAnalysis.Universe(two_water_gro_nonames, guess_bonds=True,
                                 vdwradii=self.vdw)
         self._check_universe(u)
-        assert_(u.kwargs['guess_bounds'] is True)
+        assert_(u.kwargs['guess_bonds'] is True)
         assert_equal(self.vdw, u.kwargs['vdwradii'])
 
     def test_universe_guess_bonds_off(self):
@@ -2159,7 +2159,7 @@ class TestGuessBonds(TestCase):
         assert_equal(len(u.bonds), 0)
         assert_equal(len(u.angles), 0)
         assert_equal(len(u.dihedrals), 0)
-        assert_(u.kwargs['guess_bounds'] is False)
+        assert_(u.kwargs['guess_bonds'] is False)
 
     def _check_atomgroup(self, ag, u):
         """Verify that the AtomGroup made bonds correctly,

--- a/testsuite/MDAnalysisTests/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/test_atomgroup.py
@@ -1724,7 +1724,18 @@ class TestUniverse(TestCase):
         u.dimensions = np.array([10, 11, 12, 90, 90, 90])
         assert_allclose(u.dimensions, box)
 
+    def test_universe_kwargs(self):
+        u = MDAnalysis.Universe(PSF, PDB_small, fake_kwarg=True)
+        assert_equal(len(u.atoms), 3341, "Loading universe failed somehow")
 
+        assert_(u._kwargs['fake_kwarg'] is True)
+
+        # initialize new universe from pieces of existing one
+        u2 = MDAnalysis.Universe(u.filename, u.trajectory.filename, 
+                                 **u._kwargs)
+        
+        assert_(u2._kwargs['fake_kwarg'] is True)
+    
 class TestPBCFlag(TestCase):
     @dec.skipif(parser_not_found('TRZ'),
                 'TRZ parser not available. Are you using python 3?')
@@ -2121,11 +2132,13 @@ class TestGuessBonds(TestCase):
         assert_equal(len(u.atoms[3].bonds), 2)
         assert_equal(len(u.atoms[4].bonds), 1)
         assert_equal(len(u.atoms[5].bonds), 1)
+        assert_('guess_bonds' in u._kwargs)
 
     def test_universe_guess_bonds(self):
         """Test that making a Universe with guess_bonds works"""
         u = MDAnalysis.Universe(two_water_gro, guess_bonds=True)
         self._check_universe(u)
+        assert_(u._kwargs['guess_bounds'] is True)
 
     def test_universe_guess_bonds_no_vdwradii(self):
         """Make a Universe that has atoms with unknown vdwradii."""
@@ -2136,6 +2149,8 @@ class TestGuessBonds(TestCase):
         u = MDAnalysis.Universe(two_water_gro_nonames, guess_bonds=True,
                                 vdwradii=self.vdw)
         self._check_universe(u)
+        assert_(u._kwargs['guess_bounds'] is True)
+        assert_equal(self.vdw, u._kwargs['vdwradii'])
 
     def test_universe_guess_bonds_off(self):
         u = MDAnalysis.Universe(two_water_gro_nonames, guess_bonds=False)
@@ -2143,6 +2158,7 @@ class TestGuessBonds(TestCase):
         assert_equal(len(u.bonds), 0)
         assert_equal(len(u.angles), 0)
         assert_equal(len(u.dihedrals), 0)
+        assert_(u._kwargs['guess_bounds'] is False)
 
     def _check_atomgroup(self, ag, u):
         """Verify that the AtomGroup made bonds correctly,

--- a/testsuite/MDAnalysisTests/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/test_atomgroup.py
@@ -1735,6 +1735,7 @@ class TestUniverse(TestCase):
                                  **u._kwargs)
         
         assert_(u2._kwargs['fake_kwarg'] is True)
+        assert_equal(u._kwargs, u2._kwargs)
     
 class TestPBCFlag(TestCase):
     @dec.skipif(parser_not_found('TRZ'),

--- a/testsuite/MDAnalysisTests/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/test_atomgroup.py
@@ -1724,6 +1724,7 @@ class TestUniverse(TestCase):
         u.dimensions = np.array([10, 11, 12, 90, 90, 90])
         assert_allclose(u.dimensions, box)
 
+    @staticmethod
     def test_universe_kwargs(self):
         u = MDAnalysis.Universe(PSF, PDB_small, fake_kwarg=True)
         assert_equal(len(u.atoms), 3341, "Loading universe failed somehow")

--- a/testsuite/MDAnalysisTests/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/test_atomgroup.py
@@ -1728,14 +1728,14 @@ class TestUniverse(TestCase):
         u = MDAnalysis.Universe(PSF, PDB_small, fake_kwarg=True)
         assert_equal(len(u.atoms), 3341, "Loading universe failed somehow")
 
-        assert_(u._kwargs['fake_kwarg'] is True)
+        assert_(u.kwargs['fake_kwarg'] is True)
 
         # initialize new universe from pieces of existing one
         u2 = MDAnalysis.Universe(u.filename, u.trajectory.filename, 
-                                 **u._kwargs)
+                                 **u.kwargs)
         
-        assert_(u2._kwargs['fake_kwarg'] is True)
-        assert_equal(u._kwargs, u2._kwargs)
+        assert_(u2.kwargs['fake_kwarg'] is True)
+        assert_equal(u.kwargs, u2.kwargs)
     
 class TestPBCFlag(TestCase):
     @dec.skipif(parser_not_found('TRZ'),
@@ -2133,13 +2133,13 @@ class TestGuessBonds(TestCase):
         assert_equal(len(u.atoms[3].bonds), 2)
         assert_equal(len(u.atoms[4].bonds), 1)
         assert_equal(len(u.atoms[5].bonds), 1)
-        assert_('guess_bonds' in u._kwargs)
+        assert_('guess_bonds' in u.kwargs)
 
     def test_universe_guess_bonds(self):
         """Test that making a Universe with guess_bonds works"""
         u = MDAnalysis.Universe(two_water_gro, guess_bonds=True)
         self._check_universe(u)
-        assert_(u._kwargs['guess_bounds'] is True)
+        assert_(u.kwargs['guess_bonds'] is True)
 
     def test_universe_guess_bonds_no_vdwradii(self):
         """Make a Universe that has atoms with unknown vdwradii."""
@@ -2150,8 +2150,8 @@ class TestGuessBonds(TestCase):
         u = MDAnalysis.Universe(two_water_gro_nonames, guess_bonds=True,
                                 vdwradii=self.vdw)
         self._check_universe(u)
-        assert_(u._kwargs['guess_bounds'] is True)
-        assert_equal(self.vdw, u._kwargs['vdwradii'])
+        assert_(u.kwargs['guess_bounds'] is True)
+        assert_equal(self.vdw, u.kwargs['vdwradii'])
 
     def test_universe_guess_bonds_off(self):
         u = MDAnalysis.Universe(two_water_gro_nonames, guess_bonds=False)
@@ -2159,7 +2159,7 @@ class TestGuessBonds(TestCase):
         assert_equal(len(u.bonds), 0)
         assert_equal(len(u.angles), 0)
         assert_equal(len(u.dihedrals), 0)
-        assert_(u._kwargs['guess_bounds'] is False)
+        assert_(u.kwargs['guess_bounds'] is False)
 
     def _check_atomgroup(self, ag, u):
         """Verify that the AtomGroup made bonds correctly,


### PR DESCRIPTION
Fixes #292

Changes made in this Pull Request:
 - Universe holds onto a copy of its given keyword arguments on init.

PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?

This is useful for external libraries, such as MDSynthesis
(https://github.com/datreant/MDSynthesis), to re-initialize a Universe
from its arguments.