### PR TITLE
MMTF now properly installs automatically

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -14,7 +14,7 @@ The rules for this file:
 
 ------------------------------------------------------------------------------
 ??/??/16 kain88-de, fiona-naughton, richardjgowers, tyler.je.reddy, jdetle
-         euhruska, orbeckst, rbrtdlg, jbarnoud, wouterboomsma, shanmbic
+         euhruska, orbeckst, rbrtdlg, jbarnoud, wouterboomsma, shanmbic, dotsdl
 
   * 0.16.0
 

--- a/package/setup.py
+++ b/package/setup.py
@@ -497,6 +497,7 @@ if __name__ == '__main__':
               'networkx>=1.0',
               'GridDataFormats>=0.3.2',
               'six>=1.4.0',
+              'mmtf-python>=1.0.0',
           ],
           # extras can be difficult to install through setuptools and/or
           # you might prefer to use the version available through your


### PR DESCRIPTION
Fixes ``mmtf-python`` not getting installed as a dependency

Changes made in this Pull Request:
 - added ``mmtf-python`` as a dependency to ``install_requires`` in `setup.py`


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?

