### PR TITLE
Renaming base classes

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -135,6 +135,10 @@ Changes
   * analysis.rms/align function keyword `mass_weighted` is replaced
   by generic `weights='mass'`. This new keyword allows to pass it an
   arbitrary weights array as well. (PR 1136)
+  * Renamed various base classes for clarity.  Iobase -> IOBase,
+    Reader -> ReaderBase, SingleFrameReader -> SingleFrameReaderBase,
+    Writer -> WriterBase, TopologyReader -> TopologyReaderBase,
+    SelectionWriter -> SelectionWriterBase (Issue #921)
 
 
 Deprecations (Issue #599)

--- a/package/MDAnalysis/analysis/base.py
+++ b/package/MDAnalysis/analysis/base.py
@@ -221,7 +221,7 @@ class AnalysisFromFunction(AnalysisBase):
 
         """
         if (trajectory is not None) and (not isinstance(
-                trajectory, coordinates.base.Reader)):
+                trajectory, coordinates.base.ProtoReader)):
             args = args + (trajectory,)
             trajectory = None
 

--- a/package/MDAnalysis/analysis/leaflet.py
+++ b/package/MDAnalysis/analysis/leaflet.py
@@ -64,8 +64,10 @@ import warnings
 
 import numpy as np
 import networkx as NX
-import MDAnalysis
+
+from .. import core
 from . import distances
+from .. import selections
 
 
 class LeafletFinder(object):
@@ -114,10 +116,10 @@ class LeafletFinder(object):
                  use fast :func:`~MDAnalysis.analysis.distances.distance_array`
                  implementation [``None``].
         """
-        universe = MDAnalysis.as_Universe(universe)
+        universe = core.universe.as_Universe(universe)
         self.universe = universe
         self.selectionstring = selectionstring
-        if isinstance(self.selectionstring, MDAnalysis.core.groups.AtomGroup):
+        if isinstance(self.selectionstring, core.groups.AtomGroup):
             self.selection = self.selectionstring
         else:
             self.selection = universe.select_atoms(self.selectionstring)
@@ -215,10 +217,8 @@ class LeafletFinder(object):
         See :class:`MDAnalysis.selections.base.SelectionWriter` for all
         options.
         """
-        import MDAnalysis.selections
-
-        SelectionWriter = MDAnalysis.selections.get_writer(filename, kwargs.pop('format', None))
-        writer = SelectionWriter(
+        sw = selections.get_writer(filename, kwargs.pop('format', None))
+        writer = sw(
             filename, mode=kwargs.pop('mode', 'wa'),
             preamble="leaflets based on selection={selectionstring!r} cutoff={cutoff:f}\n".format(**vars(self)),
             **kwargs)

--- a/package/MDAnalysis/auxiliary/__init__.py
+++ b/package/MDAnalysis/auxiliary/__init__.py
@@ -26,12 +26,11 @@ Auxiliary Readers --- :mod:`MDAnalysis.auxiliary`
 
 The auxiliary submodule contains code for reading 'auxiliary' data from a 
 trajectory and allowing alignment with trajectory timesteps. Additional 
-methods in :class:`MDAnalysis.coordinates.base.Reader` allow auxiliary data to 
-be added and read alongside a trajectory.
+methods in :class:`MDAnalysis.coordinates.base.ProtoReader` allow auxiliary data
+to be added and read alongside a trajectory.
 
 Auxiliary data are timeseries accompanying a trajectory not stored in the 
-regular trajectory file to be read by the trajectory
-:class:`~MDAnalysis.coordinates.base.Reader`. They may be stored 
+regular trajectory file to be read by the trajectory Reader. They may be stored 
 internally (e.g. in an array) or read from a file. In general, auxiliary data is 
 assumed to be time ordered and contain no duplicates.
 
@@ -122,8 +121,7 @@ If there are no auxiliary steps assigned to a given timestep (or none within
 
 Adding an auxiliary to a trajectory
 ...................................
-Auxiliary data may be added to a trajectory 
-(:class:`~MDAnalysis.coordinates.base.Reader` object) through the 
+Auxiliary data may be added to a trajectory Reader through the 
 :meth:`~MDAnalysis.coordinates.base.ProtoReader.add_auxiliary` method. Auxiliary data
 may be passed in as a AuxReader instance, or directly as e.g. a filename, in 
 which case :func:`~MDAnalysis.auxiliary.core.get_auxreader_for` is used to 
@@ -140,7 +138,7 @@ updated, and the representative auxiliary value(s) will be available as e.g.
 
 Iterating by an auxiliary
 .........................
-The trajectory :class:`~MDAnalysis.coordinates.base.Reader` methods 
+The trajectory :class:`~MDAnalysis.coordinates.base.ProtoReader` methods 
 :meth:`~MDAnalysis.coordinates.base.ProtoReader.next_as_aux` and
 :meth:`~MDAnalysis.coordinates.base.ProtoReader.iter_as_aux` allow for movement
 through only trajectory timesteps to which one or more steps that fall within 
@@ -156,7 +154,7 @@ is less frequent::
 If the auxiliary data are more frequent and the cutoff (if set) is 
 sufficiently high, :meth:`~MDAnalysis.coordinates.base.ProtoReader.next_as_aux` 
 and :meth:`~MDAnalysis.coordinates.base.ProtoReader.iter_as_aux` behave the same 
-as the :class:`~MDAnalysis.coordinates.base.Reader` 
+as the :class:`~MDAnalysis.coordinates.base.ProtoReader` 
 meth:`~MDAnalysis.coordinates.base.ProtoReader.next` and 
 :meth:`~MDAnalysis.coordinates.base.ProtoReader.__iter__`.
 

--- a/package/MDAnalysis/coordinates/CRD.py
+++ b/package/MDAnalysis/coordinates/CRD.py
@@ -40,7 +40,7 @@ from ..lib import util
 from . import base
 
 
-class CRDReader(base.SingleFrameReader):
+class CRDReader(base.SingleFrameReaderBase):
     """CRD reader that implements the standard and extended CRD coordinate formats
 
     .. versionchanged:: 0.11.0
@@ -108,7 +108,7 @@ class CRDReader(base.SingleFrameReader):
         return CRDWriter(filename, **kwargs)
 
 
-class CRDWriter(base.Writer):
+class CRDWriter(base.WriterBase):
     """CRD writer that implements the CHARMM CRD coordinate format.
 
     It automatically writes the CHARMM EXT extended format if there

--- a/package/MDAnalysis/coordinates/DCD.py
+++ b/package/MDAnalysis/coordinates/DCD.py
@@ -167,7 +167,7 @@ class Timestep(base.Timestep):
         np.put(self._unitcell, self._ts_order, box)
 
 
-class DCDWriter(base.Writer):
+class DCDWriter(base.WriterBase):
     """Writes to a DCD file
 
     Typical usage::
@@ -362,7 +362,7 @@ class DCDWriter(base.Writer):
             self.dcdfile = None
 
 
-class DCDReader(base.Reader):
+class DCDReader(base.ReaderBase):
     """Reads from a DCD file
 
     :Data:

--- a/package/MDAnalysis/coordinates/DLPoly.py
+++ b/package/MDAnalysis/coordinates/DLPoly.py
@@ -53,7 +53,7 @@ class Timestep(base.Timestep):
         self._unitcell[:] = core.triclinic_vectors(new)
 
 
-class ConfigReader(base.SingleFrameReader):
+class ConfigReader(base.SingleFrameReaderBase):
     """DLPoly Config file Reader
 
     .. versionadded:: 0.11.0
@@ -140,7 +140,7 @@ class ConfigReader(base.SingleFrameReader):
         ts.frame = 0
 
 
-class HistoryReader(base.Reader):
+class HistoryReader(base.ReaderBase):
     """Reads DLPoly format HISTORY files
 
     .. versionadded:: 0.11.0

--- a/package/MDAnalysis/coordinates/DMS.py
+++ b/package/MDAnalysis/coordinates/DMS.py
@@ -60,7 +60,7 @@ class Timestep(base.Timestep):
         self._unitcell = cell
 
 
-class DMSReader(base.SingleFrameReader):
+class DMSReader(base.SingleFrameReaderBase):
     """
     Reads both coordinates and velocities.
 

--- a/package/MDAnalysis/coordinates/GMS.py
+++ b/package/MDAnalysis/coordinates/GMS.py
@@ -41,7 +41,7 @@ from . import base
 import MDAnalysis.lib.util as util
 
 
-class GMSReader(base.Reader):
+class GMSReader(base.ReaderBase):
     """Reads from an GAMESS output file
 
     :Data:

--- a/package/MDAnalysis/coordinates/GRO.py
+++ b/package/MDAnalysis/coordinates/GRO.py
@@ -118,7 +118,7 @@ class Timestep(base.Timestep):
         np.put(self._unitcell, self._ts_order_z, z)
 
 
-class GROReader(base.SingleFrameReader):
+class GROReader(base.SingleFrameReaderBase):
     """Reader for the Gromacs GRO structure format.
     
     .. versionchanged:: 0.11.0
@@ -199,7 +199,7 @@ class GROReader(base.SingleFrameReader):
         return GROWriter(filename, **kwargs)
 
 
-class GROWriter(base.Writer):
+class GROWriter(base.WriterBase):
     """GRO Writer that conforms to the Trajectory API.
 
     Will attempt to write the following information from the topology:

--- a/package/MDAnalysis/coordinates/INPCRD.py
+++ b/package/MDAnalysis/coordinates/INPCRD.py
@@ -35,7 +35,7 @@ from six.moves import range
 
 from . import base
 
-class INPReader(base.SingleFrameReader):
+class INPReader(base.SingleFrameReaderBase):
     format = ['INPCRD', 'RESTRT']
     units = {'length': 'Angstrom'}
 

--- a/package/MDAnalysis/coordinates/LAMMPS.py
+++ b/package/MDAnalysis/coordinates/LAMMPS.py
@@ -172,7 +172,7 @@ class DCDReader(DCD.DCDReader):
         super(DCDReader, self).__init__(dcdfilename, **kwargs)
 
 
-class DATAReader(base.SingleFrameReader):
+class DATAReader(base.SingleFrameReaderBase):
     """Reads a single frame of coordinate information from a LAMMPS DATA file.
 
     .. versionadded:: 0.9.0
@@ -201,7 +201,7 @@ class DATAReader(base.SingleFrameReader):
             except AttributeError:
                 pass
 
-class DATAWriter(base.Writer):
+class DATAWriter(base.WriterBase):
     """Write out the current time step as a LAMMPS DATA file.
 
     This writer supports the sections Atoms, Masses, Velocities, Bonds,

--- a/package/MDAnalysis/coordinates/MMTF.py
+++ b/package/MDAnalysis/coordinates/MMTF.py
@@ -51,7 +51,7 @@ def _parse_mmtf(fn):
         return mmtf.parse(fn)
 
 
-class MMTFReader(base.SingleFrameReader):
+class MMTFReader(base.SingleFrameReaderBase):
     """Topology parser for the MMTF_ format.
 
     .. _Macromolecular Transmission Format (MMTF) format:

--- a/package/MDAnalysis/coordinates/MOL2.py
+++ b/package/MDAnalysis/coordinates/MOL2.py
@@ -50,7 +50,7 @@ from ..core import flags
 from ..lib import util
 
 
-class MOL2Reader(base.Reader):
+class MOL2Reader(base.ReaderBase):
     """Reader for MOL2 structure format.
 
     .. versionchanged:: 0.11.0
@@ -164,7 +164,7 @@ class MOL2Reader(base.Reader):
         self.ts.frame = -1
 
 
-class MOL2Writer(base.Writer):
+class MOL2Writer(base.WriterBase):
     """
 
     MOL2Writer Limitations

--- a/package/MDAnalysis/coordinates/PDB.py
+++ b/package/MDAnalysis/coordinates/PDB.py
@@ -166,7 +166,7 @@ logger = logging.getLogger("MDAnalysis.coordinates.PBD")
 # Pairs of residue name / atom name in use to deduce PDB formatted atom names
 Pair = collections.namedtuple('Atom', 'resname name')
 
-class PDBReader(base.Reader):
+class PDBReader(base.ReaderBase):
     """PDBReader that reads a `PDB-formatted`_ file, no frills.
 
     The following *PDB records* are parsed (see `PDB coordinate section`_ for
@@ -394,7 +394,7 @@ class PDBReader(base.Reader):
         self._pdbfile.close()
 
 
-class PDBWriter(base.Writer):
+class PDBWriter(base.WriterBase):
     """PDB writer that implements a subset of the `PDB 3.2 standard`_ .
 
     PDB format as used by NAMD/CHARMM: 4-letter resnames and segID are allowed,

--- a/package/MDAnalysis/coordinates/PDBQT.py
+++ b/package/MDAnalysis/coordinates/PDBQT.py
@@ -47,7 +47,7 @@ from ..lib import util
 from . import base
 
 
-class PDBQTReader(base.SingleFrameReader):
+class PDBQTReader(base.SingleFrameReaderBase):
     """PDBQTReader that reads a PDBQT-formatted file, no frills.
 
     Records read:
@@ -191,7 +191,7 @@ class PDBQTReader(base.SingleFrameReader):
         return PDBQTWriter(filename, **kwargs)
 
 
-class PDBQTWriter(base.Writer):
+class PDBQTWriter(base.WriterBase):
     """PDBQT writer that implements a subset of the PDB_ 3.2 standard and the PDBQT_ spec.
 
     .. _PDB: http://www.wwpdb.org/documentation/format32/v3.2.html

--- a/package/MDAnalysis/coordinates/PQR.py
+++ b/package/MDAnalysis/coordinates/PQR.py
@@ -108,7 +108,7 @@ from ..lib import util
 from . import base
 
 
-class PQRReader(base.SingleFrameReader):
+class PQRReader(base.SingleFrameReaderBase):
     """Read a PQR_ file into MDAnalysis.
 
     .. _PQR:
@@ -151,7 +151,7 @@ class PQRReader(base.SingleFrameReader):
         return PQRWriter(filename, **kwargs)
 
 
-class PQRWriter(base.Writer):
+class PQRWriter(base.WriterBase):
     """Write a single coordinate frame in whitespace-separated PQR format.
 
     Charges ("Q") are taken from the

--- a/package/MDAnalysis/coordinates/TRJ.py
+++ b/package/MDAnalysis/coordinates/TRJ.py
@@ -171,7 +171,7 @@ class Timestep(base.Timestep):
     order = 'C'
 
 
-class TRJReader(base.Reader):
+class TRJReader(base.ReaderBase):
     """AMBER trajectory reader.
 
     Reads the ASCII formatted `AMBER TRJ format`_. Periodic box information
@@ -379,7 +379,7 @@ class TRJReader(base.Reader):
         self.trjfile = None
 
 
-class NCDFReader(base.Reader):
+class NCDFReader(base.ReaderBase):
     """Reader for `AMBER NETCDF format`_ (version 1.0).
 
     AMBER binary trajectories are automatically recognised by the
@@ -589,7 +589,7 @@ class NCDFReader(base.Reader):
         return NCDFWriter(filename, n_atoms, **kwargs)
 
 
-class NCDFWriter(base.Writer):
+class NCDFWriter(base.WriterBase):
     """Writer for `AMBER NETCDF format`_ (version 1.0).
 
     AMBER binary trajectories are automatically recognised by the

--- a/package/MDAnalysis/coordinates/TRZ.py
+++ b/package/MDAnalysis/coordinates/TRZ.py
@@ -118,7 +118,7 @@ class Timestep(base.Timestep):
         self._unitcell[:] = triclinic_vectors(box).reshape(9)
 
 
-class TRZReader(base.Reader):
+class TRZReader(base.ReaderBase):
     """ Reads an IBIsCO or YASP trajectory file
 
     :Data:
@@ -426,7 +426,7 @@ class TRZReader(base.Reader):
             self.trzfile = None
 
 
-class TRZWriter(base.Writer):
+class TRZWriter(base.WriterBase):
     """Writes a TRZ format trajectory.
 
     :Methods:

--- a/package/MDAnalysis/coordinates/XDR.py
+++ b/package/MDAnalysis/coordinates/XDR.py
@@ -83,7 +83,7 @@ def read_numpy_offsets(filename):
     return {k: v for k, v in six.iteritems(np.load(filename))}
 
 
-class XDRBaseReader(base.Reader):
+class XDRBaseReader(base.ReaderBase):
     """Base class for libmdaxdr file formats xtc and trr
 
     This class handles integration of XDR based formats into MDAnalysis. The
@@ -248,7 +248,7 @@ class XDRBaseReader(base.Reader):
         return self._writer(filename, n_atoms=n_atoms, **kwargs)
 
 
-class XDRBaseWriter(base.Writer):
+class XDRBaseWriter(base.WriterBase):
     """Base class for libmdaxdr file formats xtc and trr"""
 
     def __init__(self, filename, n_atoms, convert_units=True, **kwargs):

--- a/package/MDAnalysis/coordinates/XYZ.py
+++ b/package/MDAnalysis/coordinates/XYZ.py
@@ -93,7 +93,7 @@ from ..exceptions import NoDataError
 from ..version import __version__
 
 
-class XYZWriter(base.Writer):
+class XYZWriter(base.WriterBase):
     """Writes an XYZ file
 
     The XYZ file format is not formally defined. This writer follows
@@ -255,7 +255,7 @@ class XYZWriter(base.Writer):
                             "".format(atom, x, y, z))
 
 
-class XYZReader(base.Reader):
+class XYZReader(base.ReaderBase):
     """Reads from an XYZ file
 
     :Data:

--- a/package/MDAnalysis/coordinates/__init__.py
+++ b/package/MDAnalysis/coordinates/__init__.py
@@ -47,18 +47,18 @@ itself.
 
 The :class:`~MDAnalysis.core.universe.Universe` contains the API entry point
 attribute :attr:`Universe.trajectory` that points to the actual
-:class:`~MDAnalysis.coordinates.base.Reader` object; all Readers are accessible
+:class:`~MDAnalysis.coordinates.base.ProtoReader` object; all Readers are accessible
 through this entry point in the same manner ("`duck typing`_").
 
 There are three types of base Reader which act as starting points for each
 specific format. These are:
 
-:class:`~MDAnalysis.coordinates.base.Reader`
+:class:`~MDAnalysis.coordinates.base.ReaderBase`
    A standard multi frame Reader which allows iteration over a single
    file to provide multiple frames of data.  This is used by formats
    such as TRR and DCD.
 
-:class:`~MDAnalysis.coordinates.base.SingleFrameReader`
+:class:`~MDAnalysis.coordinates.base.SingleFrameReaderBase`
    A simplified Reader which reads a file containing only a single
    frame of information.  This is used with formats such as GRO
    and CRD
@@ -89,14 +89,14 @@ In order to **write coordinates**, a factory function is provided
 (:func:`MDAnalysis.coordinates.core.writer`, which is also made available as
 :func:`MDAnalysis.Writer`) that returns a *Writer* appropriate for the desired
 file format (as indicated by the filename suffix). Furthermore, a trajectory
-:class:`~MDAnalysis.coordinates.base.Reader` can also have a method
-:meth:`~MDAnalysis.coordinates.base.Reader.Writer` that returns an appropriate
-:class:`~MDAnalysis.coordinates.base.Writer` for the file format of the
+:class:`~MDAnalysis.coordinates.base.ProtoReader` can also have a method
+:meth:`~MDAnalysis.coordinates.base.ProtoReader.Writer` that returns an appropriate
+:class:`~MDAnalysis.coordinates.base.WriterBase` for the file format of the
 trajectory.
 
 In analogy to :func:`MDAnalysis.coordinates.core.writer`, there is also a
 :func:`MDAnalysis.coordinates.core.reader` function available to return a
-trajectory :class:`~MDAnalysis.coordinates.base.Reader` instance although this
+trajectory :class:`~MDAnalysis.coordinates.base.ProtoReader` instance although this
 is often not needed because the :class:`~MDAnalysis.core.universe.Universe`
 class can choose an appropriate reader automatically.
 
@@ -291,8 +291,9 @@ Registry
 In various places, MDAnalysis tries to automatically select appropriate formats
 (e.g. by looking at file extensions). In order to allow it to choose the
 correct format, all I/O classes must subclass either
-:class:`MDAnalysis.coordinates.base.ProtoReader` or
-:class:`MDAnalysis.coordinates.base.Writer` and set the
+:class:`MDAnalysis.coordinates.base.ReaderBase`,
+:class:`MDAnalysis.coordinates.base.SingleFrameReaderBase`,
+or :class:`MDAnalysis.coordinates.base.WriterBase` and set the
 :attr:`~MDAnalysis.coordinates.base.ProtoReader.format` attribute with a string
 defining the expected suffix.  To assign multiple suffixes to an I/O class, a
 list of suffixes can be given.
@@ -428,7 +429,7 @@ but instead should use the attribute above.
 Trajectory Reader class
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Trajectory readers are derived from :class:`MDAnalysis.coordinates.base.Reader`.
+Trajectory readers are derived from :class:`MDAnalysis.coordinates.base.ReaderBase`.
 Typically, many methods and attributes are overriden.
 
 Methods
@@ -473,7 +474,7 @@ The following methods must be implemented in a Reader class.
 .. Note::
    a ``__del__()`` method should also be present to ensure that the
    trajectory is properly closed. However, certain types of Reader can ignore
-   this requirement. These include the :class:`SingleFrameReader` (file reading
+   this requirement. These include the :class:`SingleFrameReaderBase` (file reading
    is done within a context manager and needs no closing by hand) and the :class:`ChainReader`
    (it is a collection of Readers, each already with its own ``__del__`` method).
 
@@ -518,13 +519,13 @@ deal with missing methods gracefully.
      If the Reader is not able to provide random access to frames then it
      should raise :exc:`TypeError` on indexing. It is possible to partially
      implement ``__getitem__`` (as done on
-     :class:`MDAnalysis.coordinates.base.Reader.__getitem__` where slicing the
+     :class:`MDAnalysis.coordinates.base.ProtoReader.__getitem__` where slicing the
      full trajectory is equivalent to
-     :class:`MDAnalysis.coordinates.base.Reader.__iter__` (which is always
+     :class:`MDAnalysis.coordinates.base.ProtoReader.__iter__` (which is always
      implemented) and other slices raise :exc:`TypeError`.
 
  ``Writer(filename, **kwargs)``
-     returns a :class:`~MDAnalysis.coordinates.base.Writer` which is set up with
+     returns a :class:`~MDAnalysis.coordinates.base.WriterBase` which is set up with
      the same parameters as the trajectory that is being read (e.g. time step,
      length etc), which facilitates copying and simple on-the-fly manipulation.
 
@@ -599,9 +600,9 @@ Trajectory Writer class
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 Trajectory writers are derived from
-:class:`MDAnalysis.coordinates.base.Writer`. They are used to write
+:class:`MDAnalysis.coordinates.base.WriterBase`. They are used to write
 multiple frames to a trajectory file. Every time the
-:meth:`~MDAnalysis.coordinates.base.Writer.write` method is called,
+:meth:`~MDAnalysis.coordinates.base.WriterBase.write` method is called,
 another frame is appended to the trajectory.
 
 Typically, many methods and attributes are overriden.

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -107,17 +107,17 @@ in :mod:`MDAnalysis.coordinates.__init__`.
    .. automethod:: copy
    .. automethod:: copy_slice
 
-.. autoclass:: IObase
+.. autoclass:: IOBase
    :members:
 
 .. autoclass:: ProtoReader
    :members:
 
-.. autoclass:: Reader
+.. autoclass:: ReaderBase
    :members:
    :inherited-members:
 
-.. autoclass:: Writer
+.. autoclass:: WriterBase
    :members:
    :inherited-members:
 
@@ -783,7 +783,7 @@ class Timestep(object):
         del self.data['time']
 
 
-class IObase(object):
+class IOBase(object):
     """Base class bundling common functionality for trajectory I/O.
 
     .. versionchanged:: 0.8
@@ -1047,10 +1047,10 @@ class _Readermeta(type):
                 _READERS[f] = cls
 
 
-class ProtoReader(six.with_metaclass(_Readermeta, IObase)):
+class ProtoReader(six.with_metaclass(_Readermeta, IOBase)):
     """Base class for Readers, without a :meth:`__del__` method.
 
-    Extends :class:`IObase` with most attributes and methods of a generic
+    Extends :class:`IOBase` with most attributes and methods of a generic
     Reader, with the exception of a :meth:`__del__` method. It should be used
     as base for Readers that do not need :meth:`__del__`, especially since
     having even an empty :meth:`__del__` might lead to memory leaks.
@@ -1059,7 +1059,7 @@ class ProtoReader(six.with_metaclass(_Readermeta, IObase)):
     :mod:`MDAnalysis.coordinates.__init__` for the required attributes and
     methods.
 
-    .. SeeAlso:: :class:`Reader`
+    .. SeeAlso:: :class:`ReaderBase`
 
     .. versionchanged:: 0.11.0
        Frames now 0-based instead of 1-based
@@ -1597,11 +1597,11 @@ class ProtoReader(six.with_metaclass(_Readermeta, IObase)):
         return descriptions
 
 
-class Reader(ProtoReader):
+class ReaderBase(ProtoReader):
     """Base class for trajectory readers that extends :class:`ProtoReader` with a
     :meth:`__del__` method.
 
-    New Readers should subclass :class:`Reader` and properly implement a
+    New Readers should subclass :class:`ReaderBase` and properly implement a
     :meth:`close` method, to ensure proper release of resources (mainly file
     handles). Readers that are inherently safe in this regard should subclass
     :class:`ProtoReader` instead.
@@ -1614,16 +1614,16 @@ class Reader(ProtoReader):
 
     .. versionchanged:: 0.11.0
        Most of the base Reader class definitions were offloaded to
-       :class:`ProtoReader` so as to allow the subclassing of Readers without a
+       :class:`ProtoReader` so as to allow the subclassing of ReaderBases without a
        :meth:`__del__` method.  Created init method to create common
-       functionality, all Reader subclasses must now :func:`super` through this
+       functionality, all ReaderBase subclasses must now :func:`super` through this
        class.  Added attribute :attr:`_ts_kwargs`, which is created in init.
        Provides kwargs to be passed to :class:`Timestep`
 
     """
 
     def __init__(self, filename, convert_units=None, **kwargs):
-        super(Reader, self).__init__()
+        super(ReaderBase, self).__init__()
 
         self.filename = filename
 
@@ -1674,7 +1674,7 @@ class _Writermeta(type):
                     _MULTIFRAME_WRITERS[f] = cls
 
 
-class Writer(six.with_metaclass(_Writermeta, IObase)):
+class WriterBase(six.with_metaclass(_Writermeta, IOBase)):
     """Base class for trajectory writers.
 
     See Trajectory API definition in :mod:`MDAnalysis.coordinates.__init__` for
@@ -1750,7 +1750,7 @@ class Writer(six.with_metaclass(_Writermeta, IObase)):
         # def write_next_timestep(self, ts=None)
 
 
-class SingleFrameReader(ProtoReader):
+class SingleFrameReaderBase(ProtoReader):
     """Base class for Readers that only have one frame.
 
     To use this base class, define the method :meth:`_read_first_frame` to
@@ -1765,7 +1765,7 @@ class SingleFrameReader(ProtoReader):
     _err = "{0} only contains a single frame"
 
     def __init__(self, filename, convert_units=None, **kwargs):
-        super(SingleFrameReader, self).__init__()
+        super(SingleFrameReaderBase, self).__init__()
 
         self.filename = filename
         if convert_units is None:
@@ -1812,5 +1812,5 @@ class SingleFrameReader(ProtoReader):
     def close(self):
         # all single frame readers should use context managers to access
         # self.filename. Explicitly setting it to the null action in case
-        # the IObase.close method is ever changed from that.
+        # the IOBase.close method is ever changed from that.
         pass

--- a/package/MDAnalysis/coordinates/null.py
+++ b/package/MDAnalysis/coordinates/null.py
@@ -35,7 +35,7 @@ from __future__ import absolute_import
 from . import base
 
 
-class NullWriter(base.Writer):
+class NullWriter(base.WriterBase):
     """A trajectory Writer that does not do anything.
 
     The NullWriter is the equivalent to ``/dev/null``: it behaves like

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -149,7 +149,7 @@ class Universe(object):
     topology_format
         Provide the file format of the topology file; ``None`` guesses it from
         the file extension [``None``] Can also pass a subclass of
-        :class:`MDAnalysis.topology.base.TopologyReader` to define a custom
+        :class:`MDAnalysis.topology.base.TopologyReaderBase` to define a custom
         reader to be used on the topology file.
     format
         Provide the file format of the coordinate or trajectory file; ``None``
@@ -157,8 +157,8 @@ class Universe(object):
         effect if a list of file names is supplied because the "chained" reader
         has to guess the file format for each individual list member.
         [``None``] Can also pass a subclass of
-        :class:`MDAnalysis.coordinates.base.Reader` to define a custom reader
-        to be used on the trajectory file.
+        :class:`MDAnalysis.coordinates.base.ProtoReader` to define a custom
+        reader to be used on the trajectory file.
     guess_bonds : bool, optional
         Once Universe has been loaded, attempt to guess the connectivity
         between atoms.  This will populate the .bonds .angles and .dihedrals
@@ -356,7 +356,7 @@ class Universe(object):
             keyword has no effect if a list of file names is supplied because
             the "chained" reader has to guess the file format for each
             individual list member [``None``]. Can also pass a subclass of
-            :class:`MDAnalysis.coordinates.base.Reader` to define a custom
+            :class:`MDAnalysis.coordinates.base.ProtoReader` to define a custom
             reader to be used on the trajectory file.
         in_memory : bool (optional)
             Directly load trajectory into memory with the
@@ -1034,7 +1034,7 @@ def Merge(*args):
 
     # Take one frame of coordinates from combined atomgroups
     coords = np.vstack([a.positions for a in args])
-    trajectory = MDAnalysis.coordinates.base.Reader(None)
+    trajectory = MDAnalysis.coordinates.base.ReaderBase(None)
     ts = MDAnalysis.coordinates.base.Timestep.from_coordinates(coords)
     setattr(trajectory, "ts", ts)
     trajectory.n_frames = 1

--- a/package/MDAnalysis/selections/__init__.py
+++ b/package/MDAnalysis/selections/__init__.py
@@ -37,7 +37,7 @@ to a file so that it can be used in another programme.
 :mod:`MDAnalysis.selections.charmm`
     CHARMM_ selections
 
-The :class:`MDAnalysis.selections.base.SelectionWriter` base class and
+The :class:`MDAnalysis.selections.base.SelectionWriterBase` base class and
 helper functions are in :mod:`MDAnalysis.selections.base`, with the
 exception of `:func:get_writer`:
 
@@ -57,7 +57,7 @@ from . import jmol
 
 
 def get_writer(filename, defaultformat):
-    """Return a :class:`SelectionWriter` for *filename* or a *defaultformat*."""
+    """Return a SelectionWriter for *filename* or a *defaultformat*."""
 
     if filename:
         format = os.path.splitext(filename)[1][1:]  # strip initial dot!

--- a/package/MDAnalysis/selections/base.py
+++ b/package/MDAnalysis/selections/base.py
@@ -26,11 +26,11 @@ Base classes for the selection writers
 ======================================
 
 Specialized SelectionWriters are derived from
-:class:`SelectionWriter`. Override the :meth:`~SelectionWriter._write_head`,
-:meth:`~SelectionWriter._translate`, and :meth:`~SelectionWriter._write_tail`
+:class:`SelectionWriterBase`. Override the :meth:`~SelectionWriterBase._write_head`,
+:meth:`~SelectionWriterBase._translate`, and :meth:`~SelectionWriterBase._write_tail`
 methods.
 
-.. autoclass:: SelectionWriter
+.. autoclass:: SelectionWriterBase
    :members: __init__, write, _translate, _write_head, _write_tail, comment
 
 .. autofunction:: join
@@ -74,15 +74,15 @@ class _Selectionmeta(type):
                 _SELECTION_WRITERS[f] = cls
 
 
-class SelectionWriter(six.with_metaclass(_Selectionmeta)):
+class SelectionWriterBase(six.with_metaclass(_Selectionmeta)):
     """Export a selection in MDAnalysis to a format usable in an external package.
 
-    The :class:`SelectionWriter` writes a selection string to a file
+    The :class:`SelectionWriterBase` writes a selection string to a file
     that can be used in another package such as `VMD`_, `PyMOL`_,
     `Gromacs`_ or `CHARMM`_. In this way, analysis and visualization
     can be done with the best or most convenient tools at hand.
 
-    :class:`SelectionWriter` is a base class and child classes are
+    :class:`SelectionWriterBase` is a base class and child classes are
     derived with the appropriate customizations for the package file
     format.
 
@@ -143,7 +143,7 @@ class SelectionWriter(six.with_metaclass(_Selectionmeta)):
     def comment(self, s):
         """Return string *s* interpolated into the comment format string.
 
-        If no :attr:`SelectionWriter.commentfmt` is defined (None) then the
+        If no :attr:`SelectionWriterBase.commentfmt` is defined (None) then the
         empty string is returned because presumably there is no way to enter
         comments into the file.
 

--- a/package/MDAnalysis/selections/charmm.py
+++ b/package/MDAnalysis/selections/charmm.py
@@ -42,7 +42,7 @@ from __future__ import absolute_import
 
 from . import base
 
-class SelectionWriter(base.SelectionWriter):
+class SelectionWriter(base.SelectionWriterBase):
     format = ["CHARMM", "str"]
     ext = "str"
     continuation = '-'

--- a/package/MDAnalysis/selections/gromacs.py
+++ b/package/MDAnalysis/selections/gromacs.py
@@ -42,7 +42,7 @@ from __future__ import absolute_import
 
 from . import base
 
-class SelectionWriter(base.SelectionWriter):
+class SelectionWriter(base.SelectionWriterBase):
     format = ["Gromacs", "ndx"]
     ext = "ndx"
     default_numterms = 12

--- a/package/MDAnalysis/selections/jmol.py
+++ b/package/MDAnalysis/selections/jmol.py
@@ -42,7 +42,7 @@ from __future__ import absolute_import
 
 from . import base
 
-class SelectionWriter(base.SelectionWriter):
+class SelectionWriter(base.SelectionWriterBase):
     format = ["Jmol", "spt"]
     ext = "spt"
     default_numterms = None

--- a/package/MDAnalysis/selections/pymol.py
+++ b/package/MDAnalysis/selections/pymol.py
@@ -43,7 +43,7 @@ from __future__ import absolute_import
 
 from . import base
 
-class SelectionWriter(base.SelectionWriter):
+class SelectionWriter(base.SelectionWriterBase):
     format = ["PyMol", "pml"]
     ext = "pml"
     continuation = '\\'  # quoted backslash!

--- a/package/MDAnalysis/selections/vmd.py
+++ b/package/MDAnalysis/selections/vmd.py
@@ -41,7 +41,7 @@ from __future__ import absolute_import
 
 from . import base
 
-class SelectionWriter(base.SelectionWriter):
+class SelectionWriter(base.SelectionWriterBase):
     format = "VMD"
     ext = "vmd"
     continuation = '\\'

--- a/package/MDAnalysis/topology/CRDParser.py
+++ b/package/MDAnalysis/topology/CRDParser.py
@@ -49,7 +49,7 @@ from __future__ import absolute_import
 import numpy as np
 
 from ..lib.util import openany, FORTRANReader
-from .base import TopologyReader, change_squash
+from .base import TopologyReaderBase, change_squash
 from . import guessers
 from ..core.topology import Topology
 from ..core.topologyattrs import (
@@ -65,7 +65,7 @@ from ..core.topologyattrs import (
 )
 
 
-class CRDParser(TopologyReader):
+class CRDParser(TopologyReaderBase):
     """Parse a CHARMM CARD coordinate file for topology information.
 
     Reads the following Attributes:

--- a/package/MDAnalysis/topology/DLPolyParser.py
+++ b/package/MDAnalysis/topology/DLPolyParser.py
@@ -40,7 +40,7 @@ from __future__ import (absolute_import, division,
 import numpy as np
 
 from . import guessers
-from .base import TopologyReader
+from .base import TopologyReaderBase
 from ..core.topology import Topology
 from ..core.topologyattrs import (
     Atomids,
@@ -54,7 +54,7 @@ from ..core.topologyattrs import (
 from ..lib.util import openany
 
 
-class ConfigParser(TopologyReader):
+class ConfigParser(TopologyReaderBase):
     """DL_Poly CONFIG file parser
 
     .. versionadded:: 0.10.1
@@ -121,7 +121,7 @@ class ConfigParser(TopologyReader):
         return top
 
 
-class HistoryParser(TopologyReader):
+class HistoryParser(TopologyReaderBase):
     """DL_Poly History file parser
 
     .. versionadded:: 0.10.1

--- a/package/MDAnalysis/topology/DMSParser.py
+++ b/package/MDAnalysis/topology/DMSParser.py
@@ -46,7 +46,7 @@ import sqlite3
 import os
 
 from . import guessers
-from .base import TopologyReader, squash_by
+from .base import TopologyReaderBase, squash_by
 from ..core.topology import Topology
 from ..core.topologyattrs import (
     Atomids,
@@ -70,7 +70,7 @@ class Atomnums(AtomAttr):
     singular = 'atomnum'
 
 
-class DMSParser(TopologyReader):
+class DMSParser(TopologyReaderBase):
     """Read a topology from a DESRES_ Molecular Structure file.
 
     Format (DMS_) coordinate files (as used by the Desmond_ MD package).

--- a/package/MDAnalysis/topology/GMSParser.py
+++ b/package/MDAnalysis/topology/GMSParser.py
@@ -51,7 +51,7 @@ import numpy as np
 
 from . import guessers
 from ..lib.util import openany
-from .base import TopologyReader
+from .base import TopologyReaderBase
 from ..core.topology import Topology
 from ..core.topologyattrs import (
     Atomids,
@@ -70,7 +70,7 @@ class AtomicCharges(AtomAttr):
     per_object = 'atom'
 
 
-class GMSParser(TopologyReader):
+class GMSParser(TopologyReaderBase):
     """GAMESS_ topology parser.
 
     Creates the following Attributes:

--- a/package/MDAnalysis/topology/GROParser.py
+++ b/package/MDAnalysis/topology/GROParser.py
@@ -56,11 +56,11 @@ from ..core.topologyattrs import (
     Segids,
 )
 from ..core.topology import Topology
-from .base import TopologyReader, squash_by
+from .base import TopologyReaderBase, squash_by
 from . import guessers
 
 
-class GROParser(TopologyReader):
+class GROParser(TopologyReaderBase):
     """Reads a Gromacs GRO file
 
     Reads the following attributes:

--- a/package/MDAnalysis/topology/HoomdXMLParser.py
+++ b/package/MDAnalysis/topology/HoomdXMLParser.py
@@ -52,7 +52,7 @@ import numpy as np
 
 from . import guessers
 from ..lib.util import openany
-from .base import TopologyReader
+from .base import TopologyReaderBase
 from ..core.topology import Topology
 from ..core.topologyattrs import (
     Atomtypes,
@@ -70,7 +70,7 @@ from ..core.topologyattrs import (
 )
 
 
-class HoomdXMLParser(TopologyReader):
+class HoomdXMLParser(TopologyReaderBase):
     """Parses a Hoomd XML file to create a Topology
 
     Reads the following Attributes:

--- a/package/MDAnalysis/topology/LAMMPSParser.py
+++ b/package/MDAnalysis/topology/LAMMPSParser.py
@@ -54,7 +54,7 @@ import functools
 from . import guessers
 from ..lib.util import openany, conv_float
 from ..lib.mdamath import triclinic_box
-from .base import TopologyReader, squash_by
+from .base import TopologyReaderBase, squash_by
 from ..core.topology import Topology
 from ..core.topologyattrs import (
     Atomtypes,
@@ -137,7 +137,7 @@ HEADERS = set([
 ])
 
 
-class DATAParser(TopologyReader):
+class DATAParser(TopologyReaderBase):
     """Parse a LAMMPS DATA file for topology and coordinates.
 
     Note that LAMMPS_ DATA files can be used standalone.

--- a/package/MDAnalysis/topology/MMTFParser.py
+++ b/package/MDAnalysis/topology/MMTFParser.py
@@ -144,7 +144,7 @@ class ModelSelection(RangeSelection):
         return group[mask].unique
 
 
-class MMTFParser(base.TopologyReader):
+class MMTFParser(base.TopologyReaderBase):
     format = 'MMTF'
 
     def parse(self):

--- a/package/MDAnalysis/topology/MOL2Parser.py
+++ b/package/MDAnalysis/topology/MOL2Parser.py
@@ -47,7 +47,7 @@ import numpy as np
 
 from . import guessers
 from ..lib.util import openany
-from .base import TopologyReader, squash_by
+from .base import TopologyReaderBase, squash_by
 from ..core.topologyattrs import (
     Atomids,
     Atomnames,
@@ -63,7 +63,7 @@ from ..core.topologyattrs import (
 from ..core.topology import Topology
 
 
-class MOL2Parser(TopologyReader):
+class MOL2Parser(TopologyReaderBase):
     """Read topology from a Tripos_ MOL2_ file.
 
     Create the following Attributes:
@@ -79,7 +79,7 @@ class MOL2Parser(TopologyReader):
      - masses
 
     .. versionchanged:: 0.9
-       Now subclasses TopologyReader
+       Now subclasses TopologyReaderBase
     """
     format = 'MOL2'
 

--- a/package/MDAnalysis/topology/PDBParser.py
+++ b/package/MDAnalysis/topology/PDBParser.py
@@ -61,7 +61,7 @@ import warnings
 
 from .guessers import guess_masses, guess_types
 from ..lib import util
-from .base import TopologyReader, change_squash
+from .base import TopologyReaderBase, change_squash
 from ..core.topology import Topology
 from ..core.topologyattrs import (
     Atomnames,
@@ -87,7 +87,7 @@ def float_or_default(val, default):
         return default
 
 
-class PDBParser(TopologyReader):
+class PDBParser(TopologyReaderBase):
     """Parser that obtains a list of atoms from a standard PDB file.
 
     Creates the following Attributes:

--- a/package/MDAnalysis/topology/PDBQTParser.py
+++ b/package/MDAnalysis/topology/PDBQTParser.py
@@ -55,7 +55,7 @@ import numpy as np
 
 from . import guessers
 from ..lib import util
-from .base import TopologyReader, change_squash
+from .base import TopologyReaderBase, change_squash
 from ..core.topology import Topology
 from ..core.topologyattrs import (
     Atomids,
@@ -73,7 +73,7 @@ from ..core.topologyattrs import (
 )
 
 
-class PDBQTParser(TopologyReader):
+class PDBQTParser(TopologyReaderBase):
     """Read topology from a PDBQT file.
 
     Creates the following Attributes:

--- a/package/MDAnalysis/topology/PQRParser.py
+++ b/package/MDAnalysis/topology/PQRParser.py
@@ -61,10 +61,10 @@ from ..core.topologyattrs import (
     Segids,
 )
 from ..core.topology import Topology
-from .base import TopologyReader, squash_by
+from .base import TopologyReaderBase, squash_by
 
 
-class PQRParser(TopologyReader):
+class PQRParser(TopologyReaderBase):
     """Parse atom information from PQR file *filename*.
 
     Creates a MDAnalysis Topology with the following attributes

--- a/package/MDAnalysis/topology/PSFParser.py
+++ b/package/MDAnalysis/topology/PSFParser.py
@@ -52,7 +52,7 @@ import numpy as np
 
 from ..lib.util import openany
 from . import guessers
-from .base import TopologyReader, squash_by
+from .base import TopologyReaderBase, squash_by
 from ..core.topologyattrs import (
     Atomids,
     Atomnames,
@@ -73,7 +73,7 @@ from ..core.topology import Topology
 logger = logging.getLogger("MDAnalysis.topology.PSF")
 
 
-class PSFParser(TopologyReader):
+class PSFParser(TopologyReaderBase):
     """Read topology information from a CHARMM/NAMD/XPLOR PSF_ file.
 
     Creates a Topology with the following Attributes:

--- a/package/MDAnalysis/topology/TOPParser.py
+++ b/package/MDAnalysis/topology/TOPParser.py
@@ -78,7 +78,7 @@ from math import ceil
 from . import guessers
 from .tables import NUMBER_TO_ELEMENT
 from ..lib.util import openany, FORTRANReader
-from .base import TopologyReader
+from .base import TopologyReaderBase
 from ..core.topology import Topology
 from ..core.topologyattrs import (
     Atomnames,
@@ -102,7 +102,7 @@ class TypeIndices(AtomAttr):
     level = 'atom'
 
 
-class TOPParser(TopologyReader):
+class TOPParser(TopologyReaderBase):
     """Reads topology information from an AMBER top file.
 
     Reads the following Attributes if in topology:

--- a/package/MDAnalysis/topology/TPRParser.py
+++ b/package/MDAnalysis/topology/TPRParser.py
@@ -144,14 +144,14 @@ import xdrlib
 from . import guessers
 from ..lib.util import anyopen
 from .tpr import utils as tpr_utils
-from .base import TopologyReader
+from .base import TopologyReaderBase
 from ..core.topologyattrs import Resnums
 
 import logging
 logger = logging.getLogger("MDAnalysis.topology.TPRparser")
 
 
-class TPRParser(TopologyReader):
+class TPRParser(TopologyReaderBase):
     """Read topology information from a Gromacs_ TPR_ file.
 
     .. _Gromacs: http://www.gromacs.org

--- a/package/MDAnalysis/topology/XYZParser.py
+++ b/package/MDAnalysis/topology/XYZParser.py
@@ -44,7 +44,7 @@ import numpy as np
 
 from . import guessers
 from ..lib.util import openany
-from .base import TopologyReader
+from .base import TopologyReaderBase
 from ..core.topology import Topology
 from ..core.topologyattrs import (
     Atomnames,
@@ -57,7 +57,7 @@ from ..core.topologyattrs import (
 )
 
 
-class XYZParser(TopologyReader):
+class XYZParser(TopologyReaderBase):
     """Parse a list of atoms from an XYZ file.
 
     Creates the following attributes:

--- a/package/MDAnalysis/topology/__init__.py
+++ b/package/MDAnalysis/topology/__init__.py
@@ -191,8 +191,8 @@ trajectory. This includes
 Topology readers are generally called "parsers" in MDAnalysis (for
 historical reasons and in order to distinguish them from coordinate
 "readers"). All parsers are derived from
-:class:`MDAnalysis.topology.base.TopologyReader` and have a
-:meth:`~MDAnalysis.topology.base.TopologyReader.parse` method that
+:class:`MDAnalysis.topology.base.TopologyReaderBase` and have a
+:meth:`~MDAnalysis.topology.base.TopologyReaderBase.parse` method that
 returns a :class:`MDAnalysis.core.topology.Topology` instance.
 
 

--- a/package/MDAnalysis/topology/base.py
+++ b/package/MDAnalysis/topology/base.py
@@ -30,7 +30,7 @@ file and :exc:`ValueError` upon failing to make sense of the read data.
 Classes
 -------
 
-.. autoclass:: TopologyReader
+.. autoclass:: TopologyReaderBase
    :members:
    :inherited-members:
 
@@ -45,7 +45,7 @@ import numpy as np
 import warnings
 
 from .. import _PARSERS
-from ..coordinates.base import IObase
+from ..coordinates.base import IOBase
 from ..lib import util
 
 
@@ -62,7 +62,7 @@ class _Topologymeta(type):
                 _PARSERS[f] = cls
 
 
-class TopologyReader(six.with_metaclass(_Topologymeta, IObase)):
+class TopologyReaderBase(six.with_metaclass(_Topologymeta, IOBase)):
     """Base class for topology readers
 
     Parameters

--- a/package/doc/sphinx/source/documentation_pages/selections_modules.rst
+++ b/package/doc/sphinx/source/documentation_pages/selections_modules.rst
@@ -12,8 +12,8 @@ The classes in this module allow writing a selection to a file that can be read 
 allows a user to combine their favourite tools with MDAnalysis for further
 visualization or simulation.
 
-There exist different :class:`~MDAnalysis.selections.base.SelectionWriter` classes
-for different package. The :func:`~MDAnalysis.selections.base.get_writer` function
+There exist different :class:`~MDAnalysis.selections.base.SelectionWriterBase` classes
+for different packages. The :func:`~MDAnalysis.selections.base.get_writer` function
 can automatically pick the appropriate one, based on the file name extension in the
 table below.
 

--- a/testsuite/MDAnalysisTests/coordinates/test_reader_api.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_reader_api.py
@@ -21,7 +21,11 @@
 #
 
 import numpy as np
-from MDAnalysis.coordinates.base import Timestep, SingleFrameReader, Reader
+from MDAnalysis.coordinates.base import (
+    Timestep,
+    SingleFrameReaderBase,
+    ReaderBase
+)
 from numpy.testing import assert_equal, assert_raises
 
 """
@@ -29,7 +33,7 @@ Isolate the API definitions of Readers independent of implementations
 """
 
 
-class AmazingMultiFrameReader(Reader):
+class AmazingMultiFrameReader(ReaderBase):
     format = 'AmazingMulti'
 
     def __init__(self, filename, **kwargs):
@@ -59,7 +63,7 @@ class AmazingMultiFrameReader(Reader):
         self.ts.frame = -1
 
 
-class AmazingReader(SingleFrameReader):
+class AmazingReader(SingleFrameReaderBase):
     format = 'Amazing'
 
     # have to hack this in to get the base class to "work"

--- a/testsuite/MDAnalysisTests/coordinates/test_writer_registration.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_writer_registration.py
@@ -1,12 +1,12 @@
 from numpy.testing import assert_, assert_raises
 
 import MDAnalysis as mda
-from MDAnalysis.coordinates.base import Writer
+from MDAnalysis.coordinates.base import WriterBase
 
 
 
 class TestWriterCreation(object):
-    class MagicWriter(Writer):
+    class MagicWriter(WriterBase):
         # this writer does the 'magic' format
         format = 'MAGIC'
 

--- a/testsuite/MDAnalysisTests/core/test_universe.py
+++ b/testsuite/MDAnalysisTests/core/test_universe.py
@@ -49,10 +49,10 @@ from MDAnalysisTests import parser_not_found
 
 import MDAnalysis as mda
 import MDAnalysis.coordinates
-from MDAnalysis.topology.base import TopologyReader
+from MDAnalysis.topology.base import TopologyReaderBase
 
 
-class IOErrorParser(TopologyReader):
+class IOErrorParser(TopologyReaderBase):
     def parse(self):
         raise IOError("Useful information")
 

--- a/testsuite/MDAnalysisTests/core/test_updating_atomgroup.py
+++ b/testsuite/MDAnalysisTests/core/test_updating_atomgroup.py
@@ -115,7 +115,7 @@ class TestUpdatingSelectionNotraj(object):
         assert_(self.ag_updating._lastupdate is None)
 
 
-class UAGReader(mda.coordinates.base.Reader):
+class UAGReader(mda.coordinates.base.ReaderBase):
     """
     Positions in this reader are defined as:
     (atom number + frame number, 0, 0)

--- a/testsuite/MDAnalysisTests/core/util.py
+++ b/testsuite/MDAnalysisTests/core/util.py
@@ -225,9 +225,9 @@ _MENU = {
 }
 
 def make_FakeReader(n_atoms=None, velocities=False, forces=False):
-    from MDAnalysis.coordinates.base import SingleFrameReader
+    from MDAnalysis.coordinates.base import SingleFrameReaderBase
 
-    class FakeReader(SingleFrameReader):
+    class FakeReader(SingleFrameReaderBase):
         def __init__(self, n_atoms=None, velocities=False, forces=False):
             self.n_atoms = n_atoms if not n_atoms is None else _N_ATOMS
             self.filename = 'FakeReader'


### PR DESCRIPTION
Renamed various base classes:

IObase -> IOBase
Reader -> ReaderBase
SingleFrameReader -> SingleFrameReaderBase
Writer -> WriterBase
SelectionWriter -> SelectionWriterBase
TopologyReader -> TopologyReaderBase

Fixes #921

PR Checklist
------------
 - [ ] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
