### PR TITLE
Add unit test for MDAnalysis.analysis.distances.between()

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -43,6 +43,7 @@ Enhancements
     analysis code (Issue #743)
         
 Fixes
+  * MDAnalysis.analysis.distances.between() is no longer broken
   * GROWriter resids now truncated properly (Issue #886)
   * reading/writing lambda value in trr files (Issue #859)
   * fix __iter__/next redundancy (Issue #869)

--- a/package/MDAnalysis/analysis/distances.py
+++ b/package/MDAnalysis/analysis/distances.py
@@ -35,6 +35,7 @@ import numpy as np
 
 from MDAnalysis.lib.distances import distance_array, self_distance_array
 from MDAnalysis.lib.c_distances import contact_matrix_no_pbc, contact_matrix_pbc
+from MDAnalysis.lib.NeighborSearch import AtomNeighborSearch
 
 import warnings
 import logging
@@ -192,6 +193,6 @@ def between(group, A, B, distance):
     from MDAnalysis.core.AtomGroup import AtomGroup
 
     ns_group = AtomNeighborSearch(group)
-    resA = set(ns_group.search_list(A, distance))
-    resB = set(ns_group.search_list(B, distance))
+    resA = set(ns_group.search(A, distance))
+    resB = set(ns_group.search(B, distance))
     return AtomGroup(resB.intersection(resA))

--- a/testsuite/CHANGELOG
+++ b/testsuite/CHANGELOG
@@ -17,6 +17,7 @@ and https://github.com/MDAnalysis/mdanalysis/wiki/UnitTests
          tyler.je.reddy
 
   * 0.16
+    - Added unit test for MDAnalysis.analysis.distances.between()
     - Added unit tests for MDAnalysis.analysis.distances.dist()
     - Added unit tests for clip_matrix frustrum boundary checks
     - Added unit tests for bad file mode passed to SelectionWriter


### PR DESCRIPTION
This PR:

- adds a unit test for the [completely uncovered](https://coveralls.io/builds/7992978/source?filename=miniconda%2Fenvs%2Fpyenv%2Flib%2Fpython2.7%2Fsite-packages%2FMDAnalysis%2Fanalysis%2Fdistances.py#L192) `MDAnalysis.analysis.distances.between()` function
- the above function was actually completely broken, and that has also been fixed -- the module was missing a top level import and `between()` called a method of the not-imported object that no longer exists in the current codebase
- both package level and testsuite level `CHANGELOG` files have been updated since both testing and user-facing functionality have changed
