### PR TITLE
Libmdaxdr exceptions

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -79,6 +79,7 @@ Changes
   * Analysis.rms.RMSD now confirms to standard analysis API (Issue #893)
   * Fragments in Universe.fragment are now sorted by the index of their first
     atom. (Issue 1007)
+  * XTCFile and TRRFile only raise IOError now on error.
 
 Deprecations (Issue #599)
   * Use of rms_fit_trj deprecated in favor of AlignTraj class (Issue #845)

--- a/testsuite/MDAnalysisTests/formats/test_libmdaxdr.py
+++ b/testsuite/MDAnalysisTests/formats/test_libmdaxdr.py
@@ -42,7 +42,7 @@ class XDRFormatBaseTest(object):
     def test_raise_not_existing(self):
         self.xdrfile('foo')
 
-    @raises(ValueError)
+    @raises(IOError)
     def test_open_wrong_mode(self):
         self.xdrfile('foo', 'e')
 
@@ -51,13 +51,13 @@ class XDRFormatBaseTest(object):
         with self.xdrfile(self.multi_frame) as f:
             f.seek(100)
 
-    @raises(RuntimeError)
+    @raises(IOError)
     @run_in_tempdir()
     def test_read_write_mode_file(self):
         with self.xdrfile('foo', 'w') as f:
             f.read()
 
-    @raises(RuntimeError)
+    @raises(IOError)
     def test_read_closed(self):
         f = self.xdrfile(self.multi_frame)
         f.close()
@@ -203,7 +203,7 @@ def test_different_box_xtc():
         assert_array_almost_equal(frame_1.box + 1, frame_2.box)
 
 
-@raises(ValueError)
+@raises(IOError)
 @run_in_tempdir()
 def test_write_different_x_xtc():
     with XTCFile(XTC_multi_frame) as f_in, XTCFile('foo.xtc', 'w') as f_out:
@@ -216,7 +216,7 @@ def test_write_different_x_xtc():
                     frame.time, frame.prec)
 
 
-@raises(ValueError)
+@raises(IOError)
 @run_in_tempdir()
 def test_write_different_prec():
     mf_xtc = XTCFile(XTC_multi_frame)
@@ -309,7 +309,7 @@ def test_write_trr():
             assert_almost_equal(frame.lmbda, .01 * i)
 
 
-@raises(ValueError)
+@raises(IOError)
 @run_in_tempdir()
 def test_write_different_natoms():
     with TRRFile(TRR_multi_frame) as f_in, TRRFile('foo.trr', 'w') as f_out:
@@ -348,7 +348,7 @@ def test_write_different_box_trr():
         assert_array_almost_equal(frame_1.box + 1, frame_2.box)
 
 
-@raises(ValueError)
+@raises(IOError)
 @run_in_tempdir()
 def test_write_different_x_trr():
     with TRRFile(TRR_multi_frame) as f_in, TRRFile('foo.trr', 'w') as f_out:
@@ -362,7 +362,7 @@ def test_write_different_x_trr():
                     frame.time, frame.lmbda, natoms)
 
 
-@raises(ValueError)
+@raises(IOError)
 @run_in_tempdir()
 def test_write_different_v():
     with TRRFile(TRR_multi_frame) as f_in, TRRFile('foo.trr', 'w') as f_out:
@@ -376,7 +376,7 @@ def test_write_different_v():
                     frame.time, frame.lmbda, natoms)
 
 
-@raises(ValueError)
+@raises(IOError)
 @run_in_tempdir()
 def test_write_different_f():
     with TRRFile(TRR_multi_frame) as f_in, TRRFile('foo.trr', 'w') as f_out:


### PR DESCRIPTION
Changes made in this Pull Request:
 - only return IOError from libmdaxdr classes. In retrospect it makes more sense that all are IOError instead of a mixture of Runtime-, Value- and IOError. 


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - ~~[ ] Issue raised/referenced?~~
