### PR TITLE
fix Reader iter/next redundancy (issue #869)

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -72,6 +72,7 @@ Chronological list of authors
   - Abhinav Gupta
   - John Detlefs
   - Bart Bruininks
+  - Fiona Naughton
 
 External code
 -------------

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,12 +13,13 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-??/??/16 kain88-de,jdetle
+??/??/16 kain88-de,jdetle, fiona-naughton
 
   * 0.15.1 
 
 Fixes
   * reading/writing lambda value in trr files (Issue #859)
+  * fix __iter__/next redundancy (Issue #869)
 
 Changes
   * Added new AlignTraj class for alignment that follows the new analysis API known

--- a/package/MDAnalysis/coordinates/TRJ.py
+++ b/package/MDAnalysis/coordinates/TRJ.py
@@ -329,7 +329,7 @@ class TRJReader(base.Reader):
             while True:
                 next(self)
                 counter += 1
-        except EOFError:
+        except StopIteration:
             self.rewind()
 
         return counter

--- a/package/MDAnalysis/coordinates/TRZ.py
+++ b/package/MDAnalysis/coordinates/TRZ.py
@@ -309,7 +309,7 @@ class TRZReader(base.Reader):
             self.next()
             t1 = self.ts.time
             dt = t1 - t0
-        except IOError:
+        except StopIteration:
             return 0
         else:
             return dt
@@ -332,7 +332,7 @@ class TRZReader(base.Reader):
             self.next()
             t1 = self.ts._frame
             skip_timestep = t1 - t0
-        except IOError:
+        except StopIteration:
             return 0
         else:
             return skip_timestep

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -1060,7 +1060,12 @@ class ProtoReader(six.with_metaclass(_Readermeta, IObase)):
 
     def next(self):
         """Forward one step to next frame."""
-        return self._read_next_timestep()
+        try:
+            return self._read_next_timestep()
+        except (EOFError, IOError):
+            self.rewind()
+            raise StopIteration
+
 
     def __next__(self):
         """Forward one step to next frame when using the `next` builtin."""
@@ -1132,12 +1137,7 @@ class ProtoReader(six.with_metaclass(_Readermeta, IObase)):
 
     def __iter__(self):
         self._reopen()
-        while True:
-            try:
-                yield self._read_next_timestep()
-            except (EOFError, IOError):
-                self.rewind()
-                raise StopIteration
+        return self
 
     def _reopen(self):
         """Should position Reader to just before first frame

--- a/testsuite/MDAnalysisTests/coordinates/test_xdr.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_xdr.py
@@ -240,12 +240,8 @@ class _GromacsReader(TestCase):
             self.universe.trajectory[-1]
             self.universe.trajectory.next()
 
-        assert_raises(IOError, go_beyond_EOF)
-        try:
-            go_beyond_EOF()
-        except IOError as err:
-            assert_equal(err.errno, errno.EIO,
-                         "IOError produces wrong error code")
+        assert_raises(StopIteration, go_beyond_EOF)
+
 
 
 class TestXTCReader(_GromacsReader):


### PR DESCRIPTION
Fixes #869 

`__iter__()` now returns self, and `next()` raises `StopIteration`. 

Initially broke a couple things that expected `next()` to raise on the `IOError`/`EOFError` passed on from `_read_next_timestep()`, which is now caught to raise `StopIteration`; changed these to `StopIteration` instead (hopefully found them all!)

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?

