### PR TITLE
Issue 903 — Deprecate quiet in favor of verbose

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -117,6 +117,8 @@ Changes
 Deprecations (Issue #599)
   * Use of rms_fit_trj deprecated in favor of AlignTraj class (Issue #845)
   * Moved analysis.x3dna to the analysis.legacy module (Issue #906)
+  * The keyword argument *quiet* is deprecated in favor of *verbose*
+    throughout the library (Issue #903)
 
 05/15/16 jandom, abhinavgupta94, orbeckst, kain88-de, hainm, jbarnoud,
          dotsdl, richardjgowers, BartBruininks, jdetle

--- a/package/MDAnalysis/analysis/align.py
+++ b/package/MDAnalysis/analysis/align.py
@@ -631,8 +631,8 @@ def rms_fit_trj(
         strict=False,
         force=True,
         verbose=None,
-        quiet=None,
         in_memory=False,
+        quiet=None,
         **kwargs):
     """RMS-fit trajectory to a reference structure using a selection.
 

--- a/package/MDAnalysis/analysis/align.py
+++ b/package/MDAnalysis/analysis/align.py
@@ -191,7 +191,7 @@ from MDAnalysis.exceptions import SelectionError, SelectionWarning
 import MDAnalysis.analysis.rms as rms
 from MDAnalysis.coordinates.memory import MemoryReader
 # remove after rms_fit_trj deprecation over
-from MDAnalysis.lib.log import ProgressMeter
+from MDAnalysis.lib.log import ProgressMeter, _set_verbose
 
 from .base import AnalysisBase
 
@@ -509,8 +509,8 @@ class AlignTraj(AnalysisBase):
             exact methods
         force : boolean, optional
             Force overwrite of filename for rmsd-fitting
-        quiet : boolean, optional
-            Set logger to show minimal information
+        verbose : boolean, optional
+            Set logger to show more information
         start : int, optional
             First frame of trajectory to analyse, Default: 0
         stop : int, optional
@@ -526,9 +526,9 @@ class AlignTraj(AnalysisBase):
 
         Notes
         -----
-        If set to `quiet`, it is recommended to wrap the statement in a ``try
-        ...  finally`` to guarantee restoring of the log level in the case of
-        an exception.
+        If set to `verbose=False`, it is recommended to wrap the statement in a
+        ``try ...  finally`` to guarantee restoring of the log level in the
+        case of an exception.
 
         The `in_memory` option changes the `mobile` universe to an in-memory
         representation (see :mod:`MDAnalysis.coordinates.memory`) for the
@@ -559,7 +559,7 @@ class AlignTraj(AnalysisBase):
         # do this after setting the memory reader to have a reference to the
         # right reader.
         super(AlignTraj, self).__init__(mobile.trajectory, **kwargs)
-        if self._quiet:
+        if not self._verbose:
             logging.disable(logging.WARN)
 
         # store reference to mobile atoms
@@ -606,7 +606,7 @@ class AlignTraj(AnalysisBase):
 
     def _conclude(self):
         self._writer.close()
-        if self._quiet:
+        if not self._verbose:
             logging.disable(logging.NOTSET)
 
     def save(self, rmsdfile):
@@ -630,7 +630,8 @@ def rms_fit_trj(
         tol_mass=0.1,
         strict=False,
         force=True,
-        quiet=False,
+        verbose=None,
+        quiet=None,
         in_memory=False,
         **kwargs):
     """RMS-fit trajectory to a reference structure using a selection.
@@ -680,9 +681,9 @@ def rms_fit_trj(
       *force*
          - ``True``: Overwrite an existing output trajectory (default)
          - ``False``: simply return if the file already exists
-      *quiet*
-         - ``True``: suppress progress and logging for levels INFO and below.
-         - ``False``: show all status messages and do not change the the logging
+      *verbose*
+         - ``False``: suppress progress and logging for levels INFO and below.
+         - ``True``: show all status messages and do not change the the logging
            level (default)
       *in_memory*
          Default: ``False``
@@ -710,9 +711,13 @@ def rms_fit_trj(
        and new *strict* keyword. The new default is to be lenient whereas
        the old behavior was the equivalent of *strict* = ``True``.
 
+    .. deprecated:: 0.16::
+       The keyword argument *quiet* is deprecated in vafor of *verbose*.
+
     """
     frames = traj.trajectory
-    if quiet:
+    verbose = _set_verbose(verbose, quiet, default=True)
+    if not verbose:
         # should be part of a try ... finally to guarantee restoring the log
         # level
         logging.disable(logging.WARN)
@@ -771,7 +776,7 @@ def rms_fit_trj(
     percentage = ProgressMeter(
         n_frames,
         interval=10,
-        quiet=quiet,
+        verbose=verbose,
         format="Fitted frame %(step)5d/%(numsteps)d  [%(percentage)5.1f%%]      r")
 
     for k, ts in enumerate(frames):
@@ -806,7 +811,7 @@ def rms_fit_trj(
         np.savetxt(rmsdfile, rmsd)
         logger.info("Wrote RMSD timeseries  to file %r", rmsdfile)
 
-    if quiet:
+    if not verbose:
         # should be part of a try ... finally to guarantee restoring the log
         # level
         logging.disable(logging.NOTSET)

--- a/package/MDAnalysis/analysis/base.py
+++ b/package/MDAnalysis/analysis/base.py
@@ -36,7 +36,7 @@ import six
 
 from MDAnalysis import coordinates
 from MDAnalysis.core.groups import AtomGroup
-from MDAnalysis.lib.log import ProgressMeter
+from MDAnalysis.lib.log import ProgressMeter, _set_verbose
 
 logger = logging.getLogger(__name__)
 
@@ -90,7 +90,7 @@ class AnalysisBase(object):
     """
 
     def __init__(self, trajectory, start=None,
-                 stop=None, step=None, quiet=True):
+                 stop=None, step=None, verbose=None, quiet=None):
         """
         Parameters
         ----------
@@ -102,10 +102,11 @@ class AnalysisBase(object):
             stop frame of analysis
         step : int, optional
             number of frames to skip between each analysed frame
-        quiet : bool, optional
-            Turn off verbosity
+        verbose : bool, optional
+            Turn on verbosity
         """
-        self._quiet = quiet
+        self._verbose = _set_verbose(verbose, quiet, default=False)
+        self._quiet = not self._verbose
         self._setup_frames(trajectory, start, stop, step)
 
     def _setup_frames(self, trajectory, start=None, stop=None, step=None):
@@ -134,12 +135,19 @@ class AnalysisBase(object):
         if interval == 0:
             interval = 1
 
-        # ensure _quiet is set when __init__ wasn't called, this is to not
+        # ensure _verbose is set when __init__ wasn't called, this is to not
         # break pre 0.16.0 API usage of AnalysisBase
-        if not hasattr(self, '_quiet'):
-            self._quiet = True
+        if not hasattr(self, '_verbose'):
+            if hasattr(self, '_quiet'):
+                # Here, we are in the odd case where a children class defined
+                # self._quiet without going through AnalysisBase.__init__.
+                # Shall we issue a DeprecationWarning?
+                self._verbose = not self._quiet
+            else:
+                self._verbose = True
+                self._quiet = not self._verbose
         self._pm = ProgressMeter(self.n_frames if self.n_frames else 1,
-                                 interval=interval, quiet=self._quiet)
+                                 interval=interval, verbose=self._verbose)
 
     def _single_frame(self):
         """Calculate data from a single frame of trajectory

--- a/package/MDAnalysis/analysis/base.py
+++ b/package/MDAnalysis/analysis/base.py
@@ -141,7 +141,9 @@ class AnalysisBase(object):
             if hasattr(self, '_quiet'):
                 # Here, we are in the odd case where a children class defined
                 # self._quiet without going through AnalysisBase.__init__.
-                # Shall we issue a DeprecationWarning?
+                warnings.warn("The *_quiet* attribute of analyses is "
+                              "deprecated (from 0.16)use *_verbose* instead.",
+                              DeprecationWarning)
                 self._verbose = not self._quiet
             else:
                 self._verbose = True

--- a/package/MDAnalysis/analysis/density.py
+++ b/package/MDAnalysis/analysis/density.py
@@ -399,7 +399,7 @@ def density_from_Universe(universe, delta=1.0, atomselection='name OH2',
                           start=None, stop=None, step=None,
                           metadata=None, padding=2.0, cutoff=0, soluteselection=None,
                           use_kdtree=True, update_selection=False,
-                          quiet=False, interval=1,
+                          verbose=None, quiet=None, interval=1,
                           **kwargs):
     """Create a density grid from a :class:`MDAnalysis.Universe` object.
 
@@ -444,10 +444,10 @@ def density_from_Universe(universe, delta=1.0, atomselection='name OH2',
             Should the selection of atoms be updated for every step? [``False``]
             - ``True``: atom selection is updated for each frame, can be slow
             - ``False``: atoms are only selected at the beginning
-      quiet
-            Print status update to the screen for every *interval* frame? [``False``]
-            - ``True``: no status updates when a new frame is processed
-            - ``False``: status update every frame (including number of atoms
+      verbose
+            Print status update to the screen for every *interval* frame? [``True``]
+            - ``False``: no status updates when a new frame is processed
+            - ``True``: status update every frame (including number of atoms
               processed, which is interesting with ``update_selection=True``)
       interval
            Show status update every *interval* frame [1]
@@ -460,6 +460,9 @@ def density_from_Universe(universe, delta=1.0, atomselection='name OH2',
 
     .. versionchanged:: 0.13.0
        *update_selection* and *quite* keywords added
+
+    .. deprecated:: 0.16
+       The keyword argument *quiet* is deprecated in favor of *verbose*.
 
     """
     try:
@@ -510,7 +513,8 @@ def density_from_Universe(universe, delta=1.0, atomselection='name OH2',
     grid *= 0.0
     h = grid.copy()
 
-    pm = ProgressMeter(u.trajectory.n_frames, interval=interval, quiet=quiet,
+    pm = ProgressMeter(u.trajectory.n_frames, interval=interval,
+                       verbose=verbose, quiet=quiet,
                        format="Histogramming %(n_atoms)6d atoms in frame "
                        "%(step)5d/%(numsteps)d  [%(percentage)5.1f%%]\r")
     start, stop, step = u.trajectory.check_slice_indices(start, stop, step)

--- a/package/MDAnalysis/analysis/density.py
+++ b/package/MDAnalysis/analysis/density.py
@@ -399,7 +399,7 @@ def density_from_Universe(universe, delta=1.0, atomselection='name OH2',
                           start=None, stop=None, step=None,
                           metadata=None, padding=2.0, cutoff=0, soluteselection=None,
                           use_kdtree=True, update_selection=False,
-                          verbose=None, quiet=None, interval=1,
+                          verbose=None, interval=1, quiet=None,
                           **kwargs):
     """Create a density grid from a :class:`MDAnalysis.Universe` object.
 

--- a/package/MDAnalysis/analysis/helanal.py
+++ b/package/MDAnalysis/analysis/helanal.py
@@ -124,7 +124,7 @@ import numpy as np
 
 import MDAnalysis
 from MDAnalysis import FinishTimeException
-from MDAnalysis.lib.log import ProgressMeter
+from MDAnalysis.lib.log import ProgressMeter, _set_verbose
 from MDAnalysis.lib import mdamath
 
 import logging
@@ -157,12 +157,18 @@ def mean_abs_dev(a, mean_a=None):
         mean_a = np.mean(a)
     return np.mean(np.fabs(a - mean_a))
 
-def helanal_trajectory(universe, selection="name CA", start=None, end=None, begin=None, finish=None,
-                       matrix_filename="bending_matrix.dat", origin_pdbfile="origin.pdb",
-                       summary_filename="summary.txt", screw_filename="screw.xvg",
-                       tilt_filename="local_tilt.xvg", fitted_tilt_filename="fit_tilt.xvg",
-                       bend_filename="local_bend.xvg", twist_filename="unit_twist.xvg",
-                       prefix="helanal_", ref_axis=None, quiet=False):
+def helanal_trajectory(universe, selection="name CA",
+                       start=None, end=None, begin=None, finish=None,
+                       matrix_filename="bending_matrix.dat",
+                       origin_pdbfile="origin.pdb",
+                       summary_filename="summary.txt",
+                       screw_filename="screw.xvg",
+                       tilt_filename="local_tilt.xvg",
+                       fitted_tilt_filename="fit_tilt.xvg",
+                       bend_filename="local_bend.xvg",
+                       twist_filename="unit_twist.xvg",
+                       prefix="helanal_", ref_axis=None,
+                       verbose=None, quiet=None):
     """Perform HELANAL_ helix analysis on all frames in *universe*.
 
     .. Note::
@@ -211,8 +217,8 @@ def helanal_trajectory(universe, selection="name CA", start=None, end=None, begi
        *ref_axis*
           Calculate tilt angle relative to the axis; if ``None`` then ``[0,0,1]``
           is chosen [``None``]
-       *quiet*
-          Suppress most diagnostic output.
+       *verbose*
+          Toggle diagnostic outputs. [``True``]
 
     :Raises:
        FinishTimeException
@@ -223,7 +229,12 @@ def helanal_trajectory(universe, selection="name CA", start=None, end=None, begi
        New *quiet* keyword to silence frame progress output and most of the
        output that used to be printed to stdout is now logged to the logger
        *MDAnalysis.analysis.helanal* (at logelevel *INFO*).
+
+    .. deprecated:: 0.16
+       The *quiet* keyword argument is deprecated in favor of the New
+       *verbose* one.
     """
+    verbose = _set_verbose(verbose, quiet, default=True)
     if ref_axis is None:
         ref_axis = np.array([0., 0., 1.])
     else:
@@ -284,7 +295,7 @@ def helanal_trajectory(universe, selection="name CA", start=None, end=None, begi
     global_fitted_tilts = []
     global_screw = []
 
-    pm = ProgressMeter(trajectory.n_frames, quiet=quiet,
+    pm = ProgressMeter(trajectory.n_frames, verbose=verbose,
                        format="Frame %(step)10d: %(time)20.1f ps\r")
     for ts in trajectory:
         pm.echo(ts.frame, time=ts.time)

--- a/package/MDAnalysis/analysis/pca.py
+++ b/package/MDAnalysis/analysis/pca.py
@@ -225,7 +225,7 @@ class PCA(AnalysisBase):
             format = ("Mean Calculation Step"
                       "%(step)5d/%(numsteps)d [%(percentage)5.1f%%]\r")
             mean_pm = ProgressMeter(self.n_frames if self.n_frames else 1,
-                                    interval=interval, quiet=self._quiet,
+                                    interval=interval, verbose=self._verbose,
                                     format=format)
             for i, ts in enumerate(self._u.trajectory[self.start:self.stop:
                                                       self.step]):

--- a/package/MDAnalysis/analysis/waterdynamics.py
+++ b/package/MDAnalysis/analysis/waterdynamics.py
@@ -379,6 +379,7 @@ import numpy as np
 import multiprocessing
 
 import MDAnalysis.analysis.hbonds
+from MDAnalysis.lib.log import _set_verbose
 
 
 class HydrogenBondLifetimes(object):
@@ -545,10 +546,12 @@ class HydrogenBondLifetimes(object):
             a.append(fix)
         return a
 
-    def _HBA(self, ts, conn, universe, selAtom1, selAtom2, quiet=True):
+    def _HBA(self, ts, conn, universe, selAtom1, selAtom2,
+             verbose=None, quiet=None):
         """
         Main function for calculate C_i and C_c in parallel.
         """
+        verbose = _set_verbose(verbose, quiet, default=False)
         finalGetResidue1 = selAtom1
         finalGetResidue2 = selAtom2
         frame = ts.frame
@@ -557,7 +560,7 @@ class HydrogenBondLifetimes(object):
                                                             start=frame-1, stop=frame)
         while True:
             try:
-                h.run(quiet=quiet)
+                h.run(verbose=verbose)
                 break
             except:
                 print("error")

--- a/package/MDAnalysis/coordinates/memory.py
+++ b/package/MDAnalysis/coordinates/memory.py
@@ -80,7 +80,7 @@ of a :class:`~MDAnalysis.core.universe.Universe`::
     universe = mda.Universe(TPR, XTC)
     universe.transfer_to_memory()
 
-This operation may take a while (with `quiet=False` a progress bar is
+This operation may take a while (with `verbose=True` a progress bar is
 displayed) but then subsequent operations on the trajectory directly
 operate on the in-memory array and will be very fast.
 

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -60,7 +60,7 @@ import copy
 import MDAnalysis
 from ..lib import util
 from ..lib.util import cached
-from ..lib.log import ProgressMeter
+from ..lib.log import ProgressMeter, _set_verbose
 from ..exceptions import NoDataError
 from . import groups
 from .groups import (GroupBase, Atom, Residue, Segment,
@@ -374,7 +374,7 @@ class Universe(object):
 
         return filename, self.trajectory.format
 
-    def transfer_to_memory(self, frame_interval=1, quiet=True):
+    def transfer_to_memory(self, frame_interval=1, verbose=None, quiet=None):
         """Transfer the trajectory to in memory representation.
 
         Replaces the current trajectory reader object with one of type
@@ -385,14 +385,16 @@ class Universe(object):
         ----------
         frame_interval : int, optional
             Read in every nth frame. [1]
-        quiet : bool, optional
+        verbose : bool, optional
             Will print the progress of loading trajectory to memory, if
-            set to True. Default value is quiet.
+            set to True. Default value is False.
 
 
         .. versionadded:: 0.16.0
         """
         from ..coordinates.memory import MemoryReader
+
+        verbose = _set_verbose(verbose, quiet, default=False)
 
         if not isinstance(self.trajectory, MemoryReader):
             # Try to extract coordinates using Timeseries object
@@ -405,7 +407,7 @@ class Universe(object):
             # fall back to a slower approach
             except AttributeError:
                 pm = ProgressMeter(self.trajectory.n_frames,
-                                   interval=frame_interval, quiet=quiet)
+                                   interval=frame_interval, verbose=verbose)
                 coordinates = []  # TODO: use pre-allocated array
                 for ts in self.trajectory[::frame_interval]:
                     coordinates.append(np.copy(ts.positions))

--- a/package/MDAnalysis/lib/log.py
+++ b/package/MDAnalysis/lib/log.py
@@ -235,7 +235,7 @@ def _set_verbose(verbose, quiet, default=True):
     expected to be used as follow:
 
     .. code-block:: python
-       
+
        def method(verbose=None, quiet=None):
            # *verbose* and *quiet* are set to None to distinguish explicitly
            # set values.
@@ -254,7 +254,7 @@ def _set_verbose(verbose, quiet, default=True):
         warnings.warn("Keyword *quiet* is deprecated (from version 0.16); "
                       "use *verbose* instead.", DeprecationWarning)
         if verbose is not None and verbose == quiet:
-            raise ValueError("Keywords *verbose* and *quiet* are cotradicting each other.")
+            raise ValueError("Keywords *verbose* and *quiet* are contradicting each other.")
         return not quiet
     elif verbose is None:
         return default

--- a/package/MDAnalysis/lib/log.py
+++ b/package/MDAnalysis/lib/log.py
@@ -216,7 +216,8 @@ def _guess_string_format(template):
         return _legacy_format
 
 
-def _set_verbose(verbose, quiet, default=True):
+def _set_verbose(verbose, quiet, default=True,
+                 was='quiet', now='verbose'):
     """Return the expected value of verbosity
 
     This function aims at handling the deprecation of the *quiet* keyword in
@@ -249,12 +250,18 @@ def _set_verbose(verbose, quiet, default=True):
            # The *quiet* keyword disapeard and the default value for *verbose*
            # is set to the actual default value.
            self.verbose = verbose
+
+    In `MDAnalysis.analysis.hbonds.hbonds_analysis`, the deprecation scheme is
+    more complex: *quiet* becomes *verbose*, and *verbose* becomes *debug*.
+    Hence, this function allows to use diffrent argument names to display in
+    error messages and deprecation warnings.
     """
     if quiet is not None:
-        warnings.warn("Keyword *quiet* is deprecated (from version 0.16); "
-                      "use *verbose* instead.", DeprecationWarning)
+        warnings.warn("Keyword *{}* is deprecated (from version 0.16); "
+                      "use *{}* instead.".format(was, now), DeprecationWarning)
         if verbose is not None and verbose == quiet:
-            raise ValueError("Keywords *verbose* and *quiet* are contradicting each other.")
+            raise ValueError("Keywords *{}* and *{}* are contradicting each other."
+                             .format(now, was))
         return not quiet
     elif verbose is None:
         return default

--- a/package/MDAnalysis/lib/log.py
+++ b/package/MDAnalysis/lib/log.py
@@ -216,6 +216,52 @@ def _guess_string_format(template):
         return _legacy_format
 
 
+def _set_verbose(verbose, quiet, default=True):
+    """Return the expected value of verbosity
+
+    This function aims at handling the deprecation of the *quiet* keyword in
+    versin 0.16.
+
+    This function issues a deprecation warning if *quiet* was set (is not
+    None), and raises a ValueError if *verbose* and *quiet* are set to
+    contradicting values.
+
+    If *verbose* is set, then the function returns the set value of *verbose*.
+    If it is not set, but *quiet* is set, then the function returns
+    `not quiet`. Finally, if none of *verbose* nor *quiet* is set, then
+    *default* is returned.
+
+    During the deprecation phase of the *quiet* keyword, this function is
+    expected to be used as follow:
+
+    .. code-block:: python
+       
+       def method(verbose=None, quiet=None):
+           # *verbose* and *quiet* are set to None to distinguish explicitly
+           # set values.
+           self.verbose = _set_verbose(verbose, quiet, default=True)
+
+    At the end of the deprecation period, the code above should be replaced by:
+
+    .. code-block:: python
+
+       def method(verbose=True):
+           # The *quiet* keyword disapeard and the default value for *verbose*
+           # is set to the actual default value.
+           self.verbose = verbose
+    """
+    if quiet is not None:
+        warnings.warn("Keyword *quiet* is deprecated (from version 0.16); "
+                      "use *verbose* instead.", DeprecationWarning)
+        if verbose is not None and verbose == quiet:
+            raise ValueError("Keywords *verbose* and *quiet* are cotradicting each other.")
+        return not quiet
+    elif verbose is None:
+        return default
+    else:
+        return verbose
+
+
 class ProgressMeter(object):
     r"""Simple progress meter
 
@@ -318,22 +364,8 @@ class ProgressMeter(object):
         self.dynamic = dynamic
         self.numouts = -1
 
-        # *verbose* is effectively True by default. *quiet* is deprecated.
-        # If *quiet* is set, then a deprecation warning is raised. If both
-        # *quiet* and *verbose* are set, and they are contradicting each other,
-        # a ValueError is raised.
-        # *verbose* and *quiet* are set to None by default to distinguish the
-        # defaults from user-provided values.
-        if quiet is not None:
-            warnings.warn("Keyword *quiet* is deprecated (from version 0.16); "
-                          "use *verbose* instead.", DeprecationWarning)
-            if verbose is not None and verbose == quiet:
-                raise ValueError("Keywords *verbose* and *quiet* are cotradicting each other.")
-            self.verbose = not quiet
-        elif verbose is None:
-            self.verbose = True  # Effective default
-        else:
-            self.verbose = verbose
+        # The *quiet* keyword argument is deprecated.
+        self.verbose = _set_verbose(verbose, quiet, default=True)
 
         if format is None:
             format = "Step {step:5d}/{numsteps} [{percentage:5.1f}%]"

--- a/package/MDAnalysis/lib/log.py
+++ b/package/MDAnalysis/lib/log.py
@@ -307,8 +307,8 @@ class ProgressMeter(object):
     """
 
     def __init__(self, numsteps, format=None, interval=10, offset=1,
-                 verbose=None, quiet=None, dynamic=True,
-                 format_handling='auto'):
+                 verbose=None, dynamic=True,
+                 format_handling='auto', quiet=None):
         r"""
         Parameters
         ==========

--- a/testsuite/MDAnalysisTests/analysis/test_align.py
+++ b/testsuite/MDAnalysisTests/analysis/test_align.py
@@ -126,7 +126,7 @@ class TestAlign(TestCase):
         # align to *last frame* in target... just for the heck of it
         self.reference.trajectory[-1]
         align.rms_fit_trj(self.universe, self.reference, select="all",
-                          filename=self.outfile, quiet=True)
+                          filename=self.outfile, verbose=False)
         fitted = MDAnalysis.Universe(PSF, self.outfile)
         # RMSD against the reference frame
         # calculated on Mac OS X x86 with MDA 0.7.2 r689
@@ -147,7 +147,7 @@ class TestAlign(TestCase):
                     os.path.basename(self.universe.trajectory.filename)))
             #test filename=none and different selection
             align.rms_fit_trj(self.universe, self.reference, select="name CA",
-                              filename=None, quiet=True)
+                              filename=None, verbose=False)
             assert_(os.path.exists(filename),
                     "rms_fit_trj did not write to {}".format(filename))
 

--- a/testsuite/MDAnalysisTests/analysis/test_base.py
+++ b/testsuite/MDAnalysisTests/analysis/test_base.py
@@ -90,8 +90,9 @@ class TestAnalysisBase(object):
         assert_equal(an.n_frames, 5)
         assert_equal(an.frames, list(range(98))[::20])
 
-    def test_quiet(self):
-        a = FrameAnalysis(self.u.trajectory, quiet=False)
+    def test_verbose(self):
+        a = FrameAnalysis(self.u.trajectory, verbose=True)
+        assert_(a._verbose)
         assert_(not a._quiet)
 
     @raises(NotImplementedError)
@@ -118,11 +119,12 @@ def test_filter_baseanalysis_kwargs():
     assert_equal(1, len(kwargs))
     assert_equal(kwargs['foo'], None)
 
-    assert_equal(4, len(base_kwargs))
+    assert_equal(5, len(base_kwargs))
     assert_equal(base_kwargs['start'], None)
     assert_equal(base_kwargs['step'], 3)
     assert_equal(base_kwargs['stop'], None)
-    assert_equal(base_kwargs['quiet'], True)
+    assert_equal(base_kwargs['quiet'], None)
+    assert_equal(base_kwargs['verbose'], None)
 
 
 def simple_function(mobile):

--- a/testsuite/MDAnalysisTests/analysis/test_hbonds.py
+++ b/testsuite/MDAnalysisTests/analysis/test_hbonds.py
@@ -62,7 +62,7 @@ class TestHydrogenBondAnalysis(object):
         kw = self.kwargs.copy()
         kw.update(kwargs)
         h = MDAnalysis.analysis.hbonds.HydrogenBondAnalysis(self.universe, **kw)
-        h.run(quiet=True)
+        h.run(verbose=False)
         return h
 
     def test_helix_backbone(self):
@@ -156,7 +156,7 @@ class TestHydrogenBondAnalysisChecking(object):
             # ignore SelectionWarning
             warnings.simplefilter("ignore")
             h = MDAnalysis.analysis.hbonds.HydrogenBondAnalysis(self.universe, **kw)
-            h.run(quiet=True)
+            h.run(verbose=False)
         return h
 
     def test_check_static_selections(self):

--- a/testsuite/MDAnalysisTests/analysis/test_rms.py
+++ b/testsuite/MDAnalysisTests/analysis/test_rms.py
@@ -157,7 +157,7 @@ class TestRMSD(object):
         del self.tempdir
 
     def test_progress_meter(self):
-        RMSD = MDAnalysis.analysis.rms.RMSD(self.universe, quiet=False)
+        RMSD = MDAnalysis.analysis.rms.RMSD(self.universe, verbose=True)
         sys.stderr = sys.stdout
         RMSD.run()
         actual = sys.stderr.getvalue().strip().split('\r')[-1]
@@ -239,7 +239,7 @@ class TestRMSF(TestCase):
 
     def test_rmsf(self):
         rmsfs = MDAnalysis.analysis.rms.RMSF(self.universe.select_atoms('name CA'))
-        rmsfs.run(quiet=True)
+        rmsfs.run(verbose=False)
         test_rmsfs = np.load(rmsfArray)
 
         assert_almost_equal(rmsfs.rmsf, test_rmsfs, 5,
@@ -248,7 +248,7 @@ class TestRMSF(TestCase):
 
     def test_rmsf_single_frame(self):
         rmsfs = MDAnalysis.analysis.rms.RMSF(self.universe.select_atoms('name CA'))
-        rmsfs.run(start=5, stop=6, quiet=True)
+        rmsfs.run(start=5, stop=6, verbose=False)
 
         assert_almost_equal(rmsfs.rmsf, 0, 5,
                             err_msg="error: rmsfs should all be zero")
@@ -261,7 +261,7 @@ class TestRMSF(TestCase):
 
         self.universe = MDAnalysis.Universe(GRO, self.outfile)
         rmsfs = MDAnalysis.analysis.rms.RMSF(self.universe.select_atoms('name CA'))
-        rmsfs.run(quiet=True)
+        rmsfs.run(verbose=False)
 
         assert_almost_equal(rmsfs.rmsf, 0, 5,
                             err_msg="error: rmsfs should all be 0")

--- a/testsuite/MDAnalysisTests/analysis/test_waterdynamics.py
+++ b/testsuite/MDAnalysisTests/analysis/test_waterdynamics.py
@@ -40,25 +40,25 @@ class TestWaterdynamics(TestCase):
 
     def test_HydrogenBondLifetimes(self):
         hbl = MDAnalysis.analysis.waterdynamics.HydrogenBondLifetimes(self.universe, self.selection1, self.selection2, 0, 5, 3)
-        hbl.run(quiet=True)
+        hbl.run(verbose=False)
         assert_equal(round(hbl.timeseries[2][1],5), 0.75)
 
     def test_WaterOrientationalRelaxation(self):
         wor = MDAnalysis.analysis.waterdynamics.WaterOrientationalRelaxation(self.universe, self.selection1, 0, 5, 2)
-        wor.run(quiet=True)
+        wor.run(verbose=False)
         assert_equal(round(wor.timeseries[1][2],5), 0.35887)
 
     def test_AngularDistribution(self):
         ad = MDAnalysis.analysis.waterdynamics.AngularDistribution(self.universe,self.selection1,40)
-        ad.run(quiet=True)
+        ad.run(verbose=False)
         assert_equal(str(ad.graph[0][39]), str("0.951172947884 0.48313682125") )
 
     def test_MeanSquareDisplacement(self):
         msd = MDAnalysis.analysis.waterdynamics.MeanSquareDisplacement(self.universe, self.selection1, 0, 10, 2)
-        msd.run(quiet=True)
+        msd.run(verbose=False)
         assert_equal(round(msd.timeseries[1],5), 0.03984)
 
     def test_SurvivalProbability(self):
         sp = MDAnalysis.analysis.waterdynamics.SurvivalProbability(self.universe, self.selection1, 0, 6, 3)
-        sp.run(quiet=True)
+        sp.run(verbose=False)
         assert_equal(round(sp.timeseries[1],5), 1.0)

--- a/testsuite/MDAnalysisTests/test_log.py
+++ b/testsuite/MDAnalysisTests/test_log.py
@@ -159,24 +159,24 @@ class TestProgressMeter(TestCase):
 
 def test__set_verbose():
     # Everything agrees verbose should be True
-    assert_equal(_set_verbose(True, False, True), True)
+    assert_equal(_set_verbose(verbose=True, quiet=False, default=True), True)
     # Everything agrees verbose should be False
-    assert_equal(_set_verbose(False, True, False), False)
+    assert_equal(_set_verbose(verbose=False, quiet=True, default=False), False)
     # Make sure the default does not overwrite the user choice
-    assert_equal(_set_verbose(True, False, False), True)
-    assert_equal(_set_verbose(False, True, True), False)
+    assert_equal(_set_verbose(verbose=True, quiet=False, default=False), True)
+    assert_equal(_set_verbose(verbose=False, quiet=True, default=True), False)
     # Quiet is not provided
-    assert_equal(_set_verbose(True, None, False), True)
-    assert_equal(_set_verbose(False, None, False), False)
+    assert_equal(_set_verbose(verbose=True, quiet=None, default=False), True)
+    assert_equal(_set_verbose(verbose=False, quiet=None, default=False), False)
     # Verbose is not provided
-    assert_equal(_set_verbose(None, True, False), False)
-    assert_equal(_set_verbose(None, False, False), True)
+    assert_equal(_set_verbose(verbose=None, quiet=True, default=False), False)
+    assert_equal(_set_verbose(verbose=None, quiet=False, default=False), True)
     # Nothing is provided
-    assert_equal(_set_verbose(None, None, True), True)
-    assert_equal(_set_verbose(None, None, False), False)
+    assert_equal(_set_verbose(verbose=None, quiet=None, default=True), True)
+    assert_equal(_set_verbose(verbose=None, quiet=None, default=False), False)
     # quiet and verbose contradict each other
-    assert_raises(ValueError, _set_verbose, True, True)
-    assert_raises(ValueError, _set_verbose, False, False)
+    assert_raises(ValueError, _set_verbose, verbose=True, quiet=True)
+    assert_raises(ValueError, _set_verbose, verbose=False, quiet=False)
     # A deprecation warning is issued when quiet is set
-    assert_warns(DeprecationWarning, _set_verbose, None, True)
-    assert_warns(DeprecationWarning, _set_verbose, False, True)
+    assert_warns(DeprecationWarning, _set_verbose, verbose=None, quiet=True)
+    assert_warns(DeprecationWarning, _set_verbose, verbose=False, quiet=True)

--- a/testsuite/MDAnalysisTests/test_log.py
+++ b/testsuite/MDAnalysisTests/test_log.py
@@ -26,13 +26,16 @@ from six.moves import StringIO
 import sys
 import os
 import logging
+import warnings
 
-from numpy.testing import TestCase, assert_
+from numpy.testing import (TestCase, assert_, assert_equal,
+                           assert_raises, assert_warns)
 
 from six.moves import range
 
 import MDAnalysis
 import MDAnalysis.lib.log
+from MDAnalysis.lib.log import _set_verbose
 
 from MDAnalysisTests import tempdir
 
@@ -153,3 +156,27 @@ class TestProgressMeter(TestCase):
         self._assert_in(output, (format + '\n').format(**{'step': 1, 'numsteps': n, 'percentage': 100./n}))
         self._assert_in(output, (format + '\n').format(**{'step': n, 'numsteps': n, 'percentage': 100.}))
 
+
+def test__set_verbose():
+    # Everything agrees verbose should be True
+    assert_equal(_set_verbose(True, False, True), True)
+    # Everything agrees verbose should be False
+    assert_equal(_set_verbose(False, True, False), False)
+    # Make sure the default does not overwrite the user choice
+    assert_equal(_set_verbose(True, False, False), True)
+    assert_equal(_set_verbose(False, True, True), False)
+    # Quiet is not provided
+    assert_equal(_set_verbose(True, None, False), True)
+    assert_equal(_set_verbose(False, None, False), False)
+    # Verbose is not provided
+    assert_equal(_set_verbose(None, True, False), False)
+    assert_equal(_set_verbose(None, False, False), True)
+    # Nothing is provided
+    assert_equal(_set_verbose(None, None, True), True)
+    assert_equal(_set_verbose(None, None, False), False)
+    # quiet and verbose contradict each other
+    assert_raises(ValueError, _set_verbose, True, True)
+    assert_raises(ValueError, _set_verbose, False, False)
+    # A deprecation warning is issued when quiet is set
+    assert_warns(DeprecationWarning, _set_verbose, None, True)
+    assert_warns(DeprecationWarning, _set_verbose, False, True)


### PR DESCRIPTION
Fixes #903 

Changes made in this Pull Request:
 - Deprecate the *quiet* keyword argument in favor of *verbose* throughout the library.

I did not deprecate quiet in analysis/hbond_analysis.py because the verbose keyword argument is already in use. The module decouple the verbosity and the progress meter unlike the other analyses. I do not know what to do there.

One case that does not issue a deprecation warning, but maybe should, is when an object refers to `self._quiet`. Since the attribute is not documented in the API, I did not deprecate it.


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
