### PR TITLE
[WIP] Time estimate and formatting flexibility for the Progress Meter

### DIFF
--- a/package/MDAnalysis/analysis/base.py
+++ b/package/MDAnalysis/analysis/base.py
@@ -173,6 +173,7 @@ class AnalysisBase(object):
         """Perform the calculation"""
         logger.info("Starting preparation")
         self._prepare()
+        self._pm.start()
         for i, ts in enumerate(
                 self._trajectory[self.start:self.stop:self.step]):
             self._frame_index = i

--- a/package/MDAnalysis/lib/log.py
+++ b/package/MDAnalysis/lib/log.py
@@ -416,6 +416,9 @@ class ProgressMeter(object):
         self.estimate_time_to_completion = None
         self.etc = None
 
+    def start(self):
+        self._start_time = datetime.datetime.now()
+
     def update(self, step, **kwargs):
         """Update the state of the ProgressMeter.
 


### PR DESCRIPTION
Fixes #928 

Changes made in this Pull Request:
- `mda.lib.log.ProgressMeter` get an _elapsed_, a _time_per_iteration_, and
  an _estimate_time_to_completion_ attributes that can be used in the
  format string.
  - `mda.lib.log.ProgressMeter` get a `progress` attribute to display a visual progress bar.
## PR Checklist
- [ ] Tests?
- [ ] Docs?
- [ ] CHANGELOG updated?
- [x] Issue raised/referenced?
