### PR TITLE
Refactor align

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -126,6 +126,11 @@ Changes
   * moved coordinates.base.ChainReader to coordinates.chain.ChainReader
   * renamed private method ChainReader.get_flname() to ChainReader._get_filename()
   * totaltime now considers the first frame to be at time 0 (Issue #1137)
+  * analysis.rms.RMSF now conforms to standard analysis API (PR #1136)
+  * analysis.rms/align function keyword `mass_weighted` is replaced
+  by generic `weights='mass'`. This new keyword allows to pass it an
+  arbitrary weights array as well. (PR 1136)
+
 
 Deprecations (Issue #599)
   * Use of rms_fit_trj deprecated in favor of AlignTraj class (Issue #845)

--- a/package/MDAnalysis/analysis/align.py
+++ b/package/MDAnalysis/analysis/align.py
@@ -413,6 +413,8 @@ def alignto(mobile, reference, select="all", mass_weighted=None, weights=None,
 
     .. versionchanged:: 0.16.0
        new general 'weights' kwarg replace mass_weights, deprecated 'mass_weights'
+    .. deprecated:: 0.16.0
+       Instead of ``mass_weighted=True`` use new ``weights='mass'`
     """
     if select in ('all', None):
         # keep the EXACT order in the input AtomGroups; select_atoms('all')
@@ -551,6 +553,10 @@ class AlignTraj(AnalysisBase):
         :class:`MemoryReader` then it is *always* treated as if `in_memory` had
         been set to ``True``.
 
+        .. versionchanged:: 0.16.0
+           new general 'weights' kwarg replace mass_weights, deprecated 'mass_weights'
+        .. deprecated:: 0.16.0
+           Instead of ``mass_weighted=True`` use new ``weights='mass'`
         """
         select = rms.process_selection(select)
         self.ref_atoms = reference.select_atoms(*select['reference'])

--- a/package/MDAnalysis/analysis/align.py
+++ b/package/MDAnalysis/analysis/align.py
@@ -362,10 +362,10 @@ def alignto(mobile, reference, select="all", mass_weighted=None, weights=None,
        When using 2. or 3. with *sel1* and *sel2* then these selections can
        also each be a list of selection strings (to generate a AtomGroup with
        defined atom order as described under :ref:`ordered-selections-label`).
-    mass_weighted : boolean, optional, deprecated
+    mass_weighted : boolean, optional (deprecated)
        ``True`` uses the masses :meth:`reference.masses` as weights for the
        RMSD fit.
-    weights : str/array_like (optional)
+    weights : str/array_like, optional
        weights to be used for fit. Can be either 'mass' or an array_like
     tol_mass: float, optional
        Reject match if the atomic masses for matched atoms differ by more than
@@ -395,6 +395,7 @@ def alignto(mobile, reference, select="all", mass_weighted=None, weights=None,
     old_rmsd
         RMSD before spatial alignment
     new_rmsd
+        RMSD after spatial alignment
 
     See Also
     --------
@@ -411,7 +412,7 @@ def alignto(mobile, reference, select="all", mass_weighted=None, weights=None,
        the old behavior was the equivalent of *strict* = ``True``.
 
     .. versionchanged:: 0.16.0
-       new general 'weights' kwarg replace mass_weights
+       new general 'weights' kwarg replace mass_weights, deprecated 'mass_weights'
     """
     if select in ('all', None):
         # keep the EXACT order in the input AtomGroups; select_atoms('all')

--- a/package/MDAnalysis/analysis/align.py
+++ b/package/MDAnalysis/analysis/align.py
@@ -438,7 +438,7 @@ def alignto(mobile, reference, select="all", mass_weighted=None, weights=None,
         if mass_weighted:
             weights = 'mass'
 
-    if weights == 'mass':
+    if not isinstance(weights, (list, tuple, np.ndarray)) and weights == 'mass':
         weights = ref_atoms.masses
 
     mobile_com = mobile_atoms.center(weights)
@@ -605,7 +605,7 @@ class AlignTraj(AnalysisBase):
             if mass_weighted:
                 weights = 'mass'
 
-        if weights == 'mass':
+        if not isinstance(weights, (list, tuple, np.ndarray)) and weights == 'mass':
             weights = self.ref_atoms.masses
         self._weights = weights
 

--- a/package/MDAnalysis/analysis/align.py
+++ b/package/MDAnalysis/analysis/align.py
@@ -311,7 +311,7 @@ def _fit_to(mobile_coordinates, ref_coordinates, mobile_atoms,
     return mobile_atoms, min_rmsd
 
 
-def alignto(mobile, reference, select="all", mass_weighted=False,
+def alignto(mobile, reference, select="all", mass_weighted=None, weights=None,
             subselection=None, tol_mass=0.1, strict=False):
     """Spatially align *mobile* to *reference* by doing a RMSD fit on
         *select* atoms.
@@ -343,57 +343,58 @@ def alignto(mobile, reference, select="all", mass_weighted=False,
 
     Parameters
     ----------
-      mobile : Universe or AtomGroup
-         structure to be aligned, a
-         :class:`~MDAnalysis.core.groups.AtomGroup` or a whole
-         :class:`~MDAnalysis.core.universe.Universe`
-      reference : Universe or AtomGroup
-         reference structure, a :class:`~MDAnalysis.core.groups.AtomGroup`
-         or a whole :class:`~MDAnalysis.core.universe.Universe`
-      select: string or dict, optional
-         1. any valid selection string for
-            :meth:`~MDAnalysis.core.groups.AtomGroup.select_atoms` that
-            produces identical selections in *mobile* and *reference*; or
-         2. dictionary ``{'mobile':sel1, 'reference':sel2}``.
-            (the :func:`fasta2select` function returns such a
-            dictionary based on a ClustalW_ or STAMP_ sequence alignment); or
-         3.  tuple ``(sel1, sel2)``
+    mobile : Universe or AtomGroup
+       structure to be aligned, a
+       :class:`~MDAnalysis.core.groups.AtomGroup` or a whole
+       :class:`~MDAnalysis.core.universe.Universe`
+    reference : Universe or AtomGroup
+       reference structure, a :class:`~MDAnalysis.core.groups.AtomGroup`
+       or a whole :class:`~MDAnalysis.core.universe.Universe`
+    select: string or dict, optional
+       1. any valid selection string for
+          :meth:`~MDAnalysis.core.groups.AtomGroup.select_atoms` that
+          produces identical selections in *mobile* and *reference*; or
+       2. dictionary ``{'mobile':sel1, 'reference':sel2}``.
+          (the :func:`fasta2select` function returns such a
+          dictionary based on a ClustalW_ or STAMP_ sequence alignment); or
+       3.  tuple ``(sel1, sel2)``
 
-         When using 2. or 3. with *sel1* and *sel2* then these selections can
-         also each be a list of selection strings (to generate a AtomGroup with
-         defined atom order as described under :ref:`ordered-selections-label`).
-      mass_weighted : boolean, optional
-         ``True`` uses the masses :meth:`reference.masses` as weights for the
-         RMSD fit.
-      tol_mass: float, optional
-         Reject match if the atomic masses for matched atoms differ by more than
-         *tol_mass*, default [0.1]
-      strict: boolean, optional
-         ``True``
-             Will raise :exc:`SelectionError` if a single atom does not
-             match between the two selections.
-         ``False`` [default]
-             Will try to prepare a matching selection by dropping
-             residues with non-matching atoms. See :func:`get_matching_atoms`
-             for details.
-      subselection : string, optional
-         Apply the transformation only to this selection.
+       When using 2. or 3. with *sel1* and *sel2* then these selections can
+       also each be a list of selection strings (to generate a AtomGroup with
+       defined atom order as described under :ref:`ordered-selections-label`).
+    mass_weighted : boolean, optional, deprecated
+       ``True`` uses the masses :meth:`reference.masses` as weights for the
+       RMSD fit.
+    weights : str/array_like (optional)
+       weights to be used for fit. Can be either 'mass' or an array_like
+    tol_mass: float, optional
+       Reject match if the atomic masses for matched atoms differ by more than
+       *tol_mass*, default [0.1]
+    strict: boolean, optional
+       ``True``
+           Will raise :exc:`SelectionError` if a single atom does not
+           match between the two selections.
+       ``False`` [default]
+           Will try to prepare a matching selection by dropping
+           residues with non-matching atoms. See :func:`get_matching_atoms`
+           for details.
+    subselection : string, optional
+       Apply the transformation only to this selection.
 
-         ``None`` [default]
-             Apply to `mobile.universe.atoms` (i.e. all atoms in the
-             context of the selection from *mobile* such as the rest of a
-             protein, ligands and the surrounding water)
-         *selection-string*
-             Apply to `mobile.select_atoms(selection-string)`
-         :class:`~MDAnalysis.core.groups.AtomGroup`
-             Apply to the arbitrary group of atoms
+       ``None`` [default]
+           Apply to `mobile.universe.atoms` (i.e. all atoms in the
+           context of the selection from *mobile* such as the rest of a
+           protein, ligands and the surrounding water)
+       *selection-string*
+           Apply to `mobile.select_atoms(selection-string)`
+       :class:`~MDAnalysis.core.groups.AtomGroup`
+           Apply to the arbitrary group of atoms
 
     Returns
     -------
     old_rmsd
         RMSD before spatial alignment
     new_rmsd
-        RMSD after spatial alignment.
 
     See Also
     --------
@@ -408,6 +409,9 @@ def alignto(mobile, reference, select="all", mass_weighted=False,
        Uses :func:`get_matching_atoms` to work with incomplete selections
        and new *strict* keyword. The new default is to be lenient whereas
        the old behavior was the equivalent of *strict* = ``True``.
+
+    .. versionchanged:: 0.16.0
+       new general 'weights' kwarg replace mass_weights
     """
     if select in ('all', None):
         # keep the EXACT order in the input AtomGroups; select_atoms('all')
@@ -424,16 +428,16 @@ def alignto(mobile, reference, select="all", mass_weighted=False,
                                                  tol_mass=tol_mass,
                                                  strict=strict)
 
-    if mass_weighted:
-        # division by the mean is done in rmsd, not done in qcp, but is done in
-        # _fit_to
+    if mass_weighted is not None:
+        # TODO: print deprecation warnings for 0.17.0
+        if mass_weighted:
+            weights = 'mass'
+
+    if weights == 'mass':
         weights = ref_atoms.masses
-        ref_com = ref_atoms.center_of_mass()
-        mobile_com = mobile_atoms.center_of_mass()
-    else:
-        weights = None
-        ref_com = ref_atoms.center_of_geometry()
-        mobile_com = mobile_atoms.center_of_geometry()
+
+    mobile_com = mobile_atoms.center(weights)
+    ref_com = ref_atoms.center(weights)
 
     ref_coordinates = ref_atoms.positions - ref_com
     mobile_coordinates = mobile_atoms.positions - mobile_com

--- a/package/MDAnalysis/analysis/align.py
+++ b/package/MDAnalysis/analysis/align.py
@@ -429,7 +429,9 @@ def alignto(mobile, reference, select="all", mass_weighted=None, weights=None,
                                                  strict=strict)
 
     if mass_weighted is not None:
-        # TODO: print deprecation warnings for 0.17.0
+        warnings.warn("mass weighted is deprecated argument. Please use "
+                      " 'weights=\"mass\" instead. Will be removed in 0.17.0",
+                      category=DeprecationWarning)
         if mass_weighted:
             weights = 'mass'
 
@@ -590,7 +592,9 @@ class AlignTraj(AnalysisBase):
         self._writer = mda.Writer(self.filename, natoms)
 
         if mass_weighted is not None:
-            # TODO: print depcreatoin message til 0.17.0
+            warnings.warn("mass weighted is deprecated argument. Please use "
+                          " 'weights=\"mass\" instead. Will be removed in 0.17.0",
+                          category=DeprecationWarning)
             if mass_weighted:
                 weights = 'mass'
 

--- a/package/MDAnalysis/analysis/encore/confdistmatrix.py
+++ b/package/MDAnalysis/analysis/encore/confdistmatrix.py
@@ -69,9 +69,10 @@ def conformational_distance_matrix(ensemble,
         Function that fills the matrix with conformational distance
         values. See set_rmsd_matrix_elements for an example.
     selection : str, optional
-        use this selection
+        use this selection for the calculation of conformational distance
     superimposition_selection : str, optional
-        TODO
+        use atoms from this selection for fitting instead of those of
+        "selection"
     pairwise_align : bool, optional
         Whether to perform pairwise alignment between conformations.
         Default is True (do the superimposition)

--- a/package/MDAnalysis/analysis/encore/confdistmatrix.py
+++ b/package/MDAnalysis/analysis/encore/confdistmatrix.py
@@ -42,6 +42,7 @@ from socket import gethostname
 from datetime import datetime
 from time import sleep
 import logging
+import warnings
 
 from ...core.universe import Universe
 
@@ -53,8 +54,8 @@ from .utils import TriangularMatrix, trm_indices
 
 def conformational_distance_matrix(ensemble,
                                    conf_dist_function, selection="",
-                                   superimposition_selection="", n_jobs=1, pairwise_align=True,
-                                   mass_weighted=True, metadata=True, verbose=False):
+                                   superimposition_selection="", n_jobs=1, pairwise_align=True, weights='mass',
+                                   mass_weighted=None, metadata=True, verbose=False):
     """
     Run the conformational distance matrix calculation.
     args and kwargs are passed to conf_dist_function.
@@ -67,18 +68,26 @@ def conformational_distance_matrix(ensemble,
     conf_dist_function : function object
         Function that fills the matrix with conformational distance
         values. See set_rmsd_matrix_elements for an example.
-    pairwise_align : bool
+    selection : str, optional
+        use this selection
+    superimposition_selection : str, optional
+        TODO
+    pairwise_align : bool, optional
         Whether to perform pairwise alignment between conformations.
         Default is True (do the superimposition)
-    mass_weighted : bool
+    mass_weighted : bool, optional (deprecated)
         Whether to perform mass-weighted superimposition and metric
         calculation. Default is True.
-    metadata : bool
+    weights : str/array_like, optional
+       weights to be used for fit. Can be either 'mass' or an array_like
+    metadata : bool, optional
         Whether to build a metadata dataset for the calculated matrix.
         Default is True.
-    n_jobs : int
+    n_jobs : int, optional
         Number of cores to be used for parallel calculation
         Default is 1. -1 uses all available cores
+    verbose : bool, optional
+        enable verbose output
 
     Returns
     -------
@@ -91,6 +100,13 @@ def conformational_distance_matrix(ensemble,
     framesn = len(ensemble.trajectory.timeseries(
         ensemble.select_atoms(selection), format='fac'))
 
+    if mass_weighted is not None:
+        warnings.warn("mass weighted is deprecated argument. Please use "
+                      " 'weights=\"mass\" instead. Will be removed in 0.17.0",
+                      category=DeprecationWarning)
+        if mass_weighted:
+            weights = 'mass'
+
     # Prepare metadata recarray
     if metadata:
         metadata = np.array([(gethostname(),
@@ -100,7 +116,7 @@ def conformational_distance_matrix(ensemble,
                            framesn,
                            pairwise_align,
                            selection,
-                           mass_weighted)],
+                           weights=='mass')],
                          dtype=[('host', object),
                                 ('user', object),
                                 ('date', object),
@@ -128,20 +144,32 @@ def conformational_distance_matrix(ensemble,
     else:
         fitting_coordinates = None
 
-    # Prepare masses as necessary
-    if mass_weighted:
-        masses = ensemble.select_atoms(selection).masses.astype(np.float64)
+
+    if weights == 'mass':
+        weights = ensemble.select_atoms(selection).masses.astype(np.float64)
         if pairwise_align:
-            subset_masses = ensemble.select_atoms(subset_selection).masses.astype(np.float64)
+            subset_weights = ensemble.select_atoms(subset_selection).masses.astype(np.float64)
         else:
-            subset_masses = None
-    else:
-        masses = np.ones((ensemble.trajectory.timeseries(
+            subset_weights = None
+    elif weights is None:
+        weights = np.ones((ensemble.trajectory.timeseries(
             ensemble.select_atoms(selection))[0].shape[0])).astype(np.float64)
         if pairwise_align:
-            subset_masses = np.ones((fit_coords[0].shape[0])).astype(np.float64)
+            subset_weights = np.ones((fit_coords[0].shape[0])).astype(np.float64)
         else:
-            subset_masses = None
+            subset_weights = None
+    else:
+        if pairwise_align:
+            if len(weights) != 2:
+                raise RuntimeError("used pairwise alignment with custom "
+                                   "weights. Please provide 2 tuple with "
+                                   "weights for 'selection' and "
+                                   "'superimposition_selection'")
+            subset_weights = weights[1]
+            weights = weights[0]
+        else:
+            subset_weights = None
+
 
     # Allocate for output matrix
     matsize = framesn * (framesn + 1) / 2
@@ -155,25 +183,23 @@ def conformational_distance_matrix(ensemble,
         element,
         rmsd_coordinates,
         distmat,
-        masses,
+        weights,
         fitting_coordinates,
-        subset_masses,
-        masses) for element in indices)
+        subset_weights) for element in indices)
 
 
     # When the workers have finished, return a TriangularMatrix object
     return TriangularMatrix(distmat, metadata=metadata)
 
 
-def set_rmsd_matrix_elements(tasks, coords, rmsdmat, masses, fit_coords=None,
-                             fit_masses=None, pbar_counter=None, *args, **kwargs):
+def set_rmsd_matrix_elements(tasks, coords, rmsdmat, weights, fit_coords=None,
+                             fit_weights=None, *args, **kwargs):
 
     '''
     RMSD Matrix calculator
 
     Parameters
     ----------
-
     tasks : iterator of int of length 2
         Given a triangular matrix, this function will calculate RMSD
         values from element tasks[0] to tasks[1]. Since the matrix
@@ -182,48 +208,43 @@ def set_rmsd_matrix_elements(tasks, coords, rmsdmat, masses, fit_coords=None,
         The matrix is written as an array in a row-major
         order (see the TriangularMatrix class for details).
 
-        If fit_coords and fit_masses are specified, the structures
-        will be superimposed before calculating RMSD, and fit_coords and fit_masses
+        If fit_coords and fit_weights are specified, the structures
+        will be superimposed before calculating RMSD, and fit_coords and fit_weights
         will be used to place both structures at their center of mass and
-        compute the rotation matrix. In this case, both fit_coords and fit_masses
+        compute the rotation matrix. In this case, both fit_coords and fit_weights
         must be specified.
-
     coords : numpy.array
         Array of the ensemble coordinates
-
-    masses : numpy.array
-        Array of atomic masses, having the same order as the
+    weights : numpy.array
+        Array of atomic weights, having the same order as the
         coordinates array
-
     rmsdmat : encore.utils.TriangularMatrix
         Memory-shared triangular matrix object
-
-    fit_coords : numpy.array or None
+    fit_coords : numpy.array or None, optional
         Array of the coordinates used for fitting
-
-    fit_masses : numpy.array
-        Array of atomic masses, having the same order as the
+    fit_weights : numpy.array. optional
+        Array of atomic weights, having the same order as the
         fit_coords array
         '''
     i, j = tasks
 
-    if fit_coords is None and fit_masses is None:
-        summasses = np.sum(masses)
+    if fit_coords is None and fit_weights is None:
+        sumweights = np.sum(weights)
         rmsdmat[(i + 1) * i / 2 + j] = PureRMSD(coords[i].astype(np.float64),
                                                 coords[j].astype(np.float64),
                                                 coords[j].shape[0],
-                                                masses,
-                                                summasses)
+                                                weights,
+                                                sumweights)
 
-    elif fit_coords is not None and fit_masses is not None:
-        summasses = np.sum(masses)
-        subset_weights = np.asarray(fit_masses) / np.mean(fit_masses)
+    elif fit_coords is not None and fit_weights is not None:
+        sumweights = np.sum(weights)
+        subset_weights = np.asarray(fit_weights) / np.mean(fit_weights)
         com_i = np.average(fit_coords[i], axis=0,
-                           weights=fit_masses)
+                           weights=fit_weights)
         translated_i = coords[i] - com_i
         subset1_coords = fit_coords[i] - com_i
         com_j = np.average(fit_coords[j], axis=0,
-                           weights=fit_masses)
+                           weights=fit_weights)
         translated_j = coords[j] - com_j
         subset2_coords = fit_coords[j] - com_j
         rotamat = rotation_matrix(subset1_coords, subset2_coords,
@@ -231,9 +252,9 @@ def set_rmsd_matrix_elements(tasks, coords, rmsdmat, masses, fit_coords=None,
         rotated_i = np.transpose(np.dot(rotamat, np.transpose(translated_i)))
         rmsdmat[(i + 1) * i / 2 + j] = PureRMSD(
             rotated_i.astype(np.float64), translated_j.astype(np.float64),
-            coords[j].shape[0], masses, summasses)
+            coords[j].shape[0], weights, sumweights)
     else:
-        raise TypeError("Both fit_coords and fit_masses must be specified \
+        raise TypeError("Both fit_coords and fit_weights must be specified \
                         if one of them is given")
 
 
@@ -243,7 +264,8 @@ def get_distance_matrix(ensemble,
                         save_matrix=None,
                         superimpose=True,
                         superimposition_subset="name CA",
-                        mass_weighted=True,
+                        weights='mass',
+                        mass_weighted=None,
                         n_jobs=1,
                         verbose=False,
                         *conf_dist_args,
@@ -281,9 +303,11 @@ def get_distance_matrix(ensemble,
     superimposition_subset : str, optional
         Group for superimposition using MDAnalysis selection syntax
         (default is CA atoms: "name CA")
-    mass_weighted : bool, optional
-        calculate a mass-weighted RMSD (default is True). If set to False
+    mass_weighted : bool, optional (deprecated)
+        calculate a mass-weighted RMSD (default is None). If set to False
         the superimposition will also not be mass-weighted.
+    weights : str/array_like, optional
+        weights to be used for fit. Can be either 'mass' or an array_like
     n_jobs : int, optional
         Maximum number of cores to be used (default is 1). If -1 use all cores.
     verbose : bool, optional
@@ -324,10 +348,23 @@ def get_distance_matrix(ensemble,
 
     # Calculate the matrix
     else:
+
+        if mass_weighted is not None:
+            warnings.warn("mass weighted is deprecated argument. Please use "
+                        " 'weights=\"mass\" instead. Will be removed in 0.17.0",
+                        category=DeprecationWarning)
+            if mass_weighted:
+                weights = 'mass'
+
+        if weights == 'mass':
+            weight_type = 'Mass'
+        elif weights is None:
+            weight_type = 'None'
+        else:
+            weight_type = 'Custom'
         logging.info(
             "        Perform pairwise alignment: {0}".format(str(superimpose)))
-        logging.info("        Mass-weighted alignment and RMSD: {0}"
-            .format(str(mass_weighted)))
+        logging.info("        weighted alignment and RMSD: {0}".format(weight_type))
         if superimpose:
             logging.info(
                 "        Atoms subset for alignment: {0}"
@@ -340,7 +377,7 @@ def get_distance_matrix(ensemble,
                                                         conf_dist_function=set_rmsd_matrix_elements,
                                                         selection=selection,
                                                         pairwise_align=superimpose,
-                                                        mass_weighted=mass_weighted,
+                                                        weights=weights,
                                                         n_jobs=n_jobs,
                                                         verbose=verbose)
 

--- a/package/MDAnalysis/analysis/encore/confdistmatrix.py
+++ b/package/MDAnalysis/analysis/encore/confdistmatrix.py
@@ -144,8 +144,7 @@ def conformational_distance_matrix(ensemble,
     else:
         fitting_coordinates = None
 
-
-    if weights == 'mass':
+    if not isinstance(weights, (list, tuple, np.ndarray)) and weights == 'mass':
         weights = ensemble.select_atoms(selection).masses.astype(np.float64)
         if pairwise_align:
             subset_weights = ensemble.select_atoms(subset_selection).masses.astype(np.float64)
@@ -170,11 +169,9 @@ def conformational_distance_matrix(ensemble,
         else:
             subset_weights = None
 
-
     # Allocate for output matrix
     matsize = framesn * (framesn + 1) / 2
     distmat = np.empty(matsize, np.float64)
-
 
     # Initialize workers. Simple worker doesn't perform fitting,
     # fitter worker does.
@@ -356,7 +353,7 @@ def get_distance_matrix(ensemble,
             if mass_weighted:
                 weights = 'mass'
 
-        if weights == 'mass':
+        if not isinstance(weights, (list, tuple, np.ndarray)) and weights == 'mass':
             weight_type = 'Mass'
         elif weights is None:
             weight_type = 'None'

--- a/package/MDAnalysis/analysis/encore/confdistmatrix.py
+++ b/package/MDAnalysis/analysis/encore/confdistmatrix.py
@@ -55,7 +55,7 @@ from .utils import TriangularMatrix, trm_indices
 def conformational_distance_matrix(ensemble,
                                    conf_dist_function, selection="",
                                    superimposition_selection="", n_jobs=1, pairwise_align=True, weights='mass',
-                                   mass_weighted=None, metadata=True, verbose=False):
+                                   metadata=True, verbose=False):
     """
     Run the conformational distance matrix calculation.
     args and kwargs are passed to conf_dist_function.
@@ -75,9 +75,6 @@ def conformational_distance_matrix(ensemble,
     pairwise_align : bool, optional
         Whether to perform pairwise alignment between conformations.
         Default is True (do the superimposition)
-    mass_weighted : bool, optional (deprecated)
-        Whether to perform mass-weighted superimposition and metric
-        calculation. Default is True.
     weights : str/array_like, optional
        weights to be used for fit. Can be either 'mass' or an array_like
     metadata : bool, optional
@@ -99,13 +96,6 @@ def conformational_distance_matrix(ensemble,
     # framesn: number of frames
     framesn = len(ensemble.trajectory.timeseries(
         ensemble.select_atoms(selection), format='fac'))
-
-    if mass_weighted is not None:
-        warnings.warn("mass weighted is deprecated argument. Please use "
-                      " 'weights=\"mass\" instead. Will be removed in 0.17.0",
-                      category=DeprecationWarning)
-        if mass_weighted:
-            weights = 'mass'
 
     # Prepare metadata recarray
     if metadata:
@@ -262,7 +252,6 @@ def get_distance_matrix(ensemble,
                         superimpose=True,
                         superimposition_subset="name CA",
                         weights='mass',
-                        mass_weighted=None,
                         n_jobs=1,
                         verbose=False,
                         *conf_dist_args,
@@ -300,9 +289,6 @@ def get_distance_matrix(ensemble,
     superimposition_subset : str, optional
         Group for superimposition using MDAnalysis selection syntax
         (default is CA atoms: "name CA")
-    mass_weighted : bool, optional (deprecated)
-        calculate a mass-weighted RMSD (default is None). If set to False
-        the superimposition will also not be mass-weighted.
     weights : str/array_like, optional
         weights to be used for fit. Can be either 'mass' or an array_like
     n_jobs : int, optional
@@ -345,14 +331,6 @@ def get_distance_matrix(ensemble,
 
     # Calculate the matrix
     else:
-
-        if mass_weighted is not None:
-            warnings.warn("mass weighted is deprecated argument. Please use "
-                        " 'weights=\"mass\" instead. Will be removed in 0.17.0",
-                        category=DeprecationWarning)
-            if mass_weighted:
-                weights = 'mass'
-
         if not isinstance(weights, (list, tuple, np.ndarray)) and weights == 'mass':
             weight_type = 'Mass'
         elif weights is None:

--- a/package/MDAnalysis/analysis/encore/covariance.py
+++ b/package/MDAnalysis/analysis/encore/covariance.py
@@ -225,7 +225,7 @@ def covariance_matrix(ensemble,
     # Optionally correct with weights
     if weights is not None:
         # Calculate mass-weighted covariance matrix
-        if weights == 'mass':
+        if not isinstance(weights, (list, tuple, np.ndarray)) and weights == 'mass':
             if selection:
                 weights = ensemble.select_atoms(selection).masses
             else:

--- a/package/MDAnalysis/analysis/encore/similarity.py
+++ b/package/MDAnalysis/analysis/encore/similarity.py
@@ -169,6 +169,8 @@ Function reference
 
 """
 from __future__ import print_function
+from six.moves import range, zip
+
 import MDAnalysis as mda
 import numpy as np
 import warnings
@@ -737,7 +739,7 @@ def prepare_ensembles_for_convergence_increasing_window(ensemble,
 def hes(ensembles,
         selection="name CA",
         cov_estimator="shrinkage",
-        mass_weighted=True,
+        weights='mass',
         align=False,
         details=False,
         estimate_error=False,
@@ -751,38 +753,28 @@ def hes(ensembles,
 
     Parameters
     ----------
-
     ensembles : list
         List of Universe objects for similarity measurements.
-
     selection : str, optional
         Atom selection string in the MDAnalysis format. Default is "name CA"
-
     cov_estimator : str, optional
         Covariance matrix estimator method, either shrinkage, `shrinkage`,
         or Maximum Likelyhood, `ml`. Default is shrinkage.
-
-    mass_weighted : bool, optional
-        Whether to perform mass-weighted covariance matrix estimation
-        (default is True).
-
+    weights : str/array_like, optional
+        specify optional weights. If ``mass`` then chose masses of ensemble atoms
     align : bool, optional
         Whether to align the ensembles before calculating their similarity.
         Note: this changes the ensembles in-place, and will thus leave your
         ensembles in an altered state.
         (default is False)
-
     details : bool, optional
         Save the mean and covariance matrix for each
         ensemble in a numpy array (default is False).
-
     estimate_error : bool, optional
         Whether to perform error estimation (default is False).
-
     bootstrapping_samples : int, optional
         Number of times the similarity matrix will be bootstrapped (default
         is 100), only if estimate_error is True.
-
     calc_diagonal : bool, optional
         Whether to calculate the diagonal of the similarity scores
         (i.e. the similarities of every ensemble against itself).
@@ -790,13 +782,11 @@ def hes(ensembles,
 
     Returns
     -------
-
     numpy.array (bidimensional)
         Harmonic similarity measurements between each pair of ensembles.
 
     Notes
     -----
-
     The method assumes that each ensemble is derived from a multivariate normal
     distribution. The mean and covariance matrix are, thus, estimatated from
     the distribution of each ensemble and used for comparision by the
@@ -858,14 +848,22 @@ def hes(ensembles,
          [ 7032.19607004     0.        ]]
     """
 
+    if weights == 'mass':
+        weights = ['mass' for _ in range(len(ensembles))]
+    elif weights is not None:
+        if len(weights) != len(ensembles):
+            raise ValueError("need weights for every ensemble")
+    else:
+        weights = [None for _ in range(len(ensembles))]
+
     # Ensure in-memory trajectories either by calling align
     # with in_memory=True or by directly calling transfer_to_memory
     # on the universe.
     if align:
-        for ensemble in ensembles:
-            mda.analysis.align.AlignTraj(ensemble, ensembles[0],
+        for e, w in zip(ensembles, weights):
+            mda.analysis.align.AlignTraj(e, ensembles[0],
                                          select=selection,
-                                         mass_weighted=True,
+                                         weights=w,
                                          in_memory=True).run()
     else:
         for ensemble in ensembles:
@@ -915,7 +913,7 @@ def hes(ensembles,
                         format=('fac')),
                     axis=0).flatten())
                 sigmas.append(covariance_matrix(ensembles_list[i][t],
-                                                mass_weighted=True,
+                                                weights=weights[i],
                                                 estimator=covariance_estimator,
                                                 selection=selection))
 
@@ -936,8 +934,7 @@ def hes(ensembles,
     # of each ensemble
     values = np.zeros((out_matrix_eln, out_matrix_eln))
 
-    for e in ensembles:
-
+    for e, w in zip(ensembles, weights):
         # Extract coordinates from each ensemble
         coordinates_system = e.trajectory.timeseries(e.select_atoms(selection),
                                                      format='fac')
@@ -947,7 +944,7 @@ def hes(ensembles,
 
         # Covariance matrices in each system
         sigmas.append(covariance_matrix(e,
-                                        mass_weighted=mass_weighted,
+                                        weights=w,
                                         estimator=covariance_estimator,
                                         selection=selection))
 

--- a/package/MDAnalysis/analysis/encore/similarity.py
+++ b/package/MDAnalysis/analysis/encore/similarity.py
@@ -848,7 +848,7 @@ def hes(ensembles,
          [ 7032.19607004     0.        ]]
     """
 
-    if weights == 'mass':
+    if not isinstance(weights, (list, tuple, np.ndarray)) and weights == 'mass':
         weights = ['mass' for _ in range(len(ensembles))]
     elif weights is not None:
         if len(weights) != len(ensembles):

--- a/package/MDAnalysis/analysis/hole.py
+++ b/package/MDAnalysis/analysis/hole.py
@@ -111,7 +111,7 @@ order parameter :math:`\rho`. ::
    u = mda.Universe(MULTIPDB_HOLE) # trajectory
 
    # calculate RMSD
-   R = RMSD(u, reference=ref, select="protein", mass_weighted=True)
+   R = RMSD(u, reference=ref, select="protein", weights='mass')
    R.run()
 
    # HOLE analysis with order parameters

--- a/package/MDAnalysis/analysis/rms.py
+++ b/package/MDAnalysis/analysis/rms.py
@@ -434,7 +434,7 @@ class RMSD(AnalysisBase):
     def _prepare(self):
         self._n_atoms = self.mobile_atoms.n_atoms
 
-        if self.weights == 'mass':
+        if not isinstance(self.weights, (list, tuple, np.ndarray)) and self.weights == 'mass':
             self.weights = self.ref_atoms.masses
         if self.weights is not None:
             self.weights = (self.weights / self.weights.mean()).astype(np.float64)
@@ -582,7 +582,7 @@ class RMSF(AnalysisBase):
         """
         super(RMSF, self).__init__(atomgroup.universe.trajectory, **kwargs)
         self.atomgroup = atomgroup
-        if weights == 'mass':
+        if not isinstance(weights, (list, tuple, np.ndarray)) and weights == 'mass':
             weights = self.atomgroup.masses
         self.weights = weights
 

--- a/package/MDAnalysis/analysis/rms.py
+++ b/package/MDAnalysis/analysis/rms.py
@@ -359,7 +359,9 @@ class RMSD(AnalysisBase):
         self.groupselections = ([process_selection(s) for s in groupselections]
                                 if groupselections is not None else [])
         if mass_weighted is not None:
-            # TODO: add depcreation
+            warnings.warn("mass weighted is deprecated argument. Please use "
+                          " 'weights=\"mass\" instead. Will be removed in 0.17.0",
+                          category=DeprecationWarning)
             if mass_weighted:
                 weights = 'mass'
         self.weights = weights

--- a/package/MDAnalysis/analysis/rms.py
+++ b/package/MDAnalysis/analysis/rms.py
@@ -347,8 +347,10 @@ class RMSD(AnalysisBase):
         .. versionadded:: 0.7.7
         .. versionchanged:: 0.8
            `groupselections` added
-        .. versionchanged: 0.15.1
-           Refactor to fit with AnalysisBase API
+        .. versionchanged:: 0.16.0
+           Flexible weighting scheme with new ``weights`` keyword.
+        .. deprecated:: 0.16.0
+           Instead of ``mass_weighted=True`` use new ``weights='mass'`  Refactor to fit with AnalysisBase API
         """
         super(RMSD, self).__init__(atomgroup.universe.trajectory,
                                    **kwargs)
@@ -545,8 +547,26 @@ class RMSF(AnalysisBase):
         This method implements an algorithm for computing sums of squares while
         avoiding overflows and underflows [Welford1962]_.
 
+        References
+        ----------
+        .. [Welford1962] B. P. Welford (1962). "Note on a Method for
+           Calculating Corrected Sums of Squares and Products." Technometrics
+           4(3):419-420.
+
+       .. versionadded:: 0.11.0
+       .. versionchanged:: 0.16.0
+          Flexible weighting scheme with new ``weights`` keyword.
+       .. deprecated:: 0.16.0
+          Instead of ``mass_weighted=True`` use new ``weights='mass'`
+          Refactor to fit with AnalysisBase API
+          The keyword argument *quiet* is deprecated in favor of *verbose*.
+    """
+    def __init__(self, atomgroup, weights=None, **kwargs):
+        """
         Parameters
         ----------
+        atomgroup : mda.AtomGroup
+            Atoms for which RMSF is calculated
         start : int (optional)
             starting frame, default None becomes 0.
         stop : int (optional)
@@ -555,20 +575,11 @@ class RMSF(AnalysisBase):
             which means that the trajectory would be read until the end.
         step : int (optional)
             step between frames, default None becomes 1.
-        progout : int (optional)
-            number of frames to iterate through between updates to progress
-            output; ``None`` for no updates [10]
+        weights : str / array_like (optional)
+            used weights. If ``'mass'`` use masses of atomgroup, it ``None`` use uniform weights.
         verbose : bool (optional)
-            if ``False``, suppress all output (implies *progout* = ``None``)
-            [``True``]
-
-        References
-        ----------
-        .. [Welford1962] B. P. Welford (1962). "Note on a Method for
-           Calculating Corrected Sums of Squares and Products." Technometrics
-           4(3):419-420.
-    """
-    def __init__(self, atomgroup, weights=None, **kwargs):
+            if ``False``, suppress all output
+        """
         super(RMSF, self).__init__(atomgroup.universe.trajectory, **kwargs)
         self.atomgroup = atomgroup
         if weights == 'mass':

--- a/package/MDAnalysis/analysis/rms.py
+++ b/package/MDAnalysis/analysis/rms.py
@@ -195,15 +195,6 @@ def rmsd(a, b, weights=None, center=False, superposition=False):
     if a.shape != b.shape:
         raise ValueError('a and b must have same shape')
 
-    if weights is not None:
-        if len(weights) != len(a):
-            raise ValueError('weights must have same length as a/b')
-        # weights are constructed as relative to the mean
-        relative_weights = np.asarray(weights) / np.mean(weights)
-        relative_weights = relative_weights.astype(np.float64)
-    else:
-        relative_weights = None
-
     # superposition only works if structures are centered
     if center or superposition:
         # make copies (do not change the user data!)
@@ -211,15 +202,18 @@ def rmsd(a, b, weights=None, center=False, superposition=False):
         a = a - np.average(a, axis=0, weights=weights)
         b = b - np.average(b, axis=0, weights=weights)
 
+    if weights is not None:
+        if len(weights) != len(a):
+            raise ValueError('weights must have same length as a/b')
+        # weights are constructed as relative to the mean
+        weights = np.asarray(weights, dtype=np.float64) / np.mean(weights)
+
     if superposition:
-        if relative_weights is not None:
-            relative_weights = relative_weights.astype(np.float64)
-        return qcp.CalcRMSDRotationalMatrix(a, b, N, None,
-                                            relative_weights)
+        return qcp.CalcRMSDRotationalMatrix(a, b, N, None, weights)
     else:
         if weights is not None:
-            return np.sqrt(np.sum(relative_weights[:, np.newaxis]
-                * (( a - b ) ** 2)) / N)
+            return np.sqrt(np.sum(weights[:, np.newaxis]
+                                  * ((a - b) ** 2)) / N)
         else:
             return np.sqrt(np.sum((a - b) ** 2) / N)
 

--- a/package/MDAnalysis/analysis/rms.py
+++ b/package/MDAnalysis/analysis/rms.py
@@ -586,21 +586,21 @@ class RMSF(AnalysisBase):
             weights = self.atomgroup.masses
         self.weights = weights
 
-    def run(start=None, stop=None, step=None, progout=None,
+    def run(self, start=None, stop=None, step=None, progout=None,
             verbose=None, quiet=None):
         if np.any([el is not None for el in (start, stop, step, progout, quiet)]):
             warnings.warn("run arguments are deprecated. Please pass them at "
-                          "class construction",
+                          "class construction. These options will be removed in 0.17.0",
                           category=DeprecationWarning)
             if quiet is not None:
-                verbose = !quiet
+                verbose = not quiet
             else:
                 verbose = False
             # regenerate class with correct args
-            self = RMSD(self.atomgroup, self.weights, start=start,
-                        stop=stop, step=step, verbose=verbose)
+            super(RMSF, self).__init__(self.atomgroup.universe.trajectory,
+                                       start=start, stop=stop, step=step,
+                                       verbose=verbose)
         super(RMSF, self).run()
-
 
     def _prepare(self):
         self.sumsquares = np.zeros((self.atomgroup.n_atoms, 3))

--- a/package/MDAnalysis/analysis/rms.py
+++ b/package/MDAnalysis/analysis/rms.py
@@ -586,6 +586,22 @@ class RMSF(AnalysisBase):
             weights = self.atomgroup.masses
         self.weights = weights
 
+    def run(start=None, stop=None, step=None, progout=None,
+            verbose=None, quiet=None):
+        if np.any([el is not None for el in (start, stop, step, progout, quiet)]):
+            warnings.warn("run arguments are deprecated. Please pass them at "
+                          "class construction",
+                          category=DeprecationWarning)
+            if quiet is not None:
+                verbose = !quiet
+            else:
+                verbose = False
+            # regenerate class with correct args
+            self = RMSD(self.atomgroup, self.weights, start=start,
+                        stop=stop, step=step, verbose=verbose)
+        super(RMSF, self).run()
+
+
     def _prepare(self):
         self.sumsquares = np.zeros((self.atomgroup.n_atoms, 3))
         self.mean = self.sumsquares.copy()

--- a/package/MDAnalysis/analysis/rms.py
+++ b/package/MDAnalysis/analysis/rms.py
@@ -588,14 +588,11 @@ class RMSF(AnalysisBase):
 
     def run(self, start=None, stop=None, step=None, progout=None,
             verbose=None, quiet=None):
-        if np.any([el is not None for el in (start, stop, step, progout, quiet)]):
+        if any([el is not None for el in (start, stop, step, progout, quiet)]):
             warnings.warn("run arguments are deprecated. Please pass them at "
                           "class construction. These options will be removed in 0.17.0",
                           category=DeprecationWarning)
-            if quiet is not None:
-                verbose = not quiet
-            else:
-                verbose = False
+            verbose = _set_verbose(verbose, quiet, default=False)
             # regenerate class with correct args
             super(RMSF, self).__init__(self.atomgroup.universe.trajectory,
                                        start=start, stop=stop, step=step,

--- a/package/MDAnalysis/analysis/rms.py
+++ b/package/MDAnalysis/analysis/rms.py
@@ -328,9 +328,9 @@ class RMSD(AnalysisBase):
             .. Note:: Experimental feature. Only limited error checking
                       implemented.
 
-        filename : str (optional)
+        filename : str, optional
             write RSMD into file file :meth:`RMSD.save`
-        mass_weighted : bool deprecated
+        mass_weighted : bool (deprecated)
              do a mass-weighted RMSD fit
         weights : str/array_like (optional)
              choose weights. If 'str' uses masses as weights

--- a/testsuite/MDAnalysisTests/analysis/test_align.py
+++ b/testsuite/MDAnalysisTests/analysis/test_align.py
@@ -104,9 +104,9 @@ class TestAlign(TestCase):
     def test_rmsd(self):
         self.universe.trajectory[0]  # ensure first frame
         bb = self.universe.select_atoms('backbone')
-        first_frame = bb.positions
+        first_frame = bb.positions.copy()
         self.universe.trajectory[-1]
-        last_frame = bb.positions
+        last_frame = bb.positions.copy()
         assert_almost_equal(rms.rmsd(first_frame, first_frame), 0.0, 5,
                             err_msg="error: rmsd(X,X) should be 0")
         # rmsd(A,B) = rmsd(B,A) should be exact but spurious failures in the
@@ -120,12 +120,13 @@ class TestAlign(TestCase):
         assert_almost_equal(rmsd, 6.820321761927005, 5,
                             err_msg="RMSD calculation between 1st and last "
                             "AdK frame gave wrong answer")
-        #test mass_weighted
+        # test mass_weighted
         last_atoms_weight = self.universe.atoms.masses
         A = self.universe.trajectory[0]
         B = self.reference.trajectory[-1]
-        rmsd = align.alignto(self.universe, self.reference, mass_weighted=True)
-        rmsd_sup_weight = rms.rmsd(A, B,  weights=last_atoms_weight, center=True, superposition=True)
+        rmsd = align.alignto(self.universe, self.reference, weights='mass')
+        rmsd_sup_weight = rms.rmsd(A, B,  weights=last_atoms_weight,
+                                   center=True, superposition=True)
         assert_almost_equal(rmsd[1], rmsd_sup_weight, 6)
 
 

--- a/testsuite/MDAnalysisTests/analysis/test_align.py
+++ b/testsuite/MDAnalysisTests/analysis/test_align.py
@@ -120,7 +120,7 @@ class TestAlign(TestCase):
         assert_almost_equal(rmsd, 6.820321761927005, 5,
                             err_msg="RMSD calculation between 1st and last "
                             "AdK frame gave wrong answer")
-        # test mass_weighted
+        # test masses as weights
         last_atoms_weight = self.universe.atoms.masses
         A = self.universe.trajectory[0]
         B = self.reference.trajectory[-1]
@@ -171,8 +171,8 @@ class TestAlign(TestCase):
         rmsd_outfile = os.path.join(self.tempdir.name, 'rmsd')
         x.save(rmsd_outfile)
 
-        assert_almost_equal(x.rmsd[0], 6.929083044751061, decimal=3)
-        assert_almost_equal(x.rmsd[-1], 5.279731379771749336e-07, decimal=3)
+        assert_almost_equal(x.rmsd[0], 6.9290, decimal=3)
+        assert_almost_equal(x.rmsd[-1], 5.2797e-07, decimal=3)
 
         # RMSD against the reference frame
         # calculated on Mac OS X x86 with MDA 0.7.2 r689
@@ -187,10 +187,10 @@ class TestAlign(TestCase):
 
     def test_AlignTraj_weighted(self):
         x = align.AlignTraj(self.universe, self.reference,
-                            filename=self.outfile, mass_weighted=True).run()
+                            filename=self.outfile, weights='mass').run()
         fitted = MDAnalysis.Universe(PSF, self.outfile)
         assert_almost_equal(x.rmsd[0], 0,  decimal=3)
-        assert_almost_equal(x.rmsd[-1], 6.9033990467077579, decimal=3)
+        assert_almost_equal(x.rmsd[-1], 6.9033, decimal=3)
 
         self._assert_rmsd(fitted, 0, 0.0,
                           weights=self.universe.atoms.masses)
@@ -200,15 +200,15 @@ class TestAlign(TestCase):
     def test_AlignTraj_partial_fit(self):
         # fitting on a partial selection should still write the whole topology
         align.AlignTraj(self.universe, self.reference, select='resid 1-20',
-                        filename=self.outfile, mass_weighted=True).run()
+                        filename=self.outfile, weights='mass').run()
         MDAnalysis.Universe(PSF, self.outfile)
 
     def test_AlignTraj_in_memory(self):
         self.reference.trajectory[-1]
         x = align.AlignTraj(self.universe, self.reference,
                             filename=self.outfile, in_memory=True).run()
-        assert_almost_equal(x.rmsd[0], 6.929083044751061, decimal=3)
-        assert_almost_equal(x.rmsd[-1], 5.279731379771749336e-07, decimal=3)
+        assert_almost_equal(x.rmsd[0], 6.9290, decimal=3)
+        assert_almost_equal(x.rmsd[-1], 5.2797e-07, decimal=3)
 
         # check in memory trajectory
         self._assert_rmsd(self.universe, 0, 6.929083044751061)

--- a/testsuite/MDAnalysisTests/analysis/test_align.py
+++ b/testsuite/MDAnalysisTests/analysis/test_align.py
@@ -154,6 +154,14 @@ class TestAlign(TestCase):
                                    center=True, superposition=True)
         assert_almost_equal(rmsd[1], rmsd_sup_weight, 6)
 
+    def test_rmsd_custom_weights(self):
+        weights = np.zeros(self.universe.atoms.n_atoms)
+        ca = self.universe.atoms.CA
+        weights[ca.indices] = 1
+        rmsd = align.alignto(self.universe, self.reference, select='name CA')
+        rmsd_weights = align.alignto(self.universe, self.reference, weights=weights)
+        assert_almost_equal(rmsd[1], rmsd_weights[1], 6)
+
     @dec.slow
     @attr('issue')
     def test_rms_fit_trj(self):
@@ -222,6 +230,18 @@ class TestAlign(TestCase):
                           weights=self.universe.atoms.masses)
 
     def test_AlignTraj_custom_weights(self):
+        weights = np.zeros(self.universe.atoms.n_atoms)
+        ca = self.universe.atoms.CA
+        weights[ca.indices] = 1
+
+        x = align.AlignTraj(self.universe, self.reference,
+                            filename=self.outfile, select='name CA').run()
+        x_weights = align.AlignTraj(self.universe, self.reference,
+                                    filename=self.outfile, weights=weights).run()
+
+        assert_array_almost_equal(x.rmsd, x_weights.rmsd)
+
+    def test_AlignTraj_custom_mass_weights(self):
         x = align.AlignTraj(self.universe, self.reference,
                             filename=self.outfile, weights=self.reference.atoms.masses).run()
         fitted = MDAnalysis.Universe(PSF, self.outfile)

--- a/testsuite/MDAnalysisTests/analysis/test_encore.py
+++ b/testsuite/MDAnalysisTests/analysis/test_encore.py
@@ -159,7 +159,7 @@ inconsistent results")
             encore.confdistmatrix.set_rmsd_matrix_elements,
             selection="name CA",
             pairwise_align=True,
-            mass_weighted=True,
+            weights='mass',
             n_jobs=1)
 
         reference = rms.RMSD(self.ens1, select = "name CA")
@@ -182,7 +182,7 @@ inconsistent results")
             encore.confdistmatrix.set_rmsd_matrix_elements,
             selection=selection_string,
             pairwise_align=False,
-            mass_weighted=True,
+            weights='mass',
             n_jobs=1)
 
         print (repr(confdist_matrix.as_array()[0,:]))
@@ -214,11 +214,11 @@ inconsistent results")
     def test_ensemble_superimposition_to_reference_non_weighted():
         aligned_ensemble1 = mda.Universe(PSF, DCD)
         align.AlignTraj(aligned_ensemble1, aligned_ensemble1,
-                        select="name CA", mass_weighted=False,
+                        select="name CA",
                         in_memory=True).run()
         aligned_ensemble2 = mda.Universe(PSF, DCD)
         align.AlignTraj(aligned_ensemble2, aligned_ensemble2,
-                        select="name *", mass_weighted=False,
+                        select="name *",
                         in_memory=True).run()
 
         rmsfs1 = rms.RMSF(aligned_ensemble1.select_atoms('name *'))
@@ -239,7 +239,7 @@ inconsistent results")
                             err_msg="Harmonic Ensemble Similarity to itself not zero: {0:f}".format(result_value))
 
     def test_hes(self):
-        results, details = encore.hes([self.ens1, self.ens2], mass_weighted=True)
+        results, details = encore.hes([self.ens1, self.ens2], weights='mass')
         result_value = results[0,1]
         min_bound = 1E5
         self.assertGreater(result_value, min_bound,

--- a/testsuite/MDAnalysisTests/analysis/test_rms.py
+++ b/testsuite/MDAnalysisTests/analysis/test_rms.py
@@ -185,7 +185,7 @@ class TestRMSD(object):
 
     def test_mass_weighted_and_save(self):
         RMSD = MDAnalysis.analysis.rms.RMSD(self.universe, select='name CA',
-                                            step=49, mass_weighted=True).run()
+                                            step=49, weights='mass').run()
         RMSD.save(self.outfile)
         saved = np.loadtxt(self.outfile)
         assert_array_almost_equal(RMSD.rmsd, saved, 4,

--- a/testsuite/MDAnalysisTests/analysis/test_rms.py
+++ b/testsuite/MDAnalysisTests/analysis/test_rms.py
@@ -142,6 +142,7 @@ class Testrmsd(object):
         rmsd_superposition = rms.rmsd(A, B, center=True, superposition=True)
         assert_almost_equal(rmsd, rmsd_superposition)
 
+
 class TestRMSD(object):
     @dec.skipif(parser_not_found('DCD'),
                 'DCD parser not available. Are you using python 3?')
@@ -229,6 +230,7 @@ class TestRMSD(object):
         RMSD = MDAnalysis.analysis.rms.RMSD(self.universe)
         RMSD.save('blah')
 
+
 class TestRMSF(TestCase):
     def setUp(self):
         self.universe = MDAnalysis.Universe(GRO, XTC)
@@ -241,7 +243,7 @@ class TestRMSF(TestCase):
 
     def test_rmsf(self):
         rmsfs = MDAnalysis.analysis.rms.RMSF(self.universe.select_atoms('name CA'))
-        rmsfs.run(verbose=False)
+        rmsfs.run()
         test_rmsfs = np.load(rmsfArray)
 
         assert_almost_equal(rmsfs.rmsf, test_rmsfs, 5,
@@ -249,8 +251,8 @@ class TestRMSF(TestCase):
                             "values")
 
     def test_rmsf_single_frame(self):
-        rmsfs = MDAnalysis.analysis.rms.RMSF(self.universe.select_atoms('name CA'))
-        rmsfs.run(start=5, stop=6, verbose=False)
+        rmsfs = MDAnalysis.analysis.rms.RMSF(self.universe.select_atoms('name CA'), start=5, stop=6)
+        rmsfs.run()
 
         assert_almost_equal(rmsfs.rmsf, 0, 5,
                             err_msg="error: rmsfs should all be zero")
@@ -263,7 +265,7 @@ class TestRMSF(TestCase):
 
         self.universe = MDAnalysis.Universe(GRO, self.outfile)
         rmsfs = MDAnalysis.analysis.rms.RMSF(self.universe.select_atoms('name CA'))
-        rmsfs.run(verbose=False)
+        rmsfs.run()
 
         assert_almost_equal(rmsfs.rmsf, 0, 5,
                             err_msg="error: rmsfs should all be 0")

--- a/testsuite/MDAnalysisTests/analysis/test_rms.py
+++ b/testsuite/MDAnalysisTests/analysis/test_rms.py
@@ -151,7 +151,7 @@ class TestRMSD(object):
         self.outfile = os.path.join(self.tempdir.name, 'rmsd.txt')
         self.correct_values = [[0, 0, 0], [49, 48.9999, 4.68953]]
         self.correct_values_group = [[0, 0, 0, 0, 0],
-                                     [49, 48.9999, 4.7857, 4.7002,
+                                     [49, 49, 4.7857, 4.7004,
                                       4.68981]]
 
     def tearDown(self):

--- a/testsuite/MDAnalysisTests/analysis/test_rms.py
+++ b/testsuite/MDAnalysisTests/analysis/test_rms.py
@@ -282,6 +282,13 @@ class TestRMSF(TestCase):
         assert_almost_equal(rmsfs.rmsf, 0, 5,
                             err_msg="error: rmsfs should all be zero")
 
+    def test_rmsf_old_run(self):
+        rmsfs = rms.RMSF(self.universe.select_atoms('name CA'))
+        rmsfs.run(start=5, stop=6)
+
+        assert_almost_equal(rmsfs.rmsf, 0, 5,
+                            err_msg="error: rmsfs should all be zero")
+
     def test_rmsf_identical_frames(self):
         # write a dummy trajectory of all the same frame
         with mda.Writer(self.outfile, self.universe.atoms.n_atoms) as W:


### PR DESCRIPTION
See #1136 old PR.

I'd appreciate some help in testing the new weights options I've introduced here.

*Old text*

It stills needs some checking and tests. I would like go get this into 0.16.0 though. The RMSD class has been refactored this cycle and I'm currently not sure if the bug has been present as well in 0.15.0

Changes made in this Pull Request:

    use arbitrary weights in align.py and rms.py
    rewrite RMSF to use AnalysisBase
    fix centering bug in RMSD (should be done with chosen weights)


PR Checklist
------------
 - [x] Tests?
 - [x] tests for new deprecated option
 - [x] Docs?
 - [x] CHANGELOG updated?
 - ~~[ ] Issue raised/referenced?~~
 - [x] add deprecation warnings for `mass_weighted`
 - [x] updated functions depending on new kwarg
 - [x] fix all mass_weighted in encore. Or at least raise an issue and fix in other PR
 - [x] RMSF deprecation warnings for run