### PR TITLE
Added tests for calling next at end of Reader

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,13 +13,15 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-??/??/16 kain88-de,jdetle, fiona-naughton
+??/??/16 kain88-de,jdetle, fiona-naughton, richardjgowers
 
   * 0.15.1 
 
 Fixes
   * reading/writing lambda value in trr files (Issue #859)
   * fix __iter__/next redundancy (Issue #869)
+  * SingleFrameReader now raises StopIteration instead of IOError on calling
+    next (Issue #869)
 
 Changes
   * Added new AlignTraj class for alignment that follows the new analysis API known

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -1770,7 +1770,7 @@ class SingleFrameReader(ProtoReader):
         pass
 
     def next(self):
-        raise IOError(self._err.format(self.__class__.__name__))
+        raise StopIteration(self._err.format(self.__class__.__name__))
 
     def __iter__(self):
         yield self.ts

--- a/testsuite/MDAnalysisTests/coordinates/test_lammps.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_lammps.py
@@ -44,7 +44,7 @@ class _TestLammpsData_Coords(TestCase):
         assert_equal(self.u.dimensions, self.dimensions)
 
     def test_singleframe(self):
-        assert_raises(IOError, self.u.trajectory.next)
+        assert_raises(StopIteration, self.u.trajectory.next)
 
     def test_seek(self):
         assert_raises(IndexError, self.u.trajectory.__getitem__, 1)

--- a/testsuite/MDAnalysisTests/coordinates/test_reader_api.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_reader_api.py
@@ -103,6 +103,11 @@ class _TestReader(object):
 
         assert_equal(l, self.n_frames)
 
+    def test_raises_StopIteration(self):
+        self.reader[-1]
+
+        assert_raises(StopIteration, next, self.reader)
+
 
 class _Multi(_TestReader):
     n_frames = 10
@@ -220,7 +225,7 @@ class _Single(_TestReader):
 
 class TestSingleFrameReader(_Single):
     def test_next(self):
-        assert_raises(IOError, self.reader.next)
+        assert_raises(StopIteration, self.reader.next)
 
     # Getitem tests
     # only 0 & -1 should work
@@ -264,3 +269,4 @@ class TestSingleFrameReader(_Single):
 
     def test_read_frame(self):
         assert_raises(IndexError, self.reader._read_frame, 1)
+

--- a/testsuite/MDAnalysisTests/coordinates/test_xdr.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_xdr.py
@@ -235,7 +235,7 @@ class _GromacsReader(TestCase):
                             self.universe.atoms.positions, self.prec)
 
     @dec.slow
-    def test_EOFraisesIOErrorEIO(self):
+    def test_EOFraisesStopIteration(self):
         def go_beyond_EOF():
             self.universe.trajectory[-1]
             self.universe.trajectory.next()


### PR DESCRIPTION
Fixes #

Changes made in this Pull Request:
 - 


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?

SingleFrameReader now correctly raises a StopIteration on call of next