### PR TITLE
[WIP] TST: Added unit tests for PDBWriter handling missing topology attributes.

### DIFF
--- a/package/MDAnalysis/coordinates/PDB.py
+++ b/package/MDAnalysis/coordinates/PDB.py
@@ -850,6 +850,8 @@ class PDBWriter(base.Writer):
         <https://gist.github.com/jbarnoud/37a524330f29b5b7b096> for more
         details.
         """
+        if atomname == '':
+            return ''
         if len(atomname) >= 4:
             return atomname[:4]
         elif len(atomname) == 1:
@@ -913,13 +915,13 @@ class PDBWriter(base.Writer):
                                   "".format(attrname, default))
                 return np.array([default] * len(atoms))
         altlocs = get_attr('altLocs', ' ')
-        resnames = get_attr('resnames', ' ')
+        resnames = get_attr('resnames', 'UNK')
         icodes = get_attr('icodes', ' ')
         segids = get_attr('segids', ' ')
         resids = get_attr('resids', 1)
         occupancies = get_attr('occupancies', 1.0)
         tempfactors = get_attr('tempfactors', 0.0)
-        atomnames = get_attr('names', ' ')
+        atomnames = get_attr('names', 'X')
 
         for i, atom in enumerate(atoms):
             vals = {}

--- a/package/MDAnalysis/topology/guessers.py
+++ b/package/MDAnalysis/topology/guessers.py
@@ -90,6 +90,8 @@ def guess_atom_element(atomname):
     .. SeeAlso:: :func:`guess_atom_type` and
                  :mod:`MDAnalysis.topology.tables` (where the data are stored)
     """
+    if atomname == '':
+        return ''
     try:
         return tables.atomelements[atomname]
     except KeyError:

--- a/testsuite/MDAnalysisTests/coordinates/test_pdb.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_pdb.py
@@ -191,6 +191,13 @@ class TestPDBWriter(TestCase):
         expected = np.array(['X'] * self.u_no_names.atoms.n_atoms)
         assert_equal(u.atoms.names, expected)
 
+    @dec.slow
+    def test_writer_no_altlocs(self):
+        self.u_no_names.atoms.write(self.outfile)
+        u = mda.Universe(self.outfile)
+        expected = np.array([' '] * self.u_no_names.atoms.n_atoms)
+        assert_equal(u.atoms.altLocs, expected)
+
     @attr('issue')
     def test_write_single_frame_Writer(self):
         """Test writing a single frame from a DCD trajectory to a PDB using

--- a/testsuite/MDAnalysisTests/coordinates/test_pdb.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_pdb.py
@@ -195,7 +195,7 @@ class TestPDBWriter(TestCase):
     def test_writer_no_altlocs(self):
         self.u_no_names.atoms.write(self.outfile)
         u = mda.Universe(self.outfile)
-        expected = np.array([' '] * self.u_no_names.atoms.n_atoms)
+        expected = np.array([''] * self.u_no_names.atoms.n_atoms)
         assert_equal(u.atoms.altLocs, expected)
 
     @attr('issue')

--- a/testsuite/MDAnalysisTests/coordinates/test_pdb.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_pdb.py
@@ -198,6 +198,34 @@ class TestPDBWriter(TestCase):
         expected = np.array([''] * self.u_no_names.atoms.n_atoms)
         assert_equal(u.atoms.altLocs, expected)
 
+    @dec.slow
+    def test_writer_no_icodes(self):
+        self.u_no_names.atoms.write(self.outfile)
+        u = mda.Universe(self.outfile)
+        expected = np.array([''] * self.u_no_names.atoms.n_atoms)
+        assert_equal(u.atoms.icodes, expected)
+
+    @dec.slow
+    def test_writer_no_segids(self):
+        self.u_no_names.atoms.write(self.outfile)
+        u = mda.Universe(self.outfile)
+        expected = np.array(['SYSTEM'] * self.u_no_names.atoms.n_atoms)
+        assert_equal([atom.segid for atom in u.atoms], expected)
+
+    @dec.slow
+    def test_writer_no_occupancies(self):
+        self.u_no_names.atoms.write(self.outfile)
+        u = mda.Universe(self.outfile)
+        expected = np.ones(self.u_no_names.atoms.n_atoms)
+        assert_equal(u.atoms.occupancies, expected)
+
+    @dec.slow
+    def test_writer_no_tempfactors(self):
+        self.u_no_names.atoms.write(self.outfile)
+        u = mda.Universe(self.outfile)
+        expected = np.zeros(self.u_no_names.atoms.n_atoms)
+        assert_equal(u.atoms.tempfactors, expected)
+
     @attr('issue')
     def test_write_single_frame_Writer(self):
         """Test writing a single frame from a DCD trajectory to a PDB using


### PR DESCRIPTION
This PR is for testing `PDBWriter` handling of missing topology attributes in the "Issue 363" context.

There is one error and one failure out of the three new unit tests (which are basically the same as those used for GRO):

1. `test_writer_no_resnames` produces an array of empty strings instead of an array of `UNK` strings.
2. `test_writer_no_atom_names` produces a traceback:
```
Traceback (most recent call last):
  File "/Users/treddy/python_modules/MDAnalysis/MDA_dev/mdanalysis/testsuite/MDAnalysisTests/coordinates/test_pdb.py", line 189, in test_writer_no_atom_names
    self.u_no_names.atoms.write(self.outfile)
  File "/Users/treddy/python_modules/MDAnalysis/MDA_dev/mdanalysis/package/MDAnalysis/core/groups.py", line 1317, in write
    writer.write(self.atoms)
  File "/Users/treddy/python_modules/MDAnalysis/MDA_dev/mdanalysis/package/MDAnalysis/coordinates/PDB.py", line 766, in write
    self.write_next_timestep(self.ts, multiframe=self._multiframe)
  File "/Users/treddy/python_modules/MDAnalysis/MDA_dev/mdanalysis/package/MDAnalysis/coordinates/PDB.py", line 841, in write_next_timestep
    self._write_timestep(ts, **kwargs)
  File "/Users/treddy/python_modules/MDAnalysis/MDA_dev/mdanalysis/package/MDAnalysis/coordinates/PDB.py", line 937, in _write_timestep
    vals['element'] = guess_atom_element(atomnames[i].strip())[:2]
  File "/Users/treddy/python_modules/MDAnalysis/MDA_dev/mdanalysis/package/MDAnalysis/topology/guessers.py", line 96, in guess_atom_element
    if atomname[0].isdigit():
IndexError: string index out of range
```
I suspect that for `PDB` we may actually want to test for the absence of a whole lot of other potential attributes? There are quite a few possible data columns if I'm not mistaken.
