### PR TITLE
docs for libmdaxdr and XDR-based Gromacs formats

### DIFF
--- a/package/MDAnalysis/coordinates/TRR.py
+++ b/package/MDAnalysis/coordinates/TRR.py
@@ -28,6 +28,7 @@ Read and write GROMACS TRR trajectories.
 See Also
 --------
 MDAnalysis.coordinates.XTC: Read and write GROMACS XTC trajectory files.
+MDAnalysis.coordinates.XDR: BaseReader/Writer for XDR based formats
 """
 
 from .XDR import XDRBaseReader, XDRBaseWriter
@@ -44,18 +45,6 @@ class TRRWriter(XDRBaseWriter):
     If the data dictionary of a TimeStep contains the key 'lambda' the
     corresponding value will be used as the lambda value for written TRR file.
     If None is found the lambda is set to 0.
-
-    Parameters
-    ----------
-    filename : str
-        filename of the trajectory
-    n_atoms : int
-        number of atoms to write
-    convert_units : bool (optional)
-        convert into MDAnalysis units
-    precision : float (optional)
-        set precision of saved trjactory to this number of decimal places.
-
     """
 
     format = 'TRR'
@@ -117,17 +106,11 @@ class TRRReader(XDRBaseReader):
 
     The lambda value is written in the data dictionary of the returned TimeStep
 
