### PR TITLE
Make an error message more useful in MemoryReader

### DIFF
--- a/package/MDAnalysis/coordinates/memory.py
+++ b/package/MDAnalysis/coordinates/memory.py
@@ -256,8 +256,10 @@ class MemoryReader(base.ProtoReader):
         provided_n_atoms = kwargs.pop("n_atoms", None)
         if (provided_n_atoms is not None and
             provided_n_atoms != self.n_atoms):
-                raise ValueError("The provided value for n_atoms does not match "
-                                 "the shape of the coordinate array")
+                raise ValueError("The provided value for n_atoms ({}) "
+                                 "does not match the shape of the coordinate "
+                                 "array ({})"
+                                 .format(provided_n_atoms, self.n_atoms))
 
         self.ts = self._Timestep(self.n_atoms, **kwargs)
         self.ts.dt = dt


### PR DESCRIPTION
When the MemoryReader raise an exception because of a mismatch in the
number of atoms, the problematic numbers of atoms are displayed as part
of the exception. This make the error message more useful.