### PR TITLE
Clip matrix frustrum boundary tests

### DIFF
--- a/testsuite/CHANGELOG
+++ b/testsuite/CHANGELOG
@@ -17,6 +17,7 @@ and https://github.com/MDAnalysis/mdanalysis/wiki/UnitTests
          tyler.je.reddy
 
   * 0.16
+    - Added unit tests for clip_matrix frustrum boundary checks
     - Added unit tests for bad file mode passed to SelectionWriter
     - Added regression tests for MDAnalysis.analysis.nuclinfo (Issue #790)
     - test_imports now recursively checks subdirectories (Issue #964).

--- a/testsuite/CHANGELOG
+++ b/testsuite/CHANGELOG
@@ -16,7 +16,7 @@ and https://github.com/MDAnalysis/mdanalysis/wiki/UnitTests
 ??/??/16 jbarnoud, orbeckst, fiona-naughton, manuel.nuno.melo, richardjgowers
          tyler.je.reddy
 
-  * 0.15.1
+  * 0.16
     - Added unit tests for bad file mode passed to SelectionWriter
     - Added regression tests for MDAnalysis.analysis.nuclinfo (Issue #790)
     - test_imports now recursively checks subdirectories (Issue #964).

--- a/testsuite/MDAnalysisTests/test_transformations.py
+++ b/testsuite/MDAnalysisTests/test_transformations.py
@@ -17,6 +17,7 @@
 from six.moves import range
 
 import numpy as np
+import unittest
 from numpy.testing import assert_allclose, assert_equal
 
 from MDAnalysis.lib import transformations as t
@@ -238,7 +239,7 @@ class TestProjectionFromMatrix(object):
         assert_equal(t.is_same_transform(P0, P1), True)
 
 
-class _ClipMatrix(object):
+class _ClipMatrix(unittest.TestCase):
     def test_clip_matrix_1(self):
         frustrum = np.array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6])  # arbitrary values
         frustrum[1] += frustrum[0]
@@ -262,6 +263,24 @@ class _ClipMatrix(object):
         v = np.dot(M, [frustrum[1], frustrum[3], frustrum[4], 1.0])
         assert_allclose(v / v[3],
                         np.array([ 1.,  1., -1.,  1.]))
+
+    def test_clip_matrix_frustrum_left_right_bounds(self):
+        '''ValueError should be raised if left > right.'''
+        frustrum = np.array([0.4, 0.3, 0.3, 0.7, 0.5, 1.1])
+        with self.assertRaises(ValueError):
+           self.f(*frustrum)
+
+    def test_clip_matrix_frustrum_bottom_top_bounds(self):
+        '''ValueError should be raised if bottom > top.'''
+        frustrum = np.array([0.1, 0.3, 0.71, 0.7, 0.5, 1.1])
+        with self.assertRaises(ValueError):
+           self.f(*frustrum)
+
+    def test_clip_matrix_frustrum_near_far_bounds(self):
+        '''ValueError should be raised if near > far.'''
+        frustrum = np.array([0.1, 0.3, 0.3, 0.7, 1.5, 1.1])
+        with self.assertRaises(ValueError):
+           self.f(*frustrum)
 
 class TestClipMatrixNP(_ClipMatrix):
     f = staticmethod(t._py_clip_matrix)


### PR DESCRIPTION
This PR aims to cover missing coverage line [here](https://coveralls.io/builds/7979037/source?filename=miniconda%2Fenvs%2Fpyenv%2Flib%2Fpython2.7%2Fsite-packages%2FMDAnalysis%2Flib%2Ftransformations.py#L637) using 3 distinct unit tests for the frustrum boundary checks used by `clip_matrix` in the `transformations` module.

It does not aim or claim to be fully comprehensive for all input scenarios--it  adds a few simple tests to probe a line of code that has 0 coverage at the moment.

The PR also fixes the current version number for the testsuite `CHANGELOG` because this change was omitted in the past.
