### PR TITLE
Issue 1018 psa scipy bugfix

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -39,6 +39,7 @@ Enhancements
   * Iteration and seeking in PDB files made faster (Issue #848)
 
 Fixes
+  * Fixed TypeError in PSAnalysis heatmap-dendrogram plotting (Issue #1018)
   * ENT file format added to PDB Readers/Writers/Parsers (Issue #834)
   * rmsd now returns proper value when given array of weights (Issue #814)
   * change_release now finds number and dev (Issue #776)

--- a/package/MDAnalysis/analysis/psa.py
+++ b/package/MDAnalysis/analysis/psa.py
@@ -1730,14 +1730,13 @@ class PSAnalysis(object):
         from scipy.cluster.hierarchy import linkage, dendrogram
         from brewer2mpl import get_map
 
-        color_list = get_map('Set1', 'qualitative', 9).mpl_colors
+        # color_list = get_map('Set1', 'qualitative', 9).mpl_colors
         matplotlib.rcParams['lines.linewidth'] = 0.5
 
         Z = linkage(distArray, method=method)
-        dgram = dendrogram(Z, no_labels=no_labels, orientation='right',         \
+        dgram = dendrogram(Z, no_labels=no_labels, orientation='left',          \
                            count_sort=count_sort, distance_sort=distance_sort,  \
-                           no_plot=no_plot, color_threshold=color_threshold,    \
-                           color_list=color_list)
+                           no_plot=no_plot, color_threshold=color_threshold)
         return Z, dgram
 
 

--- a/package/MDAnalysis/analysis/psa.py
+++ b/package/MDAnalysis/analysis/psa.py
@@ -1728,7 +1728,7 @@ class PSAnalysis(object):
         """
         import matplotlib
         from scipy.cluster.hierarchy import linkage, dendrogram
-        from brewer2mpl import get_map
+        # from brewer2mpl import get_map
 
         # color_list = get_map('Set1', 'qualitative', 9).mpl_colors
         matplotlib.rcParams['lines.linewidth'] = 0.5

--- a/package/MDAnalysis/analysis/psa.py
+++ b/package/MDAnalysis/analysis/psa.py
@@ -1728,9 +1728,7 @@ class PSAnalysis(object):
         """
         import matplotlib
         from scipy.cluster.hierarchy import linkage, dendrogram
-        # from brewer2mpl import get_map
 
-        # color_list = get_map('Set1', 'qualitative', 9).mpl_colors
         matplotlib.rcParams['lines.linewidth'] = 0.5
 
         Z = linkage(distArray, method=method)

--- a/testsuite/MDAnalysisTests/analysis/test_psa.py
+++ b/testsuite/MDAnalysisTests/analysis/test_psa.py
@@ -76,6 +76,6 @@ class TestPSAnalysis(TestCase):
         err_msg = "Frechet distances did not increase after path reversal"
         assert_(self.frech_matrix[1,2] >= self.frech_matrix[0,1], err_msg)
 
-    def check_dendrogram_produced(self):
+    def test_dendrogram_produced(self):
         err_msg = "Dendrogram dictionary object was not produced"
         assert_(type(self.plot_data[1]) is dict, err_msg)

--- a/testsuite/MDAnalysisTests/analysis/test_psa.py
+++ b/testsuite/MDAnalysisTests/analysis/test_psa.py
@@ -29,6 +29,10 @@ from MDAnalysisTests import parser_not_found, tempdir
 class TestPSAnalysis(TestCase):
     @dec.skipif(parser_not_found('DCD'),
                 'DCD parser not available. Are you using python 3?')
+    @dec.skipif(module_not_found('matplotlib'),
+                "Test skipped because matplotlib is not available.")
+    @dec.skipif(module_not_found('scipy'),
+                "Test skipped because scipy is not available.")
     def setUp(self):
         self.tmpdir = tempdir.TempDir()
         self.iu1 = np.triu_indices(3, k=1)

--- a/testsuite/MDAnalysisTests/analysis/test_psa.py
+++ b/testsuite/MDAnalysisTests/analysis/test_psa.py
@@ -51,6 +51,9 @@ class TestPSAnalysis(TestCase):
         self.hausd_dists = self.hausd_matrix[self.iu1]
         self.frech_dists = self.frech_matrix[self.iu1]
 
+    def _plot(self):
+        self.plot_data = self.psa.plot()
+
     def tearDown(self):
         del self.universe1
         del self.universe2
@@ -72,3 +75,7 @@ class TestPSAnalysis(TestCase):
     def test_reversal_frechet(self):
         err_msg = "Frechet distances did not increase after path reversal"
         assert_(self.frech_matrix[1,2] >= self.frech_matrix[0,1], err_msg)
+
+    def check_dendrogram_produced(self):
+        err_msg = "Dendrogram dictionary object was not produced"
+        assert_(type(self.plot_data[1]) is dict, err_msg)

--- a/testsuite/MDAnalysisTests/analysis/test_psa.py
+++ b/testsuite/MDAnalysisTests/analysis/test_psa.py
@@ -17,6 +17,7 @@ from __future__ import print_function
 
 import MDAnalysis
 import MDAnalysis.analysis.psa
+from MDAnalysisTests import module_not_found
 
 from numpy.testing import (TestCase, dec, assert_array_less,
                            assert_array_almost_equal, assert_)

--- a/testsuite/MDAnalysisTests/analysis/test_psa.py
+++ b/testsuite/MDAnalysisTests/analysis/test_psa.py
@@ -42,6 +42,7 @@ class TestPSAnalysis(TestCase):
         self.psa.generate_paths(align=True)
         self.psa.paths[-1] = self.psa.paths[-1][::-1,:,:] # reverse third path
         self._run()
+        self._plot()
 
     def _run(self):
         self.psa.run(metric='hausdorff')


### PR DESCRIPTION
Fixes #1018 

Changes made in this Pull Request:
 - Removed `color_list` kwarg in `scipy.cluster.hierarchy.dendrogram` in `PSAnalysis.cluster`
 - Removed import of `get_map` from `brewer2mpl` package
 - Removed call to `get_map`
 - Changed `orientation` kwarg from "right" to "left" in `scipy.cluster.hierarchy.dendrogram` in `PSAnalysis.cluster` (orientation was reversed).

PR Checklist
------------
 - [x] Tests: 
   Fixes the TypeError produced when calling `PSAnalysis.plot`. Tested by running `psa_short.ipynb` using latest MDAnalysis and SciPy versions.

 - [x] Docs—no updates needed.
 - [x] CHANGELOG updated.
 - [x] Issue raised/referenced.
