### PR TITLE
WIP: Issue 363 test failure squashing

### DIFF
--- a/package/MDAnalysis/lib/NeighborSearch.py
+++ b/package/MDAnalysis/lib/NeighborSearch.py
@@ -70,7 +70,7 @@ class AtomNeighborSearch(object):
           *radius* of *atoms*.
         """
         if isinstance(atoms, Atom):
-            positions = Atom.position.reshape(1, 3)
+            positions = atoms.position.reshape(1,3)
         else:
             positions = atoms.positions
 
@@ -93,11 +93,11 @@ class AtomNeighborSearch(object):
           char (A, R, S). Return atoms(A), residues(R) or segments(S) within
           *radius* of *atoms*.
         """
-        n_atom_list = self.atom_group[indices]
         if level == 'A':
-            if len(n_atom_list) == 0:
+            if len(indices) == 0:
                 return []
             else:
+                n_atom_list = self.atom_group[indices]
                 return n_atom_list
         elif level == 'R':
             return list({a.residue for a in n_atom_list})

--- a/package/MDAnalysis/topology/PSFParser.py
+++ b/package/MDAnalysis/topology/PSFParser.py
@@ -263,7 +263,13 @@ class PSFParser(TopologyReader):
         masses = np.zeros(numlines, dtype=np.float32)
 
         for i in xrange(numlines):
-            line = lines()
+            try:
+                line = lines()
+            except StopIteration:
+                err = ("{0} is not valid PSF file"
+                       "".format(self.filename))
+                logger.error(err)
+                raise ValueError(err)
             try:
                 vals = set_type(atom_parser(line))
             except ValueError:

--- a/testsuite/MDAnalysisTests/coordinates/test_gro.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_gro.py
@@ -229,7 +229,7 @@ class TestGROWriter(TestCase, tempdir.TempDir):
         # modify coordinates so we need our own copy or we could mess up
         # parallel tests
         u = mda.Universe(GRO)
-        u.atoms[2000].position[1] = -999.9995 * 10  # nm -> A
+        u.atoms[2000].position = [11.589, -999.9995 * 10, 22.2]  # nm -> A
         assert_raises(ValueError, u.atoms.write, self.outfile2)
         del u
 
@@ -242,7 +242,7 @@ class TestGROWriter(TestCase, tempdir.TempDir):
         # parallel tests
         u = mda.Universe(GRO)
         # nm -> A  ; [ob] 9999.9996 not caught
-        u.atoms[1000].position[1] = 9999.9999 * 10
+        u.atoms[1000].position = [0, 9999.9999 * 10, 1]
         assert_raises(ValueError, u.atoms.write, self.outfile2)
         del u
 
@@ -253,7 +253,7 @@ class TestGROWriter(TestCase, tempdir.TempDir):
         # modify coordinates so we need our own copy or we could mess up
         # parallel tests
         u = mda.Universe(GRO, convert_units=False)
-        u.atoms[1000].position[1] = 9999.9999
+        u.atoms[1000].position = [22.2, 9999.9999, 37.89]
         assert_raises(ValueError, u.atoms.write, self.outfile2,
                       convert_units=False)
         del u

--- a/testsuite/MDAnalysisTests/coordinates/test_lammps.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_lammps.py
@@ -93,7 +93,8 @@ class _TestLAMMPSDATAWriter(TestCase):
 
     def test_Writer_dimensions(self):
         assert_almost_equal(self.u_ref.dimensions, self.u_new.dimensions,
-                         err_msg="attributes different after writing")
+                         err_msg="attributes different after writing",
+                         decimal=6)
 
     def test_Writer_atoms(self):
         for attr in self.all_attrs:

--- a/testsuite/MDAnalysisTests/coordinates/test_pdb.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_pdb.py
@@ -198,7 +198,7 @@ class TestPDBWriter(TestCase):
         # modify coordinates so we need our own copy or we could mess up
         # parallel tests
         u = mda.Universe(PSF, PDB_small)
-        u.atoms[2000].position[1] = -999.9995
+        u.atoms[2000].position = [0, -999.9995, 22.8]
         assert_raises(ValueError, u.atoms.write, self.outfile)
 
     @attr('issue')
@@ -209,7 +209,7 @@ class TestPDBWriter(TestCase):
         # parallel tests
         u = mda.Universe(PSF, PDB_small)
         # OB: 9999.99951 is not caught by '<=' ?!?
-        u.atoms[1000].position[1] = 9999.9996
+        u.atoms[1000].position = [90.889, 9999.9996, 12.2]
         assert_raises(ValueError, u.atoms.write, self.outfile)
         del u
 

--- a/testsuite/MDAnalysisTests/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/test_atomgroup.py
@@ -1940,12 +1940,13 @@ class TestWriteGRO(_WriteAtoms):
 @dec.skipif(parser_not_found('DCD'),
             'DCD parser not available. Are you using python 3?')
 def test_generated_residueselection():
