### PR TITLE
WIP: Reader that does not need open file handles (#239)

### DIFF
--- a/package/MDAnalysis/lib/formats/libmdaxdr.pyx
+++ b/package/MDAnalysis/lib/formats/libmdaxdr.pyx
@@ -122,11 +122,12 @@ cdef class _XDRFile:
     This class can't be initialized use one of the subclasses XTCFile, TRRFile
     """
     cdef readonly int n_atoms
-    cdef int is_open
+    cdef readonly int is_open
     cdef int reached_eof
     cdef XDRFILE *xfp
     cdef readonly fname
     cdef int current_frame
+    cdef str _mode
     cdef str mode
     cdef np.ndarray box
     cdef np.ndarray _offsets
@@ -134,8 +135,10 @@ cdef class _XDRFile:
 
     def __cinit__(self, fname, mode='r'):
         self.fname = fname.encode('utf-8')
+        self._mode = mode
         self.is_open = False
-        self.open(self.fname, mode)
+        self.open()  # to read natoms
+        self.close()
 
     def __dealloc__(self):
         self.close()
@@ -210,6 +213,7 @@ cdef class _XDRFile:
 
     def __enter__(self):
         """Support context manager"""
+        self.open(self.fname, self._mode)
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
@@ -318,7 +322,10 @@ cdef class _XDRFile:
         set_offsets
         """
         if not self._has_offsets:
+            # wrap this in try/except to ensure it gets closed?
+            self.open(self.fname, self._mode)
             self._offsets = self.calc_offsets()
+            self.close()
             self._has_offsets = True
         return self._offsets
 

--- a/testsuite/MDAnalysisTests/coordinates/test_xyz.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_xyz.py
@@ -9,10 +9,12 @@ from numpy.testing import (
     assert_array_equal,
     assert_,
 )
+import mock
 
+from MDAnalysis.lib.util import openany
 from MDAnalysis.coordinates.XYZ import XYZWriter
 
-from MDAnalysisTests.datafiles import COORDINATES_XYZ, COORDINATES_XYZ_BZ2
+from MDAnalysisTests.datafiles import XYZ, COORDINATES_XYZ, COORDINATES_XYZ_BZ2
 from MDAnalysisTests.coordinates.base import (BaseReaderTest, BaseReference,
                                               BaseWriterTest)
 from MDAnalysisTests.core.groupbase import make_Universe, FakeReader
@@ -148,3 +150,26 @@ class TestXYZWriterNames(object):
 
         u2 = mda.Universe(self.outfile)
         assert_(all(u2.atoms.names == names))
+
+
+class TestXYZReaderFH(object):
+    # tests for the new filehandle behaviour (issue #239)
+    def setUp(self):
+        self.u = mda.Universe(XYZ)
+
+    def tearDown(self):
+        del self.u
+
+    #@mock.patch('MDAnalysis.lib.util.openany', wraps=openany)
+    def test_iteration(self):
+        # check filehandle is closed
+        assert_(self.u.trajectory._file.closed)
+
+        with mock.patch('MDAnalysis.lib.util.openany', wraps=openany) as mockopen:
+            for ts in self.u.trajectory:
+                print ts.frame
+
+            assert_(mockopen.call_count == 1)
+
+        # check filehandle is closed
+        assert_(self.u.trajectory._file.closed)


### PR DESCRIPTION
Adds a new base Reader class which doesn't need to maintain an open file handle.  Should fix problems related to too many open file handles.
### Explanation

Readers have 4 "front doors", (`__getitem__`, `next`, `__iter__`, `rewind`) which are publicly accessible methods to (indirectly) manipulate the file handle.

These front doors filter through to various backend methods in the base Reader (`_sliced_iter`, `_full_iter` and `_goto_frame`)

These backend methods then create the open file handle and call things in the individual implementations (eg `XYZReader._read_frame`)

Individual implementations are oblivious to the file handle manipulation above them, they just assume that a handle exists in a known location (ie this needs to be unified in API).

**EDIT** kain88-de: issue https://github.com/MDAnalysis/mdanalysis/issues/239#issuecomment-224016331
