### PR TITLE
fixes density_from_Universe() (#1211)

### DIFF
--- a/package/MDAnalysis/analysis/density.py
+++ b/package/MDAnalysis/analysis/density.py
@@ -469,7 +469,7 @@ def density_from_Universe(universe, delta=1.0, atomselection='name OH2',
     if cutoff > 0 and soluteselection is not None:
         # special fast selection for '<atomsel> not within <cutoff> of <solutesel>'
         notwithin_coordinates = notwithin_coordinates_factory(
-            u, groupselection, soluteselection, cutoff,
+            u, atomselection, soluteselection, cutoff,
             use_kdtree=use_kdtree, updating_selection=update_selection)
         def current_coordinates():
             return notwithin_coordinates()
@@ -604,21 +604,21 @@ def notwithin_coordinates_factory(universe, sel1, sel2, cutoff,
     returns the coordinates of the "solvent" selection that are *not within* a given cut-off
     distance of the "solute". Because it is KD-tree based, it is cheap to query the KD-tree with
     a different cut-off::
-    
+
       notwithin_coordinates = notwithin_coordinates_factory(universe, 'name OH2','protein and not name H*', 3.5)
       ...
       coord = notwithin_coordinates()        # get coordinates outside cutoff 3.5 A
       coord = notwithin_coordinates(cutoff2) # can use different cut off
 
-    For programmatic convenience, the function can also function as a factory for a simple 
+    For programmatic convenience, the function can also function as a factory for a simple
     *within cutoff* query if the keyword ``not_within=False`` is set::
-  
-      within_coordinates = notwithin_coordinates_factory(universe, 'name OH2','protein and not name H*', 3.5, 
+
+      within_coordinates = notwithin_coordinates_factory(universe, 'name OH2','protein and not name H*', 3.5,
                                                          not_within=False)
       ...
       coord = within_coordinates()        # get coordinates within cutoff 3.5 A
       coord = within_coordinates(cutoff2) # can use different cut off
-    
+
     (Readability is enhanced by properly naming the generated function ``within_coordinates().)
     """
     # Benchmark of FABP system (solvent 3400 OH2, protein 2100 atoms) on G4 powerbook, 500 frames

--- a/testsuite/MDAnalysisTests/analysis/test_density.py
+++ b/testsuite/MDAnalysisTests/analysis/test_density.py
@@ -104,7 +104,7 @@ class Test_density_from_Universe(TestCase):
                   'static_sliced':
                       {'meandensity': 0.016764270747693617, },
                   'dynamic':
-                      {'meandensity': 0.00062423404854011104, },
+                      {'meandensity': 0.0012063418843728784, },
                   'notwithin':
                       {'meandensity': 0.015535385132107926, },
                   }
@@ -154,7 +154,7 @@ class Test_density_from_Universe(TestCase):
         self.check_density_from_Universe(
             self.selections['dynamic'],
             self.references['dynamic']['meandensity'],
-            update_selections=True)
+            update_selection=True)
 
     def test_density_from_Universe_notwithin(self):
         self.check_density_from_Universe(

--- a/testsuite/MDAnalysisTests/analysis/test_density.py
+++ b/testsuite/MDAnalysisTests/analysis/test_density.py
@@ -97,6 +97,7 @@ class Test_density_from_Universe(TestCase):
     delta = 2.0
     selections = {'static': "name OW",
                   'dynamic': "name OW and around 4 (protein and resid 1-10)",
+                  'solute': "protein and not name H*",
                   }
     references = {'static':
                       {'meandensity': 0.016764271713091212, },
@@ -104,7 +105,10 @@ class Test_density_from_Universe(TestCase):
                       {'meandensity': 0.016764270747693617, },
                   'dynamic':
                       {'meandensity': 0.00062423404854011104, },
+                  'notwithin':
+                      {'meandensity': 0.015535385132107926, },
                   }
+    cutoffs = {'notwithin': 4.0, }
     precision = 5
 
     @dec.skipif(module_not_found('scipy'),
@@ -151,6 +155,14 @@ class Test_density_from_Universe(TestCase):
             self.selections['dynamic'],
             self.references['dynamic']['meandensity'],
             update_selections=True)
+
+    def test_density_from_Universe_notwithin(self):
+        self.check_density_from_Universe(
+            self.selections['static'],
+            self.references['notwithin']['meandensity'],
+            soluteselection=self.selections['solute'],
+            cutoff=self.cutoffs['notwithin'])
+
 
 class TestGridImport(TestCase):
 


### PR DESCRIPTION
Fixes #1211 and PR #1232 

Changes made in this Pull Request:
- This fixes a bug in PR #1232 that slipped through (found by @macraild),
  namely, a spurious groupselection --> atomselection
- added test case for `density_from_Universe()` when using not-within coordinates
- fixed broken test for updating selection in `density_from_Universe()`
- updated docs

PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - n/a CHANGELOG updated?
 - [x] Issue raised/referenced?