-    """Test that a generated residue group always returns a ResidueGroup (Issue 47)"""
+    """Test that a generated residue group always returns a ResidueGroup (Issue 47)
+    unless there is a single residue (Issue 363 change)"""
     universe = MDAnalysis.Universe(PSF, DCD)
     # only a single Cys in AdK
     cys = universe.s4AKE.CYS
-    assert_(isinstance(cys, MDAnalysis.core.groups.ResidueGroup),
-            "Single Cys77 is NOT returned as a ResidueGroup with a single Residue (Issue 47)")
+    assert_(isinstance(cys, MDAnalysis.core.groups.Residue),
+            "Single Cys77 is NOT returned as a single Residue (Issue 47)")
 
     # multiple Met
     met = universe.s4AKE.MET

--- a/testsuite/MDAnalysisTests/test_nuclinfo.py
+++ b/testsuite/MDAnalysisTests/test_nuclinfo.py
@@ -43,20 +43,20 @@ class TestNuclinfo(TestCase):
         del self.universe
 
     def test_wc_pair(self):
-        seg1 = self.universe.residues[3].segids[0]
-        seg2 = self.universe.residues[19].segids[0]
+        seg1 = self.universe.residues[3].atoms.segids[0]
+        seg2 = self.universe.residues[19].atoms.segids[0]
         wc = nuclinfo.wc_pair(self.universe, 4, 20, seg1, seg2)
         assert_almost_equal(wc, 2.9810174, err_msg="Watson-Crick distance does not match expected value.")
 
     def test_major_pair(self):
-        seg1 = self.universe.residues[3].segids[0]
-        seg2 = self.universe.residues[19].segids[0]
+        seg1 = self.universe.residues[3].atoms.segids[0]
+        seg2 = self.universe.residues[19].atoms.segids[0]
         maj = nuclinfo.major_pair(self.universe, 4, 20, seg1, seg2)
         assert_almost_equal(maj, 2.9400151, err_msg="Watson-Crick distance does not match expected value.")
 
     def test_minor_pair(self):
-        seg1 = self.universe.residues[3].segids[0]
-        seg2 = self.universe.residues[19].segids[0]
+        seg1 = self.universe.residues[3].atoms.segids[0]
+        seg2 = self.universe.residues[19].atoms.segids[0]
 
         minor = nuclinfo.minor_pair(self.universe, 4, 20, seg1, seg2)
         assert_almost_equal(minor, 3.7739358, err_msg="Watson-Crick distance does not match expected value.")
@@ -81,8 +81,8 @@ class TestNuclinfo(TestCase):
                                   err_msg="RNA hydroxyl dihedrals do not match")
 
     def test_pseudo_dihe_baseflip(self):
-        seg1 = self.universe.residues[3].segids[0]
-        seg2 = self.universe.residues[19].segids[0]
+        seg1 = self.universe.residues[3].atoms.segids[0]
+        seg2 = self.universe.residues[19].atoms.segids[0]
 
         # There is not really a baseflip, just testing the code...
         flip = nuclinfo.pseudo_dihe_baseflip(self.universe, 4, 20, 5, seg1=seg1, seg2=seg2, seg3=seg1)


### PR DESCRIPTION
Reference: #815 

I'm going through some of the test failures and dealing with them, and I'll edit this WIP PR (against the `issue-363` branch) as I squash them. In some cases I may bend a test to pass when the actual code should be fixed instead of the test, but you can just let me know if that is the case and I'll fix it.

Summary of test failures fixed so far:

- 3 failures in `test_gro.py`: assigning the coordinates of an atom with `position` requires a shape `(3,)` array-like object and indexing to a single value with i.e., `position[1]` is not tolerated -- the test now uses a shape `(3,)` array-like object.
- 2 failures in `test_pdb.py` similar to the above
- 1 failure in `test_atomgroup.py`: selecting a single residue now returns a `Residue` instead of `ResidueGroup` [(see discussion here)](https://github.com/MDAnalysis/mdanalysis/pull/815#issuecomment-240379849)
- 1 failure in `test_lammps.py`: `test_Writer_dimensions (MDAnalysisTests.coordinates.test_lammps.TestLAMMPSDATAWriter_cnt`: relaxed test stringency to 6 floating point positions (the original test passes on my machines but not on Travis)

Summary of test errors fixed so far:

- 5 errors in `test_hbonds.py`: `lib/NeighborSearch.py` had some apparent bugs
- 4 errors in `test_nuclinfo.py`: need to use `residue.atoms` to access certain properties
- 1 error in `test_atomgroup.py`: `PSFParser.py` wasn't raising the correct exception when fed the test file `PSF_BAD`

Attempted fixes of test failures (not confirmed yet):

- 

Summary of current questions / issues:

- masses aren't getting set for the `NUCL` nucleic acid test data file -- the `dir(universe)` doesn't have `masses` or `center_of_mass`, which causes a test error for `test_nuclinfo.py`
- `ag.altLocs`, `ag.radii` and `ag.bfactors` and `ag.occupancies` seems to be attributes that are not currently being set?
- it seems that segids are not being set properly yet? I think @richardjgowers is still working on this?