### PR TITLE
Added flag at lib.distances.USED_OPENMP

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -24,6 +24,8 @@ Enhancements
   with 'quiet=False'
   * The 'run' method from all 'AnalysisBase' derived classes return the
   class itself.
+  * Added boolean flag at lib.distances.USED_OPENMP to reveal if
+    OpenMP was used in compilation (Issue #883)
 
 Fixes
   * GROWriter resids now truncated properly (Issue #886)

--- a/package/MDAnalysis/lib/distances.py
+++ b/package/MDAnalysis/lib/distances.py
@@ -21,6 +21,8 @@
 Fast C-routines to calculate distance arrays from coordinate
 arrays. Many of the functions also exist in parallel versions, that
 typically provide higher performance than the serial code.
+The boolean attribute MDAnalysis.lib.distances.USED_OPENMP can be
+checked to see if OpenMP was used in the compilation of MDAnalysis.
 
 Selection of acceleration ("backend")
 -------------------------------------
@@ -109,6 +111,8 @@ from .c_distances import (calc_distance_array,
                           calc_dihedral_triclinic,
                           ortho_pbc,
                           triclinic_pbc)
+
+from c_distances_openmp import OPENMP_ENABLED as USED_OPENMP
 
 
 def _box_check(box):

--- a/testsuite/MDAnalysisTests/test_distances.py
+++ b/testsuite/MDAnalysisTests/test_distances.py
@@ -715,3 +715,5 @@ class TestDistanceBackendSelection(object):
                                       backend="not_implemented_stuff")
 
 
+def test_used_openmpflag():
+    assert_(isinstance(MDAnalysis.lib.distances.USED_OPENMP, bool))


### PR DESCRIPTION
Fixes #883

Changes made in this Pull Request:
 - lib.distances.USED_OPENMP boolean flag


PR Checklist
------------
 - ~~[ ] Tests?~~ can't really test on Travis, checked manually by compiling with/without openmp
 - [x] test that checks that the flag is present and can be read (will be `False` on travis) (https://github.com/MDAnalysis/mdanalysis/pull/909#issuecomment-234615382 — @orbeckst)
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
