### PR TITLE
WIP: Prototype of using auxiliaries to transform a timestep

### DIFF
--- a/package/MDAnalysis/auxiliary/__init__.py
+++ b/package/MDAnalysis/auxiliary/__init__.py
@@ -523,3 +523,4 @@ _AUXREADERS = {}
 from . import base
 from . import XVG
 from .core import auxreader
+from . import transformations

--- a/package/MDAnalysis/auxiliary/base.py
+++ b/package/MDAnalysis/auxiliary/base.py
@@ -230,7 +230,13 @@ class AuxStep(object):
         return np.full_like(self.data, np.nan)
 
 
-class AuxReader(six.with_metaclass(_AuxReaderMeta)):
+class Auxiliary(object):
+    # just so we can do some autodetection later
+    # probably a much better way to do this,
+    # maybe with ABCs and overriding isinstance
+    pass
+
+class AuxReader(six.with_metaclass(_AuxReaderMeta, Auxiliary)):
     """ Base class for auxiliary readers.
 
     Allows iteration over a set of data from a trajectory, additional 

--- a/package/MDAnalysis/auxiliary/transformations.py
+++ b/package/MDAnalysis/auxiliary/transformations.py
@@ -1,0 +1,49 @@
+# -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
+#
+# MDAnalysis --- http://www.mdanalysis.org
+# Copyright (c) 2006-2016 The MDAnalysis Development Team and contributors
+# (see the file AUTHORS for the full list of names)
+#
+# Released under the GNU Public Licence, v2 or any higher version
+#
+# Please cite your use of MDAnalysis in published work:
+#
+# R. J. Gowers, M. Linke, J. Barnoud, T. J. E. Reddy, M. N. Melo, S. L. Seyler,
+# D. L. Dotson, J. Domanski, S. Buchoux, I. M. Kenney, and O. Beckstein.
+# MDAnalysis: A Python package for the rapid analysis of molecular dynamics
+# simulations. In S. Benthall and S. Rostrup editors, Proceedings of the 15th
+# Python in Science Conference, pages 102-109, Austin, TX, 2016. SciPy.
+#
+# N. Michaud-Agrawal, E. J. Denning, T. B. Woolf, and O. Beckstein.
+# MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
+# J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
+#
+"""Auxiliary transformations
+============================
+
+"""
+from .base import Auxiliary
+
+
+class Transformer(Auxiliary):
+    """Robot in disguise"""
+    def __init__(self):
+        pass
+
+    def update_ts(self, ts):
+        ts.positions += 1
+        return ts
+
+    def close(self):
+        pass
+
+
+class Packer(Auxiliary):
+    """Applied pack_into_box on the supplied AtomGroup each step"""
+    def __init__(self, ag):
+        self.ag = ag
+
+    def update_ts(self, ts):
+        self.ag.pack_into_box()
+        return ts


### PR DESCRIPTION
I've mentioned a few times that this is possible, so I thought I'd show what I meant.

This is kind of hijacking the `auxiliary` thing to make it do either adding data or manipulating data.  I quite like it, but maybe others might prefer a cleaner distinction and have `auxiliary` (what currently exists, adds data) and `modifiers` (what I'm proposing, modifies data)

Thinking about `MemoryReader`, @jbarnoud raised a good point that this method will result in the coordinates being manipulated each time they're read as `ts.positions` is a view onto the only record of the data.  Not sure the cleanest way around this, you *could* just apply the transformation onto every frame, but that would incur a big flagfall cost onto adding a transformation.  Otherwise maybe some ugly book keeping of where a transformation had been applied, and only applying if this frame had not been seen before.