-    Parameters
-    ----------
-    filename : str
-        filename of the trajectory
-    convert_units : bool (optional)
-        convert into MDAnalysis units
-    sub : atomgroup (optional)
-        Yeah what is that exactly
-    refresh_offsets : bool (optional)
-        Recalculate offsets for random access from file. If ``False`` try to
-        retrieve offsets from hidden offsets file.
+    Notes
+    -----
+    See :ref:`Notes on offsets <offsets-label>` for more information about
+    offsets.
+
     """
     format = 'TRR'
     units = {'time': 'ps', 'length': 'nm', 'velocity': 'nm/ps',

--- a/package/MDAnalysis/coordinates/XDR.py
+++ b/package/MDAnalysis/coordinates/XDR.py
@@ -19,6 +19,19 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
+"""\
+XDR based trajectory files --- :mod:`MDAnalysis.coordinates.XDR`
+================================================================
+
+This module contains helper function and classes to read the XTC and TRR file
+formats.
+
+See Also
+--------
+MDAnalysis.coordinates.XTC: Read and write GROMACS XTC trajectory files.
+MDAnalysis.coordinates.TRR: Read and write GROMACS TRR trajectory files.
+MDAnalysis.lib.formats.libmdaxdr: Low level xdr format reader
+"""
 import six
 
 import errno
@@ -31,7 +44,8 @@ from ..lib.mdamath import triclinic_box
 
 
 def offsets_filename(filename, ending='npz'):
-    """Return offset filename
+    """Return offset filename for XDR files. For this the filename is appended
+    with `_offsets.{ending}`.
 
     Parameters
     ----------
@@ -43,6 +57,7 @@ def offsets_filename(filename, ending='npz'):
     Returns
     -------
     offset_filename : str
+
     """
     head, tail = split(filename)
     return join(head, '.{tail}_offsets.{ending}'.format(tail=tail,
@@ -50,7 +65,9 @@ def offsets_filename(filename, ending='npz'):
 
 
 def read_numpy_offsets(filename):
-    """read offsets into a dictionary
+    """read offsets into dictionary.
+
+    This assume offsets have been saved using numpy
 
     Parameters
     ----------
@@ -61,14 +78,55 @@ def read_numpy_offsets(filename):
     -------
     offsets : dict
         dictionary of offsets information
+
     """
     return {k: v for k, v in six.iteritems(np.load(filename))}
 
 
 class XDRBaseReader(base.Reader):
-    """Base class for libmdaxdr file formats xtc and trr"""
+    """Base class for libmdaxdr file formats xtc and trr
+
+    This class handles integration of XDR based formats into MDAnalysis. The
+    XTC and TRR classes only implement `write_next_timestep` and
+    `_frame_to_ts`.
+
+    .. _offsets-label:
+
+    Notes
+    -----
+    XDR based readers store persistent offsets on disk. The offsets are used to
+    enable access to random frames efficiently. These offsets will be generated
+    automatically the  first time the  trajectory is opened.  Generally offsets
+    are stored  in hidden  `*_offsets.npz` files.  Afterwards opening  the same
+    file again is fast. It sometimes can happen that the stored offsets get out
+    off sync with the trajectory they refer to. For this the offsets also store
+    the number of atoms, size of the file and last modification time. If any of
+    them change  the offsets are recalculated.  Writing of the offset  file can
+    fail when the  directory where the trajectory file resides  is not writable
+    or if the  disk is full. In this  case a warning message will  be shown but
+    the offsets will nevertheless be used during the lifetime of the trajectory
+    Reader. However, the  next time the trajectory is opened,  the offsets will
+    have to be rebuilt again.
+
+    """
     def __init__(self, filename, convert_units=True, sub=None,
                  refresh_offsets=False, **kwargs):
+        """Parameters
+        ----------
+        filename : str
+            trajectory filename
+        convert_units : bool (optional)
+            convert units to MDAnalysis units
+        sub : array_like (optional)
+            `sub` is an array of indices to pick out the corresponding
+            coordinates and load only them; this requires that the topology
+            itself is that of the sub system.
+        refresh_offsets : bool (optional)
+            force refresh of offsets
+        **kwargs : dict
+            General reader arguments.
+
+        """
         super(XDRBaseReader, self).__init__(filename,
                                             convert_units=convert_units,
                                             **kwargs)
@@ -84,7 +142,6 @@ class XDRBaseReader(base.Reader):
             self._load_offsets()
         else:
             self._read_offsets(store=True)
-
         frame = self._xdr.read()
         try:
             xdr_frame = self._xdr.read()
@@ -195,6 +252,18 @@ class XDRBaseWriter(base.Writer):
     """Base class for libmdaxdr file formats xtc and trr"""
 
     def __init__(self, filename, n_atoms, convert_units=True, **kwargs):
+        """
+        Parameters
+        ----------
+        filename : str
+            filename of trajectory
+        n_atoms : int
+            number of atoms to be written
+        convert_units : bool (optional)
+            convert from MDAnalysis units to format specific units
+        **kwargs : dict
+            General writer arguments
+        """
         self.filename = filename
         self._convert_units = convert_units
         self.n_atoms = n_atoms

--- a/package/MDAnalysis/coordinates/XTC.py
+++ b/package/MDAnalysis/coordinates/XTC.py
@@ -28,6 +28,7 @@ Read and write GROMACS XTC trajectories.
 See Also
 --------
 MDAnalysis.coordinates.TRR: Read and write GROMACS TRR trajectory files.
+MDAnalysis.coordinates.XDR: BaseReader/Writer for XDR based formats
 """
 
 from .XDR import XDRBaseReader, XDRBaseWriter
@@ -36,23 +37,11 @@ from ..lib.mdamath import triclinic_vectors, triclinic_box
 
 
 class XTCWriter(XDRBaseWriter):
-    """
-    XTC is a compressed trajectory format from Gromacs. The trajectory is saved
+    """XTC is a compressed trajectory format from Gromacs. The trajectory is saved
     with reduced precision (3 decimal places by default) compared to other
     lossless formarts like TRR and DCD. The main advantage of XTC files is that
     they require significantly less disk space and the loss of precision is
     usually not a problem.
-
-    Parameters
-    ----------
-    filename : str
-        filename of the trajectory
-    n_atoms : int
-        number of atoms to write
-    convert_units : bool (optional)
-        convert into MDAnalysis units
-    precision : float (optional)
-        set precision of saved trjactory to this number of decimal places.
     """
     format = 'XTC'
     units = {'time': 'ps', 'length': 'nm'}
@@ -60,6 +49,17 @@ class XTCWriter(XDRBaseWriter):
 
     def __init__(self, filename, n_atoms, convert_units=True,
                  precision=3, **kwargs):
+        """Parameters
+        ----------
+        filename : str
+            filename of the trajectory
+        n_atoms : int
+            number of atoms to write
+        convert_units : bool (optional)
+            convert into MDAnalysis units
+        precision : float (optional)
+            set precision of saved trjactory to this number of decimal places.
+        """
         super(XTCWriter, self).__init__(filename, n_atoms, convert_units,
                                         **kwargs)
         self.precision = precision
@@ -100,17 +100,10 @@ class XTCReader(XDRBaseReader):
     require significantly less disk space and the loss of precision is usually
     not a problem.
 
-    Parameters
-    ----------
-    filename : str
-        filename of the trajectory
-    convert_units : bool (optional)
-        convert into MDAnalysis units
-    sub : atomgroup (optional)
-        Yeah what is that exactly
-    refresh_offsets : bool (optional)
-        Recalculate offsets for random access from file. If ``False`` try to
-        retrieve offsets from hidden offsets file.
+    Notes
+    -----
+    See :ref:`Notes on offsets <offsets-label>` for more information about
+    offsets.
 
     """
     format = 'XTC'

--- a/package/MDAnalysis/lib/formats/libmdaxdr.pyx
+++ b/package/MDAnalysis/lib/formats/libmdaxdr.pyx
@@ -19,6 +19,46 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
+"""\
+Low-level Gromacs XDR trajectory reading — :mod:`MDAnalysis.lib.formats.libmdaxdr`
+----------------------------------------------------------------------------------
+
+:mod:`libmdaxdr` contains the classes :class:`XTCFile` and
+:class:`TRRFile`. Both can be used to read and write frames from and to
+Gromacs_ XTC and TRR files. These classes are used internally by MDAnalysis in
+:mod:`MDAnalysis.coordinates.XTC` and :mod:`MDAnalysis.coordinates.TRR`. They
+behave similar to normal file objects.
+
+For example, one can use a :class:`XTCFile` to directly calculate mean
+coordinates (where the coordinates are stored in `x` attribute of the
+:class:`namedtuple` `frame`):
+
+.. code-block:: python
+   :emphasize-lines: 1,2,5
+
+   with XTCFile("trajectory.xtc") as xtc:
+      n_atoms = xtc.n_atoms
+      mean = np.zeros((n_atoms, 3))
+      # iterate over trajectory
+      for frame in xtc:
+          mean += frame.x
+
+The :class:`XTCFile` class can be useful as a compressed storage format.
+
+Besides iteration, :class:`XTCFile` and :class:`TRRFile` one can also seek to
+arbitrary frames using the :meth:`~XTCFile.seek` method. This is provided by
+lazily generating a offset list for stored frames. The offset list is generated
+the first time :func:`len` or :`~XTCFile.seek` is called.
+
+(For more details on how to use :class:`XTCFile` and :class:`TRRFile` on their
+own please see the source code in `lib/formats/libmdaxdr.pyx`_ for the time being.)
+
+
+.. _Gromacs: http://www.gromacs.org
+.. _`lib/formats/libmdaxdr.pyx`:
+   https://github.com/MDAnalysis/mdanalysis/blob/develop/package/MDAnalysis/lib/formats/libmdaxdr.pyx
+"""
+
 cimport numpy as np
 cimport cython
 from cython_util cimport ptr_to_ndarray
@@ -224,6 +264,7 @@ cdef class _XDRFile:
         return self
 
     def __next__(self):
+        """Return next frame"""
         if self.reached_eof:
             raise StopIteration
         return self.read()

--- a/package/doc/sphinx/source/documentation_pages/coordinates/TRR.rst
+++ b/package/doc/sphinx/source/documentation_pages/coordinates/TRR.rst
@@ -1,2 +1,3 @@
 .. automodule:: MDAnalysis.coordinates.TRR
    :members:
+   :inherited-members:

--- a/package/doc/sphinx/source/documentation_pages/coordinates/XDR.rst
+++ b/package/doc/sphinx/source/documentation_pages/coordinates/XDR.rst
@@ -1,0 +1,3 @@
+.. automodule:: MDAnalysis.coordinates.XDR
+   :members:
+   :inherited-members:

--- a/package/doc/sphinx/source/documentation_pages/coordinates/XTC.rst
+++ b/package/doc/sphinx/source/documentation_pages/coordinates/XTC.rst
@@ -1,2 +1,3 @@
 .. automodule:: MDAnalysis.coordinates.XTC
    :members:
+   :inherited-members:

--- a/package/doc/sphinx/source/documentation_pages/coordinates_modules.rst
+++ b/package/doc/sphinx/source/documentation_pages/coordinates_modules.rst
@@ -54,4 +54,4 @@ functionality should first read the :ref:`Trajectory API`.
    coordinates/core
    coordinates/chain
    coordinates/pdbextensions
-
+   coordinates/XDR

--- a/package/doc/sphinx/source/documentation_pages/lib/formats/libmdaxdr.rst
+++ b/package/doc/sphinx/source/documentation_pages/lib/formats/libmdaxdr.rst
@@ -1,0 +1,3 @@
+.. automodule:: MDAnalysis.lib.formats.libmdaxdr
+   :members:
+   :inherited-members:

--- a/package/doc/sphinx/source/documentation_pages/lib_modules.rst
+++ b/package/doc/sphinx/source/documentation_pages/lib_modules.rst
@@ -50,3 +50,18 @@ List of modules
    ./lib/transformations
    ./lib/qcprot
    ./lib/util
+
+Low level file formats
+----------------------
+
+The modules in :mod:`MDAnalysis.lib.formats` contain code to access various file
+formats in a way that is *independent from other MDAnalysis functionality*
+(i.e., they do not use any classes from :mod:`MDAnalysis.core` or
+:mod:`MDAnalysis.topology`). This low-level code is used in the
+:mod:`MDAnalysis.coordinates` module but can also be re-used by other
+Python-based projects.
+
+.. toctree::
+   :maxdepth: 1
+
+   ./lib/formats/libmdaxdr


### PR DESCRIPTION
Fixes #1003  (replaces PR #1091)

New docs for
- libmdaxdr (under formats)
- coordinates.XDR
- coordinates.{XTC,TRR}
- notes of offsets