### PR TITLE
Added unit test for discrete Frechet distance

### DIFF
--- a/testsuite/MDAnalysisTests/analysis/test_psa.py
+++ b/testsuite/MDAnalysisTests/analysis/test_psa.py
@@ -201,3 +201,36 @@ class TestAvgHausdorffSymmetric(_BaseHausdorffDistance):
         d_outer_inflation = self.h(self.path_1, inflated_path_2)
         assert_array_less(d_inner_inflation,
                           d_outer_inflation)
+
+class DiscreteFrechetDistance(TestCase):
+    # unit tests for the discrete Frechet distance
+
+    def setUp(self):
+        np.random.seed(50)
+        random_angles = np.random.random((100,)) * np.pi * 2
+        random_columns = np.column_stack((random_angles, random_angles,
+                                          np.zeros((100,))))
+        random_columns[...,0] = np.cos(random_columns[...,0])
+        random_columns[...,1] = np.sin(random_columns[...,1])
+        random_columns_2 = np.column_stack((random_angles, random_angles,
+                                            np.zeros((100,))))
+        random_columns_2[...,0] = np.cos(random_columns_2[...,0]) * 5.5
+        random_columns_2[...,1] = np.sin(random_columns_2[...,1]) * 5.5
+        self.path_1 = random_columns
+        self.path_2 = random_columns_2
+
+    def tearDown(self):
+        del self.path_1
+        del self.path_2
+
+    def test_discrete_Frechet_concentric_circles(self):
+        # test for the simple case of the discrete Frechet distance
+        # between concentric circular paths, which for a sufficiently
+        # high random discrete point density around each circle
+        # should be the absolute difference between their respective
+        # radii
+
+        expected = 4.5
+        actual = MDAnalysis.analysis.psa.discrete_frechet(self.path_1,
+                                                          self.path_2)
+        assert_almost_equal(actual, expected)


### PR DESCRIPTION
This PR adds a simple unit test for the discrete [Frechet distance](https://en.wikipedia.org/wiki/Fr%C3%A9chet_distance#Examples). Although coveralls indicates that this function is [already covered](https://coveralls.io/builds/8109105/source?filename=miniconda%2Fenvs%2Fpyenv%2Flib%2Fpython2.7%2Fsite-packages%2FMDAnalysis%2Fanalysis%2Fpsa.py#L497), the other tests are for different properties so I don't think it hurts.

As an aside, if @orbeckst or @sseyler have ideas for other computational geometry functions of this nature that they think would be broadly useful to the scientific community, that would be useful to know as the scipy devs [have asked](https://github.com/scipy/scipy/pull/6649#pullrequestreview-2474699) about what other alternative approaches may also be worth incorporating, and I enjoy doing that stuff with spare time.

It certainly seems that the Frechet distance has some advantages over Hausdorff, has [many variants](https://en.wikipedia.org/wiki/Fr%C3%A9chet_distance#Variants) and broad applications, so that may be another useful thing to have a fast implementation for.