### PR TITLE
[WIP] make Bundle (for handling simulation sets)

### DIFF
--- a/package/MDAnalysis/bundle.py
+++ b/package/MDAnalysis/bundle.py
@@ -14,6 +14,49 @@
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
 
+"""
+Bundle module
+=============
+
+This module provides classes for grouping related simulations as datreant
+Bundles and storing additional data describing each under common 
+names. [[ link datreant ]]
+
+'Additoinal data' may be timeseries (e.g. a distance measured throughout 
+the simulation), stored as auxiliary data; or single values (e.g. temperature),
+stored in datreant Categories.
+
+Simulations may be added to bundles as part of a list of simulations using
+:func:`make_bundle` (optionally adding meta/auxiliary data) or individually (at
+a specified position) using :func:`add_to_bundle`. 
+
+#[[ In each case, simulations are added to the Bundle as (persistantly stored) 
+#MDSynthesis Sims [[link]]; but may also be passed in as a MDAnalysis Universe, 
+#trajectory filename or (topology filename, trajectory filename) tuple; in which
+#case a Sim is first created using a provided/default name. ]]
+#[[ providing top/univ_kwargs separately; examples; etc... avoid doubling up with 
+#func documentation... ]]
+
+The resulting Bundle may the be used as outlined in [MDSynthesis/datreant 
+documentation] - e.g. individual simulations may be accessed by index or name::
+    bund = make_bundle([Univ1, Univ2], names=['A', 'B'])
+    bund[0]                 # returns the Sim for Univ1
+    bund['B'].universe      # returns Univ2
+Metadata are stored in Sim categories, and so may be accessed/assigned 
+individually as e.g. ``bund[0].categories[name]`` or collectively as 
+``bund.categories[name]``. 
+
+Auxiliary data is not yet integrated with Sims; they may still be 
+added/accessed directly through each universe, e.g. 
+``bundle[0].universe.trajectory.add_auxiliary()`` and 
+``bundle[0].universe.trajectory.ts.aux``, but currently are not persistently
+stored.
+
+.. autofunction:: make_bundle
+.. autofunction:: add_to_bundle
+
+"""
+import numpy as np
 
 from mdsynthesis import Sim
 import datreant.core as dtr
@@ -24,19 +67,29 @@ def make_bundle(simulations, topology=None, univ_kwargs=None, names=None,
                 data=None, auxs=None, aux_kwargs=None):
     """ Create a MDSynthesis Bundle from a set of simulations.
 
-    Simulations may be passed in as a list of MDSynthesis Sims, Universes or
-    trajectory files; in the latter case, a single topology file or corresponding
-    list of topology files must be provided with the *topology* kwarg, so the  
-    following are all valid::
-        make_bundle([Sim1, Sim2, ...])
-        make_bundle([Universe1, Universe2, ...])
-        make_bundle([traj_file1, traj_file2, ...], topology=common_topology_file)
+    Simulations are passed in as a list; each may of any of the allowed
+    simulation types (see [[ ref? or list here anyway? ]]); e.g.::
+
+        make_bundle([Sim1, Sim2, Sim3, ...])
+        make_bundle([(top_file1, traj_file1), (top_file2, traj_file2), ...])
+        make_bundle([Universe1, Sim2, traj_file3, (top_file4, traj_file4)...])
+
+    If providing just a trajectory filename, a topology file may be specified 
+    with the *topology* kwarg, either as a single common topology or a 
+    list of files corresonding to each simulation. e.g.:: 
+
+        make_bundle([traj_file1, traj_file2, ... ], topology=common_top_file)
         make_bundle([traj_file1, traj_file2, ...], 
                     topology=[top_file1, top_file2, ...])
 
-    For the trajectory case, if additional keyword arguments are required, these 
-    can be provided as *univ_kwargs*. [currently assumes we're using
-    the same kwargs for all].
+    If no topology file is provided, the trajectory file is assumed to double
+    as a topology.
+
+    When providing filenames, if additional keyword arguments are required to
+    load the corresponding Universe, these can be provided as *univ_kwargs*. 
+    Only one set of *univ_kwargs* may be provided, assumed to be common for all;
+    otherwise, simulations should be loaded separately before bundling or 
+    added separately using :func:`add_to_bundle`.
 
     If not passing in Sims, these are created, using names passed in with the
     *names* kwarg (as a list). If names are not provided, the index is 
@@ -49,7 +102,7 @@ def make_bundle(simulations, topology=None, univ_kwargs=None, names=None,
     may be gien in place of a list. e.g.::
 
         make_bundle([Sim1, Sim2], auxs={'pull_f': ['sim1.xvg', 'sim2.xvg']},
-                    data = {'dist':[1,2], 'temp':300}
+                    data = {'dist':[1,2], 'temp':300})
 
     If additional kwargs are requried for adding auxiliaries, these may 
     be supplied with *aux_kwargs*::
@@ -57,61 +110,56 @@ def make_bundle(simulations, topology=None, univ_kwargs=None, names=None,
         make_bundle([Sim1, Sim2], auxs={'pull_f': ['sim1.xvg', 'sim2.xvg']},
                      aux_kwargs={'pull_f': {'dt': 400}})
 
-    The returned Bundle may the be used as outlined in [MDSynthesis/datreant 
-    documentation] - e.g. individual simulations may be accessed by index or name::
-        bund = make_bundle([Univ1, Univ2], names=['A', 'B'])
-        bund[0]                 # returns the Sim for Univ1
-        bund['B'].universe      # returns Univ2
-    Metadata are stored in Sim categories, and so may be acessed/assigned 
-    individually as e.g. ``bund[0].categories[name]`` or collectively as 
-    ``bund.categories[name]``. 
-
-    Auxiliary data is not yet integrated with Sims; they may still be 
-    added/accessed directly through each universe, e.g. 
-    ``bundle[0].universe.trajectory.add_auxiliary()`` and 
-    ``bundle[0].universe.trajectory.ts.aux``, but currently are not persistently
-    stored.
-
+    Parameters
+    ----------
+    simulation : lst
+        list of simulation to add (ordered if required) [[ list possible types? ]]
+    topology : (str, lst), optional
+        filename for single topology corresponding to all simulations for which
+        only a trajectory filename is provided, or ordered list of topology
+        filenames corresponding to each simulation
+    univ_kwargs : dict, optional
+        dictionary of additional arguments to pass to Universe for each 
+        simulation passed as filenames
+    names : lst of str
+        ordered list of names for the simulation
+    data : dict
+        dictionary of metadata names and corresponding values to add
+    auxs : dixt
+        dictionary of auxiliary names and corresponding data to add
+    aux_kwargs : dict of dict
+        dictionary of additional arguments to use when loading each set of
+        auxiliary data
     """
