### PR TITLE
Fragments are ordered by their first atom index

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -76,6 +76,8 @@ Changes
     the old %-based syntax is still available but will be deprecated.
     (PR #944)
   * Analysis.rms.RMSD now confirms to standard analysis API (Issue #893)
+  * Fragments in Universe.fragment are now sorted by the index of their first
+    atom. (Issue 1007)
 
 Deprecations (Issue #599)
   * Use of rms_fit_trj deprecated in favor of AlignTraj class (Issue #845)

--- a/package/MDAnalysis/core/AtomGroup.py
+++ b/package/MDAnalysis/core/AtomGroup.py
@@ -4513,6 +4513,10 @@ class Universe(object):
         Generally built on demand by an Atom querying its fragment property.
 
         .. versionadded:: 0.9.0
+
+        .. versionchanged:: 0.16.0
+           Fragments are sorted by their forst atom index so their order is
+           predictable.
         """
         # Check that bond information is present, else inform
         bonds = self.bonds
@@ -4565,7 +4569,12 @@ class Universe(object):
         f.update(dict((a, _fragset((a,))) for a, val in f.items() if not val))
 
         # All the unique values in f are the fragments
-        frags = tuple([AtomGroup(list(a.ats)) for a in set(f.values())])
+        frags = tuple(
+            sorted(
+                [AtomGroup(list(a.ats)) for a in set(f.values())],
+                key=lambda x: x[0].index
+            )
+        )
 
         return frags
 

--- a/package/MDAnalysis/core/AtomGroup.py
+++ b/package/MDAnalysis/core/AtomGroup.py
@@ -4515,8 +4515,8 @@ class Universe(object):
         .. versionadded:: 0.9.0
 
         .. versionchanged:: 0.16.0
-           Fragments are sorted by their forst atom index so their order is
-           predictable.
+           Fragment atoms are sorted by their index, and framgents are sorted
+           by their first atom index so their order is predictable.
         """
         # Check that bond information is present, else inform
         bonds = self.bonds
@@ -4571,7 +4571,7 @@ class Universe(object):
         # All the unique values in f are the fragments
         frags = tuple(
             sorted(
-                [AtomGroup(list(a.ats)) for a in set(f.values())],
+                [AtomGroup(list(sorted(a.ats))) for a in set(f.values())],
                 key=lambda x: x[0].index
             )
         )

--- a/testsuite/MDAnalysisTests/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/test_atomgroup.py
@@ -1912,6 +1912,10 @@ class TestFragments(TestCase):
         ag = self.u.atoms[100:200]
         assert_equal(len(ag.fragments), 1)
 
+    def test_fragment_order(self):
+        # check the fragments are ordered by their first atom index
+        assert_(self.u.fragments[0][0].index < self.u.fragments[1][0].index)
+
 
 class TestUniverseCache(TestCase):
     def setUp(self):


### PR DESCRIPTION
Fixes #1007 

Changes made in this Pull Request:
 - Fragments in `Universe.fragments` are ordered by their first atom index, this make their order predictable.


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?

Fixes #1007