### PR TITLE
Deactivate open-files plugin in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ install:
 script:
   - pylint --rcfile=package/.pylintrc package/MDAnalysis
   - pylint --rcfile=package/.pylintrc testsuite/MDAnalysisTests
-  - ./testsuite/MDAnalysisTests/mda_nosetests --with-coverage --cover-package MDAnalysis --processes=2 --process-timeout=400 --with-memleak --with-timer --timer-top-n 50
+  - ./testsuite/MDAnalysisTests/mda_nosetests --with-coverage --cover-package MDAnalysis --processes=2 --process-timeout=400 --with-memleak --with-timer --timer-top-n 50 --no-open-files
   - |
      test ${TRAVIS_PULL_REQUEST} == "false" && \
      test ${TRAVIS_BRANCH} == ${GH_DOC_BRANCH} && \


### PR DESCRIPTION
The nose plugin that list open files has compatibility issues with the
plugin that captures stderr. To avoid obscure traceback in travis, this
commit deactivate the open-files plugin from travis runs.

See odd traceback on #1196 <https://travis-ci.org/MDAnalysis/mdanalysis/jobs/198260651#L1386>