### PR TITLE
Unit tests / exception handling in psa module

### DIFF
--- a/package/MDAnalysis/analysis/psa.py
+++ b/package/MDAnalysis/analysis/psa.py
@@ -332,7 +332,7 @@ def get_coord_axes(path):
     else:
         err_str = "Path must have 2 or 3 dimensions; the first dimensions (axis"\
                 + " 0) must correspond to frames, axis 1 (and axis 2, if"       \
-                + " present) must contain atomic coordinates.".format(N)
+                + " present) must contain atomic coordinates."
         raise ValueError(err_str)
     return N, axis
 

--- a/testsuite/CHANGELOG
+++ b/testsuite/CHANGELOG
@@ -17,6 +17,7 @@ and https://github.com/MDAnalysis/mdanalysis/wiki/UnitTests
          tyler.je.reddy
 
   * 0.16
+    - Added unit tests for MDAnalysis.analysis.psa exception handling
     - Added unit test for MDAnalysis.analysis.distances.between()
     - Added unit tests for MDAnalysis.analysis.distances.dist()
     - Added unit tests for clip_matrix frustrum boundary checks

--- a/testsuite/CHANGELOG
+++ b/testsuite/CHANGELOG
@@ -17,7 +17,6 @@ and https://github.com/MDAnalysis/mdanalysis/wiki/UnitTests
          tyler.je.reddy
 
   * 0.16
-    - Added unit tests for MDAnalysis.analysis.psa exception handling
     - Added unit test for MDAnalysis.analysis.distances.between()
     - Added unit tests for MDAnalysis.analysis.distances.dist()
     - Added unit tests for clip_matrix frustrum boundary checks

--- a/testsuite/MDAnalysisTests/analysis/test_psa.py
+++ b/testsuite/MDAnalysisTests/analysis/test_psa.py
@@ -72,3 +72,24 @@ class TestPSAnalysis(TestCase):
     def test_reversal_frechet(self):
         err_msg = "Frechet distances did not increase after path reversal"
         assert_(self.frech_matrix[1,2] >= self.frech_matrix[0,1], err_msg)
+
+class TestPSAExceptions(TestCase):
+    '''Tests for exceptions that should be raised
+    or caught by code in the psa module.'''
+
+    def test_get_path_metric_func_bad_key(self):
+        '''Test that KeyError is caught by
+        get_path_metric_func().'''
+
+        try:
+           MDAnalysis.analysis.psa.get_path_metric_func('123456')
+        except KeyError:
+            self.fail('KeyError should be caught')
+
+    def test_get_coord_axes_bad_dims(self):
+        '''Test that ValueError is raised when
+        numpy array with incorrect dimensions 
+        is fed to get_coord_axes().'''
+
+        with self.assertRaises(ValueError):
+            MDAnalysis.analysis.psa.get_coord_axes(np.zeros((5,5,5,5)))


### PR DESCRIPTION
This PR adds two unit tests that deal with exception handling in the `psa` analysis module. It turns out that one of the exceptions wasn't properly raised because a python `format` statement was used on a string with no substitution braces (and the variable being substituted, `N`, doesn't exist either!) for the error message variable generation that preceded the `raise` statement. 

The latter has been patched in the `psa` module itself, however I've only updated the testsuite `CHANGELOG` because I deemed that analysis-module level change to be relatively minor from a typical user standpoint.

Uncovered lines now covered:
[ValueError in `get_coord_axes`](https://coveralls.io/builds/8005358/source?filename=miniconda%2Fenvs%2Fpyenv%2Flib%2Fpython2.7%2Fsite-packages%2FMDAnalysis%2Fanalysis%2Fpsa.py#L333)
[KeyError in `get_path_metric_func`](https://coveralls.io/builds/8005358/source?filename=miniconda%2Fenvs%2Fpyenv%2Flib%2Fpython2.7%2Fsite-packages%2FMDAnalysis%2Fanalysis%2Fpsa.py#L254)