### PR TITLE
lib.util.Namespace raises the expected exception

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -91,6 +91,8 @@ Fixes
   * Fixed selections using operators backwards ('prop 10 > mass') and sensitivity
     about whitespace around these (PR #1156 Issue #1011 #1009)
   * Fixed PSA analysis is now using AlignTraj
+  * The namespace used for auxiliary data now raises an AttributeError instead
+    of a KeyError when accessing data by attributes (Issue #1166)
 
 Changes
   * Started unifying the API of analysis classes (named internally

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -91,8 +91,6 @@ Fixes
   * Fixed selections using operators backwards ('prop 10 > mass') and sensitivity
     about whitespace around these (PR #1156 Issue #1011 #1009)
   * Fixed PSA analysis is now using AlignTraj
-  * The namespace used for auxiliary data now raises an AttributeError instead
-    of a KeyError when accessing data by attributes (Issue #1166)
 
 Changes
   * Started unifying the API of analysis classes (named internally

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -1335,12 +1335,27 @@ class Namespace(object):
     """Class to allow storing attributes in new namespace. """
     def __getattr__(self, key):
         # a.this causes a __getattr__ call for key = 'this'
-        return self.__dict__[key]
+        try:
+            return self.__dict__[key]
+        except KeyError:
+            raise AttributeError('"{}" is not known in the namespace.'
+                                 .format(key))
+
     def __setattr__(self, key, value):
         # a.this = 10 causes a __setattr__ call for key='this' value=10
-        self.__dict__[key] = value
+        try:
+            self.__dict__[key] = value
+        except KeyError:
+            raise AttributeError('"{}" is not known in the namespace.'
+                                 .format(key))
+
     def __delattr__(self, key):
-        del self.__dict__[key]
+        try:
+            del self.__dict__[key]
+        except KeyError:
+            raise AttributeError('"{}" is not known in the namespace.'
+                                 .format(key))
+
     def __eq__(self, other):
         try:
             # this'll allow us to compare if we're storing arrays
@@ -1348,12 +1363,16 @@ class Namespace(object):
         except AssertionError:
             return False
         return True
+
     def __str__(self):
         return str(self.__dict__)
+
     def __len__(self):
         return len(self.__dict__)
+
     def __getitem__(self, key):
         return self.__dict__[key]
+
     def __iter__(self):
         for i in self.__dict__:
             yield i

--- a/testsuite/MDAnalysisTests/coordinates/base.py
+++ b/testsuite/MDAnalysisTests/coordinates/base.py
@@ -293,7 +293,7 @@ class BaseReaderTest(object):
     def test_remove_auxiliary(self):
         self.reader.remove_auxiliary('lowf')
         assert_raises(AttributeError, getattr, self.reader._auxs, 'lowf')
-        assert_raises(KeyError, getattr, self.reader.ts.aux, 'lowf')
+        assert_raises(AttributeError, getattr, self.reader.ts.aux, 'lowf')
 
     @raises(ValueError)
     def test_remove_nonexistant_auxiliary_raises_ValueError(self):
@@ -344,7 +344,7 @@ class BaseReaderTest(object):
         assert_equal(self.reader.ts.aux.lowf_renamed,
                      self.ref.aux_lowf_data[0])
         # old name should be removed
-        assert_raises(KeyError, getattr, self.reader.ts.aux, 'lowf')
+        assert_raises(AttributeError, getattr, self.reader.ts.aux, 'lowf')
         # new name should be retained
         next(self.reader)
         assert_equal(self.reader.ts.aux.lowf_renamed,


### PR DESCRIPTION
`lib.util.Namespace` allows to query a namespace by index or by
attribute. It allows to use both the following syntaxes to access the
same element:

    ns = lib.util.Namespace()
    ns['key'] = 'plop'

    ns['key']  # Access by index
    ns.key  # Access by attribute

The class is used to permit some flexibility when accessing auxiliary
data attached to trajectories.

Prior to this commit, accessing a non-existing item from a namespace by
attribute would raise a KeyError while an AttributeError should be
raise. This breaks functions that test the features of an object by
looking for some attributes, and are therefore capturing AttributeError
as a sign the attribute is missing.

In particular, raising the wrong exception confused
`numpy.lib.type_check.iscomplexobj` in numpy 1.12.0. This confusion lead
to `assert_equal` to miss behave in that version of numpy, therefore
breaking the tests for MDAnalysis when upgrading from python 1.11.3 to
1.12.0.

This commit makes sure that the expected exception is raised when
accessing an non-existing item by attribute in a Namespace object.

Adresses part of #1166

PR Checklist
------------
 - [x] Tests?
 - ~~[ ] Docs?~~
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
