### PR TITLE
update conda recipe [skip ci]

### DIFF
--- a/maintainer/conda/MDAnalysis/README.rst
+++ b/maintainer/conda/MDAnalysis/README.rst
@@ -1,0 +1,8 @@
+
+You have to specify the numpy version against which you want to build. For example
+to build with numpy 1.12 use the following command.
+
+conda build --numpy 1.12 .
+
+
+

--- a/maintainer/conda/MDAnalysis/meta.yaml
+++ b/maintainer/conda/MDAnalysis/meta.yaml
@@ -1,71 +1,52 @@
 package:
   name: mdanalysis
   # This has to be changed after a release
-  version: "0.15.0"
+  version: "0.16.0dev"
 
 source:
-   # to build from source you can speficy the path to the code directly.
-   # path: ../../../
-   # This ensures that you will build from a clean checkout
    git_url: https://github.com/MDAnalysis/mdanalysis
-   # git_branch: master
-   git_tag: release-0.15.0
+   git_branch: develop
+   # git_tag: release-0.15.0
 
 # specify the subversion of the conda package. Defaults to 0. If you make
 # changes to the conda package alone with out an increase in the source package
 # version increase this number. Should be reset to 0 after a new release
 build:
-  number: 1
+  number: 0
 
 requirements:
   build:
     - python
     - setuptools
-    - pip
-    - numpy
+    - numpy x.x
     - cython
     - biopython
-    - networkx
-    - griddataformats
     - nose
 
   run:
     - python
-    - numpy
+    - numpy x.x
+    - biopython
+    - nose
     - scipy
     - griddataformats
     - networkx
-    - biopython
     - matplotlib
+    - mock
     - seaborn
     - six
+    - psutil
     - netcdf4
-    - nose
+    - mmtf-python
 
 test:
   imports:
     - MDAnalysis
     - MDAnalysis.analysis
-    # check that distance cython modules have been build
     - MDAnalysis.lib.c_distances_openmp
     - MDAnalysis.lib.c_distances
 
-  requires:
-    # this is the same list as the run requirements
-    - python
-    - numpy
-    - scipy
-    - griddataformats
-    - networkx
-    - biopython
-    - matplotlib
-    - seaborn
-    - six
-    - netcdf4
-    - nose
-
   commands:
-    # run the testsuite with 2 processes
     - python -c 'import MDAnalysisTests; MDAnalysisTests.run(label="full", extra_argv=["-v"])'
 
 about:
@@ -73,7 +54,3 @@ about:
   license: GPLv2
   license_file: package/LICENSE
   summary: 'MDAnalysis is a Python library to analyze molecular dynamics trajectories.'
-
-# See
-# http://docs.continuum.io/conda/build.html for
-# more information about meta.yaml


### PR DESCRIPTION
The recipe is now  updated to build the current develop branch by
default. We also acknowledge that we build against specific python
versions now. This is important since we actually build against the
numpy C-API.

This is just some maintenance of the recipe. I got a bit more knowledgeable about conda after creating more conda-forge packages. 

This means that there is also a new nightly build. I'll remove the old ones that don't build against a known numpy version