### PR TITLE
Removed python as travis language

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,11 +39,12 @@ before_install:
   - ./miniconda.sh -b -p $(pwd)/miniconda
   - export PATH=$(pwd)/miniconda/bin:$PATH
   - conda config --add channels MDAnalysis
+  - conda config --add channels conda-forge
   - conda update --yes conda
   - conda install --yes pylint
 install:
-  - if [[ $SETUP == 'full' ]]; then conda create --yes -q -n pyenv python=$PYTHON_VERSION numpy scipy nose=1.3.7 mock sphinx=1.3 griddataformats six scikit-learn; fi
-  - if [[ $SETUP == 'minimal' ]]; then conda create --yes -q -n pyenv python=$PYTHON_VERSION numpy nose=1.3.7 mock sphinx=1.3 griddataformats six; fi
+  - if [[ $SETUP == 'full' ]]; then conda create --yes -q -n pyenv python=$PYTHON_VERSION numpy mmtf-python scipy nose=1.3.7 mock sphinx=1.3 six scikit-learn; fi
+  - if [[ $SETUP == 'minimal' ]]; then conda create --yes -q -n pyenv python=$PYTHON_VERSION numpy mmtf-python nose=1.3.7 mock sphinx=1.3 six; fi
   - source activate pyenv
   - |
     if [[ $SETUP == 'full' ]]; then \
@@ -51,7 +52,7 @@ install:
         conda install -c biobuilds --yes clustalw=2.1; \
     fi
   - if [[ $SETUP == 'minimal' ]]; then conda install --yes cython biopython networkx; fi
-  - pip install mmtf-python
+  - pip install griddataformats
 # ensure that cython files are rebuilt
   - find . -name '*.pyx' -exec touch '{}' \;
   - pip install -v package/

--- a/package/MDAnalysis/analysis/pca.py
+++ b/package/MDAnalysis/analysis/pca.py
@@ -102,7 +102,6 @@ from six.moves import range
 import warnings
 
 import numpy as np
-from scipy.integrate import simps
 
 from MDAnalysis import Universe
 from MDAnalysis.analysis.align import _fit_to
@@ -353,6 +352,7 @@ def cosine_content(pca_space, i):
     .. [BerkHess1] Berk Hess. Convergence of sampling in protein simulations.
                    Phys. Rev. E 65, 031910 (2002).
     """
+    from scipy.integrate import simps
     t = np.arange(len(pca_space))
     T = len(pca_space)
     cos = np.cos(np.pi * t * (i + 1) / T)

--- a/testsuite/MDAnalysisTests/analysis/test_pca.py
+++ b/testsuite/MDAnalysisTests/analysis/test_pca.py
@@ -24,11 +24,12 @@ import numpy as np
 import MDAnalysis
 import MDAnalysis.analysis.pca as pca
 
-from numpy.testing import (assert_almost_equal, assert_equal,
+from numpy.testing import (assert_almost_equal, assert_equal, dec,
                            assert_array_almost_equal, raises)
 
 from MDAnalysisTests.datafiles import (PDB, XTC, RANDOM_WALK, RANDOM_WALK_TOPO,
                                        waterPSF, waterDCD)
+from MDAnalysisTests import module_not_found
 
 
 class TestPCA(object):
@@ -86,6 +87,8 @@ class TestPCA(object):
         pca_test.transform(u2)
 
     @staticmethod
+    @dec.skipif(module_not_found('scipy'),
+                "Test skipped because scipy is not available.")
     def test_cosine_content():
         rand = MDAnalysis.Universe(RANDOM_WALK_TOPO, RANDOM_WALK)
         pca_random = pca.PCA(rand).run()


### PR DESCRIPTION
PR #986 changed the language in the travis file to Python, but this makes OSX fail.  I think this is because we don't actually use a python container, because we install our own python binary with conda.  This might fix it...
