### PR TITLE
Changed default memory layout of MemoryReader to 'fac'

### DIFF
--- a/package/MDAnalysis/analysis/encore/bootstrap.py
+++ b/package/MDAnalysis/analysis/encore/bootstrap.py
@@ -150,6 +150,6 @@ def get_ensemble_bootstrap_samples(ensemble,
             size=ensemble.trajectory.timeseries().shape[1])
         ensembles.append(
             mda.Universe(ensemble.filename,
-                        ensemble.trajectory.timeseries(format='afc')[:,indices,:],
+                        ensemble.trajectory.timeseries(format='fac')[indices,:,:],
                          format=mda.coordinates.memory.MemoryReader))
     return ensembles

--- a/package/MDAnalysis/analysis/encore/similarity.py
+++ b/package/MDAnalysis/analysis/encore/similarity.py
@@ -727,8 +727,8 @@ def prepare_ensembles_for_convergence_increasing_window(ensemble,
     for s,sl in enumerate(slices_n[:-1]):
         tmp_ensembles.append(mda.Universe(
             ensemble.filename,
-            ensemble.trajectory.timeseries()
-            [:, slices_n[s]:slices_n[s + 1], :],
+            ensemble.trajectory.timeseries(format='fac')
+            [slices_n[s]:slices_n[s + 1], :, :],
             format=MemoryReader))
 
     return tmp_ensembles

--- a/package/MDAnalysis/analysis/encore/utils.py
+++ b/package/MDAnalysis/analysis/encore/utils.py
@@ -478,6 +478,6 @@ def merge_universes(universes):
 
     return mda.Universe(
         universes[0].filename,
-        np.concatenate(tuple([e.trajectory.timeseries() for e in universes]),
-        axis=1),
+        np.concatenate(tuple([e.trajectory.timeseries(format='fac') for e in universes]),
+                       axis=0),
         format=MemoryReader)

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -400,7 +400,7 @@ class Universe(object):
             # trajectory file formats
             try:
                 coordinates = self.trajectory.timeseries(
-                    self.atoms, format='afc', step=frame_interval)
+                    self.atoms, format='fac', step=frame_interval)
             # if the Timeseries extraction fails,
             # fall back to a slower approach
             except AttributeError:
@@ -410,7 +410,7 @@ class Universe(object):
                 for ts in self.trajectory[::frame_interval]:
                     coordinates.append(np.copy(ts.positions))
                     pm.echo(ts.frame)
-                coordinates = np.array(coordinates).swapaxes(0, 1)
+                coordinates = np.array(coordinates)
 
             # Overwrite trajectory in universe with an MemoryReader
             # object, to provide fast access and allow coordinates

--- a/testsuite/MDAnalysisTests/analysis/test_encore.py
+++ b/testsuite/MDAnalysisTests/analysis/test_encore.py
@@ -44,12 +44,12 @@ class TestEncore(TestCase):
         # Create universe from templates defined in setUpClass
         self.ens1 = mda.Universe(
             self.ens1_template.filename,
-            self.ens1_template.trajectory.timeseries(),
+            self.ens1_template.trajectory.timeseries(format='fac'),
             format=mda.coordinates.memory.MemoryReader)
 
         self.ens2 = mda.Universe(
             self.ens2_template.filename,
-            self.ens2_template.trajectory.timeseries(),
+            self.ens2_template.trajectory.timeseries(format='fac'),
             format=mda.coordinates.memory.MemoryReader)
 
     def tearDown(self):
@@ -72,11 +72,11 @@ class TestEncore(TestCase):
         # Filter ensembles to only include every 5th frame
         cls.ens1_template = mda.Universe(
             cls.ens1_template.filename,
-            np.copy(cls.ens1_template.trajectory.timeseries()[:, ::5, :]),
+            np.copy(cls.ens1_template.trajectory.timeseries(format='fac')[::5, :, :]),
             format=mda.coordinates.memory.MemoryReader)
         cls.ens2_template = mda.Universe(
             cls.ens2_template.filename,
-            np.copy(cls.ens2_template.trajectory.timeseries()[:, ::5, :]),
+            np.copy(cls.ens2_template.trajectory.timeseries(format='fac')[::5, :, :]),
             format=mda.coordinates.memory.MemoryReader)
 
     @classmethod
