### PR TITLE
Tests now have a seeded random state, for reproducibility (closes #958)

### DIFF
--- a/package/MDAnalysis/lib/transformations.py
+++ b/package/MDAnalysis/lib/transformations.py
@@ -1421,11 +1421,17 @@ def quaternion_slerp(quat0, quat1, fraction, spin=0, shortestpath=True):
 
 
 def random_quaternion(rand=None):
-    """Return uniform random unit quaternion.
+    """Creates a uniform random unit quaternion.
 
-    rand: array like or None
+    Parameters
+    ----------
+    rand : array like
         Three independent random variables that are uniformly distributed
         between 0 and 1.
+
+    Returns
+    -------
+    A uniform random unit quaternion.
 
     >>> q = random_quaternion()
     >>> np.allclose(1.0, vector_norm(q))
@@ -1453,11 +1459,17 @@ def random_quaternion(rand=None):
 
 
 def random_rotation_matrix(rand=None):
-    """Return uniform random rotation matrix.
+    """Creates a uniform random rotation matrix.
 
-    rnd: array like
+    Parameters
+    ----------
+    rand : array like
         Three independent random variables that are uniformly distributed
         between 0 and 1 for each returned quaternion.
+
+    Returns
+    -------
+    A uniform random rotation matrix.
 
     >>> R = random_rotation_matrix()
     >>> np.allclose(np.dot(R.T, R), np.identity(4))

--- a/testsuite/CHANGELOG
+++ b/testsuite/CHANGELOG
@@ -16,6 +16,7 @@ and https://github.com/MDAnalysis/mdanalysis/wiki/UnitTests
 ??/??/16 jbarnoud, orbeckst, fiona-naughton, manuel.nuno.melo
 
   * 0.15.1
+    - Tests now have a seeded random state, for reproducibility (Issue #958).
     - test_imports now always uses the correct source directory (Issue #939).
     - Added a plugin to list the non-closed file handle (Issue #853, PR #874).
       The plugin can be disabled with --no-open-files.

--- a/testsuite/MDAnalysisTests/analysis/test_density.py
+++ b/testsuite/MDAnalysisTests/analysis/test_density.py
@@ -28,9 +28,10 @@ import MDAnalysis as mda
 
 from MDAnalysisTests.datafiles import TPR, XTC
 from MDAnalysisTests import module_not_found, tempdir
+from MDAnalysisTests.rng import RandomState
 
 
-class TestDensity(TestCase):
+class TestDensity(RandomState):
     nbins = 3, 4, 5
     counts = 100
     Lmax = 10.
@@ -40,8 +41,10 @@ class TestDensity(TestCase):
     def setUp(self):
         import MDAnalysis.analysis.density
 
+        super(TestDensity, self).setUp()
         self.bins = [np.linspace(0, self.Lmax, n+1) for n in self.nbins]
-        h, edges = np.histogramdd(self.Lmax*np.random.random((self.counts, 3)), bins=self.bins)
+        h, edges = np.histogramdd(self.Lmax * self.np_random.rand(self.counts, 3),
+                                  bins=self.bins)
         self.D = MDAnalysis.analysis.density.Density(h, edges,
                                                      parameters={'isDensity': False},
                                                      units={'length': 'A'})

--- a/testsuite/MDAnalysisTests/analysis/test_persistencelength.py
+++ b/testsuite/MDAnalysisTests/analysis/test_persistencelength.py
@@ -27,6 +27,7 @@ from numpy.testing import (
 
 from MDAnalysisTests.datafiles import Plength
 from MDAnalysisTests import module_not_found
+from MDAnalysisTests.rng import RandomState
 
 
 class TestPersistenceLength(object):
@@ -65,8 +66,9 @@ class TestPersistenceLength(object):
         assert_(len(p.fit) == len(p.results))
 
 
-class TestFitExponential(object):
+class TestFitExponential(RandomState):
     def setUp(self):
+        super(TestFitExponential, self).setUp()
         self.x = np.linspace(0, 250, 251)
         self.a_ref = 20.0
         self.y = np.exp(-self.x/self.a_ref)
@@ -85,6 +87,6 @@ class TestFitExponential(object):
     @dec.skipif(module_not_found('scipy'),
                 "Test skipped because scipy is not available.")
     def test_fit_noisy(self):
-        y2 = self.y + (np.random.random(len(self.y)) - 0.5) * 0.05
+        y2 = self.y + (self.np_random.rand(len(self.y)) - 0.5) * 0.05
         a = polymer.fit_exponential_decay(self.x, y2)
         assert_(np.rint(a) == self.a_ref)

--- a/testsuite/MDAnalysisTests/rng.py
+++ b/testsuite/MDAnalysisTests/rng.py
@@ -1,0 +1,39 @@
+# -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 fileencoding=utf-8
+#
+# MDAnalysis --- http://www.MDAnalysis.org
+# Copyright (c) 2006-2015 Naveen Michaud-Agrawal, Elizabeth J. Denning, Oliver Beckstein
+# and contributors (see AUTHORS for the full list)
+#
+# Released under the GNU Public Licence, v2 or any higher version
+#
+# Please cite your use of MDAnalysis in published work:
+#
+# N. Michaud-Agrawal, E. J. Denning, T. B. Woolf, and O. Beckstein.
+# MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
+# J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
+#
+
+import numpy as np
+from numpy.testing import TestCase
+import random
+
+seed = 3856349111 # from: np.uint32(hash("MDAnalysis"))
+
+class RandomState(TestCase):
+    """
+    Class that sets up random number generators of defined state for each test.
+
+    Use as base from test classes that require defined state random number
+    generators.
+    
+    If an inheriting class overrides :meth:`setUp`, be sure to also call
+    :meth:`RandomState.setUp` via :func:`super`.
+
+    At any point in a test each of the RNGs can be reseeded by using the
+    respective `seed` method.
+    """
+    def setUp(self):
+        self.np_random = np.random.RandomState(seed)
+        self.random = random.Random(seed)
+

--- a/testsuite/MDAnalysisTests/test_imports.py
+++ b/testsuite/MDAnalysisTests/test_imports.py
@@ -15,13 +15,19 @@
 #
 
 import os
-import glob
 import MDAnalysisTests
 
 class TestRelativeImports(object):
-    '''Relative imports are banned in unit testing modules (Issue #189), so run tests to enforce this policy.'''
+    """Relative imports are banned in unit testing modules (Issue #189), so run tests to enforce this policy."""
 
     path_to_testing_modules = MDAnalysisTests.__path__[0]
+    # Path relative to MDAnalysisTests
+    exclusions = ['/plugins']
+
+    @classmethod
+    def is_excluded(cls, path):
+        leaf = path[len(cls.path_to_testing_modules):]
+        return leaf in cls.exclusions
 
     @staticmethod
     def _run_test_relative_import(testing_module):
@@ -34,6 +40,11 @@ class TestRelativeImports(object):
                         "module {testing_module} at linenumber {lineno}.".format(**vars()))
 
     def test_relative_imports(self):
-        list_testing_modules = glob.glob(os.path.join(self.path_to_testing_modules, '*.py'))
-        for testing_module in list_testing_modules:
-            yield self._run_test_relative_import, testing_module
+        for dirpath, dirnames, files in os.walk(self.path_to_testing_modules):
+            if self.is_excluded(dirpath):
+                continue
+            for f in filter(lambda x: x.endswith('.py'), files):
+                fpath = os.path.join(dirpath, f)
+                if self.is_excluded(fpath):
+                    continue
+                yield self._run_test_relative_import, fpath

--- a/testsuite/MDAnalysisTests/test_transformations.py
+++ b/testsuite/MDAnalysisTests/test_transformations.py
@@ -19,9 +19,8 @@ from six.moves import range
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal, TestCase
 import math
-import random
-
 from MDAnalysis.lib import transformations as t
+from MDAnalysisTests.rng import RandomState
 
 """
 Testing transformations is weird because there are 2 versions of many of
@@ -71,9 +70,9 @@ class TestIdentityMatrixCy(_IdentityMatrix):
     f = staticmethod(t.identity_matrix)
 
 
-class _TranslationMatrix(object):
+class _TranslationMatrix(RandomState):
     def test_translation_matrix(self):
-        v = np.random.random(3) - 0.5
+        v = self.np_random.rand(3) - 0.5
         assert_allclose(v, self.f(v)[:3, 3])
 
 class TestTranslationMatrixNP(_TranslationMatrix):
@@ -83,17 +82,19 @@ class TestTranslationMatrixCy(_TranslationMatrix):
     f = staticmethod(t.translation_matrix)
 
 
-def test_translation_from_matrix():
-    # doesn't seem to have a Cython backend
-    v0 = np.random.random(3) - 0.5
-    v1 = t.translation_from_matrix(t.translation_matrix(v0))
-    assert_allclose(v0, v1)
+class TestTranslationFromMatrix(RandomState):
+    def test_translation_from_matrix(self):
+        # doesn't seem to have a Cython backend
+        v0 = self.np_random.rand(3) - 0.5
+        v1 = t.translation_from_matrix(t.translation_matrix(v0))
+        assert_allclose(v0, v1)
 
-class _ReflectionMatrix(object):
+
+class _ReflectionMatrix(RandomState):
     def test_reflection_matrix(self):
-        v0 = np.random.random(4) - 0.5
+        v0 = self.np_random.rand(4) - 0.5
         v0[3] = 1.0
-        v1 = np.random.random(3) - 0.5
+        v1 = self.np_random.rand(3) - 0.5
         R = self.f(v0, v1)
         assert_allclose(2., np.trace(R))
         assert_allclose(v0, np.dot(R, v0))
@@ -110,21 +111,22 @@ class TestReflectionMatrixCy(_ReflectionMatrix):
     f = staticmethod(t.reflection_matrix)
 
 
-def test_reflection_from_matrix():
-    v0 = np.random.random(3) - 0.5
-    v1 = np.random.random(3) - 0.5
-    M0 = t.reflection_matrix(v0, v1)
-    point, normal = t.reflection_from_matrix(M0)
-    M1 = t.reflection_matrix(point, normal)
-    assert_equal(t.is_same_transform(M0, M1), True)
+class TestReflectionFromMatrix(RandomState):
+    def test_reflection_from_matrix(self):
+        v0 = self.np_random.rand(3) - 0.5
+        v1 = self.np_random.rand(3) - 0.5
+        M0 = t.reflection_matrix(v0, v1)
+        point, normal = t.reflection_from_matrix(M0)
+        M1 = t.reflection_matrix(point, normal)
+        assert_equal(t.is_same_transform(M0, M1), True)
 
-class _RotationMatrix(object):
+class _RotationMatrix(RandomState):
     def test_rotation_matrix(self):
         R = self.f(np.pi/2.0, [0, 0, 1], [1, 0, 0])
         assert_allclose(np.dot(R, [0, 0, 0, 1]), [ 1., -1.,  0.,  1.])
-        angle = (random.random() - 0.5) * (2*np.pi)
-        direc = np.random.random(3) - 0.5
-        point = np.random.random(3) - 0.5
+        angle = (self.random.random() - 0.5) * (2*np.pi)
+        direc = self.np_random.rand(3) - 0.5
+        point = self.np_random.rand(3) - 0.5
         R0 = self.f(angle, direc, point)
         R1 = self.f(angle-2*np.pi, direc, point)
         assert_equal(t.is_same_transform(R0, R1), True)
@@ -142,18 +144,20 @@ class TestRotationMatrixCy(_RotationMatrix):
     f = staticmethod(t.rotation_matrix)
 
 
-def test_rotation_from_matrix():
-    angle = (random.random() - 0.5) * (2*np.pi)
-    direc = np.random.random(3) - 0.5
-    point = np.random.random(3) - 0.5
-    R0 = t.rotation_matrix(angle, direc, point)
-    angle, direc, point = t.rotation_from_matrix(R0)
-    R1 = t.rotation_matrix(angle, direc, point)
-    assert_equal(t.is_same_transform(R0, R1), True)
+class TestRotationFromMatrix(RandomState):
+    def test_rotation_from_matrix(self):
+        angle = (self.random.random() - 0.5) * (2*np.pi)
+        direc = self.np_random.rand(3) - 0.5
+        point = self.np_random.rand(3) - 0.5
+        R0 = t.rotation_matrix(angle, direc, point)
+        angle, direc, point = t.rotation_from_matrix(R0)
+        R1 = t.rotation_matrix(angle, direc, point)
+        assert_equal(t.is_same_transform(R0, R1), True)
 
-class _ScaleMatrix(object):
+
+class _ScaleMatrix(RandomState):
     def test_scale_matrix(self):
-        v = (np.random.rand(4, 5) - 0.5) * 20.0
+        v = (self.np_random.rand(4, 5) - 0.5) * 20.0
         v[3] = 1.0
         S = self.f(-1.234)
         assert_allclose(np.dot(S, v)[:3], -1.234*v[:3])
@@ -164,29 +168,32 @@ class TestScaleMatrixNP(_ScaleMatrix):
 class TestScaleMatrixCy(_ScaleMatrix):
     f = staticmethod(t.scale_matrix)
 
-def test_scale_from_matrix():
-    factor = random.random() * 10 - 5
-    origin = np.random.random(3) - 0.5
-    direct = np.random.random(3) - 0.5
-    S0 = t.scale_matrix(factor, origin)
-    factor, origin, direction = t.scale_from_matrix(S0)
-    S1 = t.scale_matrix(factor, origin, direction)
-    assert_equal(t.is_same_transform(S0, S1), True)
-    S0 = t.scale_matrix(factor, origin, direct)
-    factor, origin, direction = t.scale_from_matrix(S0)
-    S1 = t.scale_matrix(factor, origin, direction)
-    assert_equal(t.is_same_transform(S0, S1), True)
 
-class _ProjectionMatrix(object):
+class TestScaleFromMatrix(RandomState):
+    def test_scale_from_matrix(self):
+        factor = self.random.random() * 10 - 5
+        origin = self.np_random.rand(3) - 0.5
+        direct = self.np_random.rand(3) - 0.5
+        S0 = t.scale_matrix(factor, origin)
+        factor, origin, direction = t.scale_from_matrix(S0)
+        S1 = t.scale_matrix(factor, origin, direction)
+        assert_equal(t.is_same_transform(S0, S1), True)
+        S0 = t.scale_matrix(factor, origin, direct)
+        factor, origin, direction = t.scale_from_matrix(S0)
+        S1 = t.scale_matrix(factor, origin, direction)
+        assert_equal(t.is_same_transform(S0, S1), True)
+
+
+class _ProjectionMatrix(RandomState):
     def test_projection_matrix_1(self):
         P = self.f((0, 0, 0), (1, 0, 0))
         assert_allclose(P[1:, 1:], np.identity(4)[1:, 1:], atol=_ATOL)
 
     def test_projection_matrix_2(self):
-        point = np.random.random(3) - 0.5
-        normal = np.random.random(3) - 0.5
-        direct = np.random.random(3) - 0.5
-        persp = np.random.random(3) - 0.5
+        point = self.np_random.rand(3) - 0.5
+        normal = self.np_random.rand(3) - 0.5
+        direct = self.np_random.rand(3) - 0.5
+        persp = self.np_random.rand(3) - 0.5
         P0 = self.f(point, normal)
         P1 = self.f(point, normal, direction=direct)
         P2 = self.f(point, normal, perspective=persp)
@@ -195,7 +202,7 @@ class _ProjectionMatrix(object):
 
     def test_projection_matrix_3(self):
         P = self.f((3, 0, 0), (1, 1, 0), (1, 0, 0))
-        v0 = (np.random.rand(4, 5) - 0.5) * 20.0
+        v0 = (self.np_random.rand(4, 5) - 0.5) * 20.0
         v0[3] = 1.0
         v1 = np.dot(P, v0)
         assert_allclose(v1[1], v0[1], atol=_ATOL)
@@ -208,12 +215,13 @@ class TestProjectionMatrixCy(_ProjectionMatrix):
     f = staticmethod(t.projection_matrix)
 
 
-class TestProjectionFromMatrix(TestCase):
+class TestProjectionFromMatrix(RandomState):
     def setUp(self):
-        self.point = np.random.random(3) - 0.5
-        self.normal = np.random.random(3) - 0.5
-        self.direct = np.random.random(3) - 0.5
-        self.persp = np.random.random(3) - 0.5
+        super(TestProjectionFromMatrix, self).setUp()
+        self.point = self.np_random.rand(3) - 0.5
+        self.normal = self.np_random.rand(3) - 0.5
+        self.direct = self.np_random.rand(3) - 0.5
+        self.persp = self.np_random.rand(3) - 0.5
 
     def test_projection_from_matrix_1(self):
         P0 = t.projection_matrix(self.point, self.normal)
@@ -242,9 +250,9 @@ class TestProjectionFromMatrix(TestCase):
         assert_equal(t.is_same_transform(P0, P1), True)
 
 
-class _ClipMatrix(object):
+class _ClipMatrix(RandomState):
     def test_clip_matrix_1(self):
-        frustrum = np.random.rand(6)
+        frustrum = self.np_random.rand(6)
         frustrum[1] += frustrum[0]
         frustrum[3] += frustrum[2]
         frustrum[5] += frustrum[4]
@@ -255,7 +263,7 @@ class _ClipMatrix(object):
                          np.array([ 1.,  1.,  1.,  1.]))
 
     def test_clip_matrix_2(self):
-        frustrum = np.random.rand(6)
+        frustrum = self.np_random.rand(6)
         frustrum[1] += frustrum[0]
         frustrum[3] += frustrum[2]
         frustrum[5] += frustrum[4]
@@ -274,12 +282,12 @@ class TestClipMatrixCy(_ClipMatrix):
     f = staticmethod(t.clip_matrix)
 
 
-class _ShearMatrix(object):
+class _ShearMatrix(RandomState):
     def test_shear_matrix(self):
-        angle = (random.random() - 0.5) * 4*np.pi
-        direct = np.random.random(3) - 0.5
-        point = np.random.random(3) - 0.5
-        normal = np.cross(direct, np.random.random(3))
+        angle = (self.random.random() - 0.5) * 4*np.pi
+        direct = self.np_random.rand(3) - 0.5
+        point = self.np_random.rand(3) - 0.5
+        normal = np.cross(direct, self.np_random.rand(3))
         S = self.f(angle, direct, point, normal)
         assert_allclose(1.0, np.linalg.det(S), atol=_ATOL)
 
@@ -290,26 +298,22 @@ class TestShearMatrixCy(_ShearMatrix):
     f = staticmethod(t.shear_matrix)
 
 
-def test_shear_from_matrix():
-    # This seems to fail sometimes if the random numbers
-    # roll certain values....
-    # angle = (random.random() - 0.5) * 4*math.pi
-    # direct = np.random.random(3) - 0.5
-    # point = np.random.random(3) - 0.5
-    # normal = np.cross(direct, np.random.random(3))
-    # In this random configuration the test will fail about 0.05% of all times.
-    # Then we hit some edge-cases of the algorithm. The edge cases for these
-    # values are slightly different for the linalg library used (MKL/LAPACK).
-    # So here are some of my random numbers
-    angle = 2.8969075413405783
-    direct = np.array([-0.31117458, -0.41769518, -0.01188556])
-    point = np.array([-0.0035982, -0.40997482,  0.42241425])
-    normal = np.cross(direct, np.array([ 0.08122421,  0.4747914 ,  0.19851859]))
+class TestShearFromMatrix(RandomState):
+    def test_shear_from_matrix(self):
+        # This seems to fail sometimes if the random numbers
+        # roll certain values... In a random configuration the test will fail
+        # about 0.05% of all times. Then we hit some edge-cases of the algorithm.
+        # The edge cases for these values are slightly different for the linalg
+        # library used (MKL/LAPACK). Seeding the RNGs with our seed is stable.
+        angle = (self.random.random() - 0.5) * 4*math.pi
+        direct = self.np_random.rand(3) - 0.5
+        point = self.np_random.rand(3) - 0.5
+        normal = np.cross(direct, self.np_random.rand(3))
+        S0 = t.shear_matrix(angle, direct, point, normal)
+        angle, direct, point, normal = t.shear_from_matrix(S0)
+        S1 = t.shear_matrix(angle, direct, point, normal)
+        assert_equal(t.is_same_transform(S0, S1), True)
 
-    S0 = t.shear_matrix(angle, direct, point, normal)
-    angle, direct, point, normal = t.shear_from_matrix(S0)
-    S1 = t.shear_matrix(angle, direct, point, normal)
-    assert_equal(t.is_same_transform(S0, S1), True)
 
 class TestDecomposeMatrix(TestCase):
     def test_decompose_matrix_1(self):
@@ -330,16 +334,17 @@ class TestDecomposeMatrix(TestCase):
         assert_allclose(R0, R1)
 
 
-def test_compose_matrix():
-    scale = np.random.random(3) - 0.5
-    shear = np.random.random(3) - 0.5
-    angles = (np.random.random(3) - 0.5) * (2*math.pi)
-    trans = np.random.random(3) - 0.5
-    persp = np.random.random(4) - 0.5
-    M0 = t.compose_matrix(scale, shear, angles, trans, persp)
-    result = t.decompose_matrix(M0)
-    M1 = t.compose_matrix(*result)
-    assert_equal(t.is_same_transform(M0, M1), True)
+class TestComposeMatrix(RandomState):
+    def test_compose_matrix(self):
+        scale = self.np_random.rand(3) - 0.5
+        shear = self.np_random.rand(3) - 0.5
+        angles = (self.np_random.rand(3) - 0.5) * (2*math.pi)
+        trans = self.np_random.rand(3) - 0.5
+        persp = self.np_random.rand(4) - 0.5
+        M0 = t.compose_matrix(scale, shear, angles, trans, persp)
+        result = t.decompose_matrix(M0)
+        M1 = t.compose_matrix(*result)
+        assert_equal(t.is_same_transform(M0, M1), True)
 
 class _OrthogonalizationMatrix(object):
     def test_orthogonalization_matrix_1(self):
@@ -357,29 +362,29 @@ class TestOrthogonalizationMatrixCy(_OrthogonalizationMatrix):
     f = staticmethod(t.orthogonalization_matrix)
 
 
-class _SuperimpositionMatrix(object):
+class _SuperimpositionMatrix(RandomState):
     def test_superimposition_matrix(self):
-        v0 = np.random.rand(3, 10)
+        v0 = self.np_random.rand(3, 10)
         M = self.f(v0, v0)
         assert_allclose(M, np.identity(4), atol=_ATOL)
 
-        R = t.random_rotation_matrix(np.random.random(3))
+        R = t.random_rotation_matrix(self.np_random.rand(3))
         v0 = ((1,0,0), (0,1,0), (0,0,1), (1,1,1))
         v1 = np.dot(R, v0)
         M = self.f(v0, v1)
         assert_allclose(v1, np.dot(M, v0), atol=_ATOL)
 
-        v0 = (np.random.rand(4, 100) - 0.5) * 20.0
+        v0 = (self.np_random.rand(4, 100) - 0.5) * 20.0
         v0[3] = 1.0
         v1 = np.dot(R, v0)
         M = self.f(v0, v1)
         assert_allclose(v1, np.dot(M, v0), atol=_ATOL)
 
-        S = t.scale_matrix(random.random())
-        T = t.translation_matrix(np.random.random(3)-0.5)
+        S = t.scale_matrix(self.random.random())
+        T = t.translation_matrix(self.np_random.rand(3) - 0.5)
         M = t.concatenate_matrices(T, R, S)
         v1 = np.dot(M, v0)
-        v0[:3] += np.random.normal(0.0, 1e-9, 300).reshape(3, -1)
+        v0[:3] += self.np_random.normal(0.0, 1e-9, (3, 100))
         M = self.f(v0, v1, scaling=True)
         assert_allclose(v1, np.dot(M, v0), atol=_ATOL)
 
@@ -414,7 +419,7 @@ class TestEulerMatrixCy(_EulerMatrix):
     f = staticmethod(t.euler_matrix)
 
 
-class _EulerFromMatrix(object):
+class _EulerFromMatrix(RandomState):
     def test_euler_from_matrix_1(self):
         R0 = t.euler_matrix(1, 2, 3, 'syxz')
         al, be, ga = self.f(R0, 'syxz')
@@ -422,7 +427,7 @@ class _EulerFromMatrix(object):
         assert_allclose(R0, R1)
 
     def test_euler_from_matrix_2(self):
-        angles = (4.0*math.pi) * (np.random.random(3) - 0.5)
+        angles = (4.0*math.pi) * (self.np_random.rand(3) - 0.5)
         for axes in t._AXES2TUPLE.keys():
             R0 = t.euler_matrix(axes=axes, *angles)
             R1 = t.euler_matrix(axes=axes, *self.f(R0, axes))
@@ -483,7 +488,7 @@ class TestQuaternionMatrixCy(_QuaternionMatrix):
     f = staticmethod(t.quaternion_matrix)
 
 
-class _QuaternionFromMatrix(object):
+class _QuaternionFromMatrix(RandomState):
     def test_quaternion_from_matrix_1(self):
         q = self.f(t.identity_matrix(), True)
         assert_allclose(q, [1., 0., 0., 0.], atol=_ATOL)
@@ -513,7 +518,7 @@ class _QuaternionFromMatrix(object):
                         atol=_ATOL)
 
     def test_quaternion_from_matrix_6(self):
-        R = t.random_rotation_matrix()
+        R = t.random_rotation_matrix(self.np_random.rand(3))
         q = self.f(R)
         assert_equal(t.is_same_transform(R, t.quaternion_matrix(q)), True)
 
@@ -536,9 +541,9 @@ class TestQuaternionMultiplyCy(_QuaternionMultiply):
     f = staticmethod(t.quaternion_multiply)
 
 
-class _QuaternionConjugate(object):
+class _QuaternionConjugate(RandomState):
     def test_quaternion_conjugate(self):
-        q0 = t.random_quaternion()
+        q0 = t.random_quaternion(self.np_random.rand(3))
         q1 = self.f(q0)
         check = q1[0] == q0[0] and all(q1[1:] == -q0[1:])
         assert_equal(check, True)
@@ -550,9 +555,9 @@ class TestQuaternionConjugateCy(_QuaternionConjugate):
     f = staticmethod(t.quaternion_conjugate)
 
 
-class _QuaternionInverse(object):
+class _QuaternionInverse(RandomState):
     def test_quaternion_inverse(self):
-        q0 = t.random_quaternion()
+        q0 = t.random_quaternion(self.np_random.rand(3))
         q1 = self.f(q0)
         assert_allclose(t.quaternion_multiply(q0, q1), [1, 0, 0, 0], atol=_ATOL)
 
@@ -563,17 +568,15 @@ class TestQuaternionInverseCy(_QuaternionInverse):
     f = staticmethod(t.quaternion_inverse)
 
 def test_quaternion_real():
-    assert_allclose(t.quaternion_real([3.0, 0.0, 1.0, 2.0]),
-                    3.0)
+    assert_allclose(t.quaternion_real([3.0, 0.0, 1.0, 2.0]), 3.0)
 
 def test_quaternion_imag():
-    assert_allclose(t.quaternion_imag([3.0, 0.0, 1.0, 2.0]),
-                    [0.0, 1.0, 2.0])
+    assert_allclose(t.quaternion_imag([3.0, 0.0, 1.0, 2.0]), [0.0, 1.0, 2.0])
 
-class _QuaternionSlerp(object):
+class _QuaternionSlerp(RandomState):
     def test_quaternion_slerp(self):
-        q0 = t.random_quaternion()
-        q1 = t.random_quaternion()
+        q0 = t.random_quaternion(self.np_random.rand(3))
+        q1 = t.random_quaternion(self.np_random.rand(3))
         q = self.f(q0, q1, 0.0)
         assert_allclose(q, q0, atol=_ATOL)
 
@@ -595,13 +598,13 @@ class TestQuaternionSlerpCy(_QuaternionSlerp):
     f = staticmethod(t.quaternion_slerp)
 
 
-class _RandomQuaternion(object):
+class _RandomQuaternion(RandomState):
     def test_random_quaternion_1(self):
-        q = self.f()
+        q = self.f(self.np_random.rand(3))
         assert_allclose(1.0, t.vector_norm(q))
 
     def test_random_quaternion_2(self):
-        q = self.f(np.random.random(3))
+        q = self.f(self.np_random.rand(3))
         assert_equal(len(q.shape), 1)
         assert_equal(q.shape[0] == 4, True)
 
@@ -612,9 +615,9 @@ class TestRandomQuaternionCy(_RandomQuaternion):
     f = staticmethod(t.random_quaternion)
 
 
-class _RandomRotationMatrix(object):
+class _RandomRotationMatrix(RandomState):
     def test_random_rotation_matrix(self):
-        R = self.f()
+        R = self.f(self.np_random.rand(3))
         assert_allclose(np.dot(R.T, R), np.identity(4), atol=_ATOL)
 
 class TestRandomRotationMatrixNP(_RandomRotationMatrix):
@@ -624,14 +627,14 @@ class TestRandomRotationMatrixCy(_RandomRotationMatrix):
     f = staticmethod(t.random_rotation_matrix)
 
 
-class _InverseMatrix(object):
+class _InverseMatrix(RandomState):
     def test_inverse_matrix(self):
-        M0 = t.random_rotation_matrix()
+        M0 = t.random_rotation_matrix(self.np_random.rand(3))
         M1 = self.f(M0.T)
         assert_allclose(M1, np.linalg.inv(M0.T))
 
         for size in range(1, 7):
-            M0 = np.random.rand(size, size)
+            M0 = self.np_random.rand(size, size)
             M1 = self.f(M0)
             assert_allclose(M1, np.linalg.inv(M0), err_msg=str(size))
 
@@ -642,12 +645,13 @@ class TestInverseMatrixCy(_InverseMatrix):
     f = staticmethod(t.inverse_matrix)
 
 
-class _IsSameTransform(object):
+class _IsSameTransform(RandomState):
     def test_is_same_transform_1(self):
         assert_equal(self.f(np.identity(4), np.identity(4)), True)
 
     def test_is_same_transform_2(self):
-        assert_equal(self.f(t.random_rotation_matrix(), np.identity(4)), False)
+        R0 = t.random_rotation_matrix(self.np_random.rand(3))
+        assert_equal(self.f(R0, np.identity(4)), False)
 
 class TestIsSameTransformNP(_IsSameTransform):
     f = staticmethod(t._py_is_same_transform)
@@ -673,26 +677,26 @@ class TestRandomVectorCy(_RandomVector):
      f = staticmethod(t.random_vector)
 
 
-class _UnitVector(object):
+class _UnitVector(RandomState):
     def test_unit_vector_1(self):
-        v0 = np.random.random(3)
+        v0 = self.np_random.rand(3)
         v1 = self.f(v0)
         assert_allclose(v1, v0 / np.linalg.norm(v0), atol=_ATOL)
 
     def test_unit_vector_2(self):
-        v0 = np.random.rand(5, 4, 3)
+        v0 = self.np_random.rand(5, 4, 3)
         v1 = self.f(v0, axis=-1)
         v2 = v0 / np.expand_dims(np.sqrt(np.sum(v0*v0, axis=2)), 2)
         assert_allclose(v1, v2, atol=_ATOL)
 
     def test_unit_vector_3(self):
-        v0 = np.random.rand(5, 4, 3)
+        v0 = self.np_random.rand(5, 4, 3)
         v1 = self.f(v0, axis=1)
         v2 = v0 / np.expand_dims(np.sqrt(np.sum(v0*v0, axis=1)), 1)
         assert_allclose(v1, v2, atol=_ATOL)
 
     def test_unit_vector_4(self):
-        v0 = np.random.rand(5, 4, 3)
+        v0 = self.np_random.rand(5, 4, 3)
         v1 = np.empty((5, 4, 3), dtype=np.float64)
         v2 = v0 / np.expand_dims(np.sqrt(np.sum(v0*v0, axis=1)), 1)
         self.f(v0, axis=1, out=v1)
@@ -711,24 +715,24 @@ class TestUnitVectorCy(_UnitVector):
     f = staticmethod(t.unit_vector)
 
 
-class _VectorNorm(object):
+class _VectorNorm(RandomState):
     def test_vector_norm_1(self):
-        v = np.random.random(3)
+        v = self.np_random.rand(3)
         n = self.f(v)
         assert_allclose(n, np.linalg.norm(v), atol=_ATOL)
 
     def test_vector_norm_2(self):
-        v = np.random.rand(6, 5, 3)
+        v = self.np_random.rand(6, 5, 3)
         n = self.f(v, axis=-1)
         assert_allclose(n, np.sqrt(np.sum(v*v, axis=2)), atol=_ATOL)
 
     def test_vector_norm_3(self):
-        v = np.random.rand(6, 5, 3)
+        v = self.np_random.rand(6, 5, 3)
         n = self.f(v, axis=1)
         assert_allclose(n, np.sqrt(np.sum(v*v, axis=1)), atol=_ATOL)
 
     def test_vector_norm_4(self):
-        v = np.random.rand(5, 4, 3)
+        v = self.np_random.rand(5, 4, 3)
         n = np.empty((5, 3), dtype=np.float64)
         self.f(v, axis=1, out=n)
         assert_allclose(n, np.sqrt(np.sum(v*v, axis=1)), atol=_ATOL)

--- a/testsuite/MDAnalysisTests/test_util.py
+++ b/testsuite/MDAnalysisTests/test_util.py
@@ -28,8 +28,8 @@ from MDAnalysis.lib.util import cached
 from MDAnalysis.core.topologyobjects import TopologyGroup, Bond
 from MDAnalysis.exceptions import NoDataError
 
-
 from MDAnalysisTests.datafiles import Make_Whole
+from MDAnalysisTests.rng import RandomState
 
 
 def check_parse_residue(rstring, residue):
@@ -154,8 +154,9 @@ class TestFilename(TestCase):
         assert_equal(ns.name, self.filename2)
 
 
-class TestGeometryFunctions(TestCase):
+class TestGeometryFunctions(RandomState):
     def setUp(self):
+        super(TestGeometryFunctions, self).setUp()
         self.e1 = np.array([1., 0, 0])
         self.e2 = np.array([0, 1., 0])
         self.e3 = np.array([0, 0, 1.])
@@ -182,8 +183,8 @@ class TestGeometryFunctions(TestCase):
         assert_almost_equal(mdamath.angle(2.3456e7 * self.e1, 3.4567e-6 * self.e1), 0.0)
 
     def testAngleRandom(self):
-        for x in np.random.uniform(0, np.pi, 20):
-            r = np.random.uniform(0, 1000)
+        for x in self.np_random.uniform(0, np.pi, 20):
+            r = self.np_random.uniform(0, 1000)
             v = r * np.array([np.cos(x), np.sin(x), 0])
             assert_almost_equal(mdamath.angle(self.e1, v), x, 6)
 
@@ -195,8 +196,8 @@ class TestGeometryFunctions(TestCase):
         assert_equal(mdamath.norm(self.null), 0.0)
 
     def testNormRandom(self):
-        for x in np.random.uniform(0, np.pi, 20):
-            r = np.random.uniform(0, 1000)
+        for x in self.np_random.uniform(0, np.pi, 20):
+            r = self.np_random.uniform(0, 1000)
             v = r * np.array([np.cos(x), np.sin(x), 0])
             assert_almost_equal(mdamath.norm(v), r, 6)
 


### PR DESCRIPTION
Use of the new `RandomState` class is documented in its docstring, in `MDAnalysisTests.rng.RandomState`.

PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?

MDAnalysisTests.rng.RandomState test base class creates a random and a
numpy.random state per test instance.

Adjusted all occurrences where consistent state is needed.

Fixed test_imports, which didn't check multiple directory levels.

Minor docstring cleanup in MDAnalysis/lib/transformations.py