### PR TITLE
raise error if shape isn't equal in rotation_matrix

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -82,6 +82,7 @@ Fixes
   * Fixed NCDFWriter wrote velocities instead of forces if
     convert_units=False was set: now correctly writes forces (PR #1113)
   * Fixed warn about missing cython package in dev builds
+  * Fix align.rotation_matrix checks array shape equality (Issue #1152)
 
 Changes
   * Started unifying the API of analysis classes (named internally

--- a/package/MDAnalysis/analysis/align.py
+++ b/package/MDAnalysis/analysis/align.py
@@ -254,6 +254,10 @@ def rotation_matrix(a, b, weights=None):
 
     a = np.asarray(a, dtype=np.float64)
     b = np.asarray(b, dtype=np.float64)
+
+    if a.shape != b.shape:
+        raise ValueError("'a' and 'b' must have same shape")
+
     N = b.shape[0]
 
     if weights is not None:

--- a/testsuite/MDAnalysisTests/analysis/test_align.py
+++ b/testsuite/MDAnalysisTests/analysis/test_align.py
@@ -75,6 +75,16 @@ class TestRotationMatrix(object):
         assert_equal(rot, np.eye(3))
         assert_equal(rmsd, None)
 
+    @staticmethod
+    def test_exception():
+        a = [[0.1, 0.2, 0.3],
+             [1.1, 1.1, 1.1],
+             [2, 2, 2]]
+        b = [[0.1, 0.1, 0.1],
+             [1.1, 1.1, 1.1]]
+        assert_raises(ValueError, align.rotation_matrix, a, b)
+
+
 
 class TestAlign(TestCase):
     @dec.skipif(parser_not_found('DCD'),


### PR DESCRIPTION
Fixes #1152

Changes made in this Pull Request:
 - error is raised if shapes don't match


PR Checklist
------------
 - [x] Tests?
 ~~- [x] Docs?~~
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
