### PR TITLE
Plugin to display the open files upon test failure

### DIFF
--- a/testsuite/CHANGELOG
+++ b/testsuite/CHANGELOG
@@ -13,6 +13,14 @@ Also see https://github.com/MDAnalysis/mdanalysis/wiki/MDAnalysisTests
 and https://github.com/MDAnalysis/mdanalysis/wiki/UnitTests
 
 ------------------------------------------------------------------------------
+??/??/16 jbarnoud
+
+  * 0.15.1
+    - Added a plugin to list the non-closed file handle (Issue #853, PR #874).
+      The plugin can be disabled with --no-open-files.
+    - The test_failure test can be made fail by setting the MDA_FAILURE_TEST
+      environment variable (PR #874)
+
 05/15/16  orbeckst, jbarnoud, pedrishi, fiona-naughton, jdetle
   * 0.15.0
     - removed biopython PDB parser for coordinates and topology (Issue #777)

--- a/testsuite/MDAnalysisTests/plugins/__init__.py
+++ b/testsuite/MDAnalysisTests/plugins/__init__.py
@@ -61,7 +61,7 @@ happen only at test runtime. See Issue 344 for details.
 #  code won't be run again under coverage's watch.
 
 # Don't forget to also add your plugin to the import further ahead
-__all__ = ['memleak', 'capture_err', 'knownfailure', 'cleanup']
+__all__ = ['memleak', 'capture_err', 'knownfailure', 'cleanup', 'open_files']
 
 import distutils.version
 try:
@@ -103,7 +103,7 @@ def _check_plugins_loaded():
 loaded_plugins = dict()
 
 # ADD HERE your plugin import
-from . import memleak, capture_err, knownfailure, cleanup
+from . import memleak, capture_err, knownfailure, cleanup, open_files
 
 plugin_classes = []
 for plugin in __all__:

--- a/testsuite/MDAnalysisTests/plugins/open_files.py
+++ b/testsuite/MDAnalysisTests/plugins/open_files.py
@@ -1,0 +1,110 @@
+# -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 fileencoding=utf-8
+#
+# MDAnalysis --- http://www.MDAnalysis.org
+# Copyright (c) 2006-2015 Naveen Michaud-Agrawal, Elizabeth J. Denning,
+# Oliver Beckstein and contributors (see AUTHORS for the full list)
+#
+# Released under the GNU Public Licence, v2 or any higher version
+#
+# Please cite your use of MDAnalysis in published work:
+#
+# N. Michaud-Agrawal, E. J. Denning, T. B. Woolf, and O. Beckstein.
+# MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
+# J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
+#
+
+from __future__ import print_function
+
+import collections
+import os
+
+import psutil
+
+from nose.plugins.base import Plugin
+from nose.pyversion import exc_to_unicode, force_unicode
+from nose.util import ln
+
+
+class ReportOpenFiles(Plugin):
+    """Follow open files during the test suite.
+
+    Open files are listed when a test fails or errors. They also are listed at
+    the end of the test suite.
+
+    The plugin is enable by default. It can be disabled with the
+    --no-open-files option or with the NOSE_NO_MDA_FILES environment variable.
+    """
+    enabled = True
+    env_opt = 'NOSE_NO_MDA_FILES'
+    name = 'open-files'
+
+    def options(self, parser, env):
+        """Registers the commandline option, defaulting to enabled.
+        """
+        parser.add_option(
+            "--no-{}".format(self.name), action="store_false",
+            default=not env.get(self.env_opt), dest="do_mda_open_files",
+            help="Don't display open file handlers. [{}]".format(self.env_opt))
+
+    def configure(self, options, conf):
+        """Configure the plugin.
+        """
+        super(ReportOpenFiles, self).configure(options, conf)
+        self.config = conf # This will let other tests know about config settings.
+        try:
+            self.enabled = options.do_mda_open_files
+        except AttributeError:
+            self.enabled = False
+
+    def formatError(self, test, err):
+        """List the open files when a test errors.
+        """
+        open_files = _gather_open_files()
+
+        if not open_files:
+            return err
+
+        ec, ev, tb = err
+        ev = exc_to_unicode(ev)
+        handle_couter = collections.Counter(open_files)
+        new_ev = u'\n'.join(
+            ev.split('\n')
+            + [ln(u'>>> There {} open file handlers for {} files: <<<'
+                  .format(len(open_files), len(handle_couter)))]
+            + [ln(u'* ({}) {}'.format(count, path))
+               for path, count in handle_couter.items()]
+            + [ln(u'>>> End of the open file list. <<<')]
+        )
+        return (ec, new_ev, tb)
+
+    def formatFailure(self, test, err):
+        """List the open files when a test fails.
+        """
+        return self.formatError(test, err)
+
+    def report(self, stream):
+        """Display the number of open files at the end of the test suite.
+        """
+        open_files = _gather_open_files()
+        handle_couter = collections.Counter(open_files)
+        print('\n', file=stream)
+        print('By the end of the tests, there are {} open handle for {} files:'
+              .format(len(open_files), len(handle_couter)), file=stream)
+        for path, count in handle_couter.items():
+            print('* ({}) {}'.format(count, path), file=stream)
+
+
+def _gather_open_files():
+    """Return a list of the path to open files handled by the process.
+
+    If several file handle are open for a given file, then the path will
+    appear as many time as they are open file handle for that file.
+    """
+    process = psutil.Process(os.getpid())
+    handlers = process.open_files()
+    path = [f.path for f in handlers]
+    return path
+
+
+plugin_class = ReportOpenFiles

--- a/testsuite/MDAnalysisTests/test_failure.py
+++ b/testsuite/MDAnalysisTests/test_failure.py
@@ -1,0 +1,26 @@
+# -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 fileencoding=utf-8
+#
+# MDAnalysis --- http://www.MDAnalysis.org
+# Copyright (c) 2006-2015 Naveen Michaud-Agrawal, Elizabeth J. Denning,
+# Oliver Beckstein and contributors (see AUTHORS for the full list)
+#
+# Released under the GNU Public Licence, v2 or any higher version
+#
+# Please cite your use of MDAnalysis in published work:
+#
+# N. Michaud-Agrawal, E. J. Denning, T. B. Woolf, and O. Beckstein.
+# MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
+# J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
+#
+
+import os
+
+
+def test_failure():
+    """Fail if the MDA_FAILURE_TEST environment variable is set.
+    """
+    # Have a file open to trigger an output from the open_files plugin.
+    f = open('./failure.txt', 'w')
+    if u'MDA_FAILURE_TEST' in os.environ:
+        assert False

--- a/testsuite/setup.py
+++ b/testsuite/setup.py
@@ -208,6 +208,7 @@ For details see the report for `Issue 87`_.
               'MDAnalysis=={0!s}'.format(RELEASE),  # same as this release!
               'numpy>=1.5',
               'nose>=1.3.7',
+              'psutil>=4.0.2',
           ],
           # had 'KeyError' as zipped egg (2MB savings are not worth the
           # trouble)


### PR DESCRIPTION
Add a plugin that list open files when a test fails. This aims at testing the hypothesis that we have to many opened file descriptors, and that it could cause #853.

The plugin is enabled by default. It displays the path to the file that
have a open file handler. To disable the plugin, run mda_nosetests with
the --no-open-files option.

The commit also introduces a test that fails if the MDA_FAILURE_TEST
environment variable is set. This test comes handy to test nose behavior
upon failure.

The open-files plugin requires psutil. That requirement has been added
to setup.py.