### PR TITLE
WIP: TopologyAttr registration; prototype Topology json serialization

### DIFF
--- a/package/MDAnalysis/core/__init__.py
+++ b/package/MDAnalysis/core/__init__.py
@@ -86,6 +86,8 @@ import six
 
 __all__ = ['AtomGroup', 'Selection', 'Timeseries']
 
+# Registry of TopologyAttrs
+_TOPOLOGYATTRS = {}
 
 # set up flags for core routines (more convoluted than strictly necessary but should
 # be clean to add more flags if needed)

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -7,6 +7,7 @@ import functools
 import itertools
 
 from ..lib import mdamath
+from ..lib import util
 from . import selection
 from . import flags
 from . import levels
@@ -1049,6 +1050,100 @@ class AtomGroup(object):
             raise ValueError(
                 "improper only makes sense for a group with exactly 4 atoms")
         return topologyobjects.ImproperDihedral(self._ix, self.universe)
+
+# TODO: possibly refactor; copied directly from old AG
+    @property
+    def ts(self):
+        """Returns a Timestep that contains only the group's coordinates.
+
+        Returns
+        -------
+        A :class:`~MDAnalysis.coordinates.base.Timestep` instance,
+        which can be passed to a trajectory writer.
+
+        If the returned timestep is modified the modifications
+        will not be reflected in the base timestep. Likewise,
+        when the underlying timestep changes (either by loading a
+        new frame or by setting new positions by hand) the returned
+        timestep will not reflect those changes.
+
+        """
+        return self.universe.trajectory.ts.copy_slice(self.indices)
+
+# TODO: refactor; copied directly from old AG
+    def write(self, filename=None, format="PDB",
+              filenamefmt="%(trjname)s_%(frame)d", **kwargs):
+        """Write AtomGroup to a file.
+
+        AtomGroup.write(filename[,format])
+
+        :Keywords:
+          *filename*
+               ``None``: create TRJNAME_FRAME.FORMAT from filenamefmt [``None``]
+          *format*
+                PDB, CRD, GRO, VMD (tcl), PyMol (pml), Gromacs (ndx) CHARMM (str)
+                Jmol (spt); case-insensitive and can also be supplied as the
+                filename extension [PDB]
+          *filenamefmt*
+                format string for default filename; use substitution tokens
+                'trjname' and 'frame' ["%(trjname)s_%(frame)d"]
+          *bonds*
+                how to handle bond information, especially relevant for PDBs;
+                default is ``"conect"``.
+
+                * ``"conect"``: write only the CONECT records defined in the original
+                  file
+
+                * ``"all"``: write out all bonds, both the original defined and those
+                  guessed by MDAnalysis
+
+                * ``None``: do not write out bonds
+
+        .. versionchanged:: 0.9.0
+           Merged with write_selection.  This method can now write both
+           selections out.
+        """
+        import MDAnalysis.coordinates
+        import MDAnalysis.selections
+
+        # check that AtomGroup actually has any atoms (Issue #434)
+        if len(self.atoms) == 0:
+            raise IndexError("Cannot write an AtomGroup with 0 atoms")
+
+        trj = self.universe.trajectory  # unified trajectory API
+        frame = trj.ts.frame
+
+        if trj.n_frames == 1: kwargs.setdefault("multiframe", False)
+
+        if filename is None:
+            trjname, ext = os.path.splitext(os.path.basename(trj.filename))
+            filename = filenamefmt % vars()
+        filename = util.filename(filename, ext=format.lower(), keep=True)
+
+        # From the following blocks, one must pass.
+        # Both can't pass as the extensions don't overlap.
+        try:
+            writer = MDAnalysis.coordinates.writer(filename, **kwargs)
+        except TypeError:
+            # might be selections format
+            coords = False
+        else:
+            coords = True
+
+        try:
+            SelectionWriter = MDAnalysis.selections.get_writer(filename, format)
+        except (TypeError, NotImplementedError):
+            selection = False
+        else:
+            writer = SelectionWriter(filename, **kwargs)
+            selection = True
+
+        if not (coords or selection):
+            raise ValueError("No writer found for format: {0}".format(filename))
+        else:
+            writer.write(self.atoms)
+            if coords:  # only these writers have a close method
+                writer.close()
 
 
 class ResidueGroup(object):

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -134,6 +134,9 @@ class Universe(object):
         if isinstance(args[0], Topology):
             self._topology = args[0]
             self.filename = None
+
+            if len(coordinatefile) == 0:
+                coordinatefile = None
         else:
             self.filename = args[0]
             topology_format = kwargs.pop('topology_format', None)
@@ -154,8 +157,8 @@ class Universe(object):
                     # or if file is known as a topology & coordinate file, use that
                     if fmt is None:
                         fmt = util.guess_format(self.filename)
-                    if (fmt in MDAnalysis.coordinates._trajectory_readers
-                        and fmt in MDAnalysis.topology._topology_parsers):
+                    if (fmt in MDAnalysis.coordinates._READERS
+                        and fmt in MDAnalysis.topology._PARSERS):
                         coordinatefile = self.filename
                 if len(coordinatefile) == 0:
                     coordinatefile = None


### PR DESCRIPTION
We now register TopologyAttrs using the same metaclassing mechanism as
used for Parsers, Readers, and Writers. This is necessary in order to
deserialize Topology objects that have been serialized to JSON.

An existing Topology can now be serialized to JSON with:

``` python

top.to_json('topology.json')

```

and a Topology can be generated from its JSON form with:

``` python

top = Topology.from_json('topology.json')

```

Individual TopologyAttrs must define how to serialize themselves and
to deserialize their data to make an instance of themselves for this to
work.

Addresses #643.
