### PR TITLE
Deferred AtomGroup class mixing to __new__, allowing subclassing.

### DIFF
--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -71,7 +71,7 @@ class _MutableBase(object):
     """
     Base class that merges appropriate :class:`TopologyAttr` container classes.
 
-    Implements :attr:`__new__`. In it the instantiating class is merged with
+    Implements :meth:`__new__`. In it the instantiating class is merged with
     the appropriate base from :attr:`Universe._classes`. The resulting class is
     saved in the :attr:`Universe._class_cache` dictionary. The instantiating
     class itself is used as the dictionary key, for simplicity in cache
@@ -80,7 +80,7 @@ class _MutableBase(object):
     The resulting merged class is also cached using itself as the key, to
     simplify class reuse. This is unneeded in practice because
     :class:`_ImmutableBase` is also merged in, with higher MRO precedence, and
-    its :attr:`__new__` shortcuts to :attr:`object.__new__`, skipping the
+    its :meth:`__new__` shortcuts to :meth:`object.__new__`, skipping the
     cache-fetch process when directly reusing an already-merged class.
     """
     # This signature must be kept in sync with the __init__ signature of

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -1575,17 +1575,6 @@ class Segment(_MutableBase):
     """
     order = 'component'
 
-    def __getattr__(self, attr):
-        if attr.startswith('r'):
-            resnum = int(attr[1:]) - 1
-            return self.residues[resnum]
-        else:
-            # resname from segment
-            rg = self.residues[self.residues.resnames == attr]
-            if rg:
-                return rg
-        raise AttributeError
-
     @property
     def atoms(self):
         atomsclass = self.level.child.child.plural

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -124,6 +124,8 @@ class Universe(object):
             return
 
         coordinatefile = args[1:]
+        if not coordinatefile:
+            coordinatefile = None
 
         # if we're given a Topology object, we don't need to parse anything
         if isinstance(args[0], Topology):
@@ -152,8 +154,6 @@ class Universe(object):
                     if (fmt in MDAnalysis.coordinates._READERS
                         and fmt in MDAnalysis.topology._PARSERS):
                         coordinatefile = self.filename
-                if len(coordinatefile) == 0:
-                    coordinatefile = None
 
             # build the topology (or at least a list of atoms)
             try:  # Try and check if the topology format is a TopologyReader

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -7,6 +7,7 @@ import MDAnalysis
 from ..lib import util
 from ..lib.util import cached
 from . import groups
+from .groups import AtomGroup, ResidueGroup, SegmentGroup
 from .topology import Topology
 from .topologyattrs import AtomAttr, ResidueAttr, SegmentAttr
 
@@ -182,21 +183,26 @@ class Universe(object):
     def _generate_from_topology(self):
         # generate Universe version of each class
         # AG, RG, SG, A, R, S
+        self._class_cache = {}
         self._classes = groups.make_classes()
 
         # Put Group level stuff from topology into class
         for attr in self._topology.attrs:
             self._process_attr(attr)
 
-        # Generate atoms, residues and segments
-        self.atoms = self._classes['atomgroup'](
-                np.arange(self._topology.n_atoms), self)
+        # Generate atoms, residues and segments.
+        # These are the first such groups generated for this universe, so
+        #  there are no cached merged classes yet. Otherwise those could be
+        #  used directly to get a (very) small speedup. (Only really pays off
+        #  the readability loss if instantiating millions of AtomGroups at
+        #  once.)
+        self.atoms = AtomGroup(np.arange(self._topology.n_atoms), self)
 
-        self.residues = self._classes['residuegroup'](
-                np.arange( self._topology.n_residues), self)
+        self.residues = ResidueGroup(
+                np.arange(self._topology.n_residues), self)
 
-        self.segments = self._classes['segmentgroup'](np.arange(
-            self._topology.n_segments), self)
+        self.segments = SegmentGroup(
+                np.arange(self._topology.n_segments), self)
 
         # Update Universe namespace with segids
         for seg in self.segments:
@@ -462,9 +468,8 @@ class Universe(object):
                       for a, val in f.items() if not val))
 
         # All the unique values in f are the fragments
-        AG = self._classes['atomgroup']
-        frags = tuple([AG(np.array([at.index for at in ag]), self)
-                       for ag in set(f.values())])
+        frags = tuple([AtomGroup(np.array([at.index for at in ag]), self)
+                        for ag in set(f.values())])
 
         fragdict = {}
         for f in frags:

--- a/testsuite/MDAnalysisTests/core/groupbase.py
+++ b/testsuite/MDAnalysisTests/core/groupbase.py
@@ -21,36 +21,7 @@ from MDAnalysis.core import groups
 
 def make_Universe():
     """Make a dummy reference Universe"""
-    u = mda.Universe()
-
-    u._topology = make_topology()
-
-    # generate Universe version of each class
-    # AG, RG, SG, A, R, S
-    u._classes = groups.make_classes()
-
-    # Put Group level stuff from topology into class
-    for attr in u._topology.attrs:
-        u._process_attr(attr)
-
-    # Generate atoms, residues and segments
-    u.atoms = u._classes['atomgroup'](
-        np.arange(u._topology.n_atoms), u)
-    u.residues = u._classes['residuegroup'](
-        np.arange( u._topology.n_residues), u)
-    u.segments = u._classes['segmentgroup'](np.arange(
-        u._topology.n_segments), u)
-
-    # Update Universe namespace with segids
-    for seg in u.segments:
-        if hasattr(seg, 'segid'):
-            if seg.segid[0].isdigit():
-                name = 's' + seg.segid
-            else:
-                name = seg.segid
-            u.__dict__[name] = seg
-
-    return u
+    return mda.Universe(make_topology())
 
 def make_topology():
     """Reference topology system


### PR DESCRIPTION
`Atom/Residue/SegmentGroup`s now merge the base classes from the `Universe` that contain the `TopologyAttr`s at instantiation time, via `__new__`. This allows subclassing of said general classes.

I kept an eye on performance, as previous attempts failed to keep `AtomGroup` instantiation satisfactorily cheap. A caching scheme was set up to avoid redoing the merging for already-merged classes.

Managed to reduce the performance penalty of the caching layer to 1.5x (comparing a cache retrieval vs. a direct class use). The absolute times per call are close to the limit of python speed, around 2µs per call, and any slowdown will only be noticeable if millions of `AtomGroups` are instantiated at once.

If this small speedup is important one can always use the cached class directly. In MDAnalysis internals I figured this wasn't worth the readability loss, and use plain `AtomGroup(...)` calls.

Didn't try to run the tests.
