### PR TITLE
fix frame slice problem introduced by np.int object

### DIFF
--- a/package/MDAnalysis/analysis/hbonds/hbond_analysis.py
+++ b/package/MDAnalysis/analysis/hbonds/hbond_analysis.py
@@ -347,7 +347,6 @@ import six
 from six.moves import range, zip, map, cPickle
 
 from collections import defaultdict
-import numbers
 import numpy as np
 import warnings
 import logging

--- a/package/MDAnalysis/analysis/hbonds/hbond_analysis.py
+++ b/package/MDAnalysis/analysis/hbonds/hbond_analysis.py
@@ -594,9 +594,16 @@ class HydrogenBondAnalysis(object):
         self.distance = distance
         self.distance_type = distance_type  # note: everything except 'heavy' will give the default behavior
         self.angle = angle
-        self.traj_slice = slice(start if isinstance(start, int) else None,  # internal frames are 0 based
-                                stop if isinstance(stop, int) else None,
-                                step)
+        try:
+            start = int(start)
+        except:
+            start = None
+
+        try:
+            stop = int(stop)
+        except:
+            stop = None
+        self.traj_slice = slice(start, stop, step)
 
         # set up the donors/acceptors lists
         if donors is None:

--- a/package/MDAnalysis/analysis/hbonds/hbond_analysis.py
+++ b/package/MDAnalysis/analysis/hbonds/hbond_analysis.py
@@ -595,13 +595,7 @@ class HydrogenBondAnalysis(object):
         self.distance = distance
         self.distance_type = distance_type  # note: everything except 'heavy' will give the default behavior
         self.angle = angle
-        slice_index = []
-        for index in [start, stop, step]:
-            if isinstance(index, numbers.Integral):
-                slice_index.append(int(index))
-            else:
-                slice_index.append(None)
-        self.traj_slice = slice(*slice_index)
+        self.traj_slice = slice(start, stop, step)
 
         # set up the donors/acceptors lists
         if donors is None:

--- a/package/MDAnalysis/analysis/hbonds/hbond_analysis.py
+++ b/package/MDAnalysis/analysis/hbonds/hbond_analysis.py
@@ -347,6 +347,7 @@ import six
 from six.moves import range, zip, map, cPickle
 
 from collections import defaultdict
+import numbers
 import numpy as np
 import warnings
 import logging
@@ -596,9 +597,9 @@ class HydrogenBondAnalysis(object):
         self.angle = angle
         slice_index = []
         for index in [start, stop, step]:
-            try:
+            if isinstance(index, numbers.Integral):
                 slice_index.append(int(index))
-            except:
+            else:
                 slice_index.append(None)
         self.traj_slice = slice(*slice_index)
 

--- a/package/MDAnalysis/analysis/hbonds/hbond_analysis.py
+++ b/package/MDAnalysis/analysis/hbonds/hbond_analysis.py
@@ -594,16 +594,13 @@ class HydrogenBondAnalysis(object):
         self.distance = distance
         self.distance_type = distance_type  # note: everything except 'heavy' will give the default behavior
         self.angle = angle
-        try:
-            start = int(start)
-        except:
-            start = None
-
-        try:
-            stop = int(stop)
-        except:
-            stop = None
-        self.traj_slice = slice(start, stop, step)
+        slice_index = []
+        for index in [start, stop, step]:
+            try:
+                slice_index.append(int(index))
+            except:
+                slice_index.append(None)
+        self.traj_slice = slice(*slice_index)
 
         # set up the donors/acceptors lists
         if donors is None:

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -1296,8 +1296,7 @@ class ProtoReader(six.with_metaclass(_Readermeta, IObase)):
         """
 
         slice_dict = {'start': start, 'stop': stop, 'step': step}
-        for varname in slice_dict:
-            var = slice_dict[varname]
+        for varname, var in slice_dict.items():
             if isinstance(var, numbers.Integral):
                 slice_dict[varname] = int(var)
             elif (var is None):

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -127,6 +127,7 @@ import six
 from six.moves import range
 
 import numpy as np
+import numbers
 import copy
 import warnings
 import weakref
@@ -1293,13 +1294,21 @@ class ProtoReader(six.with_metaclass(_Readermeta, IObase)):
             range(10)[10:-1:-1]  # []
 
         """
-        for var, varname in (
-                (start, 'start'),
-                (stop, 'stop'),
-                (step, 'step')
-        ):
-            if not (isinstance(var, int) or (var is None)):
+
+        slice_dict = {'start': start, 'stop': stop, 'step': step}
+        for varname in slice_dict:
+            var = slice_dict[varname]
+            if isinstance(var, numbers.Integral):
+                slice_dict[varname] = int(var)
+            elif (var is None):
+                pass
+            else:
                 raise TypeError("{0} is not an integer".format(varname))
