### PR TITLE
totaltime assumes first frame is at time 0

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -110,6 +110,7 @@ Changes
     raising TypeError and filename is now a required arg instead of kwarg
   * moved coordinates.base.ChainReader to coordinates.chain.ChainReader
   * renamed private method ChainReader.get_flname() to ChainReader._get_filename()
+  * totaltime now considers the first frame to be at time 0 (Issue #1137)
 
 Deprecations (Issue #599)
   * Use of rms_fit_trj deprecated in favor of AlignTraj class (Issue #845)

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -1107,8 +1107,15 @@ class ProtoReader(six.with_metaclass(_Readermeta, IObase)):
 
     @property
     def totaltime(self):
-        """Total length of the trajectory n_frames * dt."""
-        return self.n_frames * self.dt
+        """Total length of the trajectory
+
+        The time is calculated as ``(n_frames - 1) * dt``, i.e., we assume that
+        the first frame no time as elapsed. Thus, a trajectory with two frames will
+        be considered to have a length of a single time step `dt` and a
+        "trajectory" with a single frame will be reported as length 0.
+
+        """
+        return (self.n_frames - 1) * self.dt
 
     @property
     def frame(self):

--- a/testsuite/MDAnalysisTests/coordinates/base.py
+++ b/testsuite/MDAnalysisTests/coordinates/base.py
@@ -167,7 +167,7 @@ class BaseReference(object):
         self.volume = mda.lib.mdamath.box_volume(self.dimensions)
         self.time = 0
         self.dt = 1
-        self.totaltime = 5
+        self.totaltime = 4
 
 
     def iter_ts(self, i):

--- a/testsuite/MDAnalysisTests/coordinates/test_dcd.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_dcd.py
@@ -115,7 +115,7 @@ class TestDCDReader(object):
         # to ~4 decimals and accumulating the inaccuracy leads to even lower
         # precision in the totaltime (consequence of fixing Issue 64)
         assert_almost_equal(self.universe.trajectory.totaltime,
-                            98.0,
+                            97.0,
                             3,
                             err_msg="wrong total length of AdK trajectory")
 
@@ -219,7 +219,7 @@ class TestDCDWriter(TestCase):
 
         uw = mda.Universe(PSF, self.outfile)
         assert_almost_equal(uw.trajectory.totaltime,
-                            uw.trajectory.n_frames * DT, 5)
+                            (uw.trajectory.n_frames - 1) * DT, 5)
         times = np.array([uw.trajectory.time for ts in uw.trajectory])
         frames = np.array([ts.frame for ts in uw.trajectory])
         assert_array_almost_equal(times, frames * DT, 5)

--- a/testsuite/MDAnalysisTests/coordinates/test_xdr.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_xdr.py
@@ -194,7 +194,7 @@ class _GromacsReader(TestCase):
         # to ~4 decimals and accumulating the inaccuracy leads to even lower
         # precision in the totaltime (consequence of fixing Issue 64)
         assert_almost_equal(self.universe.trajectory.totaltime,
-                            1000.0,
+                            900.0,
                             3,
                             err_msg="wrong total length of trajectory")
 


### PR DESCRIPTION
Fixes #1137 

Changes made in this Pull Request:
 - total time now assume the first frame is at time 0


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
