### PR TITLE
generalized centering for groups

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -51,6 +51,8 @@ Enhancements
   * Added coordinates.null.NullWriter, which behaves like a Writer but
     ignores all input; useful for suppressing output.
   * Added random access support to GMSReader and TRJReader (#1081)
+  * Added atomgroup.center(weights, pbc) method to calculate the center
+    of a group given weights
 
 Fixes
   * Removed MDAnalysis.analysis.PDBToBinaryTraj (Issue #1035)

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -391,6 +391,15 @@ class GroupBase(_MutableBase):
         center : ndarray
             weighted center of group
 
+        Examples
+        --------
+
+        To find the charge weighted center of a given Atomgroup::
+
+            >>> sel = u.select_atoms('prop mass > 4.0')
+            >>> sel.center(sel.charges)
+
+
         Notes
         -----
         If the :class:`MDAnalysis.core.flags` flag *use_pbc* is set to

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -514,7 +514,7 @@ class Masses(AtomAttr):
 
         return masses
 
-    def center_of_mass(group, **kwargs):
+    def center_of_mass(group, pbc=None):
         """Center of mass of the Group.
 
         Parameters
@@ -523,24 +523,20 @@ class Masses(AtomAttr):
             If ``True``, move all atoms within the primary unit cell before
             calculation. [``False``]
 
-        .. note::
+        Returns
+        -------
+        center : ndarray
+            center of group given masses as weights
+
+        Notes
+        -----
             The :class:`MDAnalysis.core.flags` flag *use_pbc* when set to
             ``True`` allows the *pbc* flag to be used by default.
 
         .. versionchanged:: 0.8 Added `pbc` parameter
         """
-        atomgroup = group.atoms
-
-        pbc = kwargs.pop('pbc', flags['use_pbc'])
-        masses = atomgroup.masses
-
-        if pbc:
-            positions = atomgroup.pack_into_box(inplace=False)
-        else:
-            positions = atomgroup.positions
-
-        return np.sum(positions * masses[:, np.newaxis],
-                      axis=0) / masses.sum()
+        return group.atoms.center(weights=group.atoms.masses,
+                                  pbc=pbc)
 
     transplants[GroupBase].append(
         ('center_of_mass', center_of_mass))

--- a/testsuite/MDAnalysisTests/core/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/core/test_atomgroup.py
@@ -300,3 +300,34 @@ class TestAtomGroupTransformations(object):
         assert_array_almost_equal(ag.positions[0], [np.cos(angle) + 1,
                                                     np.sin(angle) + 1,
                                                     1])
+
+class TestCenter(object):
+    def setUp(self):
+        self.u = make_Universe(trajectory=True)
+        self.ag = self.u.atoms[10:30]
+
+    def tearDown(self):
+        del self.u
+        del self.ag
+
+    def test_center_1(self):
+        weights = np.zeros(self.ag.n_atoms)
+        weights[0] = 1
+        assert_array_almost_equal(self.ag.center(weights),
+                                  self.ag.positions[0])
+
+    def test_center_2(self):
+        weights = np.zeros(self.ag.n_atoms)
+        weights[:4] = 1. / 4.
+        assert_array_almost_equal(self.ag.center(weights),
+                                  self.ag.positions[:4].mean(axis=0))
+
+    def test_center_wrong_length(self):
+        weights = np.ones(self.ag.n_atoms + 4)
+
+        assert_raises(ValueError, self.ag.center, weights)
+
+    def test_center_wrong_shape(self):
+        weights = np.ones((self.ag.n_atoms, 2))
+
+        assert_raises(TypeError, self.ag.center, weights)

--- a/testsuite/MDAnalysisTests/core/test_groups.py
+++ b/testsuite/MDAnalysisTests/core/test_groups.py
@@ -9,7 +9,6 @@ from numpy.testing import (
 
 from MDAnalysisTests.core.groupbase import make_Universe
 from MDAnalysis.core import groups
-import MDAnalysis as mda
 
 
 class TestGroupSlicing(object):

--- a/testsuite/MDAnalysisTests/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/test_atomgroup.py
@@ -290,6 +290,16 @@ class TestAtomGroup(TestCase):
         """testing that len(atomgroup) == atomgroup.n_atoms"""
         assert_equal(len(self.ag), self.ag.n_atoms, "len and n_atoms disagree")
 
+    def test_center(self):
+        weights = np.zeros(self.ag.n_atoms)
+        weights[0] = 1
+        assert_array_almost_equal(self.ag.center(weights),
+                                  self.ag.positions[0])
+
+        weights[:4] = 1. / 4.
+        assert_array_almost_equal(self.ag.center(weights),
+                                  self.ag.positions[:4].mean(axis=0))
+
     # VALID
     def test_center_of_geometry(self):
         assert_array_almost_equal(self.ag.center_of_geometry(),
@@ -2542,7 +2552,7 @@ class TestDihedralSelections(object):
     def tearDown(self):
         del self.universe
         del self.dih_prec
-    
+
     def test_phi_selection(self):
         phisel = self.universe.s4AKE.r10.phi_selection()
         assert_equal(phisel.names, ['C', 'N', 'CA', 'C'])
@@ -2606,4 +2616,3 @@ class TestDihedralSelections(object):
         u.trajectory.rewind()  # just to make sure...
         sel = u.s4AKE.r13.chi1_selection()  # LYS
         assert_almost_equal(sel.dihedral.value(), -58.428127, self.dih_prec)
-

--- a/testsuite/MDAnalysisTests/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/test_atomgroup.py
@@ -290,16 +290,6 @@ class TestAtomGroup(TestCase):
         """testing that len(atomgroup) == atomgroup.n_atoms"""
         assert_equal(len(self.ag), self.ag.n_atoms, "len and n_atoms disagree")
 
-    def test_center(self):
-        weights = np.zeros(self.ag.n_atoms)
-        weights[0] = 1
-        assert_array_almost_equal(self.ag.center(weights),
-                                  self.ag.positions[0])
-
-        weights[:4] = 1. / 4.
-        assert_array_almost_equal(self.ag.center(weights),
-                                  self.ag.positions[:4].mean(axis=0))
-
     # VALID
     def test_center_of_geometry(self):
         assert_array_almost_equal(self.ag.center_of_geometry(),


### PR DESCRIPTION
Changes made in this Pull Request:
 - Introduce a new `center` method to all groups. That will allow to calculate the center using an arbitrary weight and will also always take into account the pbc condition.

I'm adding this because I want to implement a RMSD based alignment with custom weights.


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - ~~[ ] Issue raised/referenced?~~
