### PR TITLE
Reset InterRDF variables in `_prepare`, fixes #924

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -15,7 +15,7 @@ The rules for this file:
 ------------------------------------------------------------------------------
 ??/??/16 kain88-de, fiona-naughton, richardjgowers, tyler.je.reddy, jdetle
          euhruska, orbeckst
-        
+
   * 0.15.1
 
 Enhancements
@@ -36,8 +36,9 @@ Fixes
   * Display of Deprecation warnings doesn't affect other modules anymore (Issue #754)
   * Changed nframes to n_frames in analysis modules for consistency (Issue #890)
   * fixed incompatibility with newer matplotlib in analysis.hole
-  * Fixed modules that improperly documented and/or used frame slicing 
+  * Fixed modules that improperly documented and/or used frame slicing
     defaults (#914)
+  * Fixed same interRDF can be run twice (Issue #924)
 Changes
   * Added protected variable _frame_index to to keep track of frame iteration
     number in AnalysisBase

--- a/package/MDAnalysis/analysis/rdf.py
+++ b/package/MDAnalysis/analysis/rdf.py
@@ -87,7 +87,9 @@ class InterRDF(AnalysisBase):
 
         self.rdf_settings = {'bins': nbins,
                              'range': range}
+        self._exclusion_block = exclusion_block
 
+    def _prepare(self):
         # Empty histogram to store the RDF
         count, edges = np.histogram([-1], **self.rdf_settings)
         count = count.astype(np.float64)
@@ -103,12 +105,11 @@ class InterRDF(AnalysisBase):
         self._result = np.zeros((len(self.g1), len(self.g2)), dtype=np.float64)
         # If provided exclusions, create a mask of _result which
         # lets us take these out
-        if exclusion_block is not None:
-            self._exclusion_block = exclusion_block
-            self._exclusion_mask = blocks_of(self._result, *exclusion_block)
-            self._maxrange = range[1] + 1.0
+        if self._exclusion_block is not None:
+            self._exclusion_mask = blocks_of(self._result,
+                                             *self._exclusion_block)
+            self._maxrange = self.rdf_settings['range'][1] + 1.0
         else:
-            self._exclusion_block = None
             self._exclusion_mask = None
 
     def _single_frame(self):

--- a/testsuite/MDAnalysisTests/analysis/test_rdf.py
+++ b/testsuite/MDAnalysisTests/analysis/test_rdf.py
@@ -2,8 +2,8 @@
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 fileencoding=utf-8
 #
 # MDAnalysis --- http://www.MDAnalysis.org
-# Copyright (c) 2006-2015 Naveen Michaud-Agrawal, Elizabeth J. Denning, Oliver Beckstein
-# and contributors (see AUTHORS for the full list)
+# Copyright (c) 2006-2015 Naveen Michaud-Agrawal, Elizabeth J. Denning, Oliver
+# Beckstein and contributors (see AUTHORS for the full list)
 #
 # Released under the GNU Public Licence, v2 or any higher version
 #
@@ -14,9 +14,7 @@
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
 
-from numpy.testing import (
-    assert_,
-)
+from numpy.testing import assert_
 
 import MDAnalysis as mda
 from MDAnalysis.analysis.rdf import InterRDF
@@ -50,24 +48,20 @@ class TestInterRDF(object):
     def _get_sels(self):
         s1 = self.u.atoms.OW
         s2 = self.u.atoms.HW1 + self.u.atoms.HW2
-
         return s1, s2
 
     def test_nbins(self):
         s1 = self.u.atoms[:3]
         s2 = self.u.atoms[3:]
-
-        rdf = InterRDF(s1, s2, nbins=412)
+        rdf = InterRDF(s1, s2, nbins=412).run()
 
         assert_(len(rdf.bins) == 412)
 
     def test_range(self):
         s1 = self.u.atoms[:3]
         s2 = self.u.atoms[3:]
-
         rmin, rmax = 1.0, 13.0
-
-        rdf = InterRDF(s1, s2, range=(rmin, rmax))
+        rdf = InterRDF(s1, s2, range=(rmin, rmax)).run()
 
         assert_(rdf.edges[0] == rmin)
         assert_(rdf.edges[-1] == rmax)
@@ -76,32 +70,28 @@ class TestInterRDF(object):
         # OW vs HW
         # should see 8 comparisons in count
         self._linear_water()
-
         s1, s2 = self._get_sels()
-
-        rdf = InterRDF(s1, s2)
-        rdf.run()
-
+        rdf = InterRDF(s1, s2).run()
         assert_(rdf.count.sum() == 8)
 
     def test_count(self):
         # should see two distances with 4 counts each
         self._linear_water()
-
         s1, s2 = self._get_sels()
-
-        rdf = InterRDF(s1, s2)
-        rdf.run()
-
+        rdf = InterRDF(s1, s2).run()
         assert_(len(rdf.count[rdf.count == 4]) == 2)
-        
+
+    def test_double_run(self):
+        # running rdf twice should give the same result
+        self._linear_water()
+        s1, s2 = self._get_sels()
+        rdf = InterRDF(s1, s2).run()
+        rdf.run()
+        assert_(len(rdf.count[rdf.count == 4]) == 2)
+
     def test_exclusion(self):
         # should see two distances with 4 counts each
         self._linear_water()
-
         s1, s2 = self._get_sels()
-
-        rdf = InterRDF(s1, s2, exclusion_block=(1, 2))
-        rdf.run()
-
+        rdf = InterRDF(s1, s2, exclusion_block=(1, 2)).run()
         assert_(rdf.count.sum() == 4)


### PR DESCRIPTION
Fixes #924

Changes made in this Pull Request:
 - Add a `_prepare` function to InterRDF


PR Checklist
------------
 - [x] Tests?
 - ~~[ ] Docs?~~
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?

This hasn't been done so far. This leads to wrong results if `run` is
called twice.