### PR TITLE
Issue#902

### DIFF
--- a/package/MDAnalysis/coordinates/GMS.py
+++ b/package/MDAnalysis/coordinates/GMS.py
@@ -225,12 +225,6 @@ class GMSReader(base.Reader):
 
         raise EOFError
 
-    def rewind(self):
-        """reposition on first frame"""
-        self._reopen()
-        # the next method is inherited from the Reader Class and calls _read_next_timestep
-        self.next()
-
     def _reopen(self):
         self.close()
         self.open_trajectory()

--- a/package/MDAnalysis/coordinates/PDB.py
+++ b/package/MDAnalysis/coordinates/PDB.py
@@ -318,9 +318,6 @@ class PDBReader(base.Reader):
         kwargs.setdefault('multiframe', self.n_frames > 1)
         return PDBWriter(filename, **kwargs)
 
-    def rewind(self):
-        self._read_frame(0)
-
     def _reopen(self):
         # Pretend the current TS is -1 (in 0 based) so "next" is the
         # 0th frame

--- a/package/MDAnalysis/coordinates/TRJ.py
+++ b/package/MDAnalysis/coordinates/TRJ.py
@@ -364,11 +364,6 @@ class TRJReader(base.Reader):
         self.trjfile.close()
         self.trjfile = None
 
-    def rewind(self):
-        """Reposition at the beginning of the trajectory"""
-        self._reopen()
-        next(self)
-
 
 class NCDFReader(base.Reader):
     """Reader for `AMBER NETCDF format`_ (version 1.0).

--- a/package/MDAnalysis/coordinates/XDR.py
+++ b/package/MDAnalysis/coordinates/XDR.py
@@ -142,10 +142,6 @@ class XDRBaseReader(base.Reader):
             except Exception as e:
                 warnings.warn("Couldn't save offsets because: {}".format(e))
 
-    def rewind(self):
-        """Read the first frame again"""
-        self._read_frame(0)
-
     @property
     def n_frames(self):
         """number of frames in trajectory"""

--- a/package/MDAnalysis/coordinates/XYZ.py
+++ b/package/MDAnalysis/coordinates/XYZ.py
@@ -366,12 +366,6 @@ class XYZReader(base.Reader):
         except (ValueError, IndexError) as err:
             raise EOFError(err)
 
-    def rewind(self):
-        """reposition on first frame"""
-        self._reopen()
-        # the next method calls _read_next_timestep
-        self.next()
-
     def _reopen(self):
         self.close()
         self.open_trajectory()


### PR DESCRIPTION
Fixes #902

Changes made in this Pull Request:
 - XDR (XTC TRR) and PDB now strictly follow `base.Reader.rewind` behaviour

This does mean that XDR does reopen the file rather than simply seek backwards (a backwards step for #871) but at least it's uniform starting point now.

PR Checklist
------------
 - ~~[ ] Tests?~~ n/a already covered
 - ~~[ ] Docs?~~
 - ~~[ ] CHANGELOG updated?~~ external behaviour not changed
 - [x] Issue raised/referenced?

Removed extra rewind methods, force all readers to follow base
implementation