### PR TITLE
Added self._index for easy array operations using AnalysisBase

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -15,7 +15,7 @@ The rules for this file:
 ------------------------------------------------------------------------------
 ??/??/16 kain88-de,jdetle, fiona-naughton, richardjgowers
 
-  * 0.15.1 
+  * 0.15.1
 
 Fixes
   * reading/writing lambda value in trr files (Issue #859)
@@ -24,6 +24,8 @@ Fixes
     next (Issue #869)
 
 Changes
+  * Added protected variable _frame_index to to keep track of frame iteration
+    number in AnalysisBase
   * Added new AlignTraj class for alignment that follows the new analysis API known
     as Bauhaus style.
 

--- a/package/MDAnalysis/analysis/base.py
+++ b/package/MDAnalysis/analysis/base.py
@@ -97,6 +97,7 @@ class AnalysisBase(object):
         self._prepare()
         for i, ts in enumerate(
                 self._trajectory[self.start:self.stop:self.step]):
+            self._index = i
             self._ts = ts
             # logger.info("--> Doing frame {} of {}".format(i+1, self.nframes))
             self._single_frame()

--- a/package/MDAnalysis/analysis/base.py
+++ b/package/MDAnalysis/analysis/base.py
@@ -97,7 +97,7 @@ class AnalysisBase(object):
         self._prepare()
         for i, ts in enumerate(
                 self._trajectory[self.start:self.stop:self.step]):
-            self._index = i
+            self._frame_index = i
             self._ts = ts
             # logger.info("--> Doing frame {} of {}".format(i+1, self.nframes))
             self._single_frame()


### PR DESCRIPTION
## Changes made in this Pull Request:
 -Added a protected instance variable self._index 
to be used in frame iteration much like self._ts 
can.

 - [x] CHANGELOG updated?