-    # TODO - check length of various lists match 
-    # TODO - use Group
-    # TODO - careful about overwriting existing sims/category values
-
     if names is None:
         # if names not provided, use the index for name
         names = map(str, range(len(simulations)))
-    if all(isinstance(s, str) for s in simulations):
-        # assume passing in traj/top
-        trajs = simulations
-        if not topology:
-            raise ValueError('Must supply topology file/s if providing '
-                             'simulations as trajectory files.')
-        tops = topology
-        uargs = univ_kwargs if univ_kwargs is not None else {}
-        if isinstance(tops, str):
-            # assume we've passed in a single common topology. 
-            tops = [tops]*len(trajs)
-        bundle = dtr.Bundle([Sim(name, new=True) for name in names])
-        for i, sim in enumerate(bundle):
-            sim.universe = Universe(tops[i], trajs[i], **uargs)
-    elif all(isinstance(s, Universe) for s in simulations):
-        # assume we've passed in list of Universes
-        bundle = dtr.Bundle([Sim(name, new=True) for name in names])
-        for i, sim in enumerate(bundle):
-            sim.universe = simulations[i]
-    elif all(isinstance(s, Sim) for s in simulations):
-        # assume we've passed in a list of Sims
-        bundle = dtr.Bundle(simulations)
-    else:
-        raise TypeError('Simulations must be passed in all as trajectory '
-                        'filenames, all as Universes, or all as MDSynthesis '
-                        'Sims')
+    elif len(names) != len(simulations):
+        raise ValueError("Number of simulations ({}) and number of names ({}) do "
+                         "not match".format(len(simulations), len(names)))
+
+    if not isinstance(topology, (list, np.ndarray)):
+        # assume all use the same topology
+        tops = [topology]*len(simulations)
+    elif len(topology) != len(simulations):
+        raise ValueError("Number of simulations ({}) and number of topologies ({}) "
+                         "do not match".format(len(simulations), len(topology)))
+
+    bundle = dtr.Bundle()
+    for i, sim in enumerate(simulations):
+        bundle = add_to_bundle(bundle=bundle, simulation=sim, topology=tops[i],
+                               name=names[i])
+       
 
     ## Add any auxiliaries
     auxargs = aux_kwargs if aux_kwargs is not None else {}
     if auxs is not None:
         for auxname, auxvals in auxs.items():
             args = aux_kwargs.get(auxname, {})