+
+        start = slice_dict['start']
+        stop = slice_dict['stop']
+        step = slice_dict['step']
+
         if step == 0:
             raise ValueError("Step size is zero")
 

--- a/testsuite/CHANGELOG
+++ b/testsuite/CHANGELOG
@@ -36,6 +36,7 @@ and https://github.com/MDAnalysis/mdanalysis/wiki/UnitTests
     - install external packages on Travis (SETUP == full: HOLE, clustalw)
       to test additional analysis code (Issue #898)
     - add tests for new auxiliary module
+    - trajectory slices can use any type of integer PR #1233
 
 05/15/16  orbeckst, jbarnoud, pedrishi, fiona-naughton, jdetle
   * 0.15.0

--- a/testsuite/MDAnalysisTests/coordinates/base.py
+++ b/testsuite/MDAnalysisTests/coordinates/base.py
@@ -852,11 +852,15 @@ class BaseTimestepTest(object):
         ts2 = ts.copy_slice(sl)
         self._check_slice(ts, ts2, sl)
 
-    def _check_npint_slice(self, u, ts):
-        sl = slice(np.int_(0), None, None)
-        ts1 = u.trajectory[sl]
-        self._check_slice(ts1, ts, (0, None, None))
-
+    def _check_npint_slice(self, name, ts):
+        for integers in [np.byte, np.short, np.intc, np.int_, np.longlong,
+                         np.intp, np.int8, np.int16, np.int32, np.int64, 
+                         np.ubyte, np.ushort, np.uintc, np.ulonglong,
+                         np.uintp, np.uint8, np.uint16, np.uint32, np.uint64]:
+            sl = slice(1, 2, 1)
+            ts2 = ts.copy_slice(slice(integers(1), integers(2), integers(1)))
+            self._check_slice(ts, ts2, sl)
+        
     def _check_slice(self, ts1, ts2, sl):
         if ts1.has_positions:
             assert_array_almost_equal(ts1.positions[sl], ts2.positions)
@@ -870,12 +874,12 @@ class BaseTimestepTest(object):
             return
         u = mda.Universe(*self.uni_args)
         ts = u.trajectory.ts
-
+        
         yield self._check_copy, self.name, ts
         yield self._check_independent, self.name, ts
         yield self._check_copy_slice_indices, self.name, ts
         yield self._check_copy_slice_slice, self.name, ts
-        yield self._check_npint_slice, u, ts
+        yield self._check_npint_slice, self.name, ts
 
     def test_copy_slice(self):
         for p, v, f in itertools.product([True, False], repeat=3):

--- a/testsuite/MDAnalysisTests/coordinates/base.py
+++ b/testsuite/MDAnalysisTests/coordinates/base.py
@@ -852,6 +852,11 @@ class BaseTimestepTest(object):
         ts2 = ts.copy_slice(sl)
         self._check_slice(ts, ts2, sl)
 
+    def _check_npint_slice(self, u, ts):
+        sl = slice(np.int_(0), None, None)
+        ts1 = u.trajectory[sl]
+        self._check_slice(ts1, ts, (0, None, None))
+
     def _check_slice(self, ts1, ts2, sl):
         if ts1.has_positions:
             assert_array_almost_equal(ts1.positions[sl], ts2.positions)
@@ -870,6 +875,7 @@ class BaseTimestepTest(object):
         yield self._check_independent, self.name, ts
         yield self._check_copy_slice_indices, self.name, ts
         yield self._check_copy_slice_slice, self.name, ts
+        yield self._check_npint_slice, u, ts
 
     def test_copy_slice(self):
         for p, v, f in itertools.product([True, False], repeat=3):


### PR DESCRIPTION
import numpy as np

`h = HydrogenBondAnalysis(universe, start=np.int_(1))`
should yeild the same result as 
`h = HydrogenBondAnalysis(universe, start=int(1))`

However, in the current version, if the input is not a instance of the vanilla integer object, the input will be regard as invalid and is treated as undefined. Which means `h = HydrogenBondAnalysis(universe, start=np.int_(1))` is the same as `h = HydrogenBondAnalysis(universe, start=None)`. My feeling is that the numpy integer object should deserve the same respect as the vanilla integer object. So instead of only accepting the vanilla integer object, I will try to convert the input into the vanilla integer object and only give None if the input cannot be converted.