@@ -389,12 +389,12 @@ class TestEncoreClustering(TestCase):
         # Create universe from templates defined in setUpClass
         self.ens1 = mda.Universe(
             self.ens1_template.filename,
-            self.ens1_template.trajectory.timeseries(),
+            self.ens1_template.trajectory.timeseries(format='fac'),
             format=mda.coordinates.memory.MemoryReader)
 
         self.ens2 = mda.Universe(
             self.ens2_template.filename,
-            self.ens2_template.trajectory.timeseries(),
+            self.ens2_template.trajectory.timeseries(format='fac'),
             format=mda.coordinates.memory.MemoryReader)
 
     def tearDownClass(self):
@@ -417,11 +417,11 @@ class TestEncoreClustering(TestCase):
         # Filter ensembles to only include every 5th frame
         cls.ens1_template = mda.Universe(
             cls.ens1_template.filename,
-            np.copy(cls.ens1_template.trajectory.timeseries()[:, ::5, :]),
+            np.copy(cls.ens1_template.trajectory.timeseries(format='fac')[::5, :, :]),
             format=mda.coordinates.memory.MemoryReader)
         cls.ens2_template = mda.Universe(
             cls.ens2_template.filename,
-            np.copy(cls.ens2_template.trajectory.timeseries()[:, ::5, :]),
+            np.copy(cls.ens2_template.trajectory.timeseries(format='fac')[::5, :, :]),
             format=mda.coordinates.memory.MemoryReader)
 
     @classmethod
@@ -662,12 +662,12 @@ class TestEncoreDimensionalityReduction(TestCase):
         # Create universe from templates defined in setUpClass
         self.ens1 = mda.Universe(
             self.ens1_template.filename,
-            self.ens1_template.trajectory.timeseries(),
+            self.ens1_template.trajectory.timeseries(format='fac'),
             format=mda.coordinates.memory.MemoryReader)
 
         self.ens2 = mda.Universe(
             self.ens2_template.filename,
-            self.ens2_template.trajectory.timeseries(),
+            self.ens2_template.trajectory.timeseries(format='fac'),
             format=mda.coordinates.memory.MemoryReader)
 
     def tearDownClass(self):
@@ -690,11 +690,11 @@ class TestEncoreDimensionalityReduction(TestCase):
         # Filter ensembles to only include every 5th frame
         cls.ens1_template = mda.Universe(
             cls.ens1_template.filename,
-            np.copy(cls.ens1_template.trajectory.timeseries()[:, ::5, :]),
+            np.copy(cls.ens1_template.trajectory.timeseries(format='fac')[::5, :, :]),
             format=mda.coordinates.memory.MemoryReader)
         cls.ens2_template = mda.Universe(
             cls.ens2_template.filename,
-            np.copy(cls.ens2_template.trajectory.timeseries()[:, ::5, :]),
+            np.copy(cls.ens2_template.trajectory.timeseries(format='fac')[::5, :, :]),
             format=mda.coordinates.memory.MemoryReader)
 
     @classmethod

--- a/testsuite/MDAnalysisTests/coordinates/test_memory.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_memory.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 import MDAnalysis as mda
+from MDAnalysis.coordinates.memory import MemoryReader
 from MDAnalysisTests.datafiles import DCD, PSF
 from MDAnalysisTests.coordinates.base import (BaseReference,
                                               BaseReaderTest)
@@ -145,3 +146,8 @@ class TestMemoryReader(BaseReaderTest):
     def test_get_writer_2(self):
         pass
 
+    def test_float32(self):
+        # Check that we get float32 positions even when initializing with float64
+        coordinates = np.random.uniform(size=(100, self.ref.universe.atoms.n_atoms, 3)).cumsum(0)
+        universe = mda.Universe(self.ref.universe.filename, coordinates, format=MemoryReader)
+        assert_equal(universe.trajectory.get_array().dtype, np.dtype('float32'))

--- a/testsuite/MDAnalysisTests/coordinates/test_memory.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_memory.py
@@ -61,6 +61,12 @@ class TestMemoryReader(BaseReaderTest):
         reference = MemoryReference()
         super(TestMemoryReader, self).__init__(reference)
 
+    def test_default_memory_layout(self):
+        universe1 = mda.Universe(PSF, DCD, in_memory=True)
+        universe2 = mda.Universe(PSF, DCD, in_memory=True, order='fac')
+        assert_equal(universe1.trajectory.get_array().shape,
+                     universe2.trajectory.get_array().shape)
+        
     def test_iteration(self):
         frames = 0
         for i, frame in enumerate(self.reader):


### PR DESCRIPTION
Fixes #1063 and #1065

Changes made in this Pull Request:
 - Switched default layout of MemoryReader to 'fac'
 - Ensure that the internal numpy array in a MemoryReader is always float32.


PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?
