### PR TITLE
WIP: GROWriter 363 testing

### DIFF
--- a/testsuite/MDAnalysisTests/coordinates/test_gro.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_gro.py
@@ -289,6 +289,7 @@ class TestGROWriter(TestCase, tempdir.TempDir):
                      x,
                      err_msg="Positions in Timestep were modified by writer.")
 
+    @dec.slow
     @attr('issue')
     def test_check_coordinate_limits_min(self):
         """Test that illegal GRO coordinates (x <= -999.9995 nm) are caught

--- a/testsuite/MDAnalysisTests/coordinates/test_gro.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_gro.py
@@ -296,8 +296,8 @@ class TestGROWriterLarge(TestCase, tempdir.TempDir):
         GRO files (Issue 886)."""
         outfile = os.path.join(self.tmpdir.name, 'outfile2.gro')
         target_resname = self.large_universe.residues[-1].resname
-        resid_value = 999999999999999999999
-        self.large_universe.residues[-1].atoms.resids = resid_value
+        resid_value = 9999999
+        self.large_universe.residues[-1].resid = resid_value
         self.large_universe.atoms.write(outfile)
         with open(outfile, 'rt') as mda_output:
             output_lines = mda_output.readlines()

--- a/testsuite/MDAnalysisTests/coordinates/test_gro.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_gro.py
@@ -213,6 +213,74 @@ class TestGROWriter(TestCase, tempdir.TempDir):
                             "not reproduce original coordinates")
 
     @dec.slow
+    def test_writer_no_resnames_consistency(self):
+        self.universe.residues.resnames = ''
+        self.universe.atoms.write(self.outfile)
+        u = mda.Universe(self.outfile)
+        assert_equal(u.atoms.resnames, self.universe.atoms.resnames)
+
+    @dec.slow
+    def test_writer_no_resnames_UNK(self):
+        self.universe.residues.resnames = ''
+        self.universe.atoms.write(self.outfile)
+        u = mda.Universe(self.outfile)
+        expected = np.array(['UNK'] * self.universe.atoms.n_atoms)
+        assert_equal(u.atoms.resnames, expected)
+
+    @dec.slow
+    def test_writer_None_resnames(self):
+        self.universe.residues.resnames = None
+        self.universe.atoms.write(self.outfile)
+        u = mda.Universe(self.outfile)
+        assert_equal(u.atoms.resnames, self.universe.atoms.resnames)
+
+    @dec.slow
+    def test_writer_no_resids(self):
+        self.universe.residues.resids = []
+        self.universe.atoms.write(self.outfile)
+        u = mda.Universe(self.outfile)
+        assert_equal(u.residues.resids, self.universe.residues.resids)
+
+    @dec.slow
+    def test_writer_None_resids(self):
+        self.universe.residues.resids = None
+        self.universe.atoms.write(self.outfile)
+        u = mda.Universe(self.outfile)
+        assert_equal(u.residues.resids, self.universe.residues.resids)
+
+    @dec.slow
+    def test_writer_None_resids_1_val(self):
+        self.universe.residues.resids = None
+        self.universe.atoms.write(self.outfile)
+        expected = np.ones(self.universe.atoms.n_residues)
+        u = mda.Universe(self.outfile)
+        assert_equal(u.residues.resids, expected)
+
+    @dec.slow
+    def test_writer_no_resids_1_val(self):
+        self.universe.residues.resids = []
+        self.universe.atoms.write(self.outfile)
+        u = mda.Universe(self.outfile)
+        expected = np.ones(self.universe.atoms.n_residues)
+        assert_equal(u.residues.resids, expected)
+
+    @dec.slow
+    def test_writer_no_atom_names(self):
+        self.universe.atoms.names = ''
+        self.universe.atoms.write(self.outfile)
+        u = mda.Universe(self.outfile)
+        expected = np.array(['X'] * self.universe.atoms.n_atoms)
+        assert_equal(u.atoms.names, expected)
+
+    @dec.slow
+    def test_writer_None_atom_names(self):
+        self.universe.atoms.names = None
+        self.universe.atoms.write(self.outfile)
+        u = mda.Universe(self.outfile)
+        expected = np.array(['X'] * self.universe.atoms.n_atoms)
+        assert_equal(u.atoms.names, expected)
+
+    @dec.slow
     def test_timestep_not_modified_by_writer(self):
         ts = self.universe.trajectory.ts
         x = ts._pos.copy()
@@ -221,7 +289,6 @@ class TestGROWriter(TestCase, tempdir.TempDir):
                      x,
                      err_msg="Positions in Timestep were modified by writer.")
 
