### PR TITLE
Test for LeafletFinder selection string

### DIFF
--- a/testsuite/CHANGELOG
+++ b/testsuite/CHANGELOG
@@ -17,6 +17,7 @@ and https://github.com/MDAnalysis/mdanalysis/wiki/UnitTests
          tyler.je.reddy
 
   * 0.16
+    - added test for LeafletFinder handling a selection string
     - Added unit test for MDAnalysis.analysis.distances.between()
     - Added unit tests for MDAnalysis.analysis.distances.dist()
     - Added unit tests for clip_matrix frustrum boundary checks

--- a/testsuite/MDAnalysisTests/analysis/test_leaflet.py
+++ b/testsuite/MDAnalysisTests/analysis/test_leaflet.py
@@ -27,9 +27,11 @@ class TestLeafletFinder(TestCase):
     def setUp(self):
         self.universe = MDAnalysis.Universe(Martini_membrane_gro, Martini_membrane_gro)
         self.lipid_heads = self.universe.select_atoms("name PO4")
+        self.lipid_head_string = "name PO4"
 
     def tearDown(self):
         del self.universe
+        del self.lipid_head_string
 
     def test_leaflet_finder(self):
         from MDAnalysis.analysis.leaflet import LeafletFinder
@@ -42,3 +44,11 @@ class TestLeafletFinder(TestCase):
         assert_equal(bottom_heads.indices, np.arange(2521,4670,12), err_msg="Found wrong leaflet lipids")
 
 
+    def test_string_vs_atomgroup_proper(self):
+        from MDAnalysis.analysis.leaflet import LeafletFinder
+        lfls_ag = LeafletFinder(self.universe, self.lipid_heads, pbc=True)
+        lfls_string = LeafletFinder(self.universe, self.lipid_head_string, pbc=True)
+        groups_ag = lfls_ag.groups()
+        groups_string = lfls_string.groups()
+        assert_equal(groups_string[0].indices, groups_ag[0].indices)
+        assert_equal(groups_string[1].indices, groups_ag[1].indices)


### PR DESCRIPTION
This PR adds a unit test that ensures that `LeafletFinder` returns the same result when fed a selection string instead of the atomgroup proper that is generated by that selection string. This is something a user would commonly do and matches [this missing coverage line](https://coveralls.io/builds/7924214/source?filename=miniconda%2Fenvs%2Fpyenv%2Flib%2Fpython2.7%2Fsite-packages%2FMDAnalysis%2Fanalysis%2Fleaflet.py#L117).

For clarity, we are testing to ensure that the following two statements are equivalent:

```python
leaflets = LeafletFinder(universe, 'name PO4')

leaflets = LeafletFinder(universe, universe.select_atoms('name PO4'))
```

Other notes from looking at the testing module involved:

- there's a `setUp` object that isn't being torn down after (fix this elsewhere if you want to)
- it is slightly awkward that we now have tests in the test class that both separately import `LeafletFinder`, however I believe this import mechanism is being used to skirt the scipy dependency issue for some build scenarios
