### PR TITLE
PEP8 changes to topologyattrs: Fixes #1045

### DIFF
--- a/testsuite/MDAnalysisTests/core/test_topologyattrs.py
+++ b/testsuite/MDAnalysisTests/core/test_topologyattrs.py
@@ -44,11 +44,11 @@ class TopologyAttrMixin(object):
     Sidx = np.array([0, 1, 1, 0])
 
     def setUp(self):
-        self.top = Topology(10, 4, 2, 
+        self.top = Topology(10, 4, 2,
                             attrs=[self.attrclass(self.values.copy())],
                             atom_resindex=self.Ridx,
                             residue_segindex=self.Sidx)
-        
+
         self.attr = getattr(self.top, self.attrclass.attrname)
 
     def tearDown(self):
@@ -112,12 +112,12 @@ class TestAtomnames(TestAtomAttr):
 
 class AggregationMixin(TestAtomAttr):
     def test_get_residues(self):
-        assert_array_equal(self.attr.get_residues(DummyGroup([2, 1])), 
-                           np.array([self.values[[2, 3, 9]].sum(), 
+        assert_array_equal(self.attr.get_residues(DummyGroup([2, 1])),
+                           np.array([self.values[[2, 3, 9]].sum(),
                                      self.values[[4, 5, 8]].sum()]))
 
     def test_get_segments(self):
-        assert_array_equal(self.attr.get_segments(DummyGroup([1])), 
+        assert_array_equal(self.attr.get_segments(DummyGroup([1])),
                            np.array([self.values[[4, 5, 8, 2, 3, 9]].sum()]))
 
 
@@ -142,7 +142,7 @@ class TestResidueAttr(TopologyAttrMixin):
                            self.values[[3, 2, 2]])
 
     def test_get_residues(self):
-        assert_array_equal(self.attr.get_residues(DummyGroup([1, 2, 1, 3])), 
+        assert_array_equal(self.attr.get_residues(DummyGroup([1, 2, 1, 3])),
                            self.values[[1, 2, 1, 3]])
 
     def test_set_residues(self):
@@ -156,7 +156,7 @@ class TestResidueAttr(TopologyAttrMixin):
         atoms in segments.
 
         """
-        assert_array_equal(self.attr.get_segments(DummyGroup([0, 1, 1])), 
+        assert_array_equal(self.attr.get_segments(DummyGroup([0, 1, 1])),
                            [self.values[[0, 3]], self.values[[1, 2]], self.values[[1, 2]]])
 
 
@@ -203,7 +203,7 @@ class TestSegmentAttr(TopologyAttrMixin):
                            self.values[[1, 1, 0]])
 
     def test_get_residues(self):
-        assert_array_equal(self.attr.get_residues(DummyGroup([1, 2, 1, 3])), 
+        assert_array_equal(self.attr.get_residues(DummyGroup([1, 2, 1, 3])),
                            self.values[[1, 1, 1, 0]])
 
     def test_get_segments(self):
@@ -211,11 +211,11 @@ class TestSegmentAttr(TopologyAttrMixin):
         atoms in segments.
 
         """
-        assert_array_equal(self.attr.get_segments(DummyGroup([1, 0, 0])), 
+        assert_array_equal(self.attr.get_segments(DummyGroup([1, 0, 0])),
                            self.values[[1, 0, 0]])
 
     def test_set_segments(self):
         self.attr.set_segments(DummyGroup([0, 1]),
                                np.array([23, -0.0002]))
-        assert_array_equal(self.attr.get_segments(DummyGroup([1, 0, 1])), 
-                np.array([-0.0002, 23, -0.0002]))
+        assert_array_equal(self.attr.get_segments(DummyGroup([1, 0, 1])),
+                           np.array([-0.0002, 23, -0.0002]))

--- a/testsuite/MDAnalysisTests/core/test_topologyattrs.py
+++ b/testsuite/MDAnalysisTests/core/test_topologyattrs.py
@@ -1,3 +1,17 @@
+# -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 fileencoding=utf-8
+#
+# MDAnalysis --- http://www.MDAnalysis.org
+# Copyright (c) 2006-2015 Naveen Michaud-Agrawal, Elizabeth J. Denning, Oliver Beckstein
+# and contributors (see AUTHORS for the full list)
+#
+# Released under the GNU Public Licence, v2 or any higher version
+#
+# Please cite your use of MDAnalysis in published work:
+# N. Michaud-Agrawal, E. J. Denning, T. B. Woolf, and O. Beckstein.
+# MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
+# J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
+#
 """Tests for MDAnalysis.core.topologyattrs objects.
 
 """


### PR DESCRIPTION
Fixes #1045 

PEP8 changes. With that I found some bugs. Missing imports and the self argument from member functions is often called group. For the unit-test still have to be written.

