### PR TITLE
TST: Added block_import to MDAnalysisTests.util

### DIFF
--- a/testsuite/MDAnalysisTests/__init__.py
+++ b/testsuite/MDAnalysisTests/__init__.py
@@ -150,6 +150,8 @@ try:
 except ImportError:
     pass
 
+from .util import block_import
+
 def run(*args, **kwargs):
     """Test-running function that loads plugins, sets up arguments, and calls `nose.run_exit()`"""
     try:
@@ -218,7 +220,6 @@ def parser_not_found(parser_name):
         return True
     else:
         return False
-
 
 @contextmanager
 def in_dir(dirname):

--- a/testsuite/MDAnalysisTests/coordinates/test_netcdf.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_netcdf.py
@@ -1,5 +1,3 @@
-import __builtin__
-
 import MDAnalysis as mda
 import mock
 import numpy as np
@@ -17,8 +15,9 @@ from MDAnalysisTests.datafiles import (PRMncdf, NCDF, PFncdf_Top, PFncdf_Trj,
                                        GRO, TRR, XYZ_mini)
 from MDAnalysisTests.coordinates.test_trj import _TRJReaderTest
 from MDAnalysisTests.coordinates.reference import (RefVGV, RefTZ2)
-from MDAnalysisTests import tempdir
+from MDAnalysisTests import tempdir, block_import
 from MDAnalysisTests.core.groupbase import make_Universe
+
 
 
 class _NCDFReaderTest(_TRJReaderTest):
@@ -383,21 +382,12 @@ class TestNCDFWriterVelsForces(TestCase):
 
 class TestNetCDFImport(object):
     # test ImportErrors in netCDF format Reader & Writer
-    # mock shadows the builtin import method
-    # `block_netcdf` sniffs imports and blocks netCDF import calls
+    # `block_import` sniffs imports and blocks netCDF import calls
 
-    @mock.patch('__builtin__.__import__', wraps=__builtin__.__import__)
-    def test_import_netcdfreader(self, mock_imp):
+    @block_import('netCDF4')
+    def test_import_netcdfreader(self):
         # do it here because netcdf isn't required
         from MDAnalysis.coordinates.TRJ import NCDFReader
-
-        def block_netcdf(*args, **kwargs):
-            if 'netCDF4' in args:
-                raise ImportError
-            else:
-                # returning DEFAULT allows the real import to continue
-                return mock.DEFAULT
-        mock_imp.side_effect = block_netcdf
 
         # Check the error meessage that we're giving out
         try:
@@ -414,18 +404,10 @@ class TestNetCDFImport(object):
             except OSError:
                 pass
 
-    @mock.patch('__builtin__.__import__', wraps=__builtin__.__import__)
-    def test_import_netcdfwriter(self, mock_imp):
+    @block_import('netCDF4')
+    def test_import_netcdfwriter(self):
         # do it here because netcdf isn't required
         from MDAnalysis.coordinates.TRJ import NCDFWriter
-
-        def block_netcdf(*args, **kwargs):
-            if 'netCDF4' in args:
-                raise ImportError
-            else:
-                # returning DEFAULT allows the real import to continue
-                return mock.DEFAULT
-        mock_imp.side_effect = block_netcdf
 
         with NCDFWriter('myfile.ncdf', 100) as wr:
             try:

--- a/testsuite/MDAnalysisTests/util.py
+++ b/testsuite/MDAnalysisTests/util.py
@@ -1,0 +1,60 @@
+# -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 fileencoding=utf-8
+#
+# MDAnalysis --- http://www.mdanalysis.org
+# Copyright (c) 2006-2016 The MDAnalysis Development Team and contributors
+# (see the file AUTHORS for the full list of names)
+#
+# Released under the GNU Public Licence, v2 or any higher version
+#
+# Please cite your use of MDAnalysis in published work:
+#
+# R. J. Gowers, M. Linke, J. Barnoud, T. J. E. Reddy, M. N. Melo, S. L. Seyler,
+# D. L. Dotson, J. Domanski, S. Buchoux, I. M. Kenney, and O. Beckstein.
+# MDAnalysis: A Python package for the rapid analysis of molecular dynamics
+# simulations. In S. Benthall and S. Rostrup editors, Proceedings of the 15th
+# Python in Science Conference, pages 102-109, Austin, TX, 2016. SciPy.
+#
+# N. Michaud-Agrawal, E. J. Denning, T. B. Woolf, and O. Beckstein.
+# MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
+# J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
+#
+"""
+Useful functions for running tests
+
+"""
+
+import __builtin__
+from functools import wraps
+import mock
+
+
+def block_import(package):
+    """Block import of a given package
+
+    eg:
+
+    @blocker('numpy')
+    def try_and_do_something():
+        import numpy as np  # this will fail!
+
+    Shadows the builtin import method, sniffs import requests
+    and blocks the designated package.
+    """
+    def blocker_wrapper(func):
+        @wraps(func)
+        def func_wrapper(*args, **kwargs):
+            with mock.patch('__builtin__.__import__',
+                            wraps=__builtin__.__import__) as mbi:
+                def blocker(*args, **kwargs):
+                    if package in args:
+                        raise ImportError("Blocked by block_import")
+                    else:
+                        # returning DEFAULT allows the real function to continue
+                        return mock.DEFAULT
+                mbi.side_effect = blocker
+                func(*args, **kwargs)
+        return func_wrapper
+    return blocker_wrapper
+
+


### PR DESCRIPTION
I made a wrapper which should stop a given import (and raise and ImportError instead).  Should be useful for testing the scipy warnings even on a full install