+            if len(auxvals) != len(simulations):
+                raise ValueError("Number of simulations ({}) and number of values"
+                                 " for auxiliary {} ({}) do not match".format(
+                                       len(simulations), auxname, len(auxvals)))
             for i, sim in enumerate(bundle):
                 sim.universe.trajectory.add_auxiliary(auxname=auxname, 
                                                       auxdata=auxvals[i], **args) 
@@ -119,6 +167,101 @@ def make_bundle(simulations, topology=None, univ_kwargs=None, names=None,
     ## Add any metadata
     data = data if data is not None else {}
     for key, values in data.items():
+        if (isinstance(values, (list, np.ndarray)) and 
+           len(values) != len(simulations)):
+            raise ValueError("Number of simulations ({}) and number of values for"
+                             " metadata {} ({}) do not match".format(
+                                            len(simulations), key, len(values)))
         bundle.categories[key] = values
 
     return bundle
+
+
+def add_to_bundle(bundle=None, simulation=None, name=None, index=None, 
+                  topology=None, univ_kwargs=None):
+    """ Insert *simulation* into *bundle* at the position *index* and return new
+    bundle.
+
+    If *bundle* is None, a new bundle is created containing just *simulation*
+    and returned. 
+
+    *simulation* may be [[ ... see above, or list here as well? ]]
+
+    Parameters
+    ----------
+    bundle : datreant Bundle object, optional
+        bundle to insert simulation into
+    simulation :
+        simulation to add; [[ list possible types? ]]
+    name : str
+        name for the simulation
+    index : int, optional
+        position in which to insert *simulation*. If *None* (default), the 
+        simulation will be added in the last position.
+    topology : str, optional
+        filename for corresponding topology if simulation is provided as a 
+        trajectory filename
+    univ_kwargs : dict, optional
+        dictionary of additional arguments to pass to Universe.
+
+
+    Returns
+    -------
+    bundle : datreant Bundle object
+        updated bundle
+    """
+    new_sim = _make_sim(simulation, name=name, topology=topology, 
+                        univ_kwargs=univ_kwargs)
+    if bundle is None:
+        # make a new bundle and return
+        # TODO - should we warn this is what we're doing?
+        return dtr.Bundle(simulation)
+    elif isinstance(bundle, dtr.Bundle):
+        if index is None:
+            bundle.add(new_sim)
+        else:
+            sims = [sim for sim in bundle]
+            sims.insert(index, new_sim)
+            bundle = dtr.Bundle(sims)
+        return bundle
+    else:
+         raise TypeError("Invalid bundle {}".format(bundle))
+
+
+def _make_sim(simulation, name=None, topology=None, univ_kwargs=None):
+    """ Return a MDSynthesis Sim for *simulation* with name *name*. """
+    univ_kwargs = univ_kwargs or {}
+    if isinstance(simulation, Sim):
+        # TODO - warn that name will be ignored?
+        return simulation
+    # TODO - allow to just provide name of existing saved Sim
+
+    # check we have a valid *name* and make a new Sim
+    if not isinstance(name, str):
+        raise TypeError('Invalid Sim name {}'.format(name))
+    sim = Sim(name, new=True)
+   
+    if isinstance(simulation, str):
+        # assume passing in trajectory/topology file
+        if isinstance(topology, str):
+            sim.universe = Universe(topology, simulation, **univ_kwargs)
+        elif topology is None:
+            # try load with the trajectory as topology
+            # TODO - warn that we're assuming traj acts as top?
+            sim.universe = Universe(simulation, **univ_kwargs)
+        else:
+            raise TypeError('Invalid topology {}'.format(topology))
+    elif (isinstance(simulation, tuple) and 
+         all(isinstance(x, str) for x in simulation)):
+         # assume we're passing in a tuple with top, traj filenames
+         sim.universe = Universe(simulation[0], simulation[1], **univ_kwargs)
+         # TODO - figure out if the order is wrong?
+    elif isinstance(simulation, Universe):
+         sim.universe = simulation
+    else:
+        raise TypeError('Invalid simulation {}; must be MDSynthesis Sim, '
+                        'Universe, trajectory filename or tuple of (topology, '
+                        'trajectory file names'.format(simulation))
+
+    return sim
+    

--- a/package/MDAnalysis/bundle.py
+++ b/package/MDAnalysis/bundle.py
@@ -50,14 +50,14 @@ def make_bundle(simulations, topology=None, univ_kwargs=None, names=None,
     stored.
 
     """
-    # TODO - check length of various lists match + all of same type
+    # TODO - check length of various lists match 
     # TODO - use Group
     # TODO - careful about overwriting existing sims/category values
 
     if names is None:
         # if names not provided, use the index for name
         names = map(str, range(len(simulations)))
-    if isinstance(simulations[0], str):
+    if all(isinstance(s, str) for s in simulations):
         # assume passing in traj/top
         trajs = simulations
         if not topology:
@@ -70,18 +70,19 @@ def make_bundle(simulations, topology=None, univ_kwargs=None, names=None,
             tops = [tops]*len(trajs)
         bundle = dtr.Bundle([Sim(name, new=True) for name in names])
         for i, sim in enumerate(bundle):
-            sim.universe = Universe(tops[i], trajs[i], **univ_kwargs)
-    elif isinstance(simulations[0], Universe):
+            sim.universe = Universe(tops[i], trajs[i], **uargs)
+    elif all(isinstance(s, Universe) for s in simulations):
         # assume we've passed in list of Universes
         bundle = dtr.Bundle([Sim(name, new=True) for name in names])
         for i, sim in enumerate(bundle):
             sim.universe = simulations[i]
-    elif isinstance(simulations[0], Sim):
+    elif all(isinstance(s, Sim) for s in simulations):
         # assume we've passed in a list of Sims
         bundle = dtr.Bundle(simulations)
     else:
-        raise TypeError('simulations must be trajectory filenames, '
-                        'Universes or MDSynthesis Sims')
+        raise TypeError('Simulations must be passed in all as trajectory '
+                        'filenames, all as Universes, or all as MDSynthesis '
+                        'Sims')
 
     ## Add any auxiliaries
     auxargs = aux_kwargs if aux_kwargs is not None else {}

--- a/package/MDAnalysis/bundle.py
+++ b/package/MDAnalysis/bundle.py
@@ -1,3 +1,20 @@
+# -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 
+#
+# MDAnalysis --- http://www.MDAnalysis.org
+# Copyright (c) 2006-2015 Naveen Michaud-Agrawal, Elizabeth J. Denning, Oliver
+# Beckstein and contributors (see AUTHORS for the full list)
+#
+# Released under the GNU Public Licence, v2 or any higher version
+#
+# Please cite your use of MDAnalysis in published work:
+#
+# N. Michaud-Agrawal, E. J. Denning, T. B. Woolf, and O. Beckstein.
+# MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
+# J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
+#
+
+
 from mdsynthesis import Sim
 import datreant.core as dtr
 

--- a/package/MDAnalysis/bundle.py
+++ b/package/MDAnalysis/bundle.py
@@ -45,13 +45,19 @@ def make_bundle(simulations, topology=None, univ_kwargs=None, names=None,
     Metadata and auxiliary data may be added on initialisation using the *data*  
     and *auxs* kwargs, respectively, passing in the (ordered) list of 
     values/auxiliary filenames etc for each simulation keyworded by metadata/auxiliary
-    name. If additional kwargs are requried for adding auxiliaries, these may 
-    be supplied with *aux_kwargs*. e.g.::
+    name; for metadata where all simulations have the same value, a single value
+    may be gien in place of a list. e.g.::
+
         make_bundle([Sim1, Sim2], auxs={'pull_f': ['sim1.xvg', 'sim2.xvg']},
-                    data = {'dist':[1,2]}, aux_kwargs={'pull_f': {'dt': 400}})
+                    data = {'dist':[1,2], 'temp':300}
 
+    If additional kwargs are requried for adding auxiliaries, these may 
+    be supplied with *aux_kwargs*::
 
-    The returned Bundle may the be used as outlines in [MDSynthesis/datreant 
+        make_bundle([Sim1, Sim2], auxs={'pull_f': ['sim1.xvg', 'sim2.xvg']},
+                     aux_kwargs={'pull_f': {'dt': 400}})
+
+    The returned Bundle may the be used as outlined in [MDSynthesis/datreant 
     documentation] - e.g. individual simulations may be accessed by index or name::
         bund = make_bundle([Univ1, Univ2], names=['A', 'B'])
         bund[0]                 # returns the Sim for Univ1
@@ -112,7 +118,7 @@ def make_bundle(simulations, topology=None, univ_kwargs=None, names=None,
 
     ## Add any metadata
     data = data if data is not None else {}
-    for i, sim in enumerate(bundle):
-        sim.categories.add({key: value[i] for key, value in data.items()})
+    for key, values in data.items():
+        bundle.categories[key] = values
 
     return bundle

--- a/package/MDAnalysis/make_bundle.py
+++ b/package/MDAnalysis/make_bundle.py
@@ -3,8 +3,8 @@ import datreant.core as dtr
 
 from .core.AtomGroup import Universe
 
-def make_bundle(simulations, topology=None, univ_kwargs={}, names=None, 
-                data={}, auxs={}, aux_kwargs={}):
+def make_bundle(simulations, topology=None, univ_kwargs=None, names=None, 
+                data=None, auxs=None, aux_kwargs=None):
     """ Create a MDSynthesis Bundle from a set of simulations.
 
     Simulations may be passed in as a list of MDSynthesis Sims, Universes or
@@ -50,16 +50,13 @@ def make_bundle(simulations, topology=None, univ_kwargs={}, names=None,
     stored.
 
     """
-    # TODO - check length of various lists match
+    # TODO - check length of various lists match + all of same type
     # TODO - use Group
     # TODO - careful about overwriting existing sims/category values
 
-    if not names:
+    if names is None:
         # if names not provided, use the index for name
-        names = map(str, range(len(args[0])))
-    if not isinstance(simulations, list): 
-        raise TypeError('simulations must be list of trajectory filenames, '
-                        'Universes or MDSynthesis Sims')
+        names = map(str, range(len(simulations)))
     if isinstance(simulations[0], str):
         # assume passing in traj/top
         trajs = simulations
@@ -67,6 +64,7 @@ def make_bundle(simulations, topology=None, univ_kwargs={}, names=None,
             raise ValueError('Must supply topology file/s if providing '
                              'simulations as trajectory files.')
         tops = topology
+        uargs = univ_kwargs if univ_kwargs is not None else {}
         if isinstance(tops, str):
             # assume we've passed in a single common topology. 
             tops = [tops]*len(trajs)
@@ -82,17 +80,20 @@ def make_bundle(simulations, topology=None, univ_kwargs={}, names=None,
         # assume we've passed in a list of Sims
         bundle = dtr.Bundle(simulations)
     else:
-        raise TypeError('simulations must be list of trajectory filenames, '
+        raise TypeError('simulations must be trajectory filenames, '
                         'Universes or MDSynthesis Sims')
 
     ## Add any auxiliaries
-    for auxname, auxvals in auxs.items():
-        args = aux_kwargs.get(auxname, {})
-        for i, sim in enumerate(bundle):
-            sim.universe.trajectory.add_auxiliary(auxname=auxname, 
-                                                  auxdata=auxvals[i], **args) 
+    auxargs = aux_kwargs if aux_kwargs is not None else {}
+    if auxs is not None:
+        for auxname, auxvals in auxs.items():
+            args = aux_kwargs.get(auxname, {})
+            for i, sim in enumerate(bundle):
+                sim.universe.trajectory.add_auxiliary(auxname=auxname, 
+                                                      auxdata=auxvals[i], **args) 
 
     ## Add any metadata
+    data = data if data is not None else {}
     for i, sim in enumerate(bundle):
         sim.categories.add({key: value[i] for key, value in data.items()})
 

--- a/package/MDAnalysis/make_bundle.py
+++ b/package/MDAnalysis/make_bundle.py
@@ -1,0 +1,91 @@
+from mdsynthesis import Sim
+import datreant.core as dtr
+
+from .core.AtomGroup import Universe
+
+def make_bundle(*args, **kwargs):
+    """ Create a MDSynthesis Bundle from a set of simulations.
+
+    Simulations may be passed in as a list of MDSynthesis Sims, Universes or
+    trajectory files; in the latter case, a single topology file or corresponding
+    list of topology files must also be provided as a second argument, so the 
+    following are all valid::
+        make_bundle([Sim1, Sim2, ...])
+        make_bundle([Universe1, Universe2, ...])
+        make_bundle([traj_file1, traj_file2, ...], common_topology_file)
+        make_bundle([traj_file1, traj_file2, ...], [top_file1, top_file2, ...])
+
+    For the trajectory case, if additional keyword arguments are required, these 
+    can be provided with the kwarg *univ_kwargs*. [currently assumes we're using 
+    the same kwargs for all].
+
+    If not passing in Sims, these are created, using names passed in 
+    with the *names* kwarg (as a list). If names are not provided, the index is 
+    used instead. 
+
+    Metadata and auxiliary data may be added on initialisation using the *data*  
+    and *auxs* kwargs, respectively, passing in the (ordered) list of 
+    values/auxiliary filenames etc for each simulation keyworded by metadata/auxiliary
+    name. If additional kwargs are requried for adding auxiliaries, these may 
+    be supplied with *aux_kwargs*. e.g.::
+        make_bundle([Sim1, Sim2], auxs={'pull_f': ['sim1.xvg', 'sim2.xvg']},
+                    data = {'dist':[1,2]}, aux_kwargs={'pull_f': {'dt': 400}})
+
+
+    The returned Bundle may the be used as outlines in [MDSynthesis/datreant 
+    documentation] - e.g. individual simulations may be accessed by index or name::
+        bund = make_bundle([Univ1, Univ2], names=['A', 'B'])
+        bund[0]                 # returns the Sim for Univ1
+        bund['B'].universe      # returns Univ2
+    Metadata are stored in Sim categories, and so may be acessed/assigned 
+    individually as e.g. ``bund[0].categories[name]`` or collectively as 
+    ``bund.categories[name]``. 
+
+    Auxiliary data is not yet integrated with Sims; they may still be 
+    added/accessed directly through each universe, e.g. 
+    ``bundle[0].universe.trajectory.add_auxiliary()`` and 
+    ``bundle[0].universe.trajectory.ts.aux``, but currently are not persistently
+    stored.
+
+    """
+    # TODO - check length of various lists match
+    # TODO - use Group
+    # TODO - careful about overwriting existing sims/category values
+
+    names = kwargs.get('names', map(str, range(len(args[0]))))
+    if len(args) == 2:
+        # assume passing in traj/top
+        trajs = args[0]
+        tops = args[1]
+        uargs = kwargs.get('univ_kwargs', {})
+        if isinstance(tops, str):
+            # assume we've passed in a single common topology. 
+            tops = [tops]*len(trajs)
+        bundle = dtr.Bundle([Sim(name, new=True) for name in names])
+        for i, sim in enumerate(bundle):
+            sim.universe = Universe(tops[i], trajs[i], **uargs)
+    elif isinstance(args[0][0], Universe):
+        # assume we've passed in list of Universes
+        bundle = dtr.Bundle([Sim(name, new=True) for name in names])
+        for i, sim in enumerate(bundle):
+            sim.universe = args[0][i]
+    elif isinstance(args[0][0], Sim):
+        # assume we've passed in a list of Sims
+        bundle = dtr.Bundle(args[0])
+
+    ## Add any auxiliaries
+    auxs = kwargs.get('auxs', {})
+    all_aux_args = kwargs.get('aux_kwargs', {})
+    for auxname, auxargs in auxs.items():
+        aux_args = all_aux_args.get(auxname, {})
+        for i, sim in enumerate(bundle):
+            sim.universe.trajectory.add_auxiliary(auxname=auxname, 
+                                                  auxdata=auxargs[i], 
+                                                  **aux_args) 
+
+    ## Add any metadata
+    data = kwargs.get('data', {})
+    for i, sim in enumerate(bundle):
+        sim.categories.add({key: value[i] for key, value in data.items()})
+
+    return bundle


### PR DESCRIPTION
Stemming from discussion in #843 (will deal with it in a roundabout way).

_(Uses [MDSynthesis](http://mdsynthesis.readthedocs.io/en/master/index.html). Built on top of all the auxiliary WIP #868 so all those commits show up here too, but currently only the last is relevant here; I could squash them, but not sure what the 'proper procedure' is?)_

This provides a `make_bundle` function that will return a `Bundle` of `mdsynthesis.Sim`s given a list of simulations, storing the universe and associated metadata. 

The idea is to simplifying dealing with sets of related simulations (such as from umbrella sampling) and their corresponding auxiliary data (e.g. pull force throughout simulation) + meta data (e.g. temperature). (Eventually, future analysis functions that work on sets of simulations (like WHAM) could accept a bundle as an argument, and check for required auxiliary/meta data before running etc). 

Using Bundles means MDSynthesis would now be a requirement, but saves trying to write a new wrapper within MDAnalysis.

The docstring describes the current usage. Possibly a little convoluted at the moment, but can be fixed. Likely to change when/if auxiliary data is included in MDSynthesis. (Also needs a better home than current 'make_bundle.py' in the main directory, but not sure where'd be best?).
## PR Checklist
- [ ] Tests?
- [ ] Docs?
- [ ] CHANGELOG updated?
- [ ] Issue raised/referenced?
