### PR TITLE
ENCORE - replace align.rms_fit_trj with align.AlignTraj(...).run()

### DIFF
--- a/package/MDAnalysis/analysis/encore/similarity.py
+++ b/package/MDAnalysis/analysis/encore/similarity.py
@@ -862,9 +862,9 @@ def hes(ensembles,
     if align:
         for ensemble in ensembles:
             mda.analysis.align.AlignTraj(ensemble, ensembles[0],
-                                           select=selection,
-                                           mass_weighted=True,
-                                           in_memory=True).run()
+                                         select=selection,
+                                         mass_weighted=True,
+                                         in_memory=True).run()
     else:
         for ensemble in ensembles:
             ensemble.transfer_to_memory()

--- a/package/MDAnalysis/analysis/encore/similarity.py
+++ b/package/MDAnalysis/analysis/encore/similarity.py
@@ -846,11 +846,11 @@ def hes(ensembles,
         [ 6880.34140106     0.        ]]
 
     Alternatively, for greater flexibility in how the alignment should be done
-    you can call the rms_fit_trj function manually:
+    you can call use an AlignTraj object manually:
 
         >>> from MDAnalysis.analysis import align
-        >>> align.rms_fit_trj(ens1, ens1, select="name CA", in_memory=True)
-        >>> align.rms_fit_trj(ens2, ens1, select="name CA", in_memory=True)
+        >>> align.AlignTraj(ens1, ens1, select="name CA", in_memory=True).run()
+        >>> align.AlignTraj(ens2, ens1, select="name CA", in_memory=True).run()
         >>> print encore.hes([ens1, ens2])[0]
         [[    0.          7032.19607004]
          [ 7032.19607004     0.        ]]
@@ -861,10 +861,10 @@ def hes(ensembles,
     # on the universe.
     if align:
         for ensemble in ensembles:
-            mda.analysis.align.rms_fit_trj(ensemble, ensembles[0],
+            mda.analysis.align.AlignTraj(ensemble, ensembles[0],
                                            select=selection,
                                            mass_weighted=True,
-                                           in_memory=True)
+                                           in_memory=True).run()
     else:
         for ensemble in ensembles:
             ensemble.transfer_to_memory()

--- a/testsuite/MDAnalysisTests/analysis/test_encore.py
+++ b/testsuite/MDAnalysisTests/analysis/test_encore.py
@@ -188,12 +188,12 @@ inconsistent results")
     def test_ensemble_superimposition():
         aligned_ensemble1 = mda.Universe(PSF, DCD)
         align.AlignTraj(aligned_ensemble1, aligned_ensemble1,
-                          select="name CA",
-                          in_memory=True).run()
+                        select="name CA",
+                        in_memory=True).run()
         aligned_ensemble2 = mda.Universe(PSF, DCD)
         align.AlignTraj(aligned_ensemble2, aligned_ensemble2,
-                          select="name *",
-                          in_memory=True).run()
+                        select="name *",
+                        in_memory=True).run()
 
         rmsfs1 = rms.RMSF(aligned_ensemble1.select_atoms('name *'))
         rmsfs1.run()
@@ -209,12 +209,12 @@ inconsistent results")
     def test_ensemble_superimposition_to_reference_non_weighted():
         aligned_ensemble1 = mda.Universe(PSF, DCD)
         align.AlignTraj(aligned_ensemble1, aligned_ensemble1,
-                          select="name CA", mass_weighted=False,
-                          in_memory=True).run()
+                        select="name CA", mass_weighted=False,
+                        in_memory=True).run()
         aligned_ensemble2 = mda.Universe(PSF, DCD)
         align.AlignTraj(aligned_ensemble2, aligned_ensemble2,
-                          select="name *", mass_weighted=False,
-                          in_memory=True).run()
+                        select="name *", mass_weighted=False,
+                        in_memory=True).run()
 
         rmsfs1 = rms.RMSF(aligned_ensemble1.select_atoms('name *'))
         rmsfs1.run()


### PR DESCRIPTION
Fixes #1098 

Changes made in this Pull Request:
 - replaced rms_fit_trj with AlignTraj(...).run() in similarity.py
 - replaced rms_fit_trj with AlignTraj(...).run() in tests (and slightly streamlined two of them)
 - updated the docs to reflect the changes


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?

