### PR TITLE
test_imports now recursively checks subdirs (closes #964)

### DIFF
--- a/testsuite/CHANGELOG
+++ b/testsuite/CHANGELOG
@@ -16,6 +16,7 @@ and https://github.com/MDAnalysis/mdanalysis/wiki/UnitTests
 ??/??/16 jbarnoud, orbeckst, fiona-naughton, manuel.nuno.melo, richardjgowers
 
   * 0.15.1
+    - test_imports now recursively checks subdirectories (Issue #964).
     - test_imports now always uses the correct source directory (Issue #939).
     - Added a plugin to list the non-closed file handle (Issue #853, PR #874).
       The plugin can be disabled with --no-open-files.

--- a/testsuite/CHANGELOG
+++ b/testsuite/CHANGELOG
@@ -17,6 +17,7 @@ and https://github.com/MDAnalysis/mdanalysis/wiki/UnitTests
 
   * 0.15.1
     - test_imports now recursively checks subdirectories (Issue #964).
+    - removed usage of random numbers from tests (Issue #958)
     - test_imports now always uses the correct source directory (Issue #939).
     - Added a plugin to list the non-closed file handle (Issue #853, PR #874).
       The plugin can be disabled with --no-open-files.
@@ -26,7 +27,6 @@ and https://github.com/MDAnalysis/mdanalysis/wiki/UnitTests
     - install external packages on Travis (SETUP == full: HOLE, clustalw)
       to test additional analysis code (Issue #898)
     - add tests for new auxiliary module
-    - removed usage of random numbers from tests (Issue #958)
 
 05/15/16  orbeckst, jbarnoud, pedrishi, fiona-naughton, jdetle
   * 0.15.0


### PR DESCRIPTION
Closes #964.

I also added an exclusion list, so that subdirs like `/plugins` don't get scanned.

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?

