### PR TITLE
Only filter MDAnalysis deprecation warnings

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -22,6 +22,7 @@ Fixes
   * fix __iter__/next redundancy (Issue #869)
   * SingleFrameReader now raises StopIteration instead of IOError on calling
     next (Issue #869)
+  * Display of Deprecation warnings doesn't affect other modules anymore (Issue #754)
 
 Changes
   * Added protected variable _frame_index to to keep track of frame iteration

--- a/package/MDAnalysis/__init__.py
+++ b/package/MDAnalysis/__init__.py
@@ -1,5 +1,5 @@
 # -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
-# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
 #
 # MDAnalysis --- http://www.MDAnalysis.org
 # Copyright (c) 2006-2015 Naveen Michaud-Agrawal, Elizabeth J. Denning, Oliver Beckstein
@@ -161,8 +161,9 @@ from .lib.log import start_logging, stop_logging
 logging.getLogger("MDAnalysis").addHandler(log.NullHandler())
 del logging
 
-# DeprecationWarnings are loud by default
-warnings.simplefilter('once', DeprecationWarning)
+# only MDAnalysis DeprecationWarnings are loud by default
+warnings.filterwarnings(action='once', category=DeprecationWarning,
+                        module='MDAnalysis')
 
 
 from . import units


### PR DESCRIPTION
Fixes #754

Changes made in this Pull Request:
 - our warnings filter only acts on warnings in the MDAnalysis module now.


PR Checklist
------------
 - ~~[ ] Tests?~~
 - ~~[ ] Docs?~~
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?

This gets rid of the annoying deprecation warnings in
ipython when MDAnalysis is loaded.