-    @dec.slow
     @attr('issue')
     def test_check_coordinate_limits_min(self):
         """Test that illegal GRO coordinates (x <= -999.9995 nm) are caught

--- a/testsuite/MDAnalysisTests/coordinates/test_gro.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_gro.py
@@ -16,6 +16,7 @@ from MDAnalysisTests.datafiles import (
 from MDAnalysisTests.coordinates.reference import RefAdK
 from MDAnalysisTests.coordinates.base import BaseTimestepTest
 from MDAnalysisTests import tempdir
+from MDAnalysisTests.core.groupbase import make_Universe
 
 
 class TestGROReader(TestCase, RefAdK):
@@ -190,6 +191,9 @@ class TestGROWriter(TestCase, tempdir.TempDir):
         self.tmpdir = tempdir.TempDir()
         self.outfile = self.tmpdir.name + '/gro-writer' + ext
         self.outfile2 = self.tmpdir.name + '/gro-writer2' + ext
+        self.u_no_resnames = make_Universe(['names', 'resids'])
+        self.u_no_resids = make_Universe(['names', 'resnames'])
+        self.u_no_names = make_Universe(['resids', 'resnames'])
 
     def tearDown(self):
         try:
@@ -202,6 +206,9 @@ class TestGROWriter(TestCase, tempdir.TempDir):
             pass
         del self.universe
         del self.tmpdir
+        del self.u_no_resnames
+        del self.u_no_resids
+        del self.u_no_names
 
     @dec.slow
     def test_writer(self):
@@ -213,69 +220,22 @@ class TestGROWriter(TestCase, tempdir.TempDir):
                             "not reproduce original coordinates")
 
     @dec.slow
-    def test_writer_no_resnames_consistency(self):
-        self.universe.residues.resnames = ''
-        self.universe.atoms.write(self.outfile)
+    def test_writer_no_resnames(self):
+        self.u_no_resnames.atoms.write(self.outfile)
         u = mda.Universe(self.outfile)
-        assert_equal(u.atoms.resnames, self.universe.atoms.resnames)
-
-    @dec.slow
-    def test_writer_no_resnames_UNK(self):
-        self.universe.residues.resnames = ''
-        self.universe.atoms.write(self.outfile)
-        u = mda.Universe(self.outfile)
-        expected = np.array(['UNK'] * self.universe.atoms.n_atoms)
+        expected = np.array(['UNK'] * self.u_no_resnames.atoms.n_atoms)
         assert_equal(u.atoms.resnames, expected)
 
     @dec.slow
-    def test_writer_None_resnames(self):
-        self.universe.residues.resnames = None
-        self.universe.atoms.write(self.outfile)
-        u = mda.Universe(self.outfile)
-        assert_equal(u.atoms.resnames, self.universe.atoms.resnames)
-
-    @dec.slow
     def test_writer_no_resids(self):
-        self.universe.residues.resids = []
-        self.universe.atoms.write(self.outfile)
-        u = mda.Universe(self.outfile)
-        assert_equal(u.residues.resids, self.universe.residues.resids)
-
-    @dec.slow
-    def test_writer_None_resids(self):
-        self.universe.residues.resids = None
-        self.universe.atoms.write(self.outfile)
-        u = mda.Universe(self.outfile)
-        assert_equal(u.residues.resids, self.universe.residues.resids)
-
-    @dec.slow
-    def test_writer_None_resids_1_val(self):
-        self.universe.residues.resids = None
-        self.universe.atoms.write(self.outfile)
-        expected = np.ones(self.universe.atoms.n_residues)
-        u = mda.Universe(self.outfile)
-        assert_equal(u.residues.resids, expected)
-
-    @dec.slow
-    def test_writer_no_resids_1_val(self):
-        self.universe.residues.resids = []
-        self.universe.atoms.write(self.outfile)
+        self.u_no_resids.atoms.write(self.outfile)
         u = mda.Universe(self.outfile)
         expected = np.ones(self.universe.atoms.n_residues)
         assert_equal(u.residues.resids, expected)
 
     @dec.slow
     def test_writer_no_atom_names(self):
-        self.universe.atoms.names = ''
-        self.universe.atoms.write(self.outfile)
-        u = mda.Universe(self.outfile)
-        expected = np.array(['X'] * self.universe.atoms.n_atoms)
-        assert_equal(u.atoms.names, expected)
-
-    @dec.slow
-    def test_writer_None_atom_names(self):
-        self.universe.atoms.names = None
-        self.universe.atoms.write(self.outfile)
+        self.u_no_names.atoms.write(self.outfile)
         u = mda.Universe(self.outfile)
         expected = np.array(['X'] * self.universe.atoms.n_atoms)
         assert_equal(u.atoms.names, expected)

--- a/testsuite/MDAnalysisTests/coordinates/test_gro.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_gro.py
@@ -191,9 +191,12 @@ class TestGROWriter(TestCase, tempdir.TempDir):
         self.tmpdir = tempdir.TempDir()
         self.outfile = self.tmpdir.name + '/gro-writer' + ext
         self.outfile2 = self.tmpdir.name + '/gro-writer2' + ext
-        self.u_no_resnames = make_Universe(['names', 'resids'])
-        self.u_no_resids = make_Universe(['names', 'resnames'])
-        self.u_no_names = make_Universe(['resids', 'resnames'])
+        self.u_no_resnames = make_Universe(['names', 'resids'],
+                                            trajectory=True)
+        self.u_no_resids = make_Universe(['names', 'resnames'],
+                                          trajectory=True)
+        self.u_no_names = make_Universe(['resids', 'resnames'],
+                                          trajectory=True)
 
     def tearDown(self):
         try:

--- a/testsuite/MDAnalysisTests/coordinates/test_gro.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_gro.py
@@ -233,14 +233,14 @@ class TestGROWriter(TestCase, tempdir.TempDir):
     def test_writer_no_resids(self):
         self.u_no_resids.atoms.write(self.outfile)
         u = mda.Universe(self.outfile)
-        expected = np.ones(self.universe.atoms.n_residues)
+        expected = np.ones((1,))
         assert_equal(u.residues.resids, expected)
 
     @dec.slow
     def test_writer_no_atom_names(self):
         self.u_no_names.atoms.write(self.outfile)
         u = mda.Universe(self.outfile)
-        expected = np.array(['X'] * self.universe.atoms.n_atoms)
+        expected = np.array(['X'] * self.u_no_names.atoms.n_atoms)
         assert_equal(u.atoms.names, expected)
 
     @dec.slow


### PR DESCRIPTION
Reference: #1015 

This PR adjusts & adds unit tests related to issue 363, in particular for the `GROWriter` handling of missing topology attributes.

Note that many of these new tests will now fail pending review of what the expected behaviour should actually be. For example, should handling of the `None` type be done as gracefully as an empty string?