### PR TITLE
Correct the display error of Hbond analysis

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -62,6 +62,8 @@ Enhancements
   * Added groupby method to Group objects. (PR #1112)
   * Added `singleframe` attribute to Writer API to exclude from known Writers
     for a single frame (Issue #1199 PR #1201)
+  * Correct the display error of HydrogenBondAnalysis when start is not 0 or 
+    step is not one.
 
 Fixes
   * Trajectory slicing made completely Pythonic (Issue #918 PR #1195)

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -15,7 +15,8 @@ The rules for this file:
 ------------------------------------------------------------------------------
 ??/??/16 kain88-de, fiona-naughton, richardjgowers, tyler.je.reddy, jdetle
          euhruska, orbeckst, rbrtdlg, jbarnoud, wouterboomsma, shanmbic,
-         dotsdl, manuel.nuno.melo, utkbansal, vedantrathore, shobhitagarwal1612
+         dotsdl, manuel.nuno.melo, utkbansal, vedantrathore, shobhitagarwal1612,
+         xiki-tempula
 
   * 0.16.0
 

--- a/package/MDAnalysis/analysis/hbonds/hbond_analysis.py
+++ b/package/MDAnalysis/analysis/hbonds/hbond_analysis.py
@@ -898,7 +898,7 @@ class HydrogenBondAnalysis(object):
                                quiet=kwargs.get('quiet', None),
                                default=True)
         pm = ProgressMeter(len(frames),
-                           format="HBonds frame %(step)5d/%(numsteps)d [%(percentage)5.1f%%]\r",
+                           format="HBonds frame %(current_step)5d: %(step)5d/%(numsteps)d [%(percentage)5.1f%%]\r",
                            verbose=verbose)
 
         try:
@@ -930,8 +930,8 @@ class HydrogenBondAnalysis(object):
             timestep = _get_timestep()
             self.timesteps.append(timestep)
 
-            echo = (ts.frame - (self.traj_slice.start or 0)) // (self.traj_slice.step or 1)
-            pm.echo(echo)
+            progress = (ts.frame - (self.traj_slice.start or 0)) // (self.traj_slice.step or 1)
+            pm.echo(progress, current_step = ts.frame)
             self.logger_debug("Analyzing frame %(frame)d, timestep %(timestep)f ps", vars())
             if self.update_selection1:
                 self._update_selection_1()

--- a/package/MDAnalysis/analysis/hbonds/hbond_analysis.py
+++ b/package/MDAnalysis/analysis/hbonds/hbond_analysis.py
@@ -930,7 +930,8 @@ class HydrogenBondAnalysis(object):
             timestep = _get_timestep()
             self.timesteps.append(timestep)
 
-            pm.echo(ts.frame)
+            echo = (ts.frame - (self.traj_slice.start or 0)) // (self.traj_slice.step or 1)
+            pm.echo(echo)
             self.logger_debug("Analyzing frame %(frame)d, timestep %(timestep)f ps", vars())
             if self.update_selection1:
                 self._update_selection_1()

--- a/package/MDAnalysis/analysis/hbonds/hbond_analysis.py
+++ b/package/MDAnalysis/analysis/hbonds/hbond_analysis.py
@@ -930,7 +930,7 @@ class HydrogenBondAnalysis(object):
             timestep = _get_timestep()
             self.timesteps.append(timestep)
 
-            pm.echo(progress, current_step = frame)
+            pm.echo(progress, current_step=frame)
             self.logger_debug("Analyzing frame %(frame)d, timestep %(timestep)f ps", vars())
             if self.update_selection1:
                 self._update_selection_1()

--- a/package/MDAnalysis/analysis/hbonds/hbond_analysis.py
+++ b/package/MDAnalysis/analysis/hbonds/hbond_analysis.py
@@ -898,7 +898,7 @@ class HydrogenBondAnalysis(object):
                                quiet=kwargs.get('quiet', None),
                                default=True)
         pm = ProgressMeter(len(frames),
-                           format="HBonds frame %(current_step)5d: %(step)5d/%(numsteps)d [%(percentage)5.1f%%]\r",
+                           format="HBonds frame {current_step:5d}: {step:5d}/{numsteps} [{percentage:5.1f}%]\r",
                            verbose=verbose)
 
         try:
@@ -919,7 +919,7 @@ class HydrogenBondAnalysis(object):
                     (self.traj_slice.start or 0),
                     (self.traj_slice.stop or self.u.trajectory.n_frames), self.traj_slice.step or 1)
 
-        for ts in self.u.trajectory[self.traj_slice]:
+        for progress, ts in enumerate(self.u.trajectory[self.traj_slice]):
             # all bonds for this timestep
             frame_results = []
             # dict of tuples (atomid, atomid) for quick check if
@@ -930,8 +930,7 @@ class HydrogenBondAnalysis(object):
             timestep = _get_timestep()
             self.timesteps.append(timestep)
 
-            progress = (ts.frame - (self.traj_slice.start or 0)) // (self.traj_slice.step or 1)
-            pm.echo(progress, current_step = ts.frame)
+            pm.echo(progress, current_step = frame)
             self.logger_debug("Analyzing frame %(frame)d, timestep %(timestep)f ps", vars())
             if self.update_selection1:
                 self._update_selection_1()


### PR DESCRIPTION
Fixes # display error of progress bar of Hbond analysis

When running hydrogen bond analysis, the current frame is printed accompanied by the total frame need to be analysis. However, the current frame over total frame is meaningless when the step is not 1 or the start time is not 0. Thus, this PR correct this behaviour by displaying (the current frame - start frame) // step, which gives a meaningful log of current progress.



