### PR TITLE
[MRG] Make knownfailure work even without parentheses

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -84,6 +84,7 @@ Chronological list of authors
   - Shobhit Agarwal
   - Vedant Rathore
   - Xiki Tempula
+  - Akshay Gupta
 
 External code
 -------------

--- a/testsuite/CHANGELOG
+++ b/testsuite/CHANGELOG
@@ -17,6 +17,7 @@ and https://github.com/MDAnalysis/mdanalysis/wiki/UnitTests
          tyler.je.reddy, utkbansal, vedantrathore
 
   * 0.16
+    - Make knownfailure work even without parentheses.
     - added two unit tests for MDAnalysis.analysis.polymer
     - added test for LeafletFinder handling a selection string
     - Added unit test for MDAnalysis.analysis.distances.between()

--- a/testsuite/MDAnalysisTests/__init__.py
+++ b/testsuite/MDAnalysisTests/__init__.py
@@ -98,8 +98,8 @@ especially as we are directly using this framework (imported from numpy).
 
 A number of plugins external to nose are automatically loaded. The `knownfailure`
 plugin provides the `@knownfailure()` decorator, which can be used to mark tests
-that are expected to fail. Beware that even if used with default arguments the
-parentheses must be included.
+that are expected to fail. If used with default arguments the parentheses can be 
+excluded.
 
 .. _NumPy: http://www.numpy.org/
 .. _nose:

--- a/testsuite/MDAnalysisTests/coordinates/test_dcd.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_dcd.py
@@ -154,7 +154,7 @@ class TestDCDReader(object):
         ts_skip = self.u.trajectory.timeseries(self.u.atoms, start, stop, step)
         assert_array_almost_equal(ts[:, start:stop:step,:], ts_skip, 5)
 
-    @knownfailure()
+    @knownfailure
     def _failed_slices_test(self, start, stop, step):
         self.u = mda.Universe(PSF, DCD)
         ts = self.u.trajectory.timeseries(self.u.atoms)

--- a/testsuite/MDAnalysisTests/plugins/knownfailure.py
+++ b/testsuite/MDAnalysisTests/plugins/knownfailure.py
@@ -44,7 +44,7 @@ except ImportError:
 plugin_class = KnownFailurePlugin
 plugin_class.name = "knownfailure"
 
-def knownfailure(msg="Test skipped due to expected failure", exc_type=AssertionError, mightpass=False):
+def knownfailure(args=None, msg="Test skipped due to expected failure", exc_type=AssertionError, mightpass=False):
     """If decorated function raises exception *exc_type* skip test, else raise AssertionError."""
     def knownfailure_decorator(f):
         def inner(*args, **kwargs):
@@ -61,6 +61,9 @@ def knownfailure(msg="Test skipped due to expected failure", exc_type=AssertionE
                 if not mightpass:
                     raise AssertionError('Failure expected')
         return nose.tools.make_decorator(f)(inner)
-    return knownfailure_decorator
+    if callable(args):
+        return knownfailure_decorator(args)
+    else:      
+        return knownfailure_decorator
 
 

--- a/testsuite/MDAnalysisTests/plugins/knownfailure.py
+++ b/testsuite/MDAnalysisTests/plugins/knownfailure.py
@@ -28,8 +28,8 @@ Enhances numpy's own plugin by falling back to :class:`SkipTest` exceptions when
 isn't loaded (typically, when using nose's command-line `nosetests` script, which
 does not allow for runtime loading of external plugins).
 
-Beware that the decorator must be used as a function call: `@knownfailure()`, with parentheses 
-and, optionally, arguments.
+The decorator can be used without parentheses in case of default arguments as well as 
+a function call: `@knownfailure()`, with parentheses in case of optional arguments.
 """
 
 from MDAnalysisTests.plugins import loaded_plugins, _check_plugins_loaded

--- a/testsuite/MDAnalysisTests/test_streamio.py
+++ b/testsuite/MDAnalysisTests/test_streamio.py
@@ -216,7 +216,7 @@ class TestNamedStream_filename_behavior(object):
     # Segmentation fault when run as a test on Mac OS X 10.6, Py 2.7.11 [orbeckst]
     @dec.skipif(True)
     @dec.skipif("HOME" not in os.environ)
-    @knownfailure()
+    @knownfailure
     def test_expandvars(self):
         name = "${HOME}/stories/jabberwock.txt"
         ns = self.create_NamedStream(name)


### PR DESCRIPTION
Fixes #731 

Changes made in this Pull Request:
 - modified _mdanalysis/testsuite/MDAnalysisTests/plugins/knownfailure.py_ to support knownfailure decorator to work with and without parentheses.


PR Checklist
------------
 - [ ] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
