### PR TITLE
Resolving Truncation of resids for GRO file writing (Issue 886)

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,7 +13,7 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-??/??/16 tyler.je.reddy, kain88-de,jdetle, fiona-naughton, richardjgowers
+??/??/16 kain88-de, jdetle, fiona-naughton, richardjgowers, tyler.je.reddy
 
   * 0.15.1
 

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,11 +13,12 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-??/??/16 kain88-de,jdetle, fiona-naughton, richardjgowers
+??/??/16 tyler.je.reddy, kain88-de,jdetle, fiona-naughton, richardjgowers
 
   * 0.15.1
 
 Fixes
+  * GROWriter resids now truncated properly (Issue #886)
   * reading/writing lambda value in trr files (Issue #859)
   * fix __iter__/next redundancy (Issue #869)
   * SingleFrameReader now raises StopIteration instead of IOError on calling

--- a/package/MDAnalysis/coordinates/GRO.py
+++ b/package/MDAnalysis/coordinates/GRO.py
@@ -297,9 +297,10 @@ class GROWriter(base.Writer):
             # Atom descriptions and coords
             for atom_index, atom in enumerate(atoms):
                 truncated_atom_index = int(str(atom_index + 1)[-5:])
+                truncated_resid = int(str(atom.resid)[:5])
                 if has_velocities:
                     output_gro.write(self.fmt['xyz_v'].format(
-                        resid=atom.resid,
+                        resid=truncated_resid,
                         resname=atom.resname,
                         index=truncated_atom_index,
                         name=atom.name,
@@ -308,7 +309,7 @@ class GROWriter(base.Writer):
                     ))
                 else:
                     output_gro.write(self.fmt['xyz'].format(
-                        resid=atom.resid,
+                        resid=truncated_resid,
                         resname=atom.resname,
                         index=truncated_atom_index,
                         name=atom.name,

--- a/testsuite/MDAnalysisTests/coordinates/test_gro.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_gro.py
@@ -294,7 +294,7 @@ class TestGROWriterLarge(TestCase, tempdir.TempDir):
     def test_writer_large_residue_count(self):
         """Ensure large residue number truncation for
         GRO files (Issue 886)."""
-        outfile = self.tmpdir.name + '/outfile2.gro'
+        outfile = os.path.join(self.tmpdir.name, 'outfile2.gro')
         target_resname = self.large_universe.residues[-1].resname
         resid_value = 999999999999999999999
         self.large_universe.residues[-1].atoms.resids = resid_value

--- a/testsuite/MDAnalysisTests/coordinates/test_gro.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_gro.py
@@ -261,6 +261,8 @@ class TestGROWriter(TestCase, tempdir.TempDir):
 
 class TestGROWriterLarge(TestCase, tempdir.TempDir):
 
+    # not normally recommended to use class-level
+    # setup for universe (special case here)
     @classmethod
     def setUpClass(cls):
         cls.tmpdir = tempdir.TempDir()


### PR DESCRIPTION
Fixes #886 (truncation of `.gro` file resids during writing). 

PR Checklist
------------
 - [x] Tests
 - [x] Fix the writer code proper
 - [x] CHANGELOG updated

