### PR TITLE
added tests for exceptions in Density._check_set_unit() (#1231)

### DIFF
--- a/testsuite/AUTHORS
+++ b/testsuite/AUTHORS
@@ -75,6 +75,7 @@ Chronological list of authors
   - Utkarsh Bansal
   - Shobhit Agarwal
   - Vedant Rathore
+  - Kashish Punjani
 
 External code
 -------------

--- a/testsuite/CHANGELOG
+++ b/testsuite/CHANGELOG
@@ -14,7 +14,7 @@ and https://github.com/MDAnalysis/mdanalysis/wiki/UnitTests
 
 ------------------------------------------------------------------------------
 ??/??/16 jbarnoud, orbeckst, fiona-naughton, manuel.nuno.melo, richardjgowers
-         tyler.je.reddy, utkbansal, vedantrathore
+         tyler.je.reddy, utkbansal, vedantrathore, kash1102
 
   * 0.16
     - Make knownfailure work even without parentheses.

--- a/testsuite/MDAnalysisTests/analysis/test_density.py
+++ b/testsuite/MDAnalysisTests/analysis/test_density.py
@@ -89,6 +89,18 @@ class TestDensity(TestCase):
         origin = [m[0] for m in midpoints]
         assert_almost_equal(self.D.origin, origin)
 
+    def test_check_set_unit_keyerror(self):
+        units = {'weight': 'A'}
+        assert_raises(ValueError, self.D._check_set_unit, units)
+
+    def test_check_set_unit_attributeError(self):
+        units = []
+        assert_raises(ValueError, self.D._check_set_unit, units)
+
+    def test_check_set_unit_nolength(self):
+        del self.D.units['length']
+        units = {'density': 'A^{-3}'}
+        assert_raises(ValueError, self.D._check_set_unit, units)
 
 
 class Test_density_from_Universe(TestCase):


### PR DESCRIPTION
- fixes issue #1231: tests for bad input to Density._check_set_unit() all raise
  ValueError for:
  - wrong unit type
  - wrong unit value
  - missing unit length
- Update AUTHORS and CHANGELOG
- moved new tests for exceptions in density.Density into TestDensity (@orbeckst)

(update for PR #1235 which fixes issue #1231)

PR Checklist
------------
 - [x] Tests?
 - n/a Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
