### PR TITLE
range type error for density map

### DIFF
--- a/package/MDAnalysis/analysis/density.py
+++ b/package/MDAnalysis/analysis/density.py
@@ -505,7 +505,8 @@ def density_from_Universe(universe, delta=1.0, atomselection='name OH2',
     smax = np.max(coord, axis=0) + padding
 
     BINS = fixedwidth_bins(delta, smin, smax)
-    arange = zip(BINS['min'], BINS['max'])
+    arange = np.vstack((BINS['min'], BINS['max']))
+    arange = np.transpose(arange)
     bins = BINS['Nbins']
 
     # create empty grid with the right dimensions (and get the edges)

--- a/package/MDAnalysis/coordinates/PDB.py
+++ b/package/MDAnalysis/coordinates/PDB.py
@@ -1064,3 +1064,27 @@ class MultiPDBWriter(PDBWriter):
     """
     format = 'PDB'
     multiframe = True  # For Writer registration
+
+
+class SinglePDBWriter(PDBWriter):
+    """PDB writer that implements a subset of the `PDB 3.2 standard`_ .
+
+    PDB format as used by NAMD/CHARMM: 4-letter resnames and segID, altLoc
+    is written.
+
+    By default, :class:`SinglePDBWriter` writes a single PDB frame, which
+    doesn't use the MODEL_ and ENDMDL_ records and thus, don't contain the line
+    "MODEL 1". "MODEL 1" is hated by a software (coot) which is frequently used
+    in x-ray crystallography.
+
+
+
+    .. SeeAlso::
+       This class is identical to :class:`PDBWriter`. This class overwrites the
+       MultiPDBWriter in the _SINGLEFRAME_WRITERS. It defaults to writing
+       single frame PDB files instead of multi-single frames.
+
+    .. versionadded:: 0.7.6
+
+    """
+    format = 'PDB'


### PR DESCRIPTION
When np.histogramdd is called, numpy calls the np.isfinite to check if
the range is finite or not. However, np.isfinite cannot deal with the
zip object. Thus, I transform the zip object to np.array which can pass
the np.isfinite check.