### PR TITLE
Analysis decorator fixes #946

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -15,7 +15,7 @@ The rules for this file:
 ------------------------------------------------------------------------------
 ??/??/16 kain88-de, fiona-naughton, richardjgowers, tyler.je.reddy, jdetle
          euhruska, orbeckst, rbrtdlg, jbarnoud
-        
+
   * 0.15.1
 
 Enhancements
@@ -30,7 +30,7 @@ Enhancements
     reduction.
   * Added Auxiliary module for reading additional timeseries data alongside
     trajectories (Issue #785)
-
+  * Added AnalysisFromFunction & analysis_class, see (Issue #946 and PR #950)
 Fixes
   * GROWriter resids now truncated properly (Issue #886)
   * reading/writing lambda value in trr files (Issue #859)

--- a/testsuite/MDAnalysisTests/analysis/test_base.py
+++ b/testsuite/MDAnalysisTests/analysis/test_base.py
@@ -14,21 +14,22 @@
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
 from __future__ import division
-
 from six.moves import range
 
+import numpy as np
+
 from numpy.testing import (
-    assert_, dec, raises
+    assert_, dec, raises, assert_raises, assert_equal, assert_array_equal
 )
 
 import MDAnalysis as mda
-from MDAnalysis.analysis.base import AnalysisBase
+from MDAnalysis.analysis import base
 
 from MDAnalysisTests.datafiles import PSF, DCD
 from MDAnalysisTests import parser_not_found
 
 
-class FrameAnalysis(AnalysisBase):
+class FrameAnalysis(base.AnalysisBase):
     """Just grabs frame numbers of frames it goes over"""
     def __init__(self, reader, **kwargs):
         super(FrameAnalysis, self).__init__(reader, **kwargs)
@@ -39,12 +40,12 @@ class FrameAnalysis(AnalysisBase):
         self.frames.append(self._ts.frame)
 
 
-class IncompleteAnalysis(AnalysisBase):
+class IncompleteAnalysis(base.AnalysisBase):
     def __init__(self, reader, **kwargs):
         super(IncompleteAnalysis, self).__init__(reader, **kwargs)
 
 
-class OldAPIAnalysis(AnalysisBase):
+class OldAPIAnalysis(base.AnalysisBase):
     """for version 0.15.0"""
     def __init__(self, reader, **kwargs):
         self._setup_frames(reader, **kwargs)
@@ -65,23 +66,23 @@ class TestAnalysisBase(object):
 
     def test_default(self):
         an = FrameAnalysis(self.u.trajectory).run()
-        assert_(an.n_frames == len(self.u.trajectory))
-        assert_(an.frames == list(range(len(self.u.trajectory))))
+        assert_equal(an.n_frames, len(self.u.trajectory))
+        assert_equal(an.frames, list(range(len(self.u.trajectory))))
 
     def test_start(self):
         an = FrameAnalysis(self.u.trajectory, start=20).run()
-        assert_(an.n_frames == len(self.u.trajectory) - 20)
-        assert_(an.frames == list(range(20, len(self.u.trajectory))))
+        assert_equal(an.n_frames, len(self.u.trajectory) - 20)
+        assert_equal(an.frames, list(range(20, len(self.u.trajectory))))
 
     def test_stop(self):
         an = FrameAnalysis(self.u.trajectory, stop=20).run()
-        assert_(an.n_frames == 20)
-        assert_(an.frames == list(range(20)))
+        assert_equal(an.n_frames, 20)
+        assert_equal(an.frames, list(range(20)))
 
     def test_step(self):
         an = FrameAnalysis(self.u.trajectory, step=20).run()
-        assert_(an.n_frames == 5)
-        assert_(an.frames == list(range(98))[::20])
+        assert_equal(an.n_frames, 5)
+        assert_equal(an.frames, list(range(98))[::20])
 
     def test_quiet(self):
         a = FrameAnalysis(self.u.trajectory, quiet=False)
@@ -93,3 +94,68 @@ class TestAnalysisBase(object):
 
     def test_old_api(self):
         OldAPIAnalysis(self.u.trajectory).run()
+
+
+def test_filter_baseanalysis_kwargs():
+    def bad_f(mobile, step=2):
+        pass
+
+    def good_f(mobile, ref):
+        pass
+
+    kwargs = {'step': 3, 'foo': None}
+
+    assert_raises(ValueError, base._filter_baseanalysis_kwargs, bad_f, kwargs)
+
+    base_kwargs, kwargs = base._filter_baseanalysis_kwargs(good_f, kwargs)
+
+    assert_equal(1, len(kwargs))
+    assert_equal(kwargs['foo'], None)
+
+    assert_equal(4, len(base_kwargs))
+    assert_equal(base_kwargs['start'], None)
+    assert_equal(base_kwargs['step'], 3)
+    assert_equal(base_kwargs['stop'], None)
+    assert_equal(base_kwargs['quiet'], True)
+
+
+def simple_function(mobile):
+    return mobile.center_of_geometry()
+
+
+def test_AnalysisFromFunction():
+    u = mda.Universe(PSF, DCD)
+    step = 2
+    ana1 = base.AnalysisFromFunction(simple_function, mobile=u.atoms,
+                                     step=step).run()
+    ana2 = base.AnalysisFromFunction(simple_function, u.atoms,
+                                     step=step).run()
+    ana3 = base.AnalysisFromFunction(simple_function, u.trajectory, u.atoms,
+                                     step=step).run()
+
+    results = []
+    for ts in u.trajectory[::step]:
+        results.append(simple_function(u.atoms))
+    results = np.asarray(results)
+
+    for ana in (ana1, ana2, ana3):
+        assert_array_equal(results, ana.results)
+
+
+def test_analysis_class():
+    ana_class = base.analysis_class(simple_function)
+    assert_(issubclass(ana_class, base.AnalysisBase))
+    assert_(issubclass(ana_class, base.AnalysisFromFunction))
+
+    u = mda.Universe(PSF, DCD)
+    step = 2
+    ana = ana_class(u.atoms, step=step).run()
+
+    results = []
+    for ts in u.trajectory[::step]:
+        results.append(simple_function(u.atoms))
+    results = np.asarray(results)
+
+    assert_array_equal(results, ana.results)
+
+    assert_raises(ValueError, ana_class, 2)


### PR DESCRIPTION
Fixes #946

Changes made in this Pull Request:
 - Added `AnalysisFromFunction` class
```python
 >>> def rotation_matrix(mobile, ref):
 >>>     return mda.analysis.align.rotation_matrix(mobile, ref)[0]
 >>> rot = AnalysisFromFunction(rotation_matrix, trajectory, mobile, ref).run()
 >>> print(rot.results)
```
 - Added `analysis_class` decorator
```python
>>> @analysis_class
>>> def RotationMatrix(mobile, ref):
>>>     return mda.analysis.align.rotation_matrix(mobile, ref)[0]
>>>
>>> rot = RotationMatrix(u.trajectory, mobile, ref, step=2).run()
>>> print(rot.results)
```

Trajectory is a argument that is added now and required. I guess it should be possible to infer it from the first AtomGroup found in `*args` or `**kwargs` if it is not specified.

PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
 - [x] infer trajectory from passed arguments
