### PR TITLE
Two unit tests for polymer.py

### DIFF
--- a/testsuite/CHANGELOG
+++ b/testsuite/CHANGELOG
@@ -17,6 +17,7 @@ and https://github.com/MDAnalysis/mdanalysis/wiki/UnitTests
          tyler.je.reddy
 
   * 0.16
+    - added two unit tests for MDAnalysis.analysis.polymer
     - added test for LeafletFinder handling a selection string
     - Added unit test for MDAnalysis.analysis.distances.between()
     - Added unit tests for MDAnalysis.analysis.distances.dist()

--- a/testsuite/MDAnalysisTests/analysis/test_persistencelength.py
+++ b/testsuite/MDAnalysisTests/analysis/test_persistencelength.py
@@ -17,8 +17,10 @@ from __future__ import print_function
 
 import MDAnalysis
 from MDAnalysis.analysis import polymer
+from MDAnalysis.exceptions import NoDataError
 import numpy as np
 from numpy.testing import (
+    TestCase,
     assert_,
     assert_almost_equal,
     assert_raises,
@@ -29,7 +31,7 @@ from MDAnalysisTests.datafiles import Plength
 from MDAnalysisTests import module_not_found
 
 
-class TestPersistenceLength(object):
+class TestPersistenceLength(TestCase):
     def setUp(self):
         self.u = MDAnalysis.Universe(Plength)
 
@@ -64,6 +66,28 @@ class TestPersistenceLength(object):
         assert_almost_equal(p.lp, 6.504, 3)
         assert_(len(p.fit) == len(p.results))
 
+    @dec.skipif(module_not_found('matplotlib'),
+                "Test skipped because matplotlib is not available.")
+    @dec.skipif(module_not_found('scipy'),
+                "Test skipped because scipy is not available.")
+    def test_plot_ax_return(self):
+        '''Ensure that a matplotlib axis object is
+        returned when plot() is called.'''
+        import matplotlib
+        p = self._make_p()
+        p.run()
+        p.perform_fit()
+        actual = p.plot()
+        expected = matplotlib.axes.Axes
+        self.assertIsInstance(actual, expected)
+
+    def test_raise_NoDataError(self):
+        '''Ensure that a NoDataError is raised if
+        perform_fit() is called before the run()
+        method of AnalysisBase.'''
+        with self.assertRaises(NoDataError):
+            p = self._make_p()
+            p.perform_fit()
 
 class TestFitExponential(object):
     def setUp(self):

--- a/testsuite/MDAnalysisTests/analysis/test_persistencelength.py
+++ b/testsuite/MDAnalysisTests/analysis/test_persistencelength.py
@@ -20,7 +20,6 @@ from MDAnalysis.analysis import polymer
 from MDAnalysis.exceptions import NoDataError
 import numpy as np
 from numpy.testing import (
-    TestCase,
     assert_,
     assert_almost_equal,
     assert_raises,
@@ -31,7 +30,7 @@ from MDAnalysisTests.datafiles import Plength
 from MDAnalysisTests import module_not_found
 
 
-class TestPersistenceLength(TestCase):
+class TestPersistenceLength(object):
     def setUp(self):
         self.u = MDAnalysis.Universe(Plength)
 
@@ -79,15 +78,14 @@ class TestPersistenceLength(TestCase):
         p.perform_fit()
         actual = p.plot()
         expected = matplotlib.axes.Axes
-        self.assertIsInstance(actual, expected)
+        assert_(isinstance(actual, expected))
 
     def test_raise_NoDataError(self):
         '''Ensure that a NoDataError is raised if
         perform_fit() is called before the run()
         method of AnalysisBase.'''
-        with self.assertRaises(NoDataError):
-            p = self._make_p()
-            p.perform_fit()
+        p = self._make_p()
+        assert_raises(NoDataError, p.perform_fit)
 
 class TestFitExponential(object):
     def setUp(self):


### PR DESCRIPTION
This PR should bring unit test coverage for `analysis/polymer.py` up to 100 % by covering  [one plotting scenario](https://coveralls.io/builds/8018588/source?filename=miniconda%2Fenvs%2Fpyenv%2Flib%2Fpython2.7%2Fsite-packages%2FMDAnalysis%2Fanalysis%2Fpolymer.py#L132)  and one [exception handling scenario](https://coveralls.io/builds/8018588/source?filename=miniconda%2Fenvs%2Fpyenv%2Flib%2Fpython2.7%2Fsite-packages%2FMDAnalysis%2Fanalysis%2Fpolymer.py#L122).

