### PR TITLE
[WIP] Plugin that list living Universes after tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ install:
   - chmod +x testsuite/MDAnalysisTests/mda_nosetests
 # command to run tests
 script:
-  - ./testsuite/MDAnalysisTests/mda_nosetests --with-coverage --cover-package MDAnalysis --processes=2 --process-timeout=300 --with-memleak
+  - ./testsuite/MDAnalysisTests/mda_nosetests --with-coverage --cover-package MDAnalysis --processes=2 --process-timeout=300 --with-memleak --with-universe
   - |
      test ${TRAVIS_PULL_REQUEST} == "false" && \
      test ${TRAVIS_BRANCH} == ${GH_DOC_BRANCH} && \

--- a/testsuite/MDAnalysisTests/plugins/__init__.py
+++ b/testsuite/MDAnalysisTests/plugins/__init__.py
@@ -61,7 +61,8 @@ happen only at test runtime. See Issue 344 for details.
 #  code won't be run again under coverage's watch.
 
 # Don't forget to also add your plugin to the import further ahead
-__all__ = ['memleak', 'capture_err', 'knownfailure', 'cleanup', 'open_files']
+__all__ = ['memleak', 'capture_err', 'knownfailure',
+           'cleanup', 'open_files', 'universes']
 
 import distutils.version
 try:
@@ -103,7 +104,8 @@ def _check_plugins_loaded():
 loaded_plugins = dict()
 
 # ADD HERE your plugin import
-from . import memleak, capture_err, knownfailure, cleanup, open_files
+from . import (memleak, capture_err, knownfailure,
+               cleanup, open_files, universes)
 
 plugin_classes = []
 for plugin in __all__:

--- a/testsuite/MDAnalysisTests/plugins/universes.py
+++ b/testsuite/MDAnalysisTests/plugins/universes.py
@@ -19,6 +19,7 @@ from __future__ import print_function
 import collections
 import os
 import sys
+import weakref
 
 import gc
 
@@ -69,13 +70,18 @@ class ReportUniverse(Plugin):
                 reader = universe.trajectory
                 referrers = gc.get_referrers(universe)
                 ref_counter = collections.Counter(r.__class__ for r in referrers)
+                weak_referrers = weakref.getweakrefs(universe)
                 # Exclude the reference we created in the loop.
                 n_references = sys.getrefcount(universe) - 1
+                n_weakrefs = weakref.getweakrefcount(universe)
                 print('* {}'.format(universe), file=stream)
                 print('  reader: {}'.format(reader), file=stream)
                 print('  {} references to the universe'.format(n_references),
                       file=stream)
                 print('  referenced by ' + str(ref_counter), file=stream)
+                print('  {} weak references to the universe'.format(n_weakrefs),
+                      file=stream)
+                print('  weak references by ' + str(weak_referrers), file=stream)
 
 
 plugin_class = ReportUniverse

--- a/testsuite/MDAnalysisTests/plugins/universes.py
+++ b/testsuite/MDAnalysisTests/plugins/universes.py
@@ -18,10 +18,12 @@ from __future__ import print_function
 
 import collections
 import os
+import random
 import sys
 import weakref
 
 import gc
+import objgraph
 
 from nose.plugins.base import Plugin
 from nose.pyversion import exc_to_unicode, force_unicode
@@ -82,6 +84,12 @@ class ReportUniverse(Plugin):
                 print('  {} weak references to the universe'.format(n_weakrefs),
                       file=stream)
                 print('  weak references by ' + str(weak_referrers), file=stream)
+        
+        living_atoms = [o for o in gc.get_objects() if isinstance(o, mda.core.AtomGroup.Atom)]
+        print('There are {} living atoms.'.format(len(living_atoms)), file=stream)
+
+        objgraph.show_refs(living_atoms[0], filename='sample-graph.png')
+        objgraph.show_backrefs(living_atoms[0], filename='backrefs.png', max_depth=10)
 
 
 plugin_class = ReportUniverse

