### PR TITLE
test_imports now looks in the right directory (closes #939).

### DIFF
--- a/testsuite/CHANGELOG
+++ b/testsuite/CHANGELOG
@@ -13,9 +13,10 @@ Also see https://github.com/MDAnalysis/mdanalysis/wiki/MDAnalysisTests
 and https://github.com/MDAnalysis/mdanalysis/wiki/UnitTests
 
 ------------------------------------------------------------------------------
-??/??/16 jbarnoud, orbeckst, fiona-naughton
+??/??/16 jbarnoud, orbeckst, fiona-naughton, manuel.nuno.melo
 
   * 0.15.1
+    - test_imports now always uses the correct source directory (Issue #939).
     - Added a plugin to list the non-closed file handle (Issue #853, PR #874).
       The plugin can be disabled with --no-open-files.
     - The test_failure test can be made fail by setting the MDA_FAILURE_TEST

--- a/testsuite/MDAnalysisTests/test_imports.py
+++ b/testsuite/MDAnalysisTests/test_imports.py
@@ -16,11 +16,12 @@
 
 import os
 import glob
+import MDAnalysisTests
 
 class TestRelativeImports(object):
     '''Relative imports are banned in unit testing modules (Issue #189), so run tests to enforce this policy.'''
 
-    path_to_testing_modules = os.curdir
+    path_to_testing_modules = MDAnalysisTests.__path__[0]
 
     @staticmethod
     def _run_test_relative_import(testing_module):


### PR DESCRIPTION
Fixes #939

Changes made in this Pull Request:
`test_imports` now uses `MDAnalysisTests.__path__[0]`, which should work independently of how `mda_nosetests` is invoked.

PR Checklist
------------
 - [x] Tests?
 - [ ] Docs? (Not applicable)
 - [x] CHANGELOG updated? (Not worth it, is it?)
 - [x] Issue raised/referenced?

