### PR TITLE
unit tests for SelectionWriter file mode

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -19,7 +19,6 @@ The rules for this file:
   * 0.16.0
 
 Enhancements
-  * Added unit tests for bad file mode passed to SelectionWriter
   * Added 'MemoryReader' class to allow manipulation of trajectory data
     in-memory, which can provide substantial speed-ups to certain
     calculations.
@@ -29,7 +28,6 @@ Enhancements
     this transfer after construction of the universe
   * Added 'in_memory' option to 'rms_fit_trj', which makes it possible
     to do in-place (in-memory) alignment of trajectories.
-  * Added regression tests for MDAnalysis.analysis.nuclinfo (Issue #790)
   * All classes derived from 'AnalysisBase' now display a ProgressMeter
     with 'quiet=False'
   * The 'run' method from all 'AnalysisBase' derived classes return the

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -19,6 +19,7 @@ The rules for this file:
   * 0.16.0
 
 Enhancements
+  * Added unit tests for bad file mode passed to SelectionWriter
   * Added 'MemoryReader' class to allow manipulation of trajectory data
     in-memory, which can provide substantial speed-ups to certain
     calculations.

--- a/testsuite/CHANGELOG
+++ b/testsuite/CHANGELOG
@@ -14,8 +14,11 @@ and https://github.com/MDAnalysis/mdanalysis/wiki/UnitTests
 
 ------------------------------------------------------------------------------
 ??/??/16 jbarnoud, orbeckst, fiona-naughton, manuel.nuno.melo, richardjgowers
+         tyler.je.reddy
 
   * 0.15.1
+    - Added unit tests for bad file mode passed to SelectionWriter
+    - Added regression tests for MDAnalysis.analysis.nuclinfo (Issue #790)
     - test_imports now recursively checks subdirectories (Issue #964).
     - removed usage of random numbers from tests (Issue #958)
     - test_imports now always uses the correct source directory (Issue #939).

--- a/testsuite/MDAnalysisTests/test_selections.py
+++ b/testsuite/MDAnalysisTests/test_selections.py
@@ -61,6 +61,10 @@ class _SelectionWriter(TestCase):
         g.write_selection(self.namedfile, **kwargs)
         return g
 
+    def test_write_bad_mode(self):
+        with self.assertRaises(ValueError):
+            self._write(name=self.ref_name, mode='a+')
+
 
 def ndx2array(lines):
     """Convert Gromacs NDX text file lines to integer array"""
@@ -97,10 +101,6 @@ class TestSelectionWriter_Gromacs(_SelectionWriter):
         self._write_selection(name=self.ref_name)
         self._assert_indices()
 
-    def test_write_ndx_bad_mode(self):
-        with self.assertRaises(ValueError):
-            self._write(name=self.ref_name, mode='a+')
-
 
 class TestSelectionWriter_Charmm(_SelectionWriter):
     filename = "CA.str"
@@ -129,9 +129,6 @@ class TestSelectionWriter_Charmm(_SelectionWriter):
         self._write_selection(name=self.ref_name)
         self._assert_selectionstring()
 
-    def test_write_str_bad_mode(self):
-        with self.assertRaises(ValueError):
-            self._write(name=self.ref_name, mode='a+')
 
 
 class TestSelectionWriter_PyMOL(_SelectionWriter):
@@ -158,9 +155,6 @@ class TestSelectionWriter_PyMOL(_SelectionWriter):
         self._write_selection(name=self.ref_name)
         self._assert_selectionstring()
 
-    def test_write_pml_bad_mode(self):
-        with self.assertRaises(ValueError):
-            self._write(name=self.ref_name, mode='a+')
 
 
 class TestSelectionWriter_VMD(_SelectionWriter):
@@ -184,10 +178,6 @@ class TestSelectionWriter_VMD(_SelectionWriter):
     def test_writeselection_vmd(self):
         self._write_selection(name=self.ref_name)
         self._assert_selectionstring()
-
-    def test_write_vmd_bad_mode(self):
-        with self.assertRaises(ValueError):
-            self._write(name=self.ref_name, mode='a+')
 
 
 def spt2array(line):
@@ -221,6 +211,3 @@ class TestSelectionWriter_Jmol(_SelectionWriter):
         assert_array_equal(indices, self.ref_indices,
                            err_msg="SPT indices were not written correctly")
 
-    def test_write_bad_mode(self):
-        with self.assertRaises(ValueError):
-            self._write(name=self.ref_name, mode='a+')

--- a/testsuite/MDAnalysisTests/test_selections.py
+++ b/testsuite/MDAnalysisTests/test_selections.py
@@ -97,6 +97,10 @@ class TestSelectionWriter_Gromacs(_SelectionWriter):
         self._write_selection(name=self.ref_name)
         self._assert_indices()
 
+    def test_write_ndx_bad_mode(self):
+        with self.assertRaises(ValueError):
+            self._write(name=self.ref_name, mode='a+')
+
 
 class TestSelectionWriter_Charmm(_SelectionWriter):
     filename = "CA.str"
@@ -125,6 +129,10 @@ class TestSelectionWriter_Charmm(_SelectionWriter):
         self._write_selection(name=self.ref_name)
         self._assert_selectionstring()
 
+    def test_write_str_bad_mode(self):
+        with self.assertRaises(ValueError):
+            self._write(name=self.ref_name, mode='a+')
+
 
 class TestSelectionWriter_PyMOL(_SelectionWriter):
     filename = "CA.pml"
@@ -150,6 +158,10 @@ class TestSelectionWriter_PyMOL(_SelectionWriter):
         self._write_selection(name=self.ref_name)
         self._assert_selectionstring()
 
+    def test_write_pml_bad_mode(self):
+        with self.assertRaises(ValueError):
+            self._write(name=self.ref_name, mode='a+')
+
 
 class TestSelectionWriter_VMD(_SelectionWriter):
     filename = "CA.vmd"
@@ -172,6 +184,10 @@ class TestSelectionWriter_VMD(_SelectionWriter):
     def test_writeselection_vmd(self):
         self._write_selection(name=self.ref_name)
         self._assert_selectionstring()
+
+    def test_write_vmd_bad_mode(self):
+        with self.assertRaises(ValueError):
+            self._write(name=self.ref_name, mode='a+')
 
 
 def spt2array(line):
@@ -204,3 +220,7 @@ class TestSelectionWriter_Jmol(_SelectionWriter):
                      err_msg="SPT file has wrong selection name")
         assert_array_equal(indices, self.ref_indices,
                            err_msg="SPT indices were not written correctly")
+
+    def test_write_bad_mode(self):
+        with self.assertRaises(ValueError):
+            self._write(name=self.ref_name, mode='a+')

--- a/testsuite/MDAnalysisTests/test_selections.py
+++ b/testsuite/MDAnalysisTests/test_selections.py
@@ -65,7 +65,6 @@ class _SelectionWriter(TestCase):
         with self.assertRaises(ValueError):
             self._write(name=self.ref_name, mode='a+')
 
-
 def ndx2array(lines):
     """Convert Gromacs NDX text file lines to integer array"""
     return np.array(" ".join(lines).replace("\n", "").split(), dtype=int)
@@ -130,7 +129,6 @@ class TestSelectionWriter_Charmm(_SelectionWriter):
         self._assert_selectionstring()
 
 
-
 class TestSelectionWriter_PyMOL(_SelectionWriter):
     filename = "CA.pml"
     ref_name = "CA_selection"
@@ -154,7 +152,6 @@ class TestSelectionWriter_PyMOL(_SelectionWriter):
     def test_writeselection_pml(self):
         self._write_selection(name=self.ref_name)
         self._assert_selectionstring()
-
 
 
 class TestSelectionWriter_VMD(_SelectionWriter):
@@ -210,4 +207,3 @@ class TestSelectionWriter_Jmol(_SelectionWriter):
                      err_msg="SPT file has wrong selection name")
         assert_array_equal(indices, self.ref_indices,
                            err_msg="SPT indices were not written correctly")
-


### PR DESCRIPTION
This PR adds a simple set of unit tests that ensure that `SelectionWriter` raises a `ValueError` when using an invalid file mode.

Generally speaking, a user is unlikely to encounter this particular error, but I decided to spend part of my Saturday evening looking through red lines in the coveralls report and found it [here](https://coveralls.io/builds/7924214/source?filename=miniconda%2Fenvs%2Fpyenv%2Flib%2Fpython2.7%2Fsite-packages%2FMDAnalysis%2Fselections%2Fbase.py#L104). So, a very minor increase in coverage, but ensures that this behaviour is retained moving forward.