### PR TITLE
strict attribute setting issue (#1092)

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -30,6 +30,8 @@ Enhancements
   * added support for Tinker TXYZ and ARC files
   * libmdaxdr and libdcd classes can now be pickled (PR #1680)
   * speed up atomgroup.rotate when point = (0, 0, 0) (Issue #1707)
+  * Universe.add_TopologyAttr now accepts strings to add a given attribute
+    to the Universe (Issue #1092, PR #1186)
 
 Deprecations
 
@@ -81,6 +83,8 @@ Changes
     tuple (filename_or_array, trajectory_type) (Issue #1613)
   * docs: URLs to (www|docs).mdanalysis.org now link to SSL-encrypted site
     (see issue MDAnalysis/MDAnalysis.github.io#61)
+  * attributes can not be assigned to AtomGroups (and similar objects) unless
+    they are part of the Universe topology (Issue #1092 PR #1186)
 
 
 06/29/17 richardjgowers, rathann, jbarnoud, orbeckst, utkbansal
@@ -965,7 +969,7 @@ Fixes
 
 04/01/14  orbeckst, jandom, zhuyi.xue, xdeupi, tyler.je.reddy,
           manuel.nuno.melo, danny.parton, sebastien.buchoux, denniej0,
-	  rmcgibbo, richardjgowers, lennardvanderfeltz, bernardin.alejandro
+    rmcgibbo, richardjgowers, lennardvanderfeltz, bernardin.alejandro
           matthieu.chavent
 
   * 0.8.1
@@ -1480,7 +1484,7 @@ Fixes
     alternative atoms and insertion codes that are not needed for
     handling MD simulation data).
       - The default behaviour of MDAnalysis  can be set through the flag
-	MDAnalysis.core.flag['permissive_pdb_reader']. The default is True.
+  MDAnalysis.core.flag['permissive_pdb_reader']. The default is True.
       - One can always manually select the PDB reader by providing the
         permissive keyword to Universe; e.g. Universe(...,permissive=False)
         will read the input file with the Bio.PDB reader. This might be

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -969,7 +969,7 @@ Fixes
 
 04/01/14  orbeckst, jandom, zhuyi.xue, xdeupi, tyler.je.reddy,
           manuel.nuno.melo, danny.parton, sebastien.buchoux, denniej0,
-    rmcgibbo, richardjgowers, lennardvanderfeltz, bernardin.alejandro
+          rmcgibbo, richardjgowers, lennardvanderfeltz, bernardin.alejandro
           matthieu.chavent
 
   * 0.8.1
@@ -1484,7 +1484,7 @@ Fixes
     alternative atoms and insertion codes that are not needed for
     handling MD simulation data).
       - The default behaviour of MDAnalysis  can be set through the flag
-  MDAnalysis.core.flag['permissive_pdb_reader']. The default is True.
+        MDAnalysis.core.flag['permissive_pdb_reader']. The default is True.
       - One can always manually select the PDB reader by providing the
         permissive keyword to Universe; e.g. Universe(...,permissive=False)
         will read the input file with the Bio.PDB reader. This might be

--- a/package/MDAnalysis/__init__.py
+++ b/package/MDAnalysis/__init__.py
@@ -164,6 +164,8 @@ _SINGLEFRAME_WRITERS = {}
 _MULTIFRAME_WRITERS = {}
 _PARSERS = {}
 _SELECTION_WRITERS = {}
+# Registry of TopologyAttributes
+_TOPOLOGY_ATTRS = {}
 
 # Storing anchor universes for unpickling groups
 import weakref

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -191,7 +191,10 @@ class _TopologyAttrContainer(object):
         ----------
         is_group : bool
             The :attr:`_is_group` of the returned class will be set to
-            *is_group*. It controls the type of :class:`TopologyAttr` addition.
+            *is_group*. This is used to distinguish between Groups (AtomGroup
+            etc.) and Components (Atom etc.) in internal methods when
+            considering actions such as addition between objects, adding
+            TopologyAttributes to them.
 
         Returns
         -------

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -268,10 +268,9 @@ class _TopologyAttrContainer(object):
 
     def __setattr__(self, attr, value):
         # `ag.this = 42` calls setattr(ag, 'this', 42)
-        # we scan 'this' to see if it is either 'private'
-        # or a known attribute (WHITELIST)
-        if (not attr.startswith('_') and
-            not attr in self._SETATTR_WHITELIST):
+        if not (attr.startswith('_') or  # 'private' allowed
+                attr in self._SETATTR_WHITELIST or  # known attributes allowed
+                hasattr(self, attr)):  # preexisting (eg properties) allowed
             raise AttributeError(
                 "Cannot set arbitrary attributes to a {}".format(
                     'Component' if self._singular else 'Group'))

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -260,8 +260,10 @@ class _TopologyAttrContainer(object):
     @classmethod
     def _whitelist(cls, attr):
         """Allow an attribute to be set in Groups"""
-        cls._SETATTR_WHITELIST.add(attr.attrname)
-        cls._SETATTR_WHITELIST.add(attr.singular)
+        if cls._singular:
+            cls._SETATTR_WHITELIST.add(attr.singular)
+        else:
+            cls._SETATTR_WHITELIST.add(attr.attrname)
 
 
 class _MutableBase(object):

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -201,7 +201,7 @@ class _TopologyAttrContainer(object):
         if singular:
             newcls._SETATTR_WHITELIST = {
                 'position', 'velocity', 'force', 'dimensions',
-                'atoms', 'residue', 'residues', 'segment', 'segments',
+                'atoms', 'residue', 'residues', 'segment',
             }
         else:
             newcls._SETATTR_WHITELIST = {

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -1868,6 +1868,9 @@ class AtomGroup(GroupBase):
                 which is often the case with high-resolution crystal structures
                 e.g. `resid 4 and resname ALA and altloc B` selects only the
                 atoms of ALA-4 that have an altloc B record.
+            moltype *molecule-type*
+                select by molecule type, e.g. ``moltype Protein_A``. At the
+                moment, only the TPR format defines the molecule type.
 
         **Boolean**
 

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -2877,7 +2877,8 @@ class UpdatingAtomGroup(AtomGroup):
 
     def __getattribute__(self, name):
         # ALL attribute access goes through here
-        # If the requested attribute isn't in the shortcut list, update ourselves
+        # If the requested attribute is public (not starting with '_') and
+        # isn't in the shortcut list, update ourselves
         if not (name.startswith('_') or name in _UAG_SHORTCUT_ATTRS):
             self._ensure_updated()
         # Going via object.__getattribute__ then bypasses this check stage

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -187,6 +187,8 @@ class TopologyAttr(object):
     singular = 'topologyattr'
     per_object = None  # ie Resids per_object = 'residue'
     top = None  # pointer to Topology object
+    transplants = defaultdict(list)
+    target_classes = []
 
     groupdoc = None
     singledoc = None
@@ -271,13 +273,13 @@ class Atomindices(TopologyAttr):
         raise AttributeError("Atom indices are fixed; they cannot be reset")
 
     def get_atoms(self, ag):
-        return ag._ix
+        return ag.ix
 
     def get_residues(self, rg):
-        return list(self.top.tt.residues2atoms_2d(rg._ix))
+        return list(self.top.tt.residues2atoms_2d(rg.ix))
 
     def get_segments(self, sg):
-        return list(self.top.tt.segments2atoms_2d(sg._ix))
+        return list(self.top.tt.segments2atoms_2d(sg.ix))
 
 
 class Resindices(TopologyAttr):
@@ -300,16 +302,16 @@ class Resindices(TopologyAttr):
         self._guessed = False
 
     def get_atoms(self, ag):
-        return self.top.tt.atoms2residues(ag._ix)
+        return self.top.tt.atoms2residues(ag.ix)
 
     def get_residues(self, rg):
-        return rg._ix
+        return rg.ix
 
     def set_residues(self, rg, values):
         raise AttributeError("Residue indices are fixed; they cannot be reset")
 
     def get_segments(self, sg):
-        return list(self.top.tt.segments2residues_2d(sg._ix))
+        return list(self.top.tt.segments2residues_2d(sg.ix))
 
 
 class Segindices(TopologyAttr):
@@ -333,13 +335,13 @@ class Segindices(TopologyAttr):
         self._guessed = False
 
     def get_atoms(self, ag):
-        return self.top.tt.atoms2segments(ag._ix)
+        return self.top.tt.atoms2segments(ag.ix)
 
     def get_residues(self, rg):
-        return self.top.tt.residues2segments(rg._ix)
+        return self.top.tt.residues2segments(rg.ix)
 
     def get_segments(self, sg):
-        return sg._ix
+        return sg.ix
 
     def set_segments(self, sg, values):
         raise AttributeError("Segment indices are fixed; they cannot be reset")
@@ -356,11 +358,11 @@ class AtomAttr(TopologyAttr):
     target_classes = [Atom]
 
     def get_atoms(self, ag):
-        return self.values[ag._ix]
+        return self.values[ag.ix]
 
     @_check_length
     def set_atoms(self, ag, values):
-        self.values[ag._ix] = values
+        self.values[ag.ix] = values
 
     def get_residues(self, rg):
         """By default, the values for each atom present in the set of residues
@@ -368,7 +370,7 @@ class AtomAttr(TopologyAttr):
         attributes.
 
         """
-        aixs = self.top.tt.residues2atoms_2d(rg._ix)
+        aixs = self.top.tt.residues2atoms_2d(rg.ix)
         return [self.values[aix] for aix in aixs]
 
     def set_residues(self, rg, values):
@@ -380,7 +382,7 @@ class AtomAttr(TopologyAttr):
         attributes.
 
         """
-        aixs = self.top.tt.segments2atoms_2d(sg._ix)
+        aixs = self.top.tt.segments2atoms_2d(sg.ix)
         return [self.values[aix] for aix in aixs]
 
     def set_segments(self, sg, values):
@@ -621,7 +623,7 @@ class Masses(AtomAttr):
         self._guessed = guessed
 
     def get_residues(self, rg):
-        resatoms = self.top.tt.residues2atoms_2d(rg._ix)
+        resatoms = self.top.tt.residues2atoms_2d(rg.ix)
 
         if isinstance(rg._ix, numbers.Integral):
             # for a single residue
@@ -635,7 +637,7 @@ class Masses(AtomAttr):
         return masses
 
     def get_segments(self, sg):
-        segatoms = self.top.tt.segments2atoms_2d(sg._ix)
+        segatoms = self.top.tt.segments2atoms_2d(sg.ix)
 
         if isinstance(sg._ix, numbers.Integral):
             # for a single segment
@@ -947,7 +949,7 @@ class Charges(AtomAttr):
     transplants = defaultdict(list)
 
     def get_residues(self, rg):
-        resatoms = self.top.tt.residues2atoms_2d(rg._ix)
+        resatoms = self.top.tt.residues2atoms_2d(rg.ix)
 
         if isinstance(rg._ix, numbers.Integral):
             charges = self.values[resatoms].sum()
@@ -959,7 +961,7 @@ class Charges(AtomAttr):
         return charges
 
     def get_segments(self, sg):
-        segatoms = self.top.tt.segments2atoms_2d(sg._ix)
+        segatoms = self.top.tt.segments2atoms_2d(sg.ix)
 
         if isinstance(sg._ix, numbers.Integral):
             # for a single segment
@@ -1020,18 +1022,18 @@ class ResidueAttr(TopologyAttr):
     per_object = 'residue'
 
     def get_atoms(self, ag):
-        rix = self.top.tt.atoms2residues(ag._ix)
+        rix = self.top.tt.atoms2residues(ag.ix)
         return self.values[rix]
 
     def set_atoms(self, ag, values):
         raise _wronglevel_error(self, ag)
 
     def get_residues(self, rg):
-        return self.values[rg._ix]
+        return self.values[rg.ix]
 
     @_check_length
     def set_residues(self, rg, values):
-        self.values[rg._ix] = values
+        self.values[rg.ix] = values
 
     def get_segments(self, sg):
         """By default, the values for each residue present in the set of
@@ -1039,7 +1041,7 @@ class ResidueAttr(TopologyAttr):
         in child attributes.
 
         """
-        rixs = self.top.tt.segments2residues_2d(sg._ix)
+        rixs = self.top.tt.segments2residues_2d(sg.ix)
         return [self.values[rix] for rix in rixs]
 
     def set_segments(self, sg, values):
@@ -1247,25 +1249,25 @@ class SegmentAttr(TopologyAttr):
     per_object = 'segment'
 
     def get_atoms(self, ag):
-        six = self.top.tt.atoms2segments(ag._ix)
+        six = self.top.tt.atoms2segments(ag.ix)
         return self.values[six]
 
     def set_atoms(self, ag, values):
         raise _wronglevel_error(self, ag)
 
     def get_residues(self, rg):
-        six = self.top.tt.residues2segments(rg._ix)
+        six = self.top.tt.residues2segments(rg.ix)
         return self.values[six]
 
     def set_residues(self, rg, values):
         raise _wronglevel_error(self, rg)
 
     def get_segments(self, sg):
-        return self.values[sg._ix]
+        return self.values[sg.ix]
 
     @_check_length
     def set_segments(self, sg, values):
-        self.values[sg._ix] = values
+        self.values[sg.ix] = values
 
 
 # TODO: update docs to property doc
@@ -1373,10 +1375,10 @@ class _Connection(AtomAttr):
     def get_atoms(self, ag):
         try:
             unique_bonds = set(itertools.chain(
-                *[self._bondDict[a] for a in ag._ix]))
+                *[self._bondDict[a] for a in ag.ix]))
         except TypeError:
             # maybe we got passed an Atom
-            unique_bonds = self._bondDict[ag._ix]
+            unique_bonds = self._bondDict[ag.ix]
         bond_idx, types, guessed, order = np.hsplit(
             np.array(sorted(unique_bonds)), 4)
         bond_idx = np.array(bond_idx.ravel().tolist(), dtype=np.int32)

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -166,10 +166,13 @@ def _wronglevel_error(attr, group):
 class TopologyAttr(object):
     """Base class for Topology attributes.
 
-    .. note::   This class is intended to be subclassed, and mostly amounts to
-                a skeleton. The methods here should be present in all
-                :class:`TopologyAttr` child classes, but by default they raise
-                appropriate exceptions.
+    Note
+    ----
+    This class is intended to be subclassed, and mostly amounts to
+    a skeleton. The methods here should be present in all
+    :class:`TopologyAttr` child classes, but by default they raise
+    appropriate exceptions.
+
 
     Attributes
     ----------
@@ -264,7 +267,7 @@ class Atomindices(TopologyAttr):
     """
     attrname = 'indices'
     singular = 'index'
-    target_classes = [Atom]
+    target_classes = [AtomGroup, ResidueGroup, SegmentGroup, Atom]
 
     def __init__(self):
         self._guessed = False
@@ -296,7 +299,7 @@ class Resindices(TopologyAttr):
     """
     attrname = 'resindices'
     singular = 'resindex'
-    target_classes = [Atom, Residue]
+    target_classes = [AtomGroup, ResidueGroup, SegmentGroup, Atom, Residue]
 
     def __init__(self):
         self._guessed = False
@@ -329,7 +332,8 @@ class Segindices(TopologyAttr):
     """
     attrname = 'segindices'
     singular = 'segindex'
-    target_classes = [Atom, Residue, Segment]
+    target_classes = [AtomGroup, ResidueGroup, SegmentGroup,
+                      Atom, Residue, Segment]
 
     def __init__(self):
         self._guessed = False
@@ -355,7 +359,7 @@ class AtomAttr(TopologyAttr):
     """
     attrname = 'atomattrs'
     singular = 'atomattr'
-    target_classes = [Atom]
+    target_classes = [AtomGroup, ResidueGroup, SegmentGroup, Atom]
 
     def get_atoms(self, ag):
         return self.values[ag.ix]
@@ -605,7 +609,8 @@ class Masses(AtomAttr):
     attrname = 'masses'
     singular = 'mass'
     per_object = 'atom'
-    target_classes = [Atom, Residue, Segment]
+    target_classes = [AtomGroup, ResidueGroup, SegmentGroup,
+                      Atom, Residue, Segment]
     transplants = defaultdict(list)
 
     groupdoc = """Mass of each component in the Group.
@@ -945,7 +950,8 @@ class Charges(AtomAttr):
     attrname = 'charges'
     singular = 'charge'
     per_object = 'atom'
-    target_classes = [Atom, Residue, Segment]
+    target_classes = [AtomGroup, ResidueGroup, SegmentGroup,
+                      Atom, Residue, Segment]
     transplants = defaultdict(list)
 
     def get_residues(self, rg):
@@ -1005,20 +1011,10 @@ class AltLocs(AtomAttr):
     per_object = 'atom'
 
 
-# residue attributes
-
 class ResidueAttr(TopologyAttr):
-    """Base class for Topology attributes.
-
-    .. note::   This class is intended to be subclassed, and mostly amounts to
-                a skeleton. The methods here should be present in all
-                :class:`TopologyAttr` child classes, but by default they raise
-                appropriate exceptions.
-
-    """
     attrname = 'residueattrs'
     singular = 'residueattr'
-    target_classes = [Residue]
+    target_classes = [AtomGroup, ResidueGroup, SegmentGroup, Residue]
     per_object = 'residue'
 
     def get_atoms(self, ag):
@@ -1053,14 +1049,14 @@ class Resids(ResidueAttr):
     """Residue ID"""
     attrname = 'resids'
     singular = 'resid'
-    target_classes = [Atom, Residue]
+    target_classes = [AtomGroup, ResidueGroup, SegmentGroup, Atom, Residue]
 
 
 # TODO: update docs to property doc
 class Resnames(ResidueAttr):
     attrname = 'resnames'
     singular = 'resname'
-    target_classes = [Atom, Residue]
+    target_classes = [AtomGroup, ResidueGroup, SegmentGroup, Atom, Residue]
     transplants = defaultdict(list)
 
     def getattr__(residuegroup, resname):
@@ -1218,7 +1214,7 @@ class Resnames(ResidueAttr):
 class Resnums(ResidueAttr):
     attrname = 'resnums'
     singular = 'resnum'
-    target_classes = [Atom, Residue]
+    target_classes = [AtomGroup, ResidueGroup, SegmentGroup, Atom, Residue]
 
 
 class ICodes(ResidueAttr):
@@ -1234,7 +1230,7 @@ class Moltypes(ResidueAttr):
     """
     attrname = 'moltypes'
     singular = 'moltype'
-    target_classes = [Atom, Residue]
+    target_classes = [AtomGroup, ResidueGroup, SegmentGroup, Atom, Residue]
 
 
 # segment attributes
@@ -1245,7 +1241,7 @@ class SegmentAttr(TopologyAttr):
     """
     attrname = 'segmentattrs'
     singular = 'segmentattr'
-    target_classes = [Segment]
+    target_classes = [AtomGroup, ResidueGroup, SegmentGroup, Segment]
     per_object = 'segment'
 
     def get_atoms(self, ag):
@@ -1274,7 +1270,8 @@ class SegmentAttr(TopologyAttr):
 class Segids(SegmentAttr):
     attrname = 'segids'
     singular = 'segid'
-    target_classes = [Atom, Residue, Segment]
+    target_classes = [AtomGroup, ResidueGroup, SegmentGroup,
+                      Atom, Residue, Segment]
     transplants = defaultdict(list)
 
     def getattr__(segmentgroup, segid):

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -1491,11 +1491,11 @@ class _Connection(AtomAttr):
             unique_bonds = self._bondDict[ag.ix]
         bond_idx, types, guessed, order = np.hsplit(
             np.array(sorted(unique_bonds)), 4)
-        bond_idx = np.array(bond_idx.ravel().tolist(), dtype=np.int32)
+        bond_idx = np.array(bond_idx.ravel(), dtype=np.int32)
         types = types.ravel()
         guessed = guessed.ravel()
         order = order.ravel()
-        return TopologyGroup(bond_idx, ag._u,
+        return TopologyGroup(bond_idx, ag.universe,
                              self.singular[:-1],
                              types,
                              guessed,
@@ -1542,7 +1542,7 @@ class Bonds(_Connection):
     def bonded_atoms(self):
         """An AtomGroup of all atoms bonded to this Atom"""
         idx = [b.partner(self).index for b in self.bonds]
-        return self._u.atoms[idx]
+        return self.universe.atoms[idx]
 
     transplants[Atom].append(
         ('bonded_atoms', property(bonded_atoms, None, None,

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -1491,7 +1491,7 @@ class _Connection(AtomAttr):
             unique_bonds = self._bondDict[ag.ix]
         bond_idx, types, guessed, order = np.hsplit(
             np.array(sorted(unique_bonds)), 4)
-        bond_idx = np.array(bond_idx.ravel(), dtype=np.int32)
+        bond_idx = np.array(bond_idx.ravel().tolist(), dtype=np.int32)
         types = types.ravel()
         guessed = guessed.ravel()
         order = order.ravel()

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -217,6 +217,12 @@ class TopologyAttr(six.with_metaclass(_TopologyAttrMeta, object)):
 
     @staticmethod
     def _gen_initial_values(n_atoms, n_residues, n_segments):
+        """Populate an initial empty data structure for this Attribute
+
+        The only provided parameters are the "shape" of the Universe
+
+        Eg for charges, provide np.zeros(n_atoms)
+        """
         raise NotImplementedError("No default values")
 
     @classmethod
@@ -442,7 +448,7 @@ class Atomids(AtomAttr):
 
     @staticmethod
     def _gen_initial_values(na, nr, ns):
-        return np.arange(na) + 1
+        return np.arange(1, na + 1)
 
 
 # TODO: update docs to property doc
@@ -1140,7 +1146,7 @@ class Resids(ResidueAttr):
 
     @staticmethod
     def _gen_initial_values(na, nr, ns):
-        return np.arange(nr) + 1
+        return np.arange(1, nr + 1)
 
 
 # TODO: update docs to property doc
@@ -1313,7 +1319,7 @@ class Resnums(ResidueAttr):
 
     @staticmethod
     def _gen_initial_values(na, nr, ns):
-        return np.arange(nr) + 1
+        return np.arange(1, nr + 1)
 
 
 class ICodes(ResidueAttr):

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -215,6 +215,26 @@ class TopologyAttr(six.with_metaclass(_TopologyAttrMeta, object)):
         self.values = values
         self._guessed = guessed
 
+    @staticmethod
+    def _gen_initial_values(n_atoms, n_residues, n_segments):
+        raise NotImplementedError("No default values")
+
+    @classmethod
+    def from_blank(cls, n_atoms=None, n_residues=None, n_segments=None,
+                   values=None):
+        """Create a blank version of this TopologyAttribute
+
+        Parameters
+        ----------
+        n_atoms, n_residues, n_segments : int, optional
+          Size of the TopologyAttribute
+        values : optional
+          Initial values for the TopologyAttribute
+        """
+        if values is None:
+            values = cls._gen_initial_values(n_atoms, n_residues, n_segments)
+        return cls(values)
+
     def __len__(self):
         """Length of the TopologyAttr at its intrinsic level."""
         return len(self.values)
@@ -416,6 +436,10 @@ class Atomids(AtomAttr):
     singular = 'id'
     per_object = 'atom'
 
+    @staticmethod
+    def _gen_initial_values(na, nr, ns):
+        return np.arange(na) + 1
+
 
 # TODO: update docs to property doc
 class Atomnames(AtomAttr):
@@ -425,6 +449,10 @@ class Atomnames(AtomAttr):
     singular = 'name'
     per_object = 'atom'
     transplants = defaultdict(list)
+
+    @staticmethod
+    def _gen_initial_values(na, nr, ns):
+        return np.array(['' for _ in range(na)], dtype=object)
 
     def getattr__(atomgroup, name):
         try:
@@ -585,12 +613,20 @@ class Atomtypes(AtomAttr):
     singular = 'type'
     per_object = 'atom'
 
+    @staticmethod
+    def _gen_initial_values(na, nr, ns):
+        return np.array(['' for _ in range(na)], dtype=object)
+
 
 # TODO: update docs to property doc
 class Elements(AtomAttr):
     """Element for each atom"""
     attrname = 'elements'
     singular = 'element'
+
+    @staticmethod
+    def _gen_initial_values(na, nr, ns):
+        return np.array(['' for _ in range(na)], dtype=object)
 
 
 # TODO: update docs to property doc
@@ -599,6 +635,10 @@ class Radii(AtomAttr):
     attrname = 'radii'
     singular = 'radius'
     per_object = 'atom'
+
+    @staticmethod
+    def _gen_initial_values(na, nr, ns):
+        return np.zeros(na)
 
 
 class ChainIDs(AtomAttr):
@@ -612,12 +652,20 @@ class ChainIDs(AtomAttr):
     singular = 'chainID'
     per_object = 'atom'
 
+    @staticmethod
+    def _gen_initial_values(na, nr, ns):
+        return np.array(['' for _ in range(na)], dtype=object)
+
 
 class Tempfactors(AtomAttr):
     """Tempfactor for atoms"""
     attrname = 'tempfactors'
     singular = 'tempfactor'
     per_object = 'atom'
+
+    @staticmethod
+    def _gen_initial_values(na, nr, ns):
+        return np.zeros(na)
 
 
 class Masses(AtomAttr):
@@ -641,6 +689,10 @@ class Masses(AtomAttr):
     def __init__(self, values, guessed=False):
         self.values = np.asarray(values, dtype=np.float64)
         self._guessed = guessed
+
+    @staticmethod
+    def _gen_initial_values(na, nr, ns):
+        return np.zeros(na)
 
     def get_residues(self, rg):
         resatoms = self.top.tt.residues2atoms_2d(rg.ix)
@@ -969,6 +1021,10 @@ class Charges(AtomAttr):
                       Atom, Residue, Segment]
     transplants = defaultdict(list)
 
+    @staticmethod
+    def _gen_initial_values(na, nr, ns):
+        return np.zeros(na)
+
     def get_residues(self, rg):
         resatoms = self.top.tt.residues2atoms_2d(rg.ix)
 
@@ -1010,12 +1066,20 @@ class Bfactors(AtomAttr):
     singular = 'bfactor'
     per_object = 'atom'
 
+    @staticmethod
+    def _gen_initial_values(na, nr, ns):
+        return np.zeros(na)
+
 
 # TODO: update docs to property doc
 class Occupancies(AtomAttr):
     attrname = 'occupancies'
     singular = 'occupancy'
     per_object = 'atom'
+
+    @staticmethod
+    def _gen_initial_values(na, nr, ns):
+        return np.zeros(na)
 
 
 # TODO: update docs to property doc
@@ -1024,6 +1088,10 @@ class AltLocs(AtomAttr):
     attrname = 'altLocs'
     singular = 'altLoc'
     per_object = 'atom'
+
+    @staticmethod
+    def _gen_initial_values(na, nr, ns):
+        return np.array(['' for _ in range(na)], dtype=object)
 
 
 class ResidueAttr(TopologyAttr):
@@ -1066,6 +1134,10 @@ class Resids(ResidueAttr):
     singular = 'resid'
     target_classes = [AtomGroup, ResidueGroup, SegmentGroup, Atom, Residue]
 
+    @staticmethod
+    def _gen_initial_values(na, nr, ns):
+        return np.arange(nr) + 1
+
 
 # TODO: update docs to property doc
 class Resnames(ResidueAttr):
@@ -1073,6 +1145,10 @@ class Resnames(ResidueAttr):
     singular = 'resname'
     target_classes = [AtomGroup, ResidueGroup, SegmentGroup, Atom, Residue]
     transplants = defaultdict(list)
+
+    @staticmethod
+    def _gen_initial_values(na, nr, ns):
+        return np.array(['' for _ in range(nr)], dtype=object)
 
     def getattr__(residuegroup, resname):
         try:
@@ -1231,11 +1307,19 @@ class Resnums(ResidueAttr):
     singular = 'resnum'
     target_classes = [AtomGroup, ResidueGroup, SegmentGroup, Atom, Residue]
 
+    @staticmethod
+    def _gen_initial_values(na, nr, ns):
+        return np.arange(nr) + 1
+
 
 class ICodes(ResidueAttr):
     """Insertion code for Atoms"""
     attrname = 'icodes'
     singular = 'icode'
+
+    @staticmethod
+    def _gen_initial_values(na, nr, ns):
+        return np.array(['' for _ in range(nr)], dtype=object)
 
 
 class Moltypes(ResidueAttr):
@@ -1288,6 +1372,10 @@ class Segids(SegmentAttr):
     target_classes = [AtomGroup, ResidueGroup, SegmentGroup,
                       Atom, Residue, Segment]
     transplants = defaultdict(list)
+
+    @staticmethod
+    def _gen_initial_values(na, nr, ns):
+        return np.array(['' for _ in range(ns)], dtype=object)
 
     def getattr__(segmentgroup, segid):
         try:

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -226,8 +226,12 @@ class TopologyAttr(six.with_metaclass(_TopologyAttrMeta, object)):
 
         Parameters
         ----------
-        n_atoms, n_residues, n_segments : int, optional
-          Size of the TopologyAttribute
+        n_atoms : int, optional
+          Size of the TopologyAttribute atoms
+        n_residues: int, optional
+          Size of the TopologyAttribute residues
+        n_segments : int, optional
+          Size of the TopologyAttribute segments
         values : optional
           Initial values for the TopologyAttribute
         """

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -31,6 +31,7 @@ TopologyAttrs are used to contain attributes such as atom names or resids.
 These are usually read by the TopologyParser.
 """
 from __future__ import division, absolute_import
+import six
 from six.moves import zip, range
 
 import Bio.Seq
@@ -54,6 +55,7 @@ from . import selection
 from .groups import (ComponentBase, GroupBase,
                      Atom, Residue, Segment,
                      AtomGroup, ResidueGroup, SegmentGroup)
+from .. import _TOPOLOGY_ATTRS
 
 
 def _check_length(func):
@@ -163,7 +165,20 @@ def _wronglevel_error(attr, group):
     ))
 
 
-class TopologyAttr(object):
+class _TopologyAttrMeta(type):
+    # register TopologyAttrs
+    def __init__(cls, name, bases, classdict):
+        type.__init__(type, name, bases, classdict)
+        for attr in ['attrname', 'singular']:
+            try:
+                attrname = classdict[attr]
+            except KeyError:
+                pass
+            else:
+                _TOPOLOGY_ATTRS[attrname] = cls
+
+
+class TopologyAttr(six.with_metaclass(_TopologyAttrMeta, object)):
     """Base class for Topology attributes.
 
     Note

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -696,6 +696,10 @@ class Universe(object):
         >>> u.atoms.bfactors
         array([ 0.,  0.,  0., ...,  0.,  0.,  0.])
 
+        .. versionchanged:: 0.17.0
+           Can now also add TopologyAttrs with a string of the name of the
+           attribute to add (eg 'charges'), can also supply initial values
+           using values keyword.
         """
         if isinstance(topologyattr, six.string_types):
             try:

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -687,6 +687,15 @@ class Universe(object):
           If initiating an attribute from a string, the initial values to
           use.  If not supplied, the new TopologyAttribute will have empty
           or zero values.
+
+        Example
+        -------
+        For example to add bfactors to a Universe:
+
+        >>> u.add_TopologyAttr('bfactors')
+        >>> u.atoms.bfactors
+        array([ 0.,  0.,  0., ...,  0.,  0.,  0.])
+
         """
         if isinstance(topologyattr, six.string_types):
             try:
@@ -694,7 +703,9 @@ class Universe(object):
             except KeyError:
                 raise ValueError(
                     "Unrecognised topology attribute name: '{}'."
-                    "  Possible values: '{}'".format(
+                    "  Possible values: '{}'\n"
+                    "To raise an issue go to: http://issues.mdanalysis.org"
+                    "".format(
                         topologyattr, ', '.join(sorted(_TOPOLOGY_ATTRS.keys())))
                 )
             else:

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -698,10 +698,6 @@ class Universe(object):
                                  n=n_dict[attr.per_object],
                                  m=len(attr)))
 
-        self._class_bases[GroupBase]._add_prop(attr)
-        self._class_bases[GroupBase]._whitelist(attr)
-        self._class_bases[ComponentBase]._whitelist(attr)
-
         for cls in attr.target_classes:
             self._class_bases[cls]._add_prop(attr)
 

--- a/testsuite/MDAnalysisTests/core/test_groups.py
+++ b/testsuite/MDAnalysisTests/core/test_groups.py
@@ -1016,3 +1016,28 @@ class TestInstantSelectorDeprecationWarnings(object):
     def test_SegmentGroup_nowarn_getitem(self, u):
         with no_deprecated_call():
             u.segments[0]
+
+
+class TestAttributeSetting(object):
+    @pytest.mark.parametrize('groupname', ['atoms', 'residues', 'segments'])
+    def test_setting_group_fail(self, groupname):
+        u = make_Universe()
+
+        group = getattr(u, groupname)
+        with pytest.raises(AttributeError):
+            group.this = 'that'
+
+    @pytest.mark.parametrize('groupname', ['atoms', 'residues', 'segments'])
+    def test_setting_component_fails(self, groupname):
+        u = make_Universe()
+        component = getattr(u, groupname)[0]
+
+        with pytest.raises(AttributeError):
+            component.this = 'that'
+
+    def test_atomgroup_resid(self):
+        # this should fail as you can't set the resid of an AG
+        u = make_Universe(('resids'))
+
+        with pytest.raises(AttributeError):
+            u.atoms.resid = 24

--- a/testsuite/MDAnalysisTests/core/test_groups.py
+++ b/testsuite/MDAnalysisTests/core/test_groups.py
@@ -1018,26 +1018,75 @@ class TestInstantSelectorDeprecationWarnings(object):
             u.segments[0]
 
 
+@pytest.fixture()
+def attr_universe():
+    return make_Universe(('names', 'resids', 'segids'))
+            
 class TestAttributeSetting(object):
     @pytest.mark.parametrize('groupname', ['atoms', 'residues', 'segments'])
-    def test_setting_group_fail(self, groupname):
-        u = make_Universe()
-
-        group = getattr(u, groupname)
+    def test_setting_group_fail(self, attr_universe, groupname):
+        group = getattr(attr_universe, groupname)
+ 
         with pytest.raises(AttributeError):
             group.this = 'that'
 
     @pytest.mark.parametrize('groupname', ['atoms', 'residues', 'segments'])
-    def test_setting_component_fails(self, groupname):
-        u = make_Universe()
-        component = getattr(u, groupname)[0]
+    def test_setting_component_fails(self, attr_universe, groupname):
+        component = getattr(attr_universe, groupname)[0]
 
         with pytest.raises(AttributeError):
             component.this = 'that'
 
-    def test_atomgroup_resid(self):
-        # this should fail as you can't set the resid of an AG
-        u = make_Universe(('resids'))
-
+    @pytest.mark.parametrize('attr', ['name', 'resid', 'segid'])
+    @pytest.mark.parametrize('groupname', ['atoms', 'residues', 'segments'])    
+    def test_group_set_singular(self, attr_universe, attr, groupname):
+        # this should fail as you can't set the 'name' of a 'ResidueGroup'
+        group = getattr(attr_universe, groupname)
         with pytest.raises(AttributeError):
-            u.atoms.resid = 24
+            setattr(group, attr, 24)
+
+    def test_atom_set_name(self, attr_universe):
+        attr_universe.atoms[0].name = 'this'
+        assert attr_universe.atoms[0].name == 'this'
+
+    def test_atom_set_resid(self, attr_universe):
+        with pytest.raises(NotImplementedError):
+            attr_universe.atoms[0].resid = 24
+
+    def test_atom_set_segid(self, attr_universe):
+        with pytest.raises(NotImplementedError):
+            attr_universe.atoms[0].segid = 'this'
+
+    def test_residue_set_name(self, attr_universe):
+        with pytest.raises(AttributeError):
+            attr_universe.residues[0].name = 'this'
+
+    def test_residue_set_resid(self, attr_universe):
+        attr_universe.residues[0].resid = 24
+        assert attr_universe.residues[0].resid == 24
+
+    def test_residue_set_segid(self, attr_universe):
+        with pytest.raises(NotImplementedError):
+            attr_universe.residues[0].segid = 'this'
+
+    def test_segment_set_name(self, attr_universe):
+        with pytest.raises(AttributeError):
+            attr_universe.segments[0].name = 'this'
+
+    def test_segment_set_resid(self, attr_universe):
+        with pytest.raises(AttributeError):
+            attr_universe.segments[0].resid = 24
+
+    def test_segment_set_segid(self, attr_universe):
+        attr_universe.segments[0].segid = 'this'
+        assert attr_universe.segments[0].segid == 'this'
+            
+    @pytest.mark.parametrize('attr', ['names', 'resids', 'segids'])
+    @pytest.mark.parametrize('groupname', ['atoms', 'residues', 'segments'])    
+    def test_component_set_plural(self, attr, groupname):
+        # this should fail as you can't set the 'Names' of an 'Atom'
+        u = make_Universe(('names', 'resids', 'segids'))
+        group = getattr(u, groupname)
+        comp = group[0]
+        with pytest.raises(AttributeError):
+            setattr(comp, attr, 24)

--- a/testsuite/MDAnalysisTests/core/test_universe.py
+++ b/testsuite/MDAnalysisTests/core/test_universe.py
@@ -525,3 +525,46 @@ class TestCustomReaders(object):
         u = mda.Universe(TRZ_psf, TRZ, format=MDAnalysis.coordinates.TRZ.TRZReader,
                          topology_format=MDAnalysis.topology.PSFParser.PSFParser)
         assert_equal(len(u.atoms), 8184)
+
+
+class TestAddTopologyAttr(object):
+    @pytest.fixture()
+    def universe(self):
+        return make_Universe()
+
+    def test_add_TA_fail(self, universe):
+        with pytest.raises(ValueError):
+            universe.add_TopologyAttr('silly')
+
+    def test_nodefault_fail(self, universe):
+        with pytest.raises(NotImplementedError):
+            universe.add_TopologyAttr('bonds')
+
+    @pytest.mark.parametrize(
+        'toadd,attrname,default', (
+            ['charge', 'charges', 0.0], ['charges', 'charges', 0.0],
+            ['name', 'names', ''], ['names', 'names', ''],
+            ['type', 'types', ''], ['types', 'types', ''],
+            ['element', 'elements', ''], ['elements', 'elements', ''],
+            ['radius', 'radii', 0.0], ['radii', 'radii', 0.0],
+            ['chainID', 'chainIDs', ''], ['chainIDs', 'chainIDs', ''],
+            ['tempfactor', 'tempfactors', 0.0],
+            ['tempfactors', 'tempfactors', 0.0],
+            ['mass', 'masses', 0.0], ['masses', 'masses', 0.0],
+            ['charge', 'charges', 0.0], ['charges', 'charges', 0.0],
+            ['bfactor', 'bfactors', 0.0], ['bfactors', 'bfactors', 0.0],
+            ['occupancy', 'occupancies', 0.0],
+            ['occupancies', 'occupancies', 0.0],
+            ['altLoc', 'altLocs', ''], ['altLocs', 'altLocs', ''],
+            ['resid', 'resids', 1], ['resids', 'resids', 1],
+            ['resname', 'resnames', ''], ['resnames', 'resnames', ''],
+            ['resnum', 'resnums', 1], ['resnums', 'resnums', 1],
+            ['icode', 'icodes', ''], ['icodes', 'icodes', ''],
+            ['segid', 'segids', ''], ['segids', 'segids', ''],
+        )
+    )
+    def test_add_charges(self, universe, toadd, attrname, default):
+        universe.add_TopologyAttr(toadd)
+
+        assert hasattr(universe.atoms, attrname)
+        assert getattr(universe.atoms, attrname)[0] == default

--- a/testsuite/MDAnalysisTests/core/test_universe.py
+++ b/testsuite/MDAnalysisTests/core/test_universe.py
@@ -25,7 +25,6 @@ from __future__ import absolute_import, print_function
 from six.moves import cPickle
 
 import os
-from unittest import TestCase
 
 try:
     from cStringIO import StringIO
@@ -285,7 +284,7 @@ def test_chainid_quick_select():
     assert len(u.D.atoms) == 7
 
 
-class TestGuessBonds(TestCase):
+class TestGuessBonds(object):
     """Test the AtomGroup methed guess_bonds
 
     This needs to be done both from Universe creation (via kwarg) and AtomGroup
@@ -295,11 +294,9 @@ class TestGuessBonds(TestCase):
      - fail properly if not
      - work again if vdwradii are passed.
     """
-    def setUp(self):
-        self.vdw = {'A':1.05, 'B':0.4}
-
-    def tearDown(self):
-        del self.vdw
+    @pytest.fixture()
+    def vdw(self):
+        return {'A': 1.05, 'B': 0.4}
 
     def _check_universe(self, u):
         """Verify that the Universe is created correctly"""
@@ -325,13 +322,13 @@ class TestGuessBonds(TestCase):
         with pytest.raises(ValueError):
             mda.Universe(two_water_gro_nonames, guess_bonds = True)
 
-    def test_universe_guess_bonds_with_vdwradii(self):
+    def test_universe_guess_bonds_with_vdwradii(self, vdw):
         """Unknown atom types, but with vdw radii here to save the day"""
         u = mda.Universe(two_water_gro_nonames, guess_bonds=True,
-                                vdwradii=self.vdw)
+                                vdwradii=vdw)
         self._check_universe(u)
         assert u.kwargs['guess_bonds']
-        assert_equal(self.vdw, u.kwargs['vdwradii'])
+        assert_equal(vdw, u.kwargs['vdwradii'])
 
     def test_universe_guess_bonds_off(self):
         u = mda.Universe(two_water_gro_nonames, guess_bonds=False)
@@ -372,11 +369,11 @@ class TestGuessBonds(TestCase):
         with pytest.raises(ValueError):
             ag.guess_bonds()
 
-    def test_atomgroup_guess_bonds_with_vdwradii(self):
+    def test_atomgroup_guess_bonds_with_vdwradii(self, vdw):
         u = mda.Universe(two_water_gro_nonames)
 
         ag = u.atoms[:3]
-        ag.guess_bonds(vdwradii=self.vdw)
+        ag.guess_bonds(vdwradii=vdw)
         self._check_atomgroup(ag, u)
 
 


### PR DESCRIPTION
This PR will hopefully not allow "random" attributes to be set to mda objects. Eg:

```python
u = mda.Universe()

ag = u.atoms[:10]

# set an attribute not present in the topology
ag.colours = 'red'  # this should raise an AttributeError
```

This is to avoid confusion like in #1092 
