### PR TITLE
groupby method for GroupBase

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -58,6 +58,7 @@ Enhancements
   * Universe anchors (for unpickling) now use a uuid (rather than filename)
     to distinguish themselves by default. Can still use anchor_name kwarg to
     control the anchor name manually. (PR #1125)
+  * Added groupby method to Group objects. (PR #1112)
 
 Fixes
   * Improvement of analysis/waterdynamics module (Issue #935)

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -888,6 +888,24 @@ class GroupBase(_MutableBase):
             if not all(s == 0.0):
                 o.atoms.translate(s)
 
+    def groupby(self, topattr):
+        """Obtain groupings of the components of this Group according the values
+        of a given topology attribute.
+
+        Parameters
+        ----------
+        topattr: str
+           Topology attribute to group components by.
+
+        Returns
+        -------
+        dict
+            Unique values of the topology attribute as keys, Groups as values.
+
+        """
+        return {i: self[self.__getattribute__(topattr) == i] for i in 
+                set(self.__getattribute__(topattr))}
+
 
 class AtomGroup(GroupBase):
     """A group of atoms.

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -889,8 +889,7 @@ class GroupBase(_MutableBase):
                 o.atoms.translate(s)
 
     def groupby(self, topattr):
-        """Obtain groupings of the components of this Group according the values
-        of a given topology attribute.
+        """Group together items in this group according to values of *topattr*
 
         Parameters
         ----------
@@ -902,9 +901,19 @@ class GroupBase(_MutableBase):
         dict
             Unique values of the topology attribute as keys, Groups as values.
 
+        Example
+        -------
+        To group atoms with the same mass together::
+
+          >>> ag.groupby('masses')
+          {12.010999999999999: <AtomGroup with 462 atoms>,
+          14.007: <AtomGroup with 116 atoms>,
+          15.999000000000001: <AtomGroup with 134 atoms>}
+
+        .. versionadded:: 0.16.0
         """
-        return {i: self[self.__getattribute__(topattr) == i] for i in 
-                set(self.__getattribute__(topattr))}
+        ta = getattr(self, topattr)
+        return {i: self[ta == i] for i in set(ta)}
 
 
 class AtomGroup(GroupBase):

--- a/testsuite/MDAnalysisTests/core/test_groups.py
+++ b/testsuite/MDAnalysisTests/core/test_groups.py
@@ -488,3 +488,37 @@ class TestMetaclassMagic(object):
         ag = u.atoms[[0, 1, 2]]
 
         assert_array_equal(ng.positions, ag.positions)
+
+
+class TestGroupBy(object):
+    # tests for the method 'groupby'
+    def setUp(self):
+        self.u = make_Universe(('types', 'charges', 'resids'))
+
+    def tearDown(self):
+        del self.u
+
+    def test_groupby_float(self):
+        gb = self.u.atoms.groupby('charges')
+
+        for ref in [-1.5, -0.5, 0.0, 0.5, 1.5]:
+            assert_(ref in gb)
+            g = gb[ref]
+            assert_(all(g.charges == ref))
+            assert_(len(g) == 25)
+        
+    def test_groupby_string(self):
+        gb = self.u.atoms.groupby('types')
+
+        assert_(len(gb) == 5)
+        for ref in ['TypeA', 'TypeB', 'TypeC', 'TypeD', 'TypeE']:
+            assert_(ref in gb)
+            g = gb[ref]
+            assert_(all(g.types == ref))
+            assert_(len(g) == 25)
+
+    def test_groupby_int(self):
+        gb = self.u.atoms.groupby('resids')
+
+        for g in gb.values():
+            assert_(len(g) == 5)


### PR DESCRIPTION
Addresses #1105

Changes made in this Pull Request:
 - added a general-purpose `groupby` method to `GroupBase` that allows for familiar groupby operations on single topology attributes a la `pandas` or `datreant`

e.g.

```python
import MDAnalysis as mda

u = mda.fetch_mmtf('1nmu')

# exclude all HETATM entries
protein = u.select_atoms('protein')

# make a selection across chains
sel = protein.select_atoms('(segid A and resid 10-50) or (segid C and resid 51-100)')
for seg in sel.segments:
    print(len(seg.residues.resids), seg.residues.resids[:10])
```
and then we can do:

```python
>>> sel.residues.groupby('segids')
{u'A': <ResidueGroup with 40 residues>, u'C': <ResidueGroup with 49 residues>}

>>> sel.residues.groupby('resnames')
{'ALA': <ResidueGroup with 8 residues>,
 'ARG': <ResidueGroup with 2 residues>,
 'ASN': <ResidueGroup with 2 residues>,
 'ASP': <ResidueGroup with 9 residues>,
 'GLN': <ResidueGroup with 3 residues>,
 'GLU': <ResidueGroup with 6 residues>,
 'GLY': <ResidueGroup with 10 residues>,
 'HIS': <ResidueGroup with 2 residues>,
 'ILE': <ResidueGroup with 5 residues>,
 'LEU': <ResidueGroup with 5 residues>,
 'LYS': <ResidueGroup with 9 residues>,
 'PHE': <ResidueGroup with 6 residues>,
 'PRO': <ResidueGroup with 5 residues>,
 'SER': <ResidueGroup with 1 residues>,
 'THR': <ResidueGroup with 5 residues>,
 'TRP': <ResidueGroup with 3 residues>,
 'TYR': <ResidueGroup with 4 residues>,
 'VAL': <ResidueGroup with 4 residues>}

>>> sel.groupby('masses')
{12.010999999999999: <AtomGroup with 462 atoms>,
 14.007: <AtomGroup with 116 atoms>,
 15.999000000000001: <AtomGroup with 134 atoms>}
```

before merging, it would be real nice if multiple attributes could be given so that groupings can be done on combinations of values.


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
