### PR TITLE
MOL2 parser stores bond order again

### DIFF
--- a/package/MDAnalysis/topology/MOL2Parser.py
+++ b/package/MDAnalysis/topology/MOL2Parser.py
@@ -167,15 +167,15 @@ class MOL2Parser(TopologyReader):
         attrs.append(Segids(np.array(['SYSTEM'], dtype=object)))
 
         bonds = []
-        bondorder = {}
+        bondorder = []
         for b in bond_lines:
             # bond_type can be: 1, 2, am, ar
             bid, a0, a1, bond_type = b.split()
             a0, a1 = int(a0) - 1, int(a1) - 1
             bond = tuple(sorted([a0, a1]))
-            bondorder[bond] = bond_type
+            bondorder.append(bond_type)
             bonds.append(bond)
-        attrs.append(Bonds(bonds))
+        attrs.append(Bonds(bonds, order=bondorder))
 
         top = Topology(n_atoms, n_residues, 1,
                        attrs=attrs,

--- a/testsuite/MDAnalysisTests/topology/test_mol2.py
+++ b/testsuite/MDAnalysisTests/topology/test_mol2.py
@@ -21,6 +21,7 @@
 #
 from numpy.testing import (
     assert_,
+    assert_equal,
 )
 
 import MDAnalysis as mda
@@ -60,3 +61,13 @@ class TestMOL2Parser(MOL2Base):
 
 class TestMOL2Parser2(MOL2Base):
     filename = mol2_molecules
+
+
+def test_bond_orders():
+    ref_orders = ('am 1 1 2 1 2 1 1 am 1 1 am 2 2 '
+                  '1 1 1 1 1 1 1 1 1 1 1 1 1 1 '
+                  'ar ar ar 1 ar 1 ar 1 ar 1 1 1 '
+                  '2 1 1 1 1 2 1 1 2 1 1').split()
+    u = mda.Universe(mol2_molecule)
+    orders = [bond.order for bond in u.atoms.bonds]
+    assert_equal(orders, ref_orders)


### PR DESCRIPTION
Fixes #1170

Changes made in this Pull Request:
 -  MOL2 parser stores bond order as it use to in 0.15


PR Checklist
------------
 - [x] Tests?
 - ~~[ ] Docs?~~
 - ~~[ ] CHANGELOG updated?~~ (Fixes a regression introduced after the last release)
 - [x] Issue raised/referenced?
