### PR TITLE
Fix transfer_to_memory progress meter call

### DIFF
--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -464,12 +464,16 @@ class Universe(object):
             # if the Timeseries extraction fails,
             # fall back to a slower approach
             except AttributeError:
-                pm = ProgressMeter(self.trajectory.n_frames,
-                                   interval=1, verbose=verbose)
+                n_frames = len(range(
+                    *self.trajectory.check_slice_indices(start, stop, step)
+                ))
+                pm_format = '{step}/{numsteps} frames written (frame {frame})'
+                pm = ProgressMeter(n_frames, interval=1,
+                                   verbose=verbose, format=pm_format)
                 coordinates = []  # TODO: use pre-allocated array
-                for ts in self.trajectory[start:stop:step]:
+                for i, ts in enumerate(self.trajectory[start:stop:step]):
                     coordinates.append(np.copy(ts.positions))
-                    pm.echo(ts.frame)
+                    pm.echo(i, frame=ts.frame)
                 coordinates = np.array(coordinates)
 
             # Overwrite trajectory in universe with an MemoryReader

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -465,7 +465,7 @@ class Universe(object):
             # fall back to a slower approach
             except AttributeError:
                 pm = ProgressMeter(self.trajectory.n_frames,
-                                   interval=step, verbose=verbose)
+                                   interval=1, verbose=verbose)
                 coordinates = []  # TODO: use pre-allocated array
                 for ts in self.trajectory[start:stop:step]:
                     coordinates.append(np.copy(ts.positions))

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -428,7 +428,8 @@ class Universe(object):
 
         return filename, self.trajectory.format
 
-    def transfer_to_memory(self, start=None, stop=None, step=None, verbose=None, quiet=None):
+    def transfer_to_memory(self, start=None, stop=None, step=None,
+                           verbose=None, quiet=None):
         """Transfer the trajectory to in memory representation.
 
         Replaces the current trajectory reader object with one of type
@@ -467,7 +468,7 @@ class Universe(object):
                 n_frames = len(range(
                     *self.trajectory.check_slice_indices(start, stop, step)
                 ))
-                pm_format = '{step}/{numsteps} frames written (frame {frame})'
+                pm_format = '{step}/{numsteps} frames copied to memory (frame {frame})'
                 pm = ProgressMeter(n_frames, interval=1,
                                    verbose=verbose, format=pm_format)
                 coordinates = []  # TODO: use pre-allocated array


### PR DESCRIPTION
Since I merged #1030, Universe.transfer_to_memory could instanciate a
ProgressMeter with an invalid interval. By default, that interval was
set to None, which is an invalid interval since interval must be an
integer (or must be castable to an int).

Here, I make sure Universe.transfer_to_memory always use 1 as interval
for the progress meter. This leads to the same behaviour as before #1030
was merged: the progress meter updates at every frame transferred. Note
that this behavior is not the default behavior of the progress meter,
and that the default behavior may be preferable.

Fixes #1030

PR Checklist
------------
 - [ ] Tests?
 - ~~[ ] Docs?~~
 - ~~[ ] CHANGELOG updated?~~
 - [x] Issue raised/referenced?
