### PR TITLE
BUG: rms.RMSD now properly leverages ProgressMeter. Fixes #1084.

### DIFF
--- a/package/MDAnalysis/analysis/rms.py
+++ b/package/MDAnalysis/analysis/rms.py
@@ -133,7 +133,7 @@ import warnings
 import MDAnalysis.lib.qcprot as qcp
 from MDAnalysis.analysis.base import AnalysisBase
 from MDAnalysis.exceptions import SelectionError, NoDataError
-from MDAnalysis.lib.log import ProgressMeter, _legacy_format
+from MDAnalysis.lib.log import ProgressMeter
 from MDAnalysis.lib.util import asiterable
 
 
@@ -349,7 +349,6 @@ class RMSD(AnalysisBase):
         """
         super(RMSD, self).__init__(atomgroup.universe.trajectory,
                                    **kwargs)
-        self._pm.format_handler = _legacy_format
         self.universe = atomgroup.universe
         self.reference = reference if reference is not None else self.universe
 
@@ -462,8 +461,8 @@ class RMSD(AnalysisBase):
         self.rmsd = np.zeros((self.n_frames,
                               3 + len(self._groupselections_atoms)))
 
-        self._pm.format = ("RMSD %(rmsd)5.2f A at frame "
-                           "%(step)5d/%(numsteps)d  [%(percentage)5.1f%%]\r")
+        self._pm.format = ("RMSD {rmsd:5.2f} A at frame "
+                           "{step:5d}/{numsteps}  [{percentage:5.1f}%]\r")
         self._mobile_coordinates64 = self.mobile_atoms.positions.copy().astype(np.float64)
 
     def _single_frame(self):

--- a/package/MDAnalysis/analysis/rms.py
+++ b/package/MDAnalysis/analysis/rms.py
@@ -133,7 +133,7 @@ import warnings
 import MDAnalysis.lib.qcprot as qcp
 from MDAnalysis.analysis.base import AnalysisBase
 from MDAnalysis.exceptions import SelectionError, NoDataError
-from MDAnalysis.lib.log import ProgressMeter
+from MDAnalysis.lib.log import ProgressMeter, _legacy_format
 from MDAnalysis.lib.util import asiterable
 
 
@@ -506,6 +506,9 @@ class RMSD(AnalysisBase):
             self.rmsd[self._frame_index, 2] = qcp.CalcRMSDRotationalMatrix(
                 self._ref_coordinates_64, self._mobile_coordinates64,
                 self._n_atoms, None, self._weights)
+
+        self._pm.format_handler = _legacy_format
+        self._pm.rmsd = self.rmsd[self._frame_index, 2]
 
     def save(self, filename=None):
         """Save RMSD from :attr:`RMSD.rmsd` to text file *filename*.

--- a/package/MDAnalysis/analysis/rms.py
+++ b/package/MDAnalysis/analysis/rms.py
@@ -349,6 +349,7 @@ class RMSD(AnalysisBase):
         """
         super(RMSD, self).__init__(atomgroup.universe.trajectory,
                                    **kwargs)
+        self._pm.format_handler = _legacy_format
         self.universe = atomgroup.universe
         self.reference = reference if reference is not None else self.universe
 
@@ -507,7 +508,6 @@ class RMSD(AnalysisBase):
                 self._ref_coordinates_64, self._mobile_coordinates64,
                 self._n_atoms, None, self._weights)
 
-        self._pm.format_handler = _legacy_format
         self._pm.rmsd = self.rmsd[self._frame_index, 2]
 
     def save(self, filename=None):

--- a/testsuite/MDAnalysisTests/analysis/test_rms.py
+++ b/testsuite/MDAnalysisTests/analysis/test_rms.py
@@ -21,13 +21,14 @@ import MDAnalysis
 import MDAnalysis as mda
 from MDAnalysis.analysis import rms, align
 
-from numpy.testing import (TestCase, dec,
+from numpy.testing import (TestCase, dec, assert_equal,
                            assert_almost_equal, raises, assert_,
                            assert_array_almost_equal)
 
 import numpy as np
 
 import os
+import sys
 
 from MDAnalysis.exceptions import SelectionError, NoDataError
 from MDAnalysisTests.datafiles import GRO, XTC, rmsfArray, PSF, DCD
@@ -148,6 +149,15 @@ class TestRMSD(object):
     def tearDown(self):
         del self.universe
         del self.tempdir
+
+    def test_progress_meter(self):
+        RMSD = MDAnalysis.analysis.rms.RMSD(self.universe, quiet=False)
+        sys.stderr = sys.stdout
+        RMSD.run()
+        actual = sys.stderr.getvalue().strip().split('\r')[-1]
+        expected = 'RMSD  6.93 A at frame    98/98  [100.0%]'
+        sys.stderr = sys.__stderr__
+        assert_equal(actual, expected)
 
     def test_rmsd(self):
         RMSD = MDAnalysis.analysis.rms.RMSD(self.universe, select='name CA',


### PR DESCRIPTION
Fixes #1084 

Changes made in this Pull Request:
 - I've changed the way that `rms.RMSD` interacts with `ProgressMeter` such that the progress is properly printed

Notes:
- My adjustments explicitly force `ProgressMeter` to use `_legacy_format`. This allows proper printing of the progress.
- I would argue that what should really happen is that the `ProgressMeter` gracefully handles the format string without having to be coerced like this, however the issue is tagged with easy label and this gets the job done. Furthermore, unless all cases where `AnalysisBase` is subclassed have their progress printing unit tested, changing the upstream behaviour could silently cause issues with them
- using the `format` variable name in `ProgressMeter` is a bit awkward--though it is not formally a reserved word in python, it is syntax-highlighted in many editors because of its use in `.format`, and since formatting operations are fundamental to `ProgressMeter` it just seems like it might have been better to avoid this name
- the logic in `ProgressMeter` that checks if `format` is `None` and then also uses `self.format_handling` and `self.format_handler` and `self.format` seems like it could probably be simplified
- I'd rather not turn this PR into a general cleanup operation, but it would be good to add a unit test for `RMSD` as indicated below; actually, writing a unit test for the `ProgressMeter` output might require a little creativity if we don't do something brute force like redirecting to a file

PR Checklist
------------
 - [x] Tests?

