### PR TITLE
BUG: Writing a PDB file from an ag with invalid kwargs

### DIFF
--- a/package/MDAnalysis/__init__.py
+++ b/package/MDAnalysis/__init__.py
@@ -161,6 +161,7 @@ _READERS = {}
 _SINGLEFRAME_WRITERS = {}
 _MULTIFRAME_WRITERS = {}
 _PARSERS = {}
+_SELECTION_WRITERS = {}
 
 # custom exceptions and warnings
 from .exceptions import (

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -1456,8 +1456,10 @@ class AtomGroup(GroupBase):
         try:
             writer = MDAnalysis.coordinates.writer(filename, **kwargs)
             coords = True
-        except TypeError:
+        except TypeError as e:
             # might be selections format
+            if 'got an unexpected keyword argument' in str(e):
+                raise
             coords = False
 
         try:

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -1462,7 +1462,9 @@ class AtomGroup(GroupBase):
             format = format or file_format
             format = format.strip().upper()
 
-            writer = get_writer_for(filename, format=format)
+            multiframe = kwargs.pop('multiframe', None)
+
+            writer = get_writer_for(filename, format=format, multiframe=multiframe)
             #MDAnalysis.coordinates.writer(filename, **kwargs)
             coords = True
         except (ValueError, TypeError):
@@ -1479,7 +1481,7 @@ class AtomGroup(GroupBase):
         if not (coords or selection):
             raise ValueError("No writer found for format: {}".format(filename))
         else:
-            with writer(filename, **kwargs) as w:
+            with writer(filename, n_atoms=self.n_atoms, **kwargs) as w:
                 w.write(self.atoms)
 
 

--- a/package/MDAnalysis/selections/__init__.py
+++ b/package/MDAnalysis/selections/__init__.py
@@ -47,22 +47,14 @@ from __future__ import absolute_import
 
 import os.path
 
+from .. import _SELECTION_WRITERS
+
 from . import vmd
 from . import pymol
 from . import gromacs
 from . import charmm
 from . import jmol
 
-# Signature:
-#   W = SelectionWriter(filename, **kwargs)
-#   W.write(AtomGroup)
-_selection_writers = {
-    'vmd': vmd.SelectionWriter,
-    'charmm': charmm.SelectionWriter, 'str': charmm.SelectionWriter,
-    'pymol': pymol.SelectionWriter, 'pml': pymol.SelectionWriter,
-    'gromacs': gromacs.SelectionWriter, 'ndx': gromacs.SelectionWriter,
-    'jmol': jmol.SelectionWriter, 'spt': jmol.SelectionWriter
-}
 
 def get_writer(filename, defaultformat):
     """Return a :class:`SelectionWriter` for *filename* or a *defaultformat*."""
@@ -70,8 +62,10 @@ def get_writer(filename, defaultformat):
     if filename:
         format = os.path.splitext(filename)[1][1:]  # strip initial dot!
     format = format or defaultformat  # use default if no fmt from fn
-    format = format.strip().lower()  # canonical for lookup
+    format = format.strip().upper()  # canonical for lookup
     try:
-        return _selection_writers[format]
+        return _SELECTION_WRITERS[format]
     except KeyError:
-        raise NotImplementedError("Writing as {0!r} is not implemented; only {1!r} will work.".format(format, _selection_writers.keys()))
+        raise NotImplementedError(
+            "Writing as {0!r} is not implemented;"
+            " only {1!r} will work.".format(format, _SELECTION_WRITERS.keys()))

--- a/package/MDAnalysis/selections/charmm.py
+++ b/package/MDAnalysis/selections/charmm.py
@@ -43,7 +43,7 @@ from __future__ import absolute_import
 from . import base
 
 class SelectionWriter(base.SelectionWriter):
-    format = "CHARMM"
+    format = ["CHARMM", "str"]
     ext = "str"
     continuation = '-'
     commentfmt = "! %s"

--- a/package/MDAnalysis/selections/gromacs.py
+++ b/package/MDAnalysis/selections/gromacs.py
@@ -43,7 +43,7 @@ from __future__ import absolute_import
 from . import base
 
 class SelectionWriter(base.SelectionWriter):
-    format = "Gromacs"
+    format = ["Gromacs", "ndx"]
     ext = "ndx"
     default_numterms = 12
 

--- a/package/MDAnalysis/selections/jmol.py
+++ b/package/MDAnalysis/selections/jmol.py
@@ -43,7 +43,7 @@ from __future__ import absolute_import
 from . import base
 
 class SelectionWriter(base.SelectionWriter):
-    format = "Jmol"
+    format = ["Jmol", "spt"]
     ext = "spt"
     default_numterms = None
     commentfmt = '#'

--- a/package/MDAnalysis/selections/pymol.py
+++ b/package/MDAnalysis/selections/pymol.py
@@ -44,7 +44,7 @@ from __future__ import absolute_import
 from . import base
 
 class SelectionWriter(base.SelectionWriter):
-    format = "PyMol"
+    format = ["PyMol", "pml"]
     ext = "pml"
     continuation = '\\'  # quoted backslash!
     commentfmt = "# %s"

--- a/testsuite/MDAnalysisTests/core/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/core/test_atomgroup.py
@@ -184,6 +184,12 @@ class TestAtomGroupWriting(object):
         with tempdir.in_tempdir():
             self.u.atoms.write("test.vmd")
 
+    def test_bogus_kwarg_pdb(self):
+        # test for resolution of Issue 877
+        with tempdir.in_tempdir():
+            with assert_raises(TypeError):
+                self.u.atoms.write('dummy.pdb', bogus="what?")
+
 
 class TestAtomGroupTransformations(object):
     def setUp(self):


### PR DESCRIPTION
Fixes #877 

Changes made in this Pull Request:
 - I wrote a unit test and patched the issue linked above. Note that the original author reported this as a general flaw of atomgroup writing, but it is isolated to PDB format as far as I can tell (not reproducible with gro or xyz formats)


PR Checklist
------------
 - [x] Tests?
 - [x] Issue raised/referenced?