### PR TITLE
Refactor align

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -21,7 +21,8 @@ Fixes
   * reading/writing lambda value in trr files (Issue #859)
 
 Changes
-  * Refactor of align to fit Bauhaus, wrapper added for alignment (Issue #845)
+  * Added new AlignTraj class for alignment that follows the new analysis API known
+    as Bauhaus style.
 
 Deprecations (Issue #599)
   * Use of rms_fit_trj deprecated in favor of AlignTraj class (Issue #845)

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,13 +13,18 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-??/??/16
+??/??/16 kain88-de,jdetle
 
-  * 0.15.1 kain88-de
+  * 0.15.1 
 
 Fixes
-
   * reading/writing lambda value in trr files (Issue #859)
+
+Changes
+  * Refactor of align to fit Bauhaus, wrapper added for alignment (Issue #845)
+
+Deprecations (Issue #599)
+  * Use of rms_fit_trj deprecated in favor of AlignTraj class (Issue #845)
 
 05/15/16 jandom, abhinavgupta94, orbeckst, kain88-de, hainm, jbarnoud,
          dotsdl, richardjgowers, BartBruininks, jdetle
@@ -62,7 +67,6 @@ Fixes
   * Fixed HistoryReader returning 1 based frame indices (Issue #851)
 
 Changes
-
   * Added zero_based indices for HBondsAnalysis. (Issue #807)
   * Generalized contact analysis class `Contacts` added. (Issue #702)
   * Removed Bio.PDBParser and sloppy structure builder and all of

--- a/package/MDAnalysis/analysis/align.py
+++ b/package/MDAnalysis/analysis/align.py
@@ -270,6 +270,7 @@ def _fit_to(mobile_coordinates, ref_coordinates, mobile_atoms,\
     weights : numpy array, optional
         Array to be used for weighted rmsd
 
+
     Returns
     -------
     mobile_atoms
@@ -283,7 +284,7 @@ def _fit_to(mobile_coordinates, ref_coordinates, mobile_atoms,\
     mobile_atoms.rotate(R)
     mobile_atoms.translate(ref_com)
 
-    return mobile_atoms, min_rmsd
+    return min_rmsd
 
 def alignto(mobile, reference, select="all", mass_weighted=False,
             subselection=None, tol_mass=0.1, strict=False):
@@ -416,7 +417,7 @@ def alignto(mobile, reference, select="all", mass_weighted=False,
             raise TypeError("subselection must be a selection string, a AtomGroup or Universe or None")
 
     #_fit_to DOES subtract center of mass, will provide proper min_rmsd
-    mobile_atoms, new_rmsd = _fit_to(mobile_coordinates,\
+    new_rmsd = _fit_to(mobile_coordinates,\
         ref_coordinates, mobile_atoms, mobile_com, ref_com, weights=weights)
     return old_rmsd, new_rmsd
 
@@ -524,11 +525,12 @@ class AlignTraj(AnalysisBase):
 
     def _single_frame(self):
         index = self._ts.frame
-
+        logger.info('mobile_atoms: {0}, ref atoms: {1}'.format(self.mobile_atoms.positions[0],\
+        self.ref_atoms.positions[0]))
         self.mobile_com = self.mobile_atoms.center_of_mass()
-        self.mobile.atoms, self.rmsd[index] = _fit_to(self.mobile_coordinates,\
-            self.ref_coordinates, self.mobile_atoms, self.mobile_com,\
-                self.ref_com, self.weights)
+
+        self.rmsd[index] = _fit_to(self.mobile_coordinates,self.ref_coordinates,\
+            self.mobile_atoms, self.mobile_com, self.ref_com, self.weights)
 
         self.writer.write(self.mobile.atoms)  # write whole input trajectory system
 

--- a/package/MDAnalysis/analysis/align.py
+++ b/package/MDAnalysis/analysis/align.py
@@ -255,7 +255,7 @@ def rotation_matrix(a, b, weights=None):
 
     return np.matrix(rot.reshape(3, 3)), rmsd
 
-def _fit_to(mobile_coordinates, ref_coordinates, mobile_atoms, ref_atoms,\
+def _fit_to(mobile_coordinates, ref_coordinates, mobile_atoms,\
     mobile_com, ref_com, weights=None):
     """Perform an rmsd-fitting to determine rotation matrix and align atoms
 
@@ -267,14 +267,12 @@ def _fit_to(mobile_coordinates, ref_coordinates, mobile_atoms, ref_atoms,\
         Coordinates of atoms to be fit against
     mobile_atoms : AtomGroup
         Atoms to be translated
-    ref_atoms : AtomGroup
-        Atoms to be fit against
     weights : numpy array, optional
         Array to be used for weighted rmsd
 
     Returns
     -------
-    atoms
+    mobile_atoms
         AtomGroup of translated and rotated atoms
     min_rmsd
         Minimum rmsd of coordinates
@@ -425,7 +423,7 @@ def alignto(mobile, reference, select="all", mass_weighted=False,
 
     #_fit_to DOES subtract center of mass, will provide proper min_rmsd
     mobile_atoms, new_rmsd = _fit_to(mobile_coordinates,\
-        ref_coordinates, mobile_atoms, ref_atoms, mobile_com, ref_com, weights)
+        ref_coordinates, mobile_atoms, mobile_com, ref_com, weights=weights)
 
     return old_rmsd, new_rmsd
 
@@ -541,8 +539,8 @@ class AlignTraj(AnalysisBase):
 
         self.mobile_com = self.mobile_atoms.center_of_mass()
         self.mobile.atoms, self.rmsd[index] = _fit_to(self.mobile_coordinates,\
-            self.ref_coordinates, self.mobile_atoms, self.ref_atoms,\
-            self.mobile_com, self.ref_com, self.weights)
+            self.ref_coordinates, self.mobile_atoms, self.mobile_com,\
+                self.ref_com, self.weights)
 
         self.writer.write(self.mobile.atoms)  # write whole input trajectory system
 

--- a/package/MDAnalysis/analysis/align.py
+++ b/package/MDAnalysis/analysis/align.py
@@ -268,8 +268,10 @@ def _fit_to(mobile_coordinates, ref_coordinates, mobile_atoms,\
         Coordinates of atoms to be fit against
     mobile_atoms : AtomGroup
         Atoms to be translated
-    ref_com:
-        Center of mass of reference atoms in current coordinates
+    mobile_com: ndarray
+        array of xyz coordinate of mobile center of mass
+    ref_com: ndarray
+        array of xyz coordinate of reference center of mass
     weights : numpy array, optional
         Array to be used for weighted rmsd
 
@@ -378,7 +380,7 @@ def alignto(mobile, reference, select="all", mass_weighted=False,
        the old behavior was the equivalent of *strict* = ``True``.
 
     .. versionchanged:: 0.15.1
-        Uses :func:`_fit_to` to get new minimum rmsd
+        Uses :func:`_fit_to` to get new minimum rmsd, new mobile atoms
     """
     if select in ('all', None):
         # keep the EXACT order in the input AtomGroups; select_atoms('all')
@@ -492,6 +494,7 @@ class AlignTraj(AnalysisBase):
         if filename is None:
             path, fn = os.path.split(frames.filename)
             filename = os.path.join(path, prefix + fn)
+            logger.info('none filename: {0}'.format(filename))
 
         if os.path.exists(filename) and not force:
             raise IOError('Filename already exists in path and force is not set to True')
@@ -528,11 +531,9 @@ class AlignTraj(AnalysisBase):
         self.mobile_atoms, self.rmsd[index] = _fit_to(self.mobile_coordinates,\
             self.ref_coordinates, self.mobile_atoms, self.mobile_com,\
             self.ref_com, self.weights)
-        logger.info('mobile_atoms.positions: {0}, rmsd:{1}'.format(\
-            self.mobile_atoms.positions[0], self.rmsd[index]))
          # write whole aligned input trajectory system
         self.writer.write(self.mobile_atoms)
-        
+
     def _conclude(self):
         self.writer.close()
         if self.quiet:

--- a/package/MDAnalysis/analysis/align.py
+++ b/package/MDAnalysis/analysis/align.py
@@ -30,7 +30,7 @@ cite these references when using this module.).
 Typically, one selects a group of atoms (such as the C-alphas),
 calculates the RMSD and transformation matrix, and applys the
 transformation to the current frame of a trajectory to obtain the
-rotated structure. The :func:`alignto` and :func:`rms_fit_trj`
+rotated structure. The :func:`alignto` and :class:`AlignTraj`
 functions can be used to do this for individual frames and
 trajectories respectively.
 
@@ -121,11 +121,12 @@ This will change *all* coordinates in *mobile* so that the protein
 C-alpha atoms are optimally superimposed (translation and rotation).
 
 To **fit a whole trajectory** to a reference structure with the
-:func:`rms_fit_trj` function::
+:class:`AlignTraj` class::
 
    >>> ref = Universe(PSF, PDB_small)   # reference structure 1AKE
    >>> trj = Universe(PSF, DCD)         # trajectory of change 1AKE->4AKE
-   >>> rms_fit_trj(trj, ref, filename='rmsfit.dcd')
+   >>> align =  AlignTraj(trj, ref, filename='rmsfit.dcd')
+   >>> align.run()
 
 It is also possible to align two arbitrary structures by providing a
 mapping between atoms based on a sequence alignment. This allows
@@ -133,10 +134,11 @@ fitting of structural homologs or wild type and mutant.
 
 If a alignment was provided as "sequences.aln" one would first produce
 the appropriate MDAnalysis selections with the :func:`fasta2select`
-function and then feed the resulting dictionary to :func:`rms_fit_trj`::
+function and then feed the resulting dictionary to :class:`AlignTraj`::
 
    >>> seldict = fasta2select('sequences.aln')
-   >>> rms_fit_trj(trj, ref, filename='rmsfit.dcd', select=seldict)
+   >>> align = AlignTraj(trj, ref, filename='rmsfit.dcd', select=seldict)
+   >>> align.run()
 
 (See the documentation of the functions for this advanced usage.)
 
@@ -145,7 +147,7 @@ Functions
 ---------
 
 .. autofunction:: alignto
-.. autofunction:: rms_fit_trj
+.. autoclass:: AlignTraj
 .. autofunction:: rotation_matrix
 
 .. versionchanged:: 0.10.0
@@ -153,13 +155,17 @@ Functions
    this module and is now exclusively accessible as
    :func:`~MDAnalysis.analysis.rms.rmsd`.
 
+.. versionchanged:: 0.15.1
+   Function :func:`~MDAnalysis.analysis.align.rms_fit_trj` deprecated
+   in favor of AlignTraj class.
+
 Helper functions
 ----------------
 
 The following functions are used by the other functions in this
 module. They are probably of more interest to developers than to
 normal users.
-
+.. autofunction:: _fit_to
 .. autofunction:: fasta2select
 .. autofunction:: get_matching_atoms
 
@@ -176,7 +182,7 @@ import MDAnalysis as mda
 import MDAnalysis.lib.qcprot as qcp
 from MDAnalysis.exceptions import SelectionError, SelectionWarning
 import MDAnalysis.analysis.rms as rms
-#remove after rms_fit_trj deprecation over
+# remove after rms_fit_trj deprecation over
 from MDAnalysis.lib.log import ProgressMeter
 
 from .base import AnalysisBase
@@ -233,8 +239,7 @@ def rotation_matrix(a, b, weights=None):
 
     See Also
     --------
-    :func:`rmsd` calculates the RMSD between *a* and *b*; for fitting a wholecan you also test that all warnings/exceptions are raised. The best thing is to make sure with coverage that the whole class is covered.
-
+    :func:`rmsd` calculates the RMSD between *a* and *b*; for fitting a whole
     trajectory it is more efficient to use :func:`rms_fit_trj`. A complete fit
     of two structures can be done with :func:`alignto`. """
 
@@ -243,11 +248,11 @@ def rotation_matrix(a, b, weights=None):
     N = b.shape[0]
 
     if weights is not None:
-        #qcp does NOT divide weights relative to the mean
+        # qcp does NOT divide weights relative to the mean
         weights = np.asarray(weights, dtype=np.float64) / np.mean(weights)
 
-
     rot = np.zeros(9, dtype=np.float64)
+
     # Need to transpose coordinates such that the coordinate array is
     # 3xN instead of Nx3. Also qcp requires that the dtype be float64
     # (I think we swapped the position of ref and traj in CalcRMSDRotationalMatrix
@@ -256,8 +261,9 @@ def rotation_matrix(a, b, weights=None):
     rmsd = qcp.CalcRMSDRotationalMatrix(a.T, b.T, N, rot, weights)
     return np.matrix(rot.reshape(3, 3)), rmsd
 
-def _fit_to(mobile_coordinates, ref_coordinates, mobile_atoms,\
-    mobile_com, ref_com, weights=None):
+
+def _fit_to(mobile_coordinates, ref_coordinates, mobile_atoms,
+            mobile_com, ref_com, weights=None):
     """Perform an rmsd-fitting to determine rotation matrix and align atoms
 
     Parameters
@@ -275,7 +281,6 @@ def _fit_to(mobile_coordinates, ref_coordinates, mobile_atoms,\
     weights : numpy array, optional
         Array to be used for weighted rmsd
 
-
     Returns
     -------
     mobile_atoms
@@ -283,7 +288,8 @@ def _fit_to(mobile_coordinates, ref_coordinates, mobile_atoms,\
     min_rmsd
         Minimum rmsd of coordinates
     """
-    R, min_rmsd = rotation_matrix(mobile_coordinates, ref_coordinates, weights=weights)
+    R, min_rmsd = rotation_matrix(mobile_coordinates, ref_coordinates,
+                                  weights=weights)
 
     mobile_atoms.translate(-mobile_com)
     mobile_atoms.rotate(R)
@@ -291,9 +297,11 @@ def _fit_to(mobile_coordinates, ref_coordinates, mobile_atoms,\
 
     return mobile_atoms, min_rmsd
 
+
 def alignto(mobile, reference, select="all", mass_weighted=False,
             subselection=None, tol_mass=0.1, strict=False):
-    """Spatially align *mobile* to *reference* by doing a RMSD fit on *select* atoms.
+    """Spatially align *mobile* to *reference* by doing a RMSD fit on
+        *select* atoms.
 
     The superposition is done in the following way:
 
@@ -317,35 +325,36 @@ def alignto(mobile, reference, select="all", mass_weighted=False,
     .. Warning:: The atom order for *mobile* and *reference* is *only*
        preserved when *select* is either "all" or ``None``. In any other case,
        a new selection will be made that will sort the resulting AtomGroup by
-       index and therefore destroy the correspondence between the two groups. **It
-       is safest not to mix ordered AtomGroups with selection strings.**
+       index and therefore destroy the correspondence between the two groups.
+       **It is safest not to mix ordered AtomGroups with selection strings.**
 
     Parameters
     ----------
       mobile : Universe or AtomGroup
-         structure to be aligned, a :class:`~MDAnalysis.core.AtomGroup.AtomGroup`
-         or a whole :class:`~MDAnalysis.core.AtomGroup.Universe`
+         structure to be aligned, a
+         :class:`~MDAnalysis.core.AtomGroup.AtomGroup` or a whole
+         :class:`~MDAnalysis.core.AtomGroup.Universe`
       reference : Universe or AtomGroup
          reference structure, a :class:`~MDAnalysis.core.AtomGroup.AtomGroup`
          or a whole :class:`~MDAnalysis.core.AtomGroup.Universe`
       select: string or dict, optional
          1. any valid selection string for
-            :meth:`~MDAnalysis.core.AtomGroup.AtomGroup.select_atoms` that produces identical
-            selections in *mobile* and *reference*; or
+            :meth:`~MDAnalysis.core.AtomGroup.AtomGroup.select_atoms` that
+            produces identical selections in *mobile* and *reference*; or
          2. dictionary ``{'mobile':sel1, 'reference':sel2}``.
             (the :func:`fasta2select` function returns such a
             dictionary based on a ClustalW_ or STAMP_ sequence alignment); or
          3.  tuple ``(sel1, sel2)``
 
-         When using 2. or 3. with *sel1* and *sel2* then these selections can also each be
-         a list of selection strings (to generate a AtomGroup with defined atom order as
-         described under :ref:`ordered-selections-label`).
+         When using 2. or 3. with *sel1* and *sel2* then these selections can
+         also each be a list of selection strings (to generate a AtomGroup with
+         defined atom order as described under :ref:`ordered-selections-label`).
       mass_weighted : boolean, optional
          ``True`` uses the masses :meth:`reference.masses` as weights for the
          RMSD fit.
       tol_mass: float, optional
          Reject match if the atomic masses for matched atoms differ by more than
-         *tol_mass* [0.1]
+         *tol_mass*, default [0.1]
       strict: boolean, optional
          ``True``
              Will raise :exc:`SelectionError` if a single atom does not
@@ -400,10 +409,12 @@ def alignto(mobile, reference, select="all", mass_weighted=False,
         ref_atoms = reference.select_atoms(*select['reference'])
 
     ref_atoms, mobile_atoms = get_matching_atoms(ref_atoms, mobile_atoms,
-                                                 tol_mass=tol_mass, strict=strict)
+                                                 tol_mass=tol_mass,
+                                                 strict=strict)
 
     if mass_weighted:
-        #division by the mean is done in rmsd, not done in qcp, but is done in _fit_to
+        # division by the mean is done in rmsd, not done in qcp, but is done in
+        # _fit_to
         weights = ref_atoms.masses
         ref_com = ref_atoms.center_of_mass()
         mobile_com = mobile_atoms.center_of_mass()
@@ -418,33 +429,40 @@ def alignto(mobile, reference, select="all", mass_weighted=False,
     old_rmsd = rms.rmsd(mobile_coordinates, ref_coordinates, weights)
 
     if subselection is None:
+        # mobile_atoms is Universe
         mobile_atoms = mobile.universe.atoms
-    elif type(subselection) is str:
+    elif isinstance(subselection, str):
+        # select mobile_atoms from string
         mobile_atoms = mobile.select_atoms(subselection)
     else:
         try:
+            # treat subselection as AtomGroup
             mobile_atoms = subselection.atoms
         except AttributeError:
-            raise TypeError("subselection must be a selection string, a AtomGroup or Universe or None")
+            raise TypeError("subselection must be a selection string, an"
+                            " AtomGroup or Universe or None")
 
-    #_fit_to DOES subtract center of mass, will provide proper min_rmsd
-    mobile_atoms, new_rmsd = _fit_to(mobile_coordinates,\
-        ref_coordinates, mobile_atoms, mobile_com, ref_com, weights=weights)
+    # _fit_to DOES subtract center of mass, will provide proper min_rmsd
+    mobile_atoms, new_rmsd = _fit_to(mobile_coordinates, ref_coordinates,
+                                     mobile_atoms, mobile_com, ref_com,
+                                     weights=weights)
     return old_rmsd, new_rmsd
 
 
 class AlignTraj(AnalysisBase):
-    """RMS-fit trajectory to a reference structure using a selection.
+    """rms_align trajectory to a reference structure using a selection.
 
-    Both reference *ref* and trajectory *traj* must be
+    Both reference *ref* and trajectory *mobile* must be
     :class:`MDAnalysis.Universe` instances. If they contain a
     trajectory then it is used. The output file format is determined
     by the file extension of *filename*. One can also use the same
     universe if one wants to fit to the current frame.
     """
-    def __init__(self, mobile, reference, select='all', filename=None, prefix='rmsfit_',
-                    mass_weighted=False, tol_mass=0.1, strict=False, force=True, quiet=False,
-                    start=None, stop=None, step = None, **kwargs):
+
+    def __init__(self, mobile, reference, select='all', filename=None,
+                 prefix='rmsfit_', mass_weighted=False, tol_mass=0.1,
+                 strict=False, force=True, quiet=False, start=None, stop=None,
+                 step=None, **kwargs):
         """Initialization
 
         Parameters
@@ -467,8 +485,8 @@ class AlignTraj(AnalysisBase):
         tol_mass : float, optional
             Tolerance given to `get_matching_atoms` to find appropriate atoms
         strict : boolean, optional
-            Force `get_matching_atoms` to fail if atoms can't be found using exact
-            methods
+            Force `get_matching_atoms` to fail if atoms can't be found using
+            exact methods
         force : boolean, optional
             Force overwrite of filename for rmsd-fitting
         quiet : boolean, optional
@@ -480,15 +498,20 @@ class AlignTraj(AnalysisBase):
         step : int, optional
             Step between frames to analyse, Default: 1
 
+        Notes
+        -----
+        If set to quiet, it is recommended to wrap the statement in a try ...
+        finally to guarantee restoring of the log level in the case of an
+        exception
+
         """
         self.quiet = quiet
         if self.quiet:
-            # should be part of a try ... finally to guarantee restoring the log level
             logging.disable(logging.WARN)
 
         self.mobile = mobile
         self.reference = reference
-        frames = self.mobile.trajectory
+        traj = self.mobile.trajectory
 
         select = rms.process_selection(select)
         self.ref_atoms = self.reference.select_atoms(*select['reference'])
@@ -498,17 +521,20 @@ class AlignTraj(AnalysisBase):
         kwargs.setdefault('remarks', 'RMS fitted trajectory to reference')
 
         if filename is None:
-            path, fn = os.path.split(frames.filename)
+            path, fn = os.path.split(traj.filename)
             filename = os.path.join(path, prefix + fn)
-            logger.info('none filename: {0}'.format(filename))
+            logger.info('filename of rms_align with no filename given'
+                        ': {0}'.format(filename))
 
         if os.path.exists(filename) and not force:
-            raise IOError('Filename already exists in path and force is not set to True')
+            raise IOError(
+                'Filename already exists in path and force is not set'
+                ' to True')
         self.filename = filename
 
         self.natoms = self.mobile_atoms.n_atoms
-        self.ref_atoms, self.mobile_atoms = get_matching_atoms(self.ref_atoms,
-                            self.mobile_atoms, tol_mass=tol_mass, strict=strict)
+        self.ref_atoms, self.mobile_atoms = get_matching_atoms(
+            self.ref_atoms, self.mobile_atoms, tol_mass=tol_mass, strict=strict)
 
         self.writer = mda.Writer(filename, self.natoms)
 
@@ -519,7 +545,7 @@ class AlignTraj(AnalysisBase):
             self.weights = None
 
         logger.info("RMS-fitting on {0:d} atoms.".format(len(self.ref_atoms)))
-        self._setup_frames(frames, start,stop,step)
+        self._setup_frames(traj, start, stop, step)
 
     def _prepare(self):
         # reference centre of mass system
@@ -530,15 +556,15 @@ class AlignTraj(AnalysisBase):
 
     def _single_frame(self):
         index = self._ts.frame
-
-        self.mobile_com = self.mobile_atoms.center_of_mass()
-        self.mobile_coordinates = self.mobile_atoms.positions.copy() - self.mobile_com
-
-        self.mobile_atoms, self.rmsd[index] = _fit_to(self.mobile_coordinates,\
-            self.ref_coordinates, self.mobile_atoms, self.mobile_com,\
-            self.ref_com, self.weights)
-         # write whole aligned input trajectory system
-        self.writer.write(self.mobile_atoms)
+        mobile_com = self.mobile_atoms.center_of_mass()
+        mobile_coordinates = self.mobile_atoms.positions - mobile_com
+        mobile_atoms, self.rmsd[index] = _fit_to(mobile_coordinates,
+                                                 self.ref_coordinates,
+                                                 self.mobile_atoms,
+                                                 mobile_com,
+                                                 self.ref_com, self.weights)
+        # write whole aligned input trajectory system
+        self.writer.write(mobile_atoms)
 
     def _conclude(self):
         self.writer.close()
@@ -546,12 +572,28 @@ class AlignTraj(AnalysisBase):
             logging.disable(logging.NOTSET)
 
     def save(self, rmsdfile):
+        # these are the values of the new rmsd between the aligned trajectory
+        # and reference structure
         np.savetxt(rmsdfile, self.rmsd)
         logger.info("Wrote RMSD timeseries  to file %r", rmsdfile)
 
-@deprecate(new_name="AlignTraj", message="This function will be removed in 0.17")
-def rms_fit_trj(traj, reference, select='all', filename=None, rmsdfile=None, prefix='rmsfit_',
-                mass_weighted=False, tol_mass=0.1, strict=False, force=True, quiet=False, **kwargs):
+
+@deprecate(
+    new_name="AlignTraj",
+    message="This function will be removed in 0.17")
+def rms_fit_trj(
+        traj,
+        reference,
+        select='all',
+        filename=None,
+        rmsdfile=None,
+        prefix='rmsfit_',
+        mass_weighted=False,
+        tol_mass=0.1,
+        strict=False,
+        force=True,
+        quiet=False,
+        **kwargs):
     """RMS-fit trajectory to a reference structure using a selection.
 
     Both reference *ref* and trajectory *traj* must be
@@ -568,16 +610,15 @@ def rms_fit_trj(traj, reference, select='all', filename=None, rmsdfile=None, pre
          (uses the current time step of the object)
       *select*
          1. any valid selection string for
-            :meth:`~MDAnalysis.core.AtomGroup.AtomGroup.select_atoms` that produces identical
-            selections in *mobile* and *reference*; or
+            :meth:`~MDAnalysis.core.AtomGroup.AtomGroup.select_atoms` that
+            produces identical selections in *mobile* and *reference*; or
          2. a dictionary ``{'mobile':sel1, 'reference':sel2}`` (the
             :func:`fasta2select` function returns such a
             dictionary based on a ClustalW_ or STAMP_ sequence alignment); or
          3. a tuple ``(sel1, sel2)``
-
-         When using 2. or 3. with *sel1* and *sel2* then these selections can also each be
-         a list of selection strings (to generate a AtomGroup with defined atom order as
-         described under :ref:`ordered-selections-label`).
+         When using 2. or 3. with *sel1* and *sel2* then these selections can
+         also each be a list of selection strings (to generate a AtomGroup with
+         defined atom order as described under :ref:`ordered-selections-label`).
       *filename*
          file name for the RMS-fitted trajectory or pdb; defaults to the
          original trajectory filename (from *traj*) with *prefix* prepended
@@ -629,7 +670,8 @@ def rms_fit_trj(traj, reference, select='all', filename=None, rmsdfile=None, pre
     """
     frames = traj.trajectory
     if quiet:
-        # should be part of a try ... finally to guarantee restoring the log level
+        # should be part of a try ... finally to guarantee restoring the log
+        # level
         logging.disable(logging.WARN)
 
     kwargs.setdefault('remarks', 'RMS fitted trajectory to reference')
@@ -640,7 +682,8 @@ def rms_fit_trj(traj, reference, select='all', filename=None, rmsdfile=None, pre
     else:
         _Writer = frames.OtherWriter
     if os.path.exists(filename) and not force:
-        logger.warn("{0} already exists and will NOT be overwritten; use force=True if you want this".format(filename))
+        logger.warn(
+            "{0} already exists and will NOT be overwritten; use force=True if you want this".format(filename))
         return filename
     writer = _Writer(filename, **kwargs)
     del _Writer
@@ -650,13 +693,13 @@ def rms_fit_trj(traj, reference, select='all', filename=None, rmsdfile=None, pre
     traj_atoms = traj.select_atoms(*select['mobile'])
     natoms = traj_atoms.n_atoms
 
-    ref_atoms, traj_atoms = get_matching_atoms(ref_atoms, traj_atoms,
-                                                 tol_mass=tol_mass, strict=strict)
+    ref_atoms, traj_atoms = get_matching_atoms(
+        ref_atoms, traj_atoms, tol_mass=tol_mass, strict=strict)
 
     logger.info("RMS-fitting on {0:d} atoms.".format(len(ref_atoms)))
     if mass_weighted:
         # if performing a mass-weighted alignment/rmsd calculation
-        weights = np.asarray(ref_atoms.masses)
+        weights = ref_atoms.masses
     else:
         weights = None
 
@@ -677,8 +720,11 @@ def rms_fit_trj(traj, reference, select='all', filename=None, rmsdfile=None, pre
     rot = np.zeros(9, dtype=np.float64)  # allocate space for calculation
     R = np.matrix(rot.reshape(3, 3))
 
-    percentage = ProgressMeter(nframes, interval=10, quiet=quiet,
-                               format="Fitted frame %(step)5d/%(numsteps)d  [%(percentage)5.1f%%]\r")
+    percentage = ProgressMeter(
+        nframes,
+        interval=10,
+        quiet=quiet,
+        format="Fitted frame %(step)5d/%(numsteps)d  [%(percentage)5.1f%%]      r")
 
     for k, ts in enumerate(frames):
         # shift coordinates for rotation fitting
@@ -691,15 +737,17 @@ def rms_fit_trj(traj, reference, select='all', filename=None, rmsdfile=None, pre
         # (I think we swapped the position of ref and traj in CalcRMSDRotationalMatrix
         # so that R acts **to the left** and can be broadcasted; we're saving
         # one transpose. [orbeckst])
-        rmsd[k] = qcp.CalcRMSDRotationalMatrix(ref_coordinates.T.astype(np.float64),
-                                               traj_coordinates.T.astype(np.float64),
-                                               natoms, rot, weights)
+        rmsd[k] = qcp.CalcRMSDRotationalMatrix(
+            ref_coordinates.T.astype(
+                np.float64), traj_coordinates.T.astype(
+                np.float64), natoms, rot, weights)
         R[:, :] = rot.reshape(3, 3)
 
         # Transform each atom in the trajectory (use inplace ops to avoid copying arrays)
         # (Marginally (~3%) faster than "ts.positions[:] = (ts.positions - x_com) * R + ref_com".)
         ts.positions -= x_com
-        ts.positions[:] = ts.positions * R  # R acts to the left & is broadcasted N times.
+        # R acts to the left & is broadcasted N times.
+        ts.positions[:] = ts.positions * R
         ts.positions += ref_com
 
         writer.write(traj.atoms)  # write whole input trajectory system
@@ -712,7 +760,8 @@ def rms_fit_trj(traj, reference, select='all', filename=None, rmsdfile=None, pre
         logger.info("Wrote RMSD timeseries  to file %r", rmsdfile)
 
     if quiet:
-        # should be part of a try ... finally to guarantee restoring the log level
+        # should be part of a try ... finally to guarantee restoring the log
+        # level
         logging.disable(logging.NOTSET)
 
     return filename
@@ -736,15 +785,15 @@ def sequence_alignment(mobile, reference, **kwargs):
         Atom group to be aligned against
     ** kwargs
       *match_score*
-         score for matching residues, default is [2]
+         score for matching residues, default :2
       *mismatch_penalty*
-         penalty for residues that do not match , default is [-1]
+         penalty for residues that do not match , default : -1
       *gap_penalty*
          penalty for opening a gap; the high default value creates compact
          alignments for highly identical sequences but might not be suitable
-         for sequences with low identity, default is [-2]
+         for sequences with low identity, default : -2
       *gapextension_penalty*
-         penalty for extending a gap, defualt is [-0.1]
+         penalty for extending a gap, default: -0.1
 
     Returns
     -------
@@ -813,30 +862,27 @@ def fasta2select(fastafilename, is_aligned=False,
         ``True``
             use the alignment in the file (e.g. from STAMP) [``False``]
     ref_offset : int, optional
-        default [0], add this number to the column number in the FASTA file
-        to get the original residue number
+        add this number to the column number in the FASTA file
+        to get the original residue number, default: 0
     target_offset : int, optional
-        default [0], add this number to the column number in the FASTA file
-        to get the original residue number
+        add this number to the column number in the FASTA file
+        to get the original residue number, default: 0
     ref_resids : str, optional
         sequence of resids as they appear in the reference structure
     target_resids : str, optional
         sequence of resids as they appear in the target
     alnfilename : str, optional
-        default [``None``]
         filename of ClustalW alignment (clustal format) that is
         produced by *clustalw* when *is_aligned* = ``False``.
-        ``None`` uses the name and path of *fastafilename* and
+        default ``None`` uses the name and path of *fastafilename* and
         subsititutes the suffix with '.aln'.
     treefilename: str, optional
-        default [``None``]
         filename of ClustalW guide tree (Newick format);
-        if ``None``  the the filename is generated from *alnfilename*
+        if default ``None``  the the filename is generated from *alnfilename*
         with the suffix '.dnd' instead of '.aln'
     clustalw : str, optional
-        default ["ClustalW2"]
         path to the ClustalW (or ClustalW2) binary; only
-        needed for *is_aligned* = ``False``
+        needed for *is_aligned* = ``False``, default: "ClustalW2"
 
     Returns
     -------
@@ -854,7 +900,8 @@ def fasta2select(fastafilename, is_aligned=False,
     if is_aligned:
         logger.info("Using provided alignment %r", fastafilename)
         with open(fastafilename) as fasta:
-            alignment = Bio.AlignIO.read(fasta, "fasta", alphabet=protein_gapped)
+            alignment = Bio.AlignIO.read(
+                fasta, "fasta", alphabet=protein_gapped)
     else:
         from Bio.Align.Applications import ClustalwCommandline
         import os.path
@@ -865,29 +912,42 @@ def fasta2select(fastafilename, is_aligned=False,
         if treefilename is None:
             filepath, ext = os.path.splitext(alnfilename)
             treefilename = filepath + '.dnd'
-        run_clustalw = ClustalwCommandline(clustalw, infile=fastafilename, type="protein",
-                                           align=True, outfile=alnfilename, newtree=treefilename)
-        logger.debug("Aligning sequences in %(fastafilename)r with %(clustalw)r.", vars())
+        run_clustalw = ClustalwCommandline(
+            clustalw,
+            infile=fastafilename,
+            type="protein",
+            align=True,
+            outfile=alnfilename,
+            newtree=treefilename)
+        logger.debug(
+            "Aligning sequences in %(fastafilename)r with %(clustalw)r.",
+            vars())
         logger.debug("ClustalW commandline: %r", str(run_clustalw))
         try:
             stdout, stderr = run_clustalw()
         except:
             logger.exception("ClustalW %(clustalw)r failed", vars())
-            logger.info("(You can get clustalw2 from http://www.clustal.org/clustal2/)")
+            logger.info(
+                "(You can get clustalw2 from http://www.clustal.org/clustal2/)")
             raise
         with open(alnfilename) as aln:
-            alignment = Bio.AlignIO.read(aln, "clustal", alphabet=protein_gapped)
-        logger.info("Using clustalw sequence alignment {0!r}".format(alnfilename))
-        logger.info("ClustalW Newick guide tree was also produced: {0!r}".format(treefilename))
+            alignment = Bio.AlignIO.read(
+                aln, "clustal", alphabet=protein_gapped)
+        logger.info(
+            "Using clustalw sequence alignment {0!r}".format(alnfilename))
+        logger.info(
+            "ClustalW Newick guide tree was also produced: {0!r}".format(treefilename))
 
     nseq = len(alignment)
     if nseq != 2:
-        raise ValueError("Only two sequences in the alignment can be processed.")
+        raise ValueError(
+            "Only two sequences in the alignment can be processed.")
 
     orig_resids = [ref_resids, target_resids]  # implict assertion that
     # we only have two sequences in the alignment
     offsets = [ref_offset, target_offset]
-    for iseq, a in enumerate(alignment):  # need iseq index to change orig_resids
+    for iseq, a in enumerate(
+            alignment):  # need iseq index to change orig_resids
         if orig_resids[iseq] is None:
             # build default: assume consecutive numbering of all
             # residues in the alignment
@@ -897,7 +957,12 @@ def fasta2select(fastafilename, is_aligned=False,
         else:
             orig_resids[iseq] = np.asarray(orig_resids[iseq])
     # add offsets to the sequence <--> resid translation table
-    seq2resids = [resids + offset for resids, offset in zip(orig_resids, offsets)]
+    seq2resids = [
+        resids +
+        offset for resids,
+        offset in zip(
+            orig_resids,
+            offsets)]
     del orig_resids
     del offsets
 
@@ -947,11 +1012,13 @@ def fasta2select(fastafilename, is_aligned=False,
     res_list = []  # collect individual selection string
     # could collect just resid and type (with/without CB) and
     # then post-process and use ranges for continuous stretches, eg
-    # ( resid 1:35 and ( backbone or name CB ) ) or ( resid 36 and backbone ) ...
+    # ( resid 1:35 and ( backbone or name CB ) ) or ( resid 36 and backbone )
 
-    GAP = alignment[0].seq.alphabet.gap_char  # should be the same for both seqs
+    # should be the same for both seqs
+    GAP = alignment[0].seq.alphabet.gap_char
     if GAP != alignment[1].seq.alphabet.gap_char:
-        raise ValueError("Different gap characters in sequence 'target' and 'mobile'.")
+        raise ValueError(
+            "Different gap characters in sequence 'target' and 'mobile'.")
     for ipos in range(alignment.get_alignment_length()):
         aligned = list(alignment[:, ipos])
         if GAP in aligned:
@@ -1052,11 +1119,12 @@ def get_matching_atoms(ag1, ag2, tol_mass=0.1, strict=False):
                 ag1.n_atoms, ag2.n_atoms,
                 ag1.n_residues, ag2.n_residues)
             dbgmsg = "mismatched residue numbers\n" + \
-                "\n".join(["{0} | {1}"  for r1, r2 in
+                "\n".join(["{0} | {1}" for r1, r2 in
                            zip_longest(ag1.resids, ag2.resids)])
             logger.error(errmsg)
             logger.debug(dbgmsg)
             raise SelectionError(errmsg)
+
         else:
             msg = ("Reference and trajectory atom selections do not contain "
                    "the same number of atoms: \n"
@@ -1066,8 +1134,9 @@ def get_matching_atoms(ag1, ag2, tol_mass=0.1, strict=False):
                 raise SelectionError(msg)
 
             # continue with trying to creating a valid selection
-            warnings.warn(msg + "\nbut we attempt to create a valid selection.",
-                          category=SelectionWarning)
+            warnings.warn(
+                msg + "\nbut we attempt to create a valid selection.",
+                category=SelectionWarning)
 
         # continue with trying to salvage the selection:
         # - number of atoms is different
@@ -1080,10 +1149,12 @@ def get_matching_atoms(ag1, ag2, tol_mass=0.1, strict=False):
         # pairwise2 consumes too much memory for thousands of characters in
         # each sequence. Perhaps a solution would be pairwise alignment per residue.
         #
-        # aln_elem = Bio.pairwise2.align.globalms("".join([MDAnalysis.topology.core.guess_atom_element(n) for n in gref.atoms.names]),
-        #    "".join([MDAnalysis.topology.core.guess_atom_element(n) for n in models[0].atoms.names]),
-        #                               2, -1, -1, -0.1,
-        #                               one_alignment_only=True)
+        # aln_elem = Bio.pairwise2.align.globalms("".join([MDAnalysis.topology.
+        # core.guess_atom_element(n) for n in gref.atoms.names]),
+        # "".join([MDAnalysis.topology.core.guess_atom_element(n)
+        # for n in models[0].atoms.names]),
+        # 2, -1, -1, -0.1,
+        # one_alignment_only=True)
 
         # For now, just remove the residues that don't have matching numbers
         rsize1 = np.array([r.n_atoms for r in ag1.residues])
@@ -1094,42 +1165,56 @@ def get_matching_atoms(ag1, ag2, tol_mass=0.1, strict=False):
             if strict:
                 # diagnostics
                 mismatch_resindex = np.arange(ag1.n_residues)[mismatch_mask]
-                def log_mismatch(number, ag, rsize, mismatch_resindex=mismatch_resindex):
+
+                def log_mismatch(
+                        number,
+                        ag,
+                        rsize,
+                        mismatch_resindex=mismatch_resindex):
                     logger.error("Offending residues: group {0}: {1}".format(
-                            number,
-                            ", ".join(["{0[0]}{0[1]} ({0[2]})".format(r) for r in
-                                       zip(ag.resnames[mismatch_resindex],
-                                           ag.resids[mismatch_resindex],
-                                           rsize[mismatch_resindex]
+                        number,
+                        ", ".join(["{0[0]}{0[1]} ({0[2]})".format(r) for r in
+                                   zip(ag.resnames[mismatch_resindex],
+                                       ag.resids[mismatch_resindex],
+                                       rsize[mismatch_resindex]
                                        )])))
                 logger.error("Found {0} residues with non-matching numbers of atoms (#)".format(
-                        mismatch_mask.sum()))
+                    mismatch_mask.sum()))
                 log_mismatch(1, ag1, rsize1)
                 log_mismatch(2, ag2, rsize2)
 
-                raise SelectionError("Different number of atoms in some residues. "
-                                     "(Use strict=False to attempt using matching atoms only.)")
+                raise SelectionError(
+                    "Different number of atoms in some residues. "
+                    "(Use strict=False to attempt using matching atoms only.)")
 
             def get_atoms_byres(g, match_mask=np.logical_not(mismatch_mask)):
-                # not pretty... but need to do things on a per-atom basis in order
-                # to preserve original selection
+                # not pretty... but need to do things on a per-atom basis in
+                # order to preserve original selection
                 ag = g.atoms
                 good = ag.resids[match_mask]
                 resids = np.array([a.resid for a in ag])  # resid for each atom
-                ix_good = np.in1d(resids, good)   # boolean array for all matching atoms
-                return ag[np.arange(len(ag))[ix_good]]   # workaround for missing boolean indexing
+                # boolean array for all matching atoms
+                ix_good = np.in1d(resids, good)
+                # workaround for missing boolean indexing
+                return ag[np.arange(len(ag))[ix_good]]
             _ag1 = get_atoms_byres(ag1)
             _ag2 = get_atoms_byres(ag2)
 
             # diagnostics
             # (ugly workaround for missing boolean indexing of AtomGroup)
-            # note: ag[arange(len(ag))[boolean]] is ~2x faster than ag[where[boolean]]
+            # note: ag[arange(len(ag))[boolean]] is ~2x faster than
+            # ag[where[boolean]]
             mismatch_resindex = np.arange(ag1.n_residues)[mismatch_mask]
             logger.warn("Removed {0} residues with non-matching numbers of atoms".format(
-                    mismatch_mask.sum()))
-            logger.debug("Removed residue ids: group 1: {0}".format(ag1.resids[mismatch_resindex]))
-            logger.debug("Removed residue ids: group 2: {0}".format(ag2.resids[mismatch_resindex]))
-            # replace after logging (still need old ag1 and ag2 for diagnostics)
+                mismatch_mask.sum()))
+            logger.debug(
+                "Removed residue ids: group 1: {0}".format(
+                    ag1.resids[mismatch_resindex]))
+            logger.debug(
+                "Removed residue ids: group 2: {0}".format(
+                    ag2.resids[mismatch_resindex]))
+            # replace after logging (still need old ag1 and ag2 for
+            # diagnostics)
             ag1 = _ag1
             ag2 = _ag2
             del _ag1, _ag2
@@ -1144,10 +1229,20 @@ def get_matching_atoms(ag1, ag2, tol_mass=0.1, strict=False):
 
         logger.error("Atoms: reference | trajectory")
         for ar, at in zip(ag1[mismatch_atomindex], ag2[mismatch_atomindex]):
-            logger.error("{0!s:>4} {1:3d} {2!s:>3} {3!s:>3} {4:6.3f}  |  {5!s:>4} {6:3d} {7!s:>3} {8!s:>3} {9:6.3f}".format(ar.segid, ar.resid, ar.resname, ar.name, ar.mass,
-                          at.segid, at.resid, at.resname, at.name, at.mass))
-        errmsg = ("Inconsistent selections, masses differ by more than {0}; " + \
-            "mis-matching atoms are shown above.").format(tol_mass)
+            logger.error(
+                "{0!s:>4} {1:3d} {2!s:>3} {3!s:>3} {4:6.3f}  |  {5!s:>4} {6:3d} {7!s:>3} {8!s:>3} {9:6.3f}".format(
+                    ar.segid,
+                    ar.resid,
+                    ar.resname,
+                    ar.name,
+                    ar.mass,
+                    at.segid,
+                    at.resid,
+                    at.resname,
+                    at.name,
+                    at.mass))
+        errmsg = ("Inconsistent selections, masses differ by more than {0}; " +
+                  "mis-matching atoms are shown above.").format(tol_mass)
         logger.error(errmsg)
         raise SelectionError(errmsg)
     return ag1, ag2

--- a/package/MDAnalysis/analysis/align.py
+++ b/package/MDAnalysis/analysis/align.py
@@ -394,8 +394,6 @@ def alignto(mobile, reference, select="all", mass_weighted=False,
        and new *strict* keyword. The new default is to be lenient whereas
        the old behavior was the equivalent of *strict* = ``True``.
 
-    .. versionchanged:: 0.15.1
-        Uses :func:`_fit_to` to get new minimum rmsd
     """
     if select in ('all', None):
         # keep the EXACT order in the input AtomGroups; select_atoms('all')

--- a/package/MDAnalysis/analysis/align.py
+++ b/package/MDAnalysis/analysis/align.py
@@ -320,18 +320,19 @@ def alignto(mobile, reference, select="all", mass_weighted=False,
        index and therefore destroy the correspondence between the two groups. **It
        is safest not to mix ordered AtomGroups with selection strings.**
 
-    :Arguments:
-      *mobile*
+    Parameters
+    ----------
+      mobile : Universe or AtomGroup
          structure to be aligned, a :class:`~MDAnalysis.core.AtomGroup.AtomGroup`
          or a whole :class:`~MDAnalysis.core.AtomGroup.Universe`
-      *reference*
+      reference : Universe or AtomGroup
          reference structure, a :class:`~MDAnalysis.core.AtomGroup.AtomGroup`
          or a whole :class:`~MDAnalysis.core.AtomGroup.Universe`
-      *select*
+      select: string or dict, optional
          1. any valid selection string for
             :meth:`~MDAnalysis.core.AtomGroup.AtomGroup.select_atoms` that produces identical
             selections in *mobile* and *reference*; or
-         2. dictionary ``{'mobile':sel1, 'reference':sel2}``
+         2. dictionary ``{'mobile':sel1, 'reference':sel2}``.
             (the :func:`fasta2select` function returns such a
             dictionary based on a ClustalW_ or STAMP_ sequence alignment); or
          3.  tuple ``(sel1, sel2)``
@@ -339,21 +340,21 @@ def alignto(mobile, reference, select="all", mass_weighted=False,
          When using 2. or 3. with *sel1* and *sel2* then these selections can also each be
          a list of selection strings (to generate a AtomGroup with defined atom order as
          described under :ref:`ordered-selections-label`).
-      *mass_weighted* : boolean
+      mass_weighted : boolean, optional
          ``True`` uses the masses :meth:`reference.masses` as weights for the
          RMSD fit.
-      *tol_mass*
+      tol_mass: float, optional
          Reject match if the atomic masses for matched atoms differ by more than
          *tol_mass* [0.1]
-      *strict*
+      strict: boolean, optional
          ``True``
-             Will raise :exc:`SelectioError` if a single atom does not
+             Will raise :exc:`SelectionError` if a single atom does not
              match between the two selections.
          ``False`` [default]
              Will try to prepare a matching selection by dropping
              residues with non-matching atoms. See :func:`get_matching_atoms`
              for details.
-      *subselection*
+      subselection : string, optional
          Apply the transformation only to this selection.
 
          ``None`` [default]
@@ -365,10 +366,15 @@ def alignto(mobile, reference, select="all", mass_weighted=False,
          :class:`~MDAnalysis.core.AtomGroup.AtomGroup`
              Apply to the arbitrary group of atoms
 
-    :Returns: RMSD before and after spatial alignment.
+    Returns
+    -------
+    old_rmsd
+        RMSD before spatial alignment
+    new_rmsd
+        RMSD after spatial alignment.
 
     .. SeeAlso:: For RMSD-fitting trajectories it is more efficient to
-                 use :func:`rms_fit_trj`.
+                 use :class:`AlignTraj`.
 
     .. versionchanged:: 0.8
        Added check that the two groups describe the same atoms including
@@ -380,7 +386,7 @@ def alignto(mobile, reference, select="all", mass_weighted=False,
        the old behavior was the equivalent of *strict* = ``True``.
 
     .. versionchanged:: 0.15.1
-        Uses :func:`_fit_to` to get new minimum rmsd, new mobile atoms
+        Uses :func:`_fit_to` to get new minimum rmsd
     """
     if select in ('all', None):
         # keep the EXACT order in the input AtomGroups; select_atoms('all')
@@ -586,7 +592,7 @@ def rms_fit_trj(traj, reference, select='all', filename=None, rmsdfile=None, pre
          *tol_mass* [0.1]
       *strict*
          Default: ``False``
-         - ``True``: Will raise :exc:`SelectioError` if a single atom does not
+         - ``True``: Will raise :exc:`SelectionError` if a single atom does not
            match between the two selections.
          - ``False``: Will try to prepare a matching selection by dropping
            residues with non-matching atoms. See :func:`get_matching_atoms`
@@ -969,29 +975,41 @@ def get_matching_atoms(ag1, ag2, tol_mass=0.1, strict=False):
     The log file (see :func:`MDAnalysis.start_logging`) will contain detailed
     information about mismatches.
 
-    :Arguments:
-      *ag1*, *ag2*
-         :class:`~MDAnalysis.core.AtomGroup.AtomGroup` instances that are compared
-    :Keywords:
-      *tol_mass*
+    Parameters
+    ----------
+    ag1 : AtomGroup
+        First :class:`~MDAnalysis.core.AtomGroup.AtomGroup` instance that is
+        compared
+    ag2 : AtomGroup
+        Second :class:`~MDAnalysis.core.AtomGroup.AtomGroup` instance that is
+        compared
+    tol_mass : float, optional
          Reject if the atomic masses for matched atoms differ by more than
          *tol_mass* [0.1]
-      *strict*
-         ``True``
-             Will raise :exc:`SelectioError` if a single atom does not
-             match between the two selections.
-         ``False`` [default]
-             Will try to prepare a matching selection by dropping
-             residues with non-matching atoms. See :func:`get_matching_atoms`
-             for details.
+    strict : boolean, optional
+        ``True``
+            Will raise :exc:`SelectionError` if a single atom does not
+            match between the two selections.
+        ``False`` [default]
+            Will try to prepare a matching selection by dropping
+            residues with non-matching atoms. See :func:`get_matching_atoms`
+            for details.
 
-    :Returns: Tuple ``(g1, g2)`` with :class:`~MDAnalysis.core.AtomGroup.AtomGroup` instances
-              that match, atom by atom. The groups are either the original groups if all matches
-              or slices of the original groups.
+    Returns
+    -------
+    ``(g1, g2)``
+        Tuple with :class:`~MDAnalysis.core.AtomGroup.AtomGroup` instances
+        that match, atom by atom. The groups are either the original groups if all matches
+        or slices of the original groups.
 
-    :Raises: :exc:`SelectionError` if the number of residues does not match or if in the final
-             matching masses differ by more than *tol*.
+    Raises
+    ------
+    :exc:`SelectionError`
+        Error raised if the number of residues does not match or if in the final
+        matching masses differ by more than *tol*.
 
+    Notes
+    ----- 
     The algorithm could be improved by using e.g. the Needleman-Wunsch
     algorithm in :mod:`Bio.profile2` to align atoms in each residue (doing a
     global alignment is too expensive).

--- a/package/MDAnalysis/analysis/align.py
+++ b/package/MDAnalysis/analysis/align.py
@@ -394,8 +394,6 @@ def alignto(mobile, reference, select="all", mass_weighted=False,
        and new *strict* keyword. The new default is to be lenient whereas
        the old behavior was the equivalent of *strict* = ``True``.
 
-    .. versionchanged:: 0.15.1
-        Uses :func:`_fit_to` to get new minimum rmsd
     """
     if select in ('all', None):
         # keep the EXACT order in the input AtomGroups; select_atoms('all')
@@ -544,7 +542,7 @@ class AlignTraj(AnalysisBase):
         else:
             self.weights = None
 
-        logger.info("RMS-fitting on {0:d} atoms.".format(len(self.ref_atoms)))
+        logger.info("RMS-alignment on {0:d} atoms.".format(len(self.ref_atoms)))
         self._setup_frames(traj, start, stop, step)
 
     def _prepare(self):
@@ -572,8 +570,9 @@ class AlignTraj(AnalysisBase):
             logging.disable(logging.NOTSET)
 
     def save(self, rmsdfile):
-        # these are the values of the new rmsd between the aligned trajectory
-        # and reference structure
+        """Saves the rmsd values of the trajectory frames versus the reference
+            structure
+        """
         np.savetxt(rmsdfile, self.rmsd)
         logger.info("Wrote RMSD timeseries  to file %r", rmsdfile)
 

--- a/package/MDAnalysis/analysis/align.py
+++ b/package/MDAnalysis/analysis/align.py
@@ -728,23 +728,32 @@ def sequence_alignment(mobile, reference, **kwargs):
     low sequence identity, more specialized tools such as clustalw,
     muscle, tcoffee, or similar should be used.
 
-    :Arguments:
-       *mobile*
-          protein atom group
-       *reference*
-          protein atom group
-
-    :Keywords:
+    Parameters
+    ----------
+    mobile : AtomGroup
+        Atom group to be aligned
+    reference : AtomGroup
+        Atom group to be aligned against
+    ** kwargs
       *match_score*
-         score for matching residues [2]
+         score for matching residues, default is [2]
       *mismatch_penalty*
-         penalty for residues that do not match [-1]
+         penalty for residues that do not match , default is [-1]
       *gap_penalty*
          penalty for opening a gap; the high default value creates compact
          alignments for highly identical sequences but might not be suitable
-         for sequences with low identity [-2]
+         for sequences with low identity, default is [-2]
       *gapextension_penalty*
-         penalty for extending a gap [-0.1]
+         penalty for extending a gap, defualt is [-0.1]
+
+    Returns
+    -------
+    aln[0]
+        Tuple of top sequence matching output ('Sequence A', 'Sequence B', score,
+        begin, end ,prev_pos, nex_pos)
+
+    BioPython documentation:
+        http://biopython.org/DIST/docs/api/Bio.pairwise2-module.html
 
     .. versionadded:: 0.10.0
     """
@@ -793,40 +802,48 @@ def fasta2select(fastafilename, is_aligned=False,
 
     (This translation table *is* combined with any value for *xxx_offset*!)
 
-    :Arguments:
-      *fastafilename*
-         FASTA file with first sequence as reference and
-         second the one to be aligned (ORDER IS IMPORTANT!)
-      *is_aligned*
-         False: run clustalw for sequence alignment; True: use
-         the alignment in the file (e.g. from STAMP) [``False``]
-      *ref_offset*
-         add this number to the column number in the FASTA file
-         to get the original residue number
-      *target_offset*
-         same for the target
-      *ref_resids*
-         sequence of resids as they appear in the reference structure
-      *target_resids*
-         sequence of resids as they appear in the target
-      *alnfilename*
-         filename of ClustalW alignment (clustal format) that is
-         produced by *clustalw* when *is_aligned* = ``False``.
-         ``None`` uses the name and path of *fastafilename* and
-         subsititutes the suffix with '.aln'.[``None``]
-      *treefilename*
-         filename of ClustalW guide tree (Newick format);
-         if ``None``  the the filename is generated from *alnfilename*
-         with the suffix '.dnd' instead of '.aln' [``None``]
-      *clustalw*
-         path to the ClustalW (or ClustalW2) binary; only
-         needed for *is_aligned* = ``False`` ["clustalw2"]
+    Parameters
+    ----------
+    fastafilename : str, path to filename
+        FASTA file with first sequence as reference and
+        second the one to be aligned (ORDER IS IMPORTANT!)
+    is_aligned : boolean, optional
+        ``False`` : [default]
+            run clustalw for sequence alignment;
+        ``True``
+            use the alignment in the file (e.g. from STAMP) [``False``]
+    ref_offset : int, optional
+        default [0], add this number to the column number in the FASTA file
+        to get the original residue number
+    target_offset : int, optional
+        default [0], add this number to the column number in the FASTA file
+        to get the original residue number
+    ref_resids : str, optional
+        sequence of resids as they appear in the reference structure
+    target_resids : str, optional
+        sequence of resids as they appear in the target
+    alnfilename : str, optional
+        default [``None``]
+        filename of ClustalW alignment (clustal format) that is
+        produced by *clustalw* when *is_aligned* = ``False``.
+        ``None`` uses the name and path of *fastafilename* and
+        subsititutes the suffix with '.aln'.
+    treefilename: str, optional
+        default [``None``]
+        filename of ClustalW guide tree (Newick format);
+        if ``None``  the the filename is generated from *alnfilename*
+        with the suffix '.dnd' instead of '.aln'
+    clustalw : str, optional
+        default ["ClustalW2"]
+        path to the ClustalW (or ClustalW2) binary; only
+        needed for *is_aligned* = ``False``
 
-    :Returns:
-      *select_dict*
-          dictionary with 'reference' and 'mobile' selection string
-          that can be used immediately in :func:`rms_fit_trj` as
-          ``select=select_dict``.
+    Returns
+    -------
+    select_dict
+        dictionary with 'reference' and 'mobile' selection string
+        that can be used immediately in :func:`rms_fit_trj` as
+        ``select=select_dict``.
     """
     import Bio.SeqIO
     import Bio.AlignIO
@@ -1009,7 +1026,7 @@ def get_matching_atoms(ag1, ag2, tol_mass=0.1, strict=False):
         matching masses differ by more than *tol*.
 
     Notes
-    ----- 
+    -----
     The algorithm could be improved by using e.g. the Needleman-Wunsch
     algorithm in :mod:`Bio.profile2` to align atoms in each residue (doing a
     global alignment is too expensive).

--- a/package/MDAnalysis/analysis/align.py
+++ b/package/MDAnalysis/analysis/align.py
@@ -491,8 +491,7 @@ class AlignTraj(AnalysisBase):
             filename = os.path.join(path, prefix + fn)
 
         if os.path.exists(filename) and not force:
-            logger.warn("{0} already exists and will NOT be overwritten; use force=True if you want this".format(filename))
-
+            raise IOError('Filename already exists in path and force is not set to True')
         self.filename = filename
 
         self.natoms = self.mobile_atoms.n_atoms
@@ -525,7 +524,6 @@ class AlignTraj(AnalysisBase):
 
     def _single_frame(self):
         index = self._ts.frame
-        logger.info('mobile_atoms: {0}, ref atoms: {1}'.format(self.mobile_atoms.positions[0],\
         self.ref_atoms.positions[0]))
         self.mobile_com = self.mobile_atoms.center_of_mass()
 

--- a/package/MDAnalysis/analysis/base.py
+++ b/package/MDAnalysis/analysis/base.py
@@ -1,5 +1,5 @@
 # -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
-# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
 #
 # MDAnalysis --- http://www.MDAnalysis.org
 # Copyright (c) 2006-2015 Naveen Michaud-Agrawal, Elizabeth J. Denning, Oliver Beckstein
@@ -27,6 +27,8 @@ from six.moves import range
 
 import numpy as np
 import logging
+from MDAnalysis.lib.log import ProgressMeter
+
 
 
 logger = logging.getLogger(__name__)
@@ -36,14 +38,14 @@ class AnalysisBase(object):
     """Base class for defining multi frame analysis
 
     The analysis base class is designed as a template for creating
-    multiframe analysis.  
+    multiframe analysis.
 
     The class implements the following methods:
 
     _setup_frames(trajectory, start=None, stop=None, step=None)
       Pass a Reader object and define the desired iteration pattern
       through the trajectory
-      
+
     run
       The user facing run method.  Calls the analysis methods
       defined below
@@ -73,10 +75,13 @@ class AnalysisBase(object):
         self.stop = stop
         self.step = step
         self.nframes = len(range(start, stop, step))
+        if self.nframes > 0:
+            self.percentage = ProgressMeter(self.nframes, interval=10, format=
+        "Fitted frame %(step)5d/%(numsteps)d  [%(percentage)5.1f%%]\r")
 
     def _single_frame(self):
         """Calculate data from a single frame of trajectory
- 
+        
         Don't worry about normalising, just deal with a single frame.
         """
         pass
@@ -101,7 +106,8 @@ class AnalysisBase(object):
             self._ts = ts
             #logger.info("--> Doing frame {} of {}".format(i+1, self.nframes))
             self._single_frame()
+            if self.nframes > 0:
+                self.percentage.echo(self._ts.frame)
+
         logger.info("Finishing up")
         self._conclude()
-
-

--- a/package/MDAnalysis/analysis/base.py
+++ b/package/MDAnalysis/analysis/base.py
@@ -21,15 +21,12 @@ Analysis building blocks --- :mod:`MDAnalysis.analysis.base`
 A collection of useful building blocks for creating Analysis
 classes.
 
-
 """
 from six.moves import range
 
 import numpy as np
 import logging
 from MDAnalysis.lib.log import ProgressMeter
-
-
 
 logger = logging.getLogger(__name__)
 
@@ -75,10 +72,10 @@ class AnalysisBase(object):
         self.stop = stop
         self.step = step
         self.nframes = len(range(start, stop, step))
-    
+
     def _single_frame(self):
         """Calculate data from a single frame of trajectory
-        
+
         Don't worry about normalising, just deal with a single frame.
         """
         pass
@@ -101,7 +98,7 @@ class AnalysisBase(object):
         for i, ts in enumerate(
                 self._trajectory[self.start:self.stop:self.step]):
             self._ts = ts
-            #logger.info("--> Doing frame {} of {}".format(i+1, self.nframes))
+            # logger.info("--> Doing frame {} of {}".format(i+1, self.nframes))
             self._single_frame()
         logger.info("Finishing up")
         self._conclude()

--- a/package/MDAnalysis/analysis/base.py
+++ b/package/MDAnalysis/analysis/base.py
@@ -75,10 +75,7 @@ class AnalysisBase(object):
         self.stop = stop
         self.step = step
         self.nframes = len(range(start, stop, step))
-        if self.nframes > 0:
-            self.percentage = ProgressMeter(self.nframes, interval=10, format=
-        "Fitted frame %(step)5d/%(numsteps)d  [%(percentage)5.1f%%]\r")
-
+    
     def _single_frame(self):
         """Calculate data from a single frame of trajectory
         
@@ -106,8 +103,5 @@ class AnalysisBase(object):
             self._ts = ts
             #logger.info("--> Doing frame {} of {}".format(i+1, self.nframes))
             self._single_frame()
-            if self.nframes > 0:
-                self.percentage.echo(self._ts.frame)
-
         logger.info("Finishing up")
         self._conclude()

--- a/package/MDAnalysis/analysis/rms.py
+++ b/package/MDAnalysis/analysis/rms.py
@@ -211,7 +211,7 @@ def rmsd(a, b, weights=None, center=False, superposition=False):
             return np.sqrt(np.sum((a - b) ** 2) / N)
 
 
-def _process_selection(select):
+def process_selection(select):
     """Return a canonical selection dictionary.
 
     Parameters

--- a/testsuite/MDAnalysisTests/analysis/test_align.py
+++ b/testsuite/MDAnalysisTests/analysis/test_align.py
@@ -102,6 +102,14 @@ class TestAlign(TestCase):
         assert_almost_equal(rmsd, 6.820321761927005, 5,
                             err_msg="RMSD calculation between 1st and last "
                             "AdK frame gave wrong answer")
+        #test mass_weighted
+        last_atoms_weight = self.universe.atoms.masses
+        A = self.universe.trajectory[0]
+        B = self.reference.trajectory[-1]
+        rmsd = align.alignto(self.universe, self.reference, mass_weighted=True)
+        rmsd_sup_weight = rms.rmsd(A, B,  weights=last_atoms_weight, center=True, superposition=True)
+        assert_almost_equal(rmsd[1], rmsd_sup_weight, 6)
+
 
     @dec.slow
     @attr('issue')
@@ -118,6 +126,11 @@ class TestAlign(TestCase):
         self._assert_rmsd(fitted, 0, 6.929083044751061)
         self._assert_rmsd(fitted, -1, 0.0)
 
+        #test filename=none
+        align.rms_fit_trj(self.universe, self.reference, select="all",
+                          filename=None, quiet=True)
+        #test os.path_exists and not force
+
     def test_AlignTraj(self):
         self.reference.trajectory[-1]
         self.tempdir = tempdir.TempDir()
@@ -130,6 +143,14 @@ class TestAlign(TestCase):
         # VMD: 6.9378711
         self._assert_rmsd(fitted, 0, 6.929083044751061)
         self._assert_rmsd(fitted, -1, 0.0)
+        #test weighted
+
+        #test filename=none
+        #test os.path_exists and not force
+        #test .save()
+        x = align.AlignTraj(self.universe,self.reference,filename=self.outfile,\
+        mass_weighted=True)
+        x.run()
         del self.outfile
         del fitted
 
@@ -160,6 +181,9 @@ class TestAlign(TestCase):
             return MDAnalysis.analysis.align.alignto(a, b)
 
         assert_raises(SelectionError, different_atoms)
+
+        #TODO
+        #Assert raised type error for subselection
 
 
 class TestAlignmentProcessing(TestCase):

--- a/testsuite/MDAnalysisTests/analysis/test_align.py
+++ b/testsuite/MDAnalysisTests/analysis/test_align.py
@@ -138,6 +138,12 @@ class TestAlign(TestCase):
         x = align.AlignTraj(self.universe,self.reference,filename=self.outfile)
         x.run()
         fitted = MDAnalysis.Universe(PSF, self.outfile)
+
+        self.rmsd_outfile = path.join(self.tempdir.name, 'rmsd')
+        x.save(self.rmsd_outfile)
+        assert_almost_equal(x.rmsd[0],6.929083044751061, decimal = 3)
+        assert_almost_equal(x.rmsd[-1],5.279731379771749336e-07, decimal = 3)
+
         # RMSD against the reference frame
         # calculated on Mac OS X x86 with MDA 0.7.2 r689
         # VMD: 6.9378711
@@ -145,20 +151,18 @@ class TestAlign(TestCase):
         self._assert_rmsd(fitted, -1, 0.0)
         del self.outfile
         #test weighted
-
-        #test filename=none
-        #test os.path_exists and not force
-        #test .save()
         self.outfile = path.join(self.tempdir.name, 'AlignTraj_weighted_test.dcd')
         x = align.AlignTraj(self.universe,self.reference,filename=self.outfile,\
         mass_weighted=True)
         x.run()
-        self.rmsd_outfile = path.join(self.tempdir.name, 'rmsd')
-        x.save(self.rmsd_outfile)
-        self._assert_rmsd(fitted, 0, 6.929083044751061)
-        self._assert_rmsd(fitted, -1, 0.0)
+
+
+        del self.rmsd_outfile
         del self.outfile
         del fitted
+        #test filename=none
+        #test os.path_exists and not force
+        #test .save()
 
     def _assert_rmsd(self, fitted, frame, desired):
         fitted.trajectory[frame]

--- a/testsuite/MDAnalysisTests/analysis/test_align.py
+++ b/testsuite/MDAnalysisTests/analysis/test_align.py
@@ -152,14 +152,10 @@ class TestAlign(TestCase):
         del self.outfile
         #test weighted
         self.outfile = path.join(self.tempdir.name, 'AlignTraj_weighted_test.dcd')
-        x = align.AlignTraj(self.universe,self.reference,filename=self.outfile,\
-        mass_weighted=True)
+        x = align.AlignTraj(self.universe,self.reference,filename=self.outfile, 
+                            mass_weighted=True)
         x.run()
 
-
-        del self.rmsd_outfile
-        del self.outfile
-        del fitted
         #test filename=none
         #test os.path_exists and not force
         #test .save()
@@ -192,8 +188,6 @@ class TestAlign(TestCase):
 
         assert_raises(SelectionError, different_atoms)
 
-        #TODO
-        #Assert raised type error for subselection
 
 
 class TestAlignmentProcessing(TestCase):

--- a/testsuite/MDAnalysisTests/analysis/test_align.py
+++ b/testsuite/MDAnalysisTests/analysis/test_align.py
@@ -143,14 +143,20 @@ class TestAlign(TestCase):
         # VMD: 6.9378711
         self._assert_rmsd(fitted, 0, 6.929083044751061)
         self._assert_rmsd(fitted, -1, 0.0)
+        del self.outfile
         #test weighted
 
         #test filename=none
         #test os.path_exists and not force
         #test .save()
+        self.outfile = path.join(self.tempdir.name, 'AlignTraj_weighted_test.dcd')
         x = align.AlignTraj(self.universe,self.reference,filename=self.outfile,\
         mass_weighted=True)
         x.run()
+        self.rmsd_outfile = path.join(self.tempdir.name, 'rmsd')
+        x.save(self.rmsd_outfile)
+        self._assert_rmsd(fitted, 0, 6.929083044751061)
+        self._assert_rmsd(fitted, -1, 0.0)
         del self.outfile
         del fitted
 

--- a/testsuite/MDAnalysisTests/analysis/test_align.py
+++ b/testsuite/MDAnalysisTests/analysis/test_align.py
@@ -118,6 +118,19 @@ class TestAlign(TestCase):
         self._assert_rmsd(fitted, 0, 6.929083044751061)
         self._assert_rmsd(fitted, -1, 0.0)
 
+    def test_AlignTraj(self):
+        self.reference.trajectory[-1]
+        self.tempdir = tempdir.TempDir()
+        self.outfile = path.join(self.tempdir.name, 'AlignTraj_test.dcd')
+        x = align.AlignTraj(self.universe,self.reference,filename=self.outfile)
+        x.run()
+        fitted = MDAnalysis.Universe(PSF, self.outfile)
+        # RMSD against the reference frame
+        # calculated on Mac OS X x86 with MDA 0.7.2 r689
+        # VMD: 6.9378711
+        self._assert_rmsd(fitted, 0, 6.929083044751061)
+        self._assert_rmsd(fitted, -1, 0.0)
+
     def _assert_rmsd(self, fitted, frame, desired):
         fitted.trajectory[frame]
         rmsd = rms.rmsd(self.reference.atoms.positions,

--- a/testsuite/MDAnalysisTests/analysis/test_align.py
+++ b/testsuite/MDAnalysisTests/analysis/test_align.py
@@ -130,6 +130,8 @@ class TestAlign(TestCase):
         # VMD: 6.9378711
         self._assert_rmsd(fitted, 0, 6.929083044751061)
         self._assert_rmsd(fitted, -1, 0.0)
+        del self.outfile
+        del fitted
 
     def _assert_rmsd(self, fitted, frame, desired):
         fitted.trajectory[frame]


### PR DESCRIPTION
Fixes #845 

Changes made in this Pull Request:
 - Refactor of rms_fit_trj to fit_trj class inheriting from AnalysisBase 
 - Minor changes to other functions in analysis for some constancy
 - Made name of new fit_trj class AlignTraj
 - Eliminated division by mean in weighting as this is already done in RMSD functions
 - Simplified method for getting filewriter
 -  Added _fit_to function to return mobile atoms and new rmsd that is called in both AlignTraj
and Alignto
 - Added tests to increase code cover
 - Deprecated rms_fit_traj in favor of Align Traj
 - Updated docs of functions to fit numpy doc strings, added some additional information for biopython functions
 
Open question: There is a conflict in the functions right now where there isn't really a unified API,
some functions pass a boolean for mass_weighted and then perform a weighted rmsd using the atomic masses as the weights, which makes the alignment easier as it is the center of mass of the atoms that is subtracted from the mobile_coordinates to be aligned against. If we want more flexibility for alignment using custom weights in these functions something would have to change, but I think we might want to leave that for another pull request, as it isn't really a refactor but a change in functionality. 
  
PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
