### PR TITLE
Issue 1018 psa scipy bugfix (#1019)

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -108,6 +108,7 @@ Enhancements
   * Iteration and seeking in PDB files made faster (Issue #848)
 
 Fixes
+  * Fixed TypeError in PSAnalysis heatmap-dendrogram plotting (Issue #1018)
   * ENT file format added to PDB Readers/Writers/Parsers (Issue #834)
   * rmsd now returns proper value when given array of weights (Issue #814)
   * change_release now finds number and dev (Issue #776)

--- a/package/MDAnalysis/analysis/psa.py
+++ b/package/MDAnalysis/analysis/psa.py
@@ -1727,16 +1727,13 @@ class PSAnalysis(object):
         """
         import matplotlib
         from scipy.cluster.hierarchy import linkage, dendrogram
-        from brewer2mpl import get_map
 
-        color_list = get_map('Set1', 'qualitative', 9).mpl_colors
         matplotlib.rcParams['lines.linewidth'] = 0.5
 
         Z = linkage(distArray, method=method)
-        dgram = dendrogram(Z, no_labels=no_labels, orientation='right',         \
+        dgram = dendrogram(Z, no_labels=no_labels, orientation='left',          \
                            count_sort=count_sort, distance_sort=distance_sort,  \
-                           no_plot=no_plot, color_threshold=color_threshold,    \
-                           color_list=color_list)
+                           no_plot=no_plot, color_threshold=color_threshold)
         return Z, dgram
 
 

--- a/testsuite/MDAnalysisTests/analysis/test_psa.py
+++ b/testsuite/MDAnalysisTests/analysis/test_psa.py
@@ -17,7 +17,6 @@ from __future__ import print_function
 
 import MDAnalysis
 import MDAnalysis.analysis.psa
-from MDAnalysisTests import module_not_found
 
 from numpy.testing import (TestCase, dec, assert_array_less,
                            assert_array_almost_equal, assert_,


### PR DESCRIPTION
Fixes #1018 

Note: See PR #1019 – I needed to make it a patch against develop instead of master.

Changes made in this Pull Request:
* Removed 'color_list' and changed 'orientation' kwargs in dendrogram() in PSAnalysis.cluster
* Commented out import from brewer2mpl as well; leaving there in case alternative dendro coloring arises.
* Removed brewer2mpl import and corresponding call to get_map
* Updated changelog with reference to issue 1018
* Added small test to check dendrogram returns a dict
* Fixed test method name for dendrogram test
* Added missing line to psa tests to generate plot
* Added decorators to psa tests to skip when matplotlib/scipy not installed
* Added import for module_not_found for psa tests


PR Checklist
------------
 - [x] Tests?
 -  Docs? n/a
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?

