### PR TITLE
Small reorganization and optimization

### DIFF
--- a/testsuite/MDAnalysisTests/test_modelling.py
+++ b/testsuite/MDAnalysisTests/test_modelling.py
@@ -20,7 +20,7 @@ from MDAnalysis.tests.datafiles import PSF, DCD, PDB_small, GRO, TRR, \
     capping_input, capping_output, capping_ace, capping_nma, \
     merge_protein, merge_ligand, merge_water
 import MDAnalysis.core.groups
-from MDAnalysis.core.groups import make_classes
+from MDAnalysis.core.groups import make_classes, AtomGroup
 from MDAnalysis import NoDataError
 from MDAnalysisTests import parser_not_found, tempdir
 
@@ -34,8 +34,7 @@ import os
 from MDAnalysis import Universe, Merge
 from MDAnalysis.analysis.align import alignto
 
-AtomGroup = make_classes()['atomgroup']
-
+AtomGroup = make_classes()[1][AtomGroup]
 
 def capping(ref, ace, nma, output):
     resids = ref.select_atoms("all").resids


### PR DESCRIPTION
Major changes
---------------
- Separated the roles of `GroupBase` and of container of `TopologyAttrs`. Created the `TopologyAttrContainer` class. This clarifies their use and removes some code duplication over `GroupBase` and `ComponentBase`. Also allows `AtomGroup` et al. to cleanly inherit from `GroupBase` at class declaration time.
- `Universe` class dictionaries are now hashed by the classes themselves, instead of (fragile) strings such as `'atomgroup'`.

Minor fixes
-----------
- The strategy to find mergeable classes when instantiating `AtomGroups` was changed, and no longer relies on an `order` class attribute (it now scans the class's MRO to find the nearest relevant parent).
- Base class caching is now done immediately by `make_classes`, and no longer lazily.

Test- and performance-wise, same result as the current issue-363 HEAD, under the latest tests (from @kain88-de's fork, at commit kain88-de@8ec1d5bc1001821ee0926066c38feb86192f7576).