### PR TITLE
fix the type problem for density plot.

### DIFF
--- a/package/MDAnalysis/analysis/density.py
+++ b/package/MDAnalysis/analysis/density.py
@@ -505,7 +505,8 @@ def density_from_Universe(universe, delta=1.0, atomselection='name OH2',
     smax = np.max(coord, axis=0) + padding
 
     BINS = fixedwidth_bins(delta, smin, smax)
-    arange = zip(BINS['min'], BINS['max'])
+    arange = np.vstack((BINS['min'], BINS['max']))
+    arange = np.transpose(arange)
     bins = BINS['Nbins']
 
     # create empty grid with the right dimensions (and get the edges)


### PR DESCRIPTION
When np.histogramdd is called, numpy calls the np.isfinite to check if
the range is finite or not. However, np.isfinite cannot deal with the
zip object. Thus, I transform the zip object to np.array which can pass
the np.isfinite check.