--- a/testsuite/MDAnalysisTests/plugins/universes.py
+++ b/testsuite/MDAnalysisTests/plugins/universes.py
@@ -1,0 +1,81 @@
+# -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 fileencoding=utf-8
+#
+# MDAnalysis --- http://www.MDAnalysis.org
+# Copyright (c) 2006-2015 Naveen Michaud-Agrawal, Elizabeth J. Denning,
+# Oliver Beckstein and contributors (see AUTHORS for the full list)
+#
+# Released under the GNU Public Licence, v2 or any higher version
+#
+# Please cite your use of MDAnalysis in published work:
+#
+# N. Michaud-Agrawal, E. J. Denning, T. B. Woolf, and O. Beckstein.
+# MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
+# J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
+#
+
+from __future__ import print_function
+
+import collections
+import os
+import sys
+
+import gc
+
+from nose.plugins.base import Plugin
+from nose.pyversion import exc_to_unicode, force_unicode
+from nose.util import ln
+
+
+class ReportUniverse(Plugin):
+    """Track leaking Universes.
+    """
+    enabled = False
+    env_opt = 'NOSE_MDA_UNIVERSE'
+    name = 'universe'
+
+    def options(self, parser, env):
+        """Registers the commandline option, defaulting to disabled.
+        """
+        parser.add_option(
+            "--with-{}".format(self.name), action="store_true",
+            default=env.get(self.env_opt, False), dest="do_mda_universe",
+            help="Track leaking Universes. [{}]".format(self.env_opt))
+
+    def configure(self, options, conf):
+        """Configure the plugin.
+        """
+        super(ReportUniverse, self).configure(options, conf)
+        self.config = conf # This will let other tests know about config settings.
+        try:
+            self.enabled = options.do_mda_universe
+        except AttributeError:
+            self.enabled = False
+
+    def report(self, stream):
+        # We need to import MDAnalysis to have the list of the living Universes.
+        # Yet, we should avoid importing the library at the beginning of the
+        # test as it could mask some errors and mess up with coverage tracking.
+        # Therefore, MDAnalysis is imported here--in the function--only were
+        # it is needed, and only if the plugin is enabled.
+        import MDAnalysis as mda
+
+        print('\n', file=stream)
+        print('There are {} living Universes at the end of the tests.'
+              .format(len(mda._anchor_universes)), file=stream)
+        if mda._anchor_universes:
+            print('These univerese are still referenced:', file=stream)
+            for universe in mda._anchor_universes:
+                reader = universe.trajectory
+                referrers = gc.get_referrers(universe)
+                ref_counter = collections.Counter(r.__class__ for r in referrers)
+                # Exclude the reference we created in the loop.
+                n_references = sys.getrefcount(universe) - 1
+                print('* {}'.format(universe), file=stream)
+                print('  reader: {}'.format(reader), file=stream)
+                print('  {} references to the universe'.format(n_references),
+                      file=stream)
+                print('  referenced by ' + str(ref_counter), file=stream)
+
+
+plugin_class = ReportUniverse

--- a/testsuite/setup.py
+++ b/testsuite/setup.py
@@ -209,6 +209,7 @@ For details see the report for `Issue 87`_.
               'numpy>=1.5',
               'nose>=1.3.7',
               'psutil>=4.0.2',
+              'objgraph',
           ],
           # had 'KeyError' as zipped egg (2MB savings are not worth the
           # trouble)


### PR DESCRIPTION
Useful for #875, discussion started in #874.

The plugin can be enable by running mda_nosetests with the
`--with-universe` option or with the NOSE_MDA_UNIVERSE environment
variable.

The plugin lists the leaving Universes, so as the reader they use and
the references that still exist to these universes.

The plugin is disabled by default because it is quite verbose, and
because it relies on the gc module which availability may depends on the
python implementation.