### PR TITLE
Added zero-based indices for donors and acceptors in HBond Analysis.

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -49,6 +49,8 @@ Fixes
    (Issue #755)
 
 Changes
+  
+  * Added zero_based indices for HBondsAnalysis. (Issue #807) 
   * Generalized contact analysis class `Contacts` added. (Issue #702)
   * Removed Bio.PDBParser and sloppy structure builder and all of
     MDAnalysis.coordinates.pdb (Issue #777)

--- a/package/MDAnalysis/analysis/hbonds/hbond_analysis.py
+++ b/package/MDAnalysis/analysis/hbonds/hbond_analysis.py
@@ -215,9 +215,8 @@ All protein-water hydrogen bonds can be analysed with ::
 
   import MDAnalysis
   import MDAnalysis.analysis.hbonds
-  from MDAnalysisTests.datafiles import PSF, DCD
 
-  u = MDAnalysis.Universe(PSF, DCD)
+  u = MDAnalysis.Universe('topology', 'trajectory')
   h = MDAnalysis.analysis.hbonds.HydrogenBondAnalysis(u, 'protein', distance=3.0, angle=120.0)
   h.run()
 
@@ -232,6 +231,11 @@ for the format and further options.
    *larger* group, e.g. the water when looking at water-protein
    H-bonds or the whole protein when looking at ligand-protein
    interactions.
+
+.. Note::
+
+   The topology supplied and the trajectory must reflect the same total number
+   of atoms.
 
 .. TODO: how to analyse the ouput and notes on selection updating
 

--- a/package/MDAnalysis/analysis/hbonds/hbond_analysis.py
+++ b/package/MDAnalysis/analysis/hbonds/hbond_analysis.py
@@ -213,10 +213,12 @@ Example
 
 All protein-water hydrogen bonds can be analysed with ::
 
+  import MDAnalysis
   import MDAnalysis.analysis.hbonds
+  from MDAnalysisTests.datafiles import PSF, DCD
 
-  u = MDAnalysis.Universe(PSF, PDB)
-  h = MDAnalysis.analysis.hbonds.HydrogenBondAnalysis(u, 'protein', 'resname TIP3', distance=3.0, angle=120.0)
+  u = MDAnalysis.Universe(PSF, DCD)
+  h = MDAnalysis.analysis.hbonds.HydrogenBondAnalysis(u, 'protein', distance=3.0, angle=120.0)
   h.run()
 
 The results are stored as the attribute
@@ -255,10 +257,14 @@ Classes
         results = [
             [ # frame 1
                [ # hbond 1
-                  <donor index>, <acceptor index>, <donor string>, <acceptor string>, <distance>, <angle>
+                  <donor index (1-based)>, <acceptor index (1-based)>, <donor index (0-based)>,
+                  <acceptor index (0-based)>, <donor string>, <acceptor string>,
+                  <distance>, <angle>
                ],
                [ # hbond 2
-                  <donor index>, <acceptor index>, <donor string>, <acceptor string>, <distance>, <angle>
+                  <donor index (1-based)>, <acceptor index (1-based)>, <donor index (0-based)>,
+                  <acceptor index (0-based)>, <donor string>, <acceptor string>,
+                  <distance>, <angle>
                ],
                ....
             ],
@@ -267,7 +273,6 @@ Classes
             ],
             ...
         ]
-
       The time of each step is not stored with each hydrogen bond frame but in
       :attr:`~HydrogenBondAnalysis.timesteps`.
 
@@ -498,8 +503,7 @@ class HydrogenBondAnalysis(object):
             last trajectory frame for analysis, ``None`` is the last one [``None``]
           *step*
             read every *step* between *start* and *stop*, ``None`` selects 1.
-            Note that not all trajectory readers perform well with a step different
-            from 1 [``None``]
+            Note that not all trajectory reader from 1 [``None``]
           *verbose*
             If set to ``True`` enables per-frame debug logging. This is disabled
             by default because it generates a very large amount of output in

--- a/testsuite/MDAnalysisTests/analysis/test_hbonds.py
+++ b/testsuite/MDAnalysisTests/analysis/test_hbonds.py
@@ -26,7 +26,7 @@ import numpy as np
 import itertools
 import warnings
 
-from MDAnalysisTests.datafiles import PDB_helix
+from MDAnalysisTests.datafiles import PDB_helix, PSF, DCD
 
 
 class TestHydrogenBondAnalysis(TestCase):
@@ -58,6 +58,12 @@ class TestHydrogenBondAnalysis(TestCase):
         assert_equal(len(h.timeseries[0]),
                      self.values['num_bb_hbonds'], "wrong number of backbone hydrogen bonds")
         assert_equal(h.timesteps, [0.0])
+
+    def test_zero_vs_1based(self):
+        h = self._run()
+        if h.timeseries[0]:
+            assert_equal((int(h.timeseries[0][0][0])-int(h.timeseries[0][0][2])),1)
+            assert_equal((int(h.timeseries[0][0][1])-int(h.timeseries[0][0][3])),1)
 
     def test_generate_table(self):
         h = self._run()
@@ -191,6 +197,3 @@ class TestHydrogenBondAnalysisChecking(object):
                 yield run_HBA_dynamic_selections, s1, s2, s1type
         finally:
             self._tearDown() # manually tear down (because with yield cannot use TestCase)
-
-
-

--- a/testsuite/MDAnalysisTests/analysis/test_hbonds.py
+++ b/testsuite/MDAnalysisTests/analysis/test_hbonds.py
@@ -26,7 +26,7 @@ import numpy as np
 import itertools
 import warnings
 
-from MDAnalysisTests.datafiles import PDB_helix, PSF, DCD
+from MDAnalysisTests.datafiles import PDB_helix, GRO, XTC
 
 
 class TestHydrogenBondAnalysis(TestCase):
@@ -74,8 +74,12 @@ class TestHydrogenBondAnalysis(TestCase):
         assert_array_equal(h.table.donor_resid, self.values['donor_resid'])
         assert_array_equal(h.table.acceptor_resnm, self.values['acceptor_resnm'])
 
-    # TODO: Expand tests because the following ones are a bit superficial
-    #       because we should really run them on a trajectory
+    @staticmethod
+    def test_true_traj():
+        u = MDAnalysis.Universe(GRO, XTC)
+        h = MDAnalysis.analysis.hbonds.HydrogenBondAnalysis(u,'protein','resname ASP', distance=3.0, angle=120.0)
+        h.run()
+        assert_equal(len(h.timeseries), 10)
 
     def test_count_by_time(self):
         h = self._run()


### PR DESCRIPTION
Fixes #807, #838 

Changes made in this Pull Request:
 - Added references to 0-based indices in docs
 - Timeseries, counting by type, and timesteps by type now all have zero-based index
 - Added deprecation warning for 1-based indices upon calling HBondAnalysis
 - Recsql ids now also include zero-based indices even though they are redundant for uniqueness, figured that this would help when removing all references to 1-based indices later.
 - I went with a somewhat different name for 0-based indices than what was suggested in #807, just because it is shorter and I think it gets across the same thing. (donor_idx_zero instead of donor_atom_indices)

(Added versionchanged:: 0.15.0 4 times in different places saying essentially the same thing, I figured this was probably overkill but you could tell me where to delete extraneous stuff rather than where to add)


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
