### PR TITLE
Temporarily remove python 3 travis builds, allow osx to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,13 @@ env:
   matrix:
     - SETUP=minimal PYTHON_VERSION=2.7
     - SETUP=full PYTHON_VERSION=2.7
-    - SETUP=minimal PYTHON_VERSION=3.3
-    - SETUP=full PYTHON_VERSION=3.3
+      #- SETUP=minimal PYTHON_VERSION=3.3
+      #- SETUP=full PYTHON_VERSION=3.3
 matrix:
   allow_failures:
-    - env: SETUP=minimal PYTHON_VERSION=3.3
-    - env: SETUP=full PYTHON_VERSION=3.3
+      #- env: SETUP=minimal PYTHON_VERSION=3.3
+      #- env: SETUP=full PYTHON_VERSION=3.3
+    - os: osx
 
 before_install:
   - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then wget http://repo.continuum.io/miniconda/Miniconda-latest-MacOSX-x86_64.sh -O miniconda.sh; fi


### PR DESCRIPTION
Python 3 builds are to far from passing to be relevant on travis. This
commit disable them.

OS X builds fail because of an issue with surviving file descriptors
that is fixed in the new topology scheme. This commit allows the os x
build to fail.

The allowed failure of OS X build should be removed once #815 is merged. The python 3 builds should be reactivated once #929 is merged.