### PR TITLE
Hausdorff distance unit tests

### DIFF
--- a/package/MDAnalysis/analysis/psa.py
+++ b/package/MDAnalysis/analysis/psa.py
@@ -338,7 +338,7 @@ def get_coord_axes(path):
 
 
 def hausdorff(P, Q):
-    r"""Calculate the Hausdorff distance between two paths.
+    r"""Calculate the undirected Hausdorff distance between two paths.
 
     *P* (*Q*) is a :class:`numpy.ndarray` of :math:`N_p` (:math:`N_q`) time
     steps, :math:`N` atoms, and :math:`3N` coordinates (e.g.,
@@ -377,7 +377,8 @@ def hausdorff(P, Q):
 
 
 def hausdorff_wavg(P, Q):
-    r"""Calculate the weighted average Hausdorff distance between two paths.
+    r"""Calculate the weighted average (undirected) Hausdorff distance between
+    two paths.
 
     *P* (*Q*) is a :class:`numpy.ndarray` of :math:`N_p` (:math:`N_q`) time
     steps, :math:`N` atoms, and :math:`3N` coordinates (e.g.,
@@ -421,7 +422,7 @@ def hausdorff_wavg(P, Q):
 
 
 def hausdorff_avg(P, Q):
-    r"""Calculate the average Hausdorff distance between two paths.
+    r"""Calculate the average (undirected) Hausdorff distance between two paths.
 
     *P* (*Q*) is a :class:`numpy.ndarray` of :math:`N_p` (:math:`N_q`) time
     steps, :math:`N` atoms, and :math:`3N` coordinates (e.g.,

--- a/package/MDAnalysis/analysis/psa.py
+++ b/package/MDAnalysis/analysis/psa.py
@@ -338,7 +338,7 @@ def get_coord_axes(path):
 
 
 def hausdorff(P, Q):
-    r"""Calculate the undirected Hausdorff distance between two paths.
+    r"""Calculate the Hausdorff distance between two paths.
 
     *P* (*Q*) is a :class:`numpy.ndarray` of :math:`N_p` (:math:`N_q`) time
     steps, :math:`N` atoms, and :math:`3N` coordinates (e.g.,
@@ -377,8 +377,7 @@ def hausdorff(P, Q):
 
 
 def hausdorff_wavg(P, Q):
-    r"""Calculate the weighted average (undirected) Hausdorff distance between
-    two paths.
+    r"""Calculate the weighted average  Hausdorff distance between two paths.
 
     *P* (*Q*) is a :class:`numpy.ndarray` of :math:`N_p` (:math:`N_q`) time
     steps, :math:`N` atoms, and :math:`3N` coordinates (e.g.,
@@ -422,7 +421,7 @@ def hausdorff_wavg(P, Q):
 
 
 def hausdorff_avg(P, Q):
-    r"""Calculate the average (undirected) Hausdorff distance between two paths.
+    r"""Calculate the average Hausdorff distance between two paths.
 
     *P* (*Q*) is a :class:`numpy.ndarray` of :math:`N_p` (:math:`N_q`) time
     steps, :math:`N` atoms, and :math:`3N` coordinates (e.g.,

--- a/package/MDAnalysis/analysis/psa.py
+++ b/package/MDAnalysis/analysis/psa.py
@@ -377,7 +377,7 @@ def hausdorff(P, Q):
 
 
 def hausdorff_wavg(P, Q):
-    r"""Calculate the weighted average  Hausdorff distance between two paths.
+    r"""Calculate the weighted average Hausdorff distance between two paths.
 
     *P* (*Q*) is a :class:`numpy.ndarray` of :math:`N_p` (:math:`N_q`) time
     steps, :math:`N` atoms, and :math:`3N` coordinates (e.g.,

--- a/testsuite/MDAnalysisTests/analysis/test_psa.py
+++ b/testsuite/MDAnalysisTests/analysis/test_psa.py
@@ -19,11 +19,12 @@ import MDAnalysis
 import MDAnalysis.analysis.psa
 
 from numpy.testing import (TestCase, dec, assert_array_less,
-                           assert_array_almost_equal, assert_)
+                           assert_array_almost_equal, assert_,
+                           assert_almost_equal)
 import numpy as np
 
 from MDAnalysisTests.datafiles import PSF, DCD, DCD2
-from MDAnalysisTests import parser_not_found, tempdir
+from MDAnalysisTests import parser_not_found, tempdir, module_not_found
 
 
 class TestPSAnalysis(TestCase):
@@ -94,9 +95,13 @@ class TestPSAExceptions(TestCase):
         with self.assertRaises(ValueError):
             MDAnalysis.analysis.psa.get_coord_axes(np.zeros((5,5,5,5)))
 
-class TestHausdorffDistance(TestCase):
-    '''Unit tests for various Hausdorff distance
+class _BaseHausdorffDistance(TestCase):
+    '''Base Class setup and unit tests
+    for various Hausdorff distance
     calculation properties.'''
+
+    @dec.skipif(module_not_found('scipy'),
+                'scipy not available')
 
     def setUp(self):
         self.random_angles = np.random.random((100,)) * np.pi * 2
@@ -123,16 +128,76 @@ class TestHausdorffDistance(TestCase):
         del self.path_1
         del self.path_2
 
-    def test_hausdorff_wavg_asymmetry(self):
-        '''Ensure that weighted Hausdorff distance
-        is asymmetric. This is a general property
-        of maximum functions. Compare an inner and
-        outer circle, the latter with single point
-        beyond the circle.'''
-        forward = MDAnalysis.analysis.psa.hausdorff(self.path_1,
-                                                         self.path_2)
-        reverse = MDAnalysis.analysis.psa.hausdorff(self.path_2,
-                                                         self.path_1)
-        self.assertNotEqual(forward, reverse)
+    def test_symmetry(self):
+        '''Ensure that the undirected (symmetric)
+        Hausdorff distance is actually symmetric
+        for a given Hausdorff metric, h.'''
+        forward = self.h(self.path_1, self.path_2)
+        reverse = self.h(self.path_2, self.path_1)
+        self.assertEqual(forward, reverse)
 
+    def test_hausdorff_value(self):
+        '''Test that the undirected Hausdorff
+        distance matches expected value for
+        the simple case here.'''
+        actual = self.h(self.path_1, self.path_2)
+        # unless I pin down the random generator
+        # seems unstable to use decimal > 2
+        assert_almost_equal(actual, self.expected,
+                            decimal=2)
 
+class TestHausdorffSymmetric(_BaseHausdorffDistance):
+    '''Tests for conventional and symmetric (undirected)
+    Hausdorff distance between point sets in 3D.'''
+
+    def setUp(self):
+        super(TestHausdorffSymmetric, self).setUp()
+        self.h = MDAnalysis.analysis.psa.hausdorff
+        # radii differ by ~ 2.3 for outlier
+        self.expected = 2.3
+
+class TestWeightedAvgHausdorffSymmetric(_BaseHausdorffDistance):
+    '''Tests for weighted average and symmetric (undirected)
+    Hausdorff distance between point sets in 3D.'''
+    def setUp(self):
+        super(TestWeightedAvgHausdorffSymmetric, self).setUp()
+        import scipy
+        import scipy.spatial
+        self.h = MDAnalysis.analysis.psa.hausdorff_wavg
+        self.distance_matrix = scipy.spatial.distance.cdist(self.path_1,
+                                                            self.path_2)
+        self.expected = (np.mean(np.amin(self.distance_matrix, axis=0)) +
+                         np.mean(np.amin(self.distance_matrix, axis = 1))) / 2.
+
+    def test_asymmetric_weight(self):
+        '''Test to ensure that increasing N points in one of the paths
+        does NOT increase the weight of its contributions.'''
+        inflated_path_1 = np.concatenate((self.path_1, self.path_1))
+        inflated_path_2 = np.concatenate((self.path_2, self.path_2))
+        d_inner_inflation = self.h(inflated_path_1, self.path_2)
+        d_outer_inflation = self.h(self.path_1, inflated_path_2)
+        assert_almost_equal(d_inner_inflation,
+                            d_outer_inflation)
+
+class TestAvgHausdorffSymmetric(_BaseHausdorffDistance):
+    '''Tests for unweighted average and symmetric (undirected)
+    Hausdorff distance between point sets in 3D.'''
+    def setUp(self):
+        super(TestAvgHausdorffSymmetric, self).setUp()
+        import scipy
+        import scipy.spatial
+        self.h = MDAnalysis.analysis.psa.hausdorff_avg
+        self.distance_matrix = scipy.spatial.distance.cdist(self.path_1,
+                                                            self.path_2)
+        self.expected = np.mean(np.append(np.amin(self.distance_matrix, axis=0),
+                                np.amin(self.distance_matrix, axis = 1)))
+
+    def test_asymmetric_weight(self):
+        '''Test to ensure that increasing N points in one of the paths
+        increases the weight of its contributions.'''
+        inflated_path_1 = np.concatenate((self.path_1, self.path_1))
+        inflated_path_2 = np.concatenate((self.path_2, self.path_2))
+        d_inner_inflation = self.h(inflated_path_1, self.path_2)
+        d_outer_inflation = self.h(self.path_1, inflated_path_2)
+        assert_array_less(d_inner_inflation,
+                          d_outer_inflation)

--- a/testsuite/MDAnalysisTests/analysis/test_psa.py
+++ b/testsuite/MDAnalysisTests/analysis/test_psa.py
@@ -93,3 +93,46 @@ class TestPSAExceptions(TestCase):
 
         with self.assertRaises(ValueError):
             MDAnalysis.analysis.psa.get_coord_axes(np.zeros((5,5,5,5)))
+
+class TestHausdorffDistance(TestCase):
+    '''Unit tests for various Hausdorff distance
+    calculation properties.'''
+
+    def setUp(self):
+        self.random_angles = np.random.random((100,)) * np.pi * 2
+        self.random_columns = np.column_stack((self.random_angles,
+                                               self.random_angles,
+                                               np.zeros((100,))))
+        self.random_columns[...,0] = np.cos(self.random_columns[...,0])
+        self.random_columns[...,1] = np.sin(self.random_columns[...,1])
+        self.random_columns_2 = np.column_stack((self.random_angles,
+                                                 self.random_angles,
+                                                 np.zeros((100,))))
+        self.random_columns_2[1:,0] = np.cos(self.random_columns_2[1:,0]) * 2.0
+        self.random_columns_2[1:,1] = np.sin(self.random_columns_2[1:,1]) * 2.0
+        # move one point farther out so we don't have two perfect circles
+        self.random_columns_2[0,0] = np.cos(self.random_columns_2[0,0]) * 3.3
+        self.random_columns_2[0,1] = np.sin(self.random_columns_2[0,1]) * 3.3
+        self.path_1 = self.random_columns
+        self.path_2 = self.random_columns_2
+
+    def tearDown(self):
+        del self.random_angles
+        del self.random_columns
+        del self.random_columns_2
+        del self.path_1
+        del self.path_2
+
+    def test_hausdorff_wavg_asymmetry(self):
+        '''Ensure that weighted Hausdorff distance
+        is asymmetric. This is a general property
+        of maximum functions. Compare an inner and
+        outer circle, the latter with single point
+        beyond the circle.'''
+        forward = MDAnalysis.analysis.psa.hausdorff(self.path_1,
+                                                         self.path_2)
+        reverse = MDAnalysis.analysis.psa.hausdorff(self.path_2,
+                                                         self.path_1)
+        self.assertNotEqual(forward, reverse)
+
+


### PR DESCRIPTION
I'm quite certain I've discovered a problem with the [Hausdorff distance](https://en.wikipedia.org/wiki/Hausdorff_distance) calculation code. I was in the process of writing a unit test that verifies that the [Hausdorff distance is asymmetric](http://cgm.cs.mcgill.ca/~godfried/teaching/cg-projects/98/normand/main.html) (different from path_1 to path_2 than from path_2 to path_1). Actually, I was working on the weighted Hausdorff distance, but switched back to the normal one after discovering the issue.

While you can see the unit test set up code in the diff for this PR, for clarity let me show you the plot for the artificial paths I've created (z = 0 for simplicity, but feeding in 3D coords b/c that's what our stuff usually is):
![hausdorff](https://cloud.githubusercontent.com/assets/7903078/18810167/19ff91f4-8287-11e6-937b-7fef8fa10819.png)

Now, you'll notice that path_2 has one point that is off the outer circle path. path_1 has a radius of 1 and path_2 has a radius of 2, and the outlier in path_2 has a radial distance of 3.3. What this means is that the Hausdorff distance from path_2 to path_1 should be around 2.3, because that will be the "maximum minimum" distance -- i.e., for all points in path_2, the largest minimum distance to a point in path_1.

Conversely, the Hausdorff ("maximum minimum") distance from path_1 to path_2 should be far smaller, because any given point in that inner circle will always have the option to choose a minimum distance point that is closer than the outlier.

So, when my unit test runs:
```python
132         forward = MDAnalysis.analysis.psa.hausdorff(self.path_1,
133                                                          self.path_2)
134         reverse = MDAnalysis.analysis.psa.hausdorff(self.path_2,
135                                                          self.path_1)
136         self.assertNotEqual(forward, reverse)
``` 

The unexpected result is that both directions give a value of ~2.3:
```
Traceback (most recent call last):
  File "/Users/treddy/python_modules/MDAnalysis/MDA_dev/mdanalysis/testsuite/MDAnalysisTests/analysis/test_psa.py", line 136, in test_hausdorff_wavg_asymmetry
    self.assertNotEqual(forward, reverse)
AssertionError: 2.2999999999999998 == 2.2999999999999998
```

Why is this happening? Well, it turns out that the function (`hausdorff`) returns a distance based on this block of code:
```python
 375     return ( max( np.amax(np.amin(d, axis=0)),                                  \
 376                   np.amax(np.amin(d, axis=1)) ) / N  )**0.5
```
While this may initially look correct, because you are (in fact) calculating the maximum minimum distances, it is definitely not because it is being done for **both** axes--that means that you calculated the Hausdorff distance twice on the assumption that it is the same in each direction, but it is not. 

How do you fix this? Probably deleting `np.amax(np.amin(d, axis=0))` would be a step in the right direction, to be verified with additional unit tests, etc. Basically, axis=1 should find the minimum across each row, which is from the first argument path to the second argument path, but NOT do the columns as well.