### PR TITLE
Fixes #1227

### DIFF
--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -251,17 +251,20 @@ class Universe(object):
             self._generate_from_topology()
 
             # Load coordinates
-            # if passed Topology object as top
-            if self.filename is None:
-                coordinatefile = None
-            elif len(args) == 1:
-                # Can the topology file also act as coordinate file?
-                try:
-                    _ = get_reader_for(self.filename, format=kwargs.get('format', None))
-                except ValueError:
+            if len(args) == 1:
+                if self.filename is None:
+                    # If we got the topology as a Topology object, then we
+                    # cannot read coordinates from it.
                     coordinatefile = None
                 else:
-                    coordinatefile = [self.filename]
+                    # Can the topology file also act as coordinate file?
+                    try:
+                        _ = get_reader_for(self.filename,
+                                           format=kwargs.get('format', None))
+                    except ValueError:
+                        coordinatefile = None
+                    else:
+                        coordinatefile = [self.filename]
             else:
                 coordinatefile = args[1:]
             self.load_new(coordinatefile, **kwargs)

--- a/testsuite/MDAnalysisTests/core/test_universe.py
+++ b/testsuite/MDAnalysisTests/core/test_universe.py
@@ -172,6 +172,14 @@ class TestUniverseCreation(object):
         assert_(u2.kwargs['fake_kwarg'] is True)
         assert_equal(u.kwargs, u2.kwargs)
 
+    @staticmethod
+    def test_universe_topology_class_with_coords():
+        u = mda.Universe(PSF, PDB_small)
+        u2 = mda.Universe(u._topology, PDB_small)
+        assert_(isinstance(u2.trajectory, type(u.trajectory)))
+        assert_equal(u.trajectory.n_frames, u2.trajectory.n_frames)
+        assert_(u2._topology is u._topology)
+
 
 class TestUniverse(object):
     # older tests, still useful


### PR DESCRIPTION
At Universe creation, the coordinates were not read when the topology
was provided as a Topology object. Skipping the coordinates was likely
there to by accident because of the case where only the topology is
given. This commit moves the skip, so trying to read coordinates is
skipped only when no coordinates are provided: we do not try to read
coordinates from a Topology object.

Fixes #1227 

PR Checklist
------------
 - [X] Tests?
 - ~[ ] Docs?~ Fixes a defect
 - ~[ ] CHANGELOG updated?~ Fixes a defect
 - [X] Issue raised/referenced?
