### PR TITLE
Add unit tests for MDAnalysis.analysis.distances.dist()

### DIFF
--- a/testsuite/CHANGELOG
+++ b/testsuite/CHANGELOG
@@ -17,6 +17,7 @@ and https://github.com/MDAnalysis/mdanalysis/wiki/UnitTests
          tyler.je.reddy
 
   * 0.16
+    - Added unit tests for MDAnalysis.analysis.distances.dist()
     - Added unit tests for clip_matrix frustrum boundary checks
     - Added unit tests for bad file mode passed to SelectionWriter
     - Added regression tests for MDAnalysis.analysis.nuclinfo (Issue #790)

--- a/testsuite/MDAnalysisTests/analysis/test_distances.py
+++ b/testsuite/MDAnalysisTests/analysis/test_distances.py
@@ -124,3 +124,9 @@ class TestDist(TestCase):
                 offset=33)[:2]
         assert_equal(actual, np.array([self.ag.atoms.resids + 33,
                                        self.ag2.atoms.resids + 33]))
+
+    def test_mismatch_exception(self):
+        '''A ValueError should be raised if the two atomgroups
+        don't have the same number of atoms.'''
+        with self.assertRaises(ValueError):
+            MDAnalysis.analysis.distances.dist(self.ag[:19], self.ag2)

--- a/testsuite/MDAnalysisTests/analysis/test_distances.py
+++ b/testsuite/MDAnalysisTests/analysis/test_distances.py
@@ -17,6 +17,7 @@ from __future__ import print_function
 
 import MDAnalysis
 from MDAnalysisTests import module_not_found
+from MDAnalysisTests.datafiles import GRO
 
 from numpy.testing import TestCase, assert_equal, dec
 import numpy as np
@@ -75,3 +76,51 @@ class TestContactMatrix(TestCase):
                      "wrong shape (should be {0})".format(self.shape))
         assert_equal(contacts.toarray(), self.res_pbc)
 
+class TestDist(TestCase):
+    '''Tests for MDAnalysis.analysis.distances.dist().
+    Imports do not happen at the top level of the module
+    because of the scipy dependency.'''
+
+    @dec.skipif(module_not_found('scipy'),
+                "Test skipped because scipy is not available.")
+
+    def setUp(self):
+        import MDAnalysis.analysis.distances
+        import scipy
+        import scipy.spatial
+        self.u = MDAnalysis.Universe(GRO)
+        self.ag = self.u.atoms[:20]
+        self.u2 = MDAnalysis.Universe(GRO)
+        self.ag2 = self.u2.atoms[:20]
+        self.ag2.positions = np.random.shuffle(self.ag2.positions)
+        self.expected = np.diag(scipy.spatial.distance.cdist(
+                                                self.ag.positions,
+                                                self.ag2.positions))
+
+    def tearDown(self):
+        del self.u
+        del self.ag
+        del self.u2
+        del self.ag2
+        del self.expected
+
+    def test_pairwise_dist(self):
+        '''Ensure that pairwise distances between atoms are
+        correctly calculated.'''
+        actual = MDAnalysis.analysis.distances.dist(self.ag, self.ag2)[2]
+        assert_equal(actual, self.expected)
+
+    def test_pairwise_dist_offset_effect(self):
+        '''Test that feeding in offsets to dist() doesn't alter
+        pairwise distance matrix.'''
+        actual = MDAnalysis.analysis.distances.dist(self.ag, self.ag2,
+                                                    offset=229)[2]
+        assert_equal(actual, self.expected)
+
+
+    def test_offset_calculation(self):
+        '''Test that offsets fed to dist() are correctly calculated.'''
+        actual = MDAnalysis.analysis.distances.dist(self.ag, self.ag2,
+                offset=33)[:2]
+        assert_equal(actual, np.array([self.ag.atoms.resids + 33,
+                                       self.ag2.atoms.resids + 33]))


### PR DESCRIPTION
This PR adds a few unit tests for `MDAnalysis.analysis.distances.dist()`, which is currently [completely not covered](https://coveralls.io/builds/7979037/source?filename=miniconda%2Fenvs%2Fpyenv%2Flib%2Fpython2.7%2Fsite-packages%2FMDAnalysis%2Fanalysis%2Fdistances.py#L149).

Top level scipy-related module imports probably aren't possible for the usual reasons.

