### PR TITLE
Regression tests for nuclinfo.minor_pair

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -20,6 +20,8 @@ The rules for this file:
 
 Enhancements
 
+  * Added regression tests for MDAnalysis.analysis.nuclinfo.minor_pair
+    (Issue #790)
   * All classes derived from 'AnalysisBase' now display a ProgressMeter
   with 'quiet=False'
   * The 'run' method from all 'AnalysisBase' derived classes return the

--- a/testsuite/MDAnalysisTests/analysis/test_nuclinfo.py
+++ b/testsuite/MDAnalysisTests/analysis/test_nuclinfo.py
@@ -40,3 +40,11 @@ class TestNuclinfo(object):
     def test_wc_pair_2(self):
         val = nuclinfo.wc_pair(self.u, 22, 23, seg1='RNAA', seg2='RNAA')
         assert_almost_equal(val, 4.601, decimal=3)
+
+    def test_minor_pair_1(self):
+        val = nuclinfo.minor_pair(self.u, 3, 17, seg1='RNAA', seg2='RNAA')
+        assert_almost_equal(val, 16.649, decimal=3)
+
+    def test_minor_pair_2(self):
+        val = nuclinfo.minor_pair(self.u, 20, 5, seg1='RNAA', seg2='RNAA')
+        assert_almost_equal(val, 4.356, decimal=3)


### PR DESCRIPTION
This PR simply adds two regression tests for `MDAnalysis.analysis.nuclinfo.minor_pair`

It is a subset of the additions required for Issue #790. I realize that optimally I might do all of the regression tests and close the issue, but just wanted something relatively simple I could "get done" with a few spare minutes.
