### PR TITLE
Test coverage increase for core/selection

### DIFF
--- a/package/MDAnalysis/core/selection.py
+++ b/package/MDAnalysis/core/selection.py
@@ -54,15 +54,6 @@ from ..lib import distances
 from ..exceptions import SelectionError, NoDataError
 
 
-def unique(ag):
-    """Return the unique elements of ag"""
-    try:
-        return ag.universe.atoms[np.unique(ag.indices)]
-    except NoDataError:
-        # zero length AG has no Universe
-        return ag
-
-
 def is_keyword(val):
     """Is val a selection keyword?
 
@@ -147,7 +138,7 @@ class AndOperation(LogicOperation):
         # Mask which lsel indices appear in rsel
         mask = np.in1d(rsel.indices, lsel.indices)
         # and mask rsel according to that
-        return unique(rsel[mask])
+        return rsel[mask].unique
 
 
 class OrOperation(LogicOperation):
@@ -191,7 +182,7 @@ class AllSelection(Selection):
         # are unique by construction.
         if group is group.universe.atoms:
             return group
-        return unique(group[:])
+        return group[:].unique
 
 
 class UnarySelection(Selection):
@@ -206,7 +197,7 @@ class NotSelection(UnarySelection):
 
     def apply(self, group):
         notsel = self.sel.apply(group)
-        return unique(group[~np.in1d(group.indices, notsel.indices)])
+        return group[~np.in1d(group.indices, notsel.indices)].unique
 
 
 class GlobalSelection(UnarySelection):
@@ -214,7 +205,7 @@ class GlobalSelection(UnarySelection):
     precedence = 5
 
     def apply(self, group):
-        return unique(self.sel.apply(group.universe.atoms))
+        return self.sel.apply(group.universe.atoms).unique
 
 
 class ByResSelection(UnarySelection):
@@ -226,7 +217,7 @@ class ByResSelection(UnarySelection):
         unique_res = np.unique(res.resids)
         mask = np.in1d(group.resids, unique_res)
 
-        return unique(group[mask])
+        return group[mask].unique
 
 
 class DistanceSelection(Selection):
@@ -279,7 +270,7 @@ class AroundSelection(DistanceSelection):
         # These are the indices from SYS that were seen when
         # probing with SEL
         unique_idx = np.unique(np.concatenate(found_indices))
-        return unique(sys[unique_idx.astype(np.int32)])
+        return sys[unique_idx.astype(np.int32)].unique
 
     def _apply_distmat(self, group):
         sel = self.sel.apply(group)
@@ -291,7 +282,7 @@ class AroundSelection(DistanceSelection):
 
         mask = (dist <= self.cutoff).any(axis=1)
 
-        return unique(sys[mask])
+        return sys[mask].unique
 
 
 class SphericalLayerSelection(DistanceSelection):
@@ -318,7 +309,7 @@ class SphericalLayerSelection(DistanceSelection):
         kdtree.search(ref, self.inRadius)
         found_IntIndices = kdtree.get_indices()
         found_indices = list(set(found_ExtIndices) - set(found_IntIndices))
-        return unique(group[found_indices])
+        return group[found_indices].unique
 
     def _apply_distmat(self, group):
         sel = self.sel.apply(group)
@@ -331,7 +322,7 @@ class SphericalLayerSelection(DistanceSelection):
         mask = d < self.exRadius
         mask &= d > self.inRadius
 
-        return unique(group[mask])
+        return group[mask].unique
 
 
 class SphericalZoneSelection(DistanceSelection):
@@ -355,7 +346,7 @@ class SphericalZoneSelection(DistanceSelection):
         kdtree.search(ref, self.cutoff)
         found_indices = kdtree.get_indices()
 
-        return unique(group[found_indices])
+        return group[found_indices].unique
 
     def _apply_distmat(self, group):
         sel = self.sel.apply(group)
@@ -366,7 +357,7 @@ class SphericalZoneSelection(DistanceSelection):
                                      group.positions,
                                      box=box)[0]
         idx = d < self.cutoff
-        return unique(group[idx])
+        return group[idx].unique
 
 
 class CylindricalSelection(Selection):
@@ -427,7 +418,7 @@ class CylindricalSelection(Selection):
             # Only for cylayer, cyzone doesn't have inRadius
             pass
 
-        return unique(group[mask])
+        return group[mask].unique
 
 
 class CylindricalZoneSelection(CylindricalSelection):
@@ -472,7 +463,7 @@ class PointSelection(DistanceSelection):
         kdtree.search(self.ref, self.cutoff)
         found_indices = kdtree.get_indices()
 
-        return unique(group[found_indices])
+        return group[found_indices].unique
 
     def _apply_distmat(self, group):
         ref_coor = self.ref[np.newaxis, ...]
@@ -482,7 +473,7 @@ class PointSelection(DistanceSelection):
 
         dist = distances.distance_array(group.positions, ref_coor, box)
         mask = (dist <= self.cutoff).any(axis=1)
-        return unique(group[mask])
+        return group[mask].unique
 
 
 class AtomSelection(Selection):
@@ -499,7 +490,7 @@ class AtomSelection(Selection):
             sub = sub[sub.resids == self.resid]
         if sub:
             sub = sub[sub.segids == self.segid]
-        return unique(sub)
+        return sub.unique
 
 
 class BondedSelection(Selection):
@@ -560,7 +551,7 @@ class FullSelgroupSelection(Selection):
     @deprecate(old_name='fullgroup', new_name='global group',
                message=' This will be removed in v0.15.0')
     def apply(self, group):
-        return unique(self.grp)
+        return self.grp.unique
 
 
 class StringSelection(Selection):
@@ -585,7 +576,7 @@ class StringSelection(Selection):
                 values = getattr(group, self.field).astype(np.str_)
                 mask |= np.char.startswith(values, val[:wc_pos])
 
-        return unique(group[mask])
+        return group[mask].unique
 
 
 class AtomNameSelection(StringSelection):
@@ -684,7 +675,7 @@ class ResidSelection(Selection):
         else:
             mask = self._sel_without_icodes(vals)
 
-        return unique(group[mask])
+        return group[mask].unique
 
     def _sel_without_icodes(self, vals):
         # Final mask that gets applied to group
@@ -789,7 +780,7 @@ class ResnumSelection(RangeSelection):
                 thismask = vals == lower
 
             mask |= thismask
-        return unique(group[mask])
+        return group[mask].unique
 
 
 class ByNumSelection(RangeSelection):
@@ -807,7 +798,7 @@ class ByNumSelection(RangeSelection):
                 thismask = vals == lower
 
             mask |= thismask
-        return unique(group[mask])
+        return group[mask].unique
 
 
 
@@ -853,7 +844,7 @@ class ProteinSelection(Selection):
 
     def apply(self, group):
         mask = np.in1d(group.resnames, self.prot_res)
-        return unique(group[mask])
+        return group[mask].unique
 
 
 class NucleicSelection(Selection):
@@ -885,7 +876,7 @@ class NucleicSelection(Selection):
 
     def apply(self, group):
         mask = np.in1d(group.resnames, self.nucl_res)
-        return unique(group[mask])
+        return group[mask].unique
 
 
 class BackboneSelection(ProteinSelection):
@@ -900,7 +891,7 @@ class BackboneSelection(ProteinSelection):
     def apply(self, group):
         mask = np.in1d(group.names, self.bb_atoms)
         mask &= np.in1d(group.resnames, self.prot_res)
-        return unique(group[mask])
+        return group[mask].unique
 
 
 class NucleicBackboneSelection(NucleicSelection):
@@ -915,7 +906,7 @@ class NucleicBackboneSelection(NucleicSelection):
     def apply(self, group):
         mask = np.in1d(group.names, self.bb_atoms)
         mask &= np.in1d(group.resnames, self.nucl_res)
-        return unique(group[mask])
+        return group[mask].unique
 
 
 class BaseSelection(NucleicSelection):
@@ -935,7 +926,7 @@ class BaseSelection(NucleicSelection):
     def apply(self, group):
         mask = np.in1d(group.names, self.base_atoms)
         mask &= np.in1d(group.resnames, self.nucl_res)
-        return unique(group[mask])
+        return group[mask].unique
 
 
 class NucleicSugarSelection(NucleicSelection):
@@ -947,7 +938,7 @@ class NucleicSugarSelection(NucleicSelection):
     def apply(self, group):
         mask = np.in1d(group.names, self.sug_atoms)
         mask &= np.in1d(group.resnames, self.nucl_res)
-        return unique(group[mask])
+        return group[mask].unique
 
 
 class PropertySelection(Selection):
@@ -1001,7 +992,7 @@ class PropertySelection(Selection):
             values = np.abs(values)
         mask = self.operator(values, self.value)
 
-        return unique(group[mask])
+        return group[mask].unique
 
 
 class SameSelection(Selection):
@@ -1050,7 +1041,7 @@ class SameSelection(Selection):
             allfrags = functools.reduce(lambda x, y: x + y, res.fragments)
 
             mask = np.in1d(group.indices, allfrags.indices)
-            return unique(group[mask])
+            return group[mask].unique
         # [xyz] must come before self.prop_trans lookups too!
         try:
             pos_idx = {'x': 0, 'y': 1, 'z': 2}[self.prop]
@@ -1062,7 +1053,7 @@ class SameSelection(Selection):
             vals = getattr(res, attrname)
             mask = np.in1d(getattr(group, attrname), vals)
 
-            return unique(group[mask])
+            return group[mask].unique
         else:
             vals = res.positions[:, pos_idx]
             pos = group.positions[:, pos_idx]
@@ -1070,7 +1061,7 @@ class SameSelection(Selection):
             # isclose only does one value at a time
             mask = np.vstack([np.isclose(pos, v)
                               for v in vals]).any(axis=0)
-            return unique(group[mask])
+            return group[mask].unique
 
 
 class SelectionParser(object):

--- a/package/MDAnalysis/topology/MMTFParser.py
+++ b/package/MDAnalysis/topology/MMTFParser.py
@@ -90,7 +90,7 @@ from ..core.topologyattrs import (
     Segids,
     SegmentAttr,  # for model
 )
-from ..core.selection import RangeSelection, unique
+from ..core.selection import RangeSelection
 
 
 def _parse_mmtf(fn):
@@ -141,7 +141,7 @@ class ModelSelection(RangeSelection):
                 thismask = vals == lower
 
             mask |= thismask
-        return unique(group[mask])
+        return group[mask].unique
 
 
 class MMTFParser(base.TopologyReader):

--- a/testsuite/MDAnalysisTests/core/test_atomselections.py
+++ b/testsuite/MDAnalysisTests/core/test_atomselections.py
@@ -53,7 +53,6 @@ from MDAnalysis.tests.datafiles import (
     PDB_full,
     PDB_icodes,
 )
-from MDAnalysisTests.plugins.knownfailure import knownfailure
 from MDAnalysisTests import parser_not_found
 
 
@@ -115,21 +114,18 @@ class TestSelectionsCHARMM(object):
 
     # resnum selections are boring here because we haven't really a mechanism yet
     # to assign the canonical PDB resnums
-    @knownfailure('No default resnums')
     def test_resnum_single(self):
-        assert 1 == 2
-        #sel = self.universe.select_atoms('resnum 100')
-        #assert_equal(sel.n_atoms, 7)
-        #assert_equal(sel.residues.resids, [100])
-        #assert_equal(sel.residues.resnames, ['GLY'])
+        sel = self.universe.select_atoms('resnum 100')
+        assert_equal(sel.n_atoms, 7)
+        assert_equal(sel.residues.resids, [100])
+        assert_equal(sel.residues.resnames, ['GLY'])
 
-    @knownfailure('No default resnums')
     def test_resnum_range(self):
-        assert 1 == 2
-        #sel = self.universe.select_atoms('resnum 100:105')
-        #assert_equal(sel.n_atoms, 89)
-        #assert_equal(sel.residues.resids, range(100, 106))
-        #assert_equal(sel.residues.resnames, ['GLY', 'ILE', 'ASN', 'VAL', 'ASP', 'TYR'])
+        sel = self.universe.select_atoms('resnum 100:105')
+        assert_equal(sel.n_atoms, 89)
+        assert_equal(sel.residues.resids, range(100, 106))
+        assert_equal(sel.residues.resnames,
+                     ['GLY', 'ILE', 'ASN', 'VAL', 'ASP', 'TYR'])
 
     def test_resname(self):
         sel = self.universe.select_atoms('resname LEU')
@@ -226,8 +222,6 @@ class TestSelectionsCHARMM(object):
         assert_equal(subsel[0].index, 1)
         assert_equal(subsel[-1].index, 4)
 
-    # TODO:
-    # and also for selection keywords such as 'nucleic'
     def test_byres(self):
         sel = self.universe.select_atoms('byres bynum 0:5')
 
@@ -247,28 +241,36 @@ class TestSelectionsCHARMM(object):
                            ("Found wrong residues with same resname as "
                             "resids 10 or 11"))
 
-    @knownfailure("Can't set segids")
     def test_same_segment(self):
         """Test the 'same ... as' construct (Issue 217)"""
-        assert 1 == 2
-        #self.universe.residues[:100].set_segids("A")  # make up some segments
-        #self.universe.residues[100:150].set_segids("B")
-        #self.universe.residues[150:].set_segids("C")
 
-        #target_resids = np.arange(100)+1
-        #sel = self.universe.select_atoms("same segment as resid 10")
-        #assert_equal(len(sel), 1520, "Found a wrong number of atoms in the same segment of resid 10")
-        #assert_array_equal(sel.residues.resids, target_resids, "Found wrong residues in the same segment of resid 10")
+        SNew_A = self.universe.add_Segment(segid='A')
+        SNew_B = self.universe.add_Segment(segid='B')
+        SNew_C = self.universe.add_Segment(segid='C')
 
-        #target_resids = np.arange(100,150)+1
-        #sel = self.universe.select_atoms("same segment as resid 110")
-        #assert_equal(len(sel), 797, "Found a wrong number of atoms in the same segment of resid 110")
-        #assert_array_equal(sel.residues.resids, target_resids, "Found wrong residues in the same segment of resid 110")
+        self.universe.residues[:100].segments = SNew_A
+        self.universe.residues[100:150].segments = SNew_B
+        self.universe.residues[150:].segments = SNew_C
 
-        #target_resids = np.arange(150,self.universe.atoms.n_residues)+1
-        #sel = self.universe.select_atoms("same segment as resid 160")
-        #assert_equal(len(sel), 1024, "Found a wrong number of atoms in the same segment of resid 160")
-        #assert_array_equal(sel.residues.resids, target_resids, "Found wrong residues in the same segment of resid 160")
+        target_resids = np.arange(100) + 1
+        sel = self.universe.select_atoms("same segment as resid 10")
+        assert_equal(len(sel), 1520, "Found a wrong number of atoms in the same segment of resid 10")
+        assert_array_equal(sel.residues.resids,
+                           target_resids, "Found wrong residues in the same segment of resid 10")
+
+        target_resids = np.arange(100, 150) + 1
+        sel = self.universe.select_atoms("same segment as resid 110")
+        assert_equal(len(sel), 797,
+                     "Found a wrong number of atoms in the same segment of resid 110")
+        assert_array_equal(sel.residues.resids, target_resids,
+                           "Found wrong residues in the same segment of resid 110")
+
+        target_resids = np.arange(150, self.universe.atoms.n_residues) + 1
+        sel = self.universe.select_atoms("same segment as resid 160")
+        assert_equal(len(sel), 1024,
+                     "Found a wrong number of atoms in the same segment of resid 160")
+        assert_array_equal(sel.residues.resids, target_resids,
+                           "Found wrong residues in the same segment of resid 160")
 
     def test_empty_same(self):
         ag = self.universe.select_atoms('resname MET')
@@ -753,13 +755,16 @@ class TestBondedSelection(object):
 
         assert_(len(ag) == 3)
 
-    @knownfailure()
-    def test_nobonds_warns(self):
-        assert 1 == 2
-        #self.u.bonds = TopologyGroup([], self.u)
+    @staticmethod
+    def test_nobonds_warns():
+        u = make_Universe(('names',))
 
-        #assert_warns(UserWarning,
-        #self.u.select_atoms, 'type 2 and bonded name N')
+        # empty bond topology attr
+        batt = mda.core.topologyattrs.Bonds([])
+        u.add_TopologyAttr(batt)
+
+        assert_warns(UserWarning,
+                     u.select_atoms, 'bonded name AAA')
 
 
 class TestSelectionErrors(object):

--- a/testsuite/MDAnalysisTests/core/test_atomselections.py
+++ b/testsuite/MDAnalysisTests/core/test_atomselections.py
@@ -783,7 +783,8 @@ class TestSelectionErrors(object):
         for selstr in [
                 'name and H',  # string selection
                 'name )',
-                'resid abcd',  # range selection
+                'resid abcd',  # resid arg parsing selection
+                'resnum 7a7',  # rangeselection arg parsing
                 'resid 1-',
                 'prop chicken == tasty',
                 'prop chicken <= 7.4',

--- a/testsuite/MDAnalysisTests/topology/test_mmtf.py
+++ b/testsuite/MDAnalysisTests/topology/test_mmtf.py
@@ -105,12 +105,6 @@ class TestMMTFgzUniverse(object):
             assert_(isinstance(m, AtomGroup))
             assert_(len(m) == 570)
 
-    def test_model_selection(self):
-        m1 = self.u.select_atoms('model 0')
-        m2 = self.u.select_atoms('model 1')
-
-        assert_(len(m1) == 570)
-        assert_(len(m2) == 570)
 
 class TestMMTFgzUniverseFromDecoder(TestMMTFgzUniverse):
     def setUp(self):
@@ -125,3 +119,43 @@ class TestMMTFFetch(TestMMTFUniverse):
         mock_fetch.return_value = top
         self.u = mda.fetch_mmtf('173D')  # string is irrelevant
         
+
+class TestSelectModels(object):
+    # tests for 'model' keyword in select_atoms
+    def setUp(self):
+        self.u = mda.Universe(MMTF_gz)
+
+    def tearDown(self):
+        del self.u
+
+    def test_model_selection(self):
+        m1 = self.u.select_atoms('model 0')
+        m2 = self.u.select_atoms('model 1')
+
+        assert_(len(m1) == 570)
+        assert_(len(m2) == 570)
+
+    def test_model_multiple(self):
+        m2plus = self.u.select_atoms('model 1-10')
+
+        assert_(len(m2plus) == 570)
+
+    def test_model_multiple_2(self):
+        m2plus = self.u.select_atoms('model 1:10')
+
+        assert_(len(m2plus) == 570)
+
+    def test_model_multiple_3(self):
+        m1and2 = self.u.select_atoms('model 0-1')
+
+        assert_(len(m1and2) == 1140)
+
+    def test_model_multiple_4(self):
+        m1and2 = self.u.select_atoms('model 0:1')
+
+        assert_(len(m1and2) == 1140)
+
+    def test_model_multiple_5(self):
+        m1and2 = self.u.select_atoms('model 0 1')
+
+        assert_(len(m1and2) == 1140)


### PR DESCRIPTION
Changes made in this Pull Request:

Removed `core.selection.unique` in preference of `AG.unique` method

AtomGroup has intrinsic unique method so use this over an auxiliary
method

Tests:

Reactivated skipped tests in test_atomselections

Removed TODO about nucleic tests, these have now been added