### PR TITLE
Minor fixes

### DIFF
--- a/package/MDAnalysis/analysis/encore/similarity.py
+++ b/package/MDAnalysis/analysis/encore/similarity.py
@@ -19,8 +19,7 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-"""
-=================================================================================
+"""=================================================================================
 Ensemble Similarity Calculations --- :mod:`MDAnalysis.analysis.encore.similarity`
 =================================================================================
 
@@ -56,9 +55,12 @@ When using this module in published work please cite [Tiberti2015]_.
 References
 ==========
 
-    .. [Lindorff-Larsen2009] Similarity Measures for Protein Ensembles. Lindorff-Larsen, K. Ferkinghoff-Borg, J. PLoS ONE 2008, 4, e4203.
+.. [Lindorff-Larsen2009] Similarity Measures for Protein
+   Ensembles. Lindorff-Larsen, K. Ferkinghoff-Borg, J. PLoS ONE 2008, 4, e4203.
 
-    .. [Tiberti2015] ENCORE: Software for Quantitative Ensemble Comparison. Matteo Tiberti, Elena Papaleo, Tone Bengtsen, Wouter Boomsma, Kresten Lindorff- Larsen. PLoS Comput Biol. 2015, 11
+.. [Tiberti2015] ENCORE: Software for Quantitative Ensemble Comparison. Matteo
+   Tiberti, Elena Papaleo, Tone Bengtsen, Wouter Boomsma, Kresten
+   Lindorff-Larsen. PLoS Comput Biol. 2015, 11, e1004415.
 
 .. _Examples:
 Examples
@@ -165,7 +167,6 @@ Function reference
 ==================
 
 .. All functions are included via automodule :members:.
-
 
 """
 from __future__ import print_function, division, absolute_import

--- a/package/MDAnalysis/analysis/encore/utils.py
+++ b/package/MDAnalysis/analysis/encore/utils.py
@@ -21,6 +21,7 @@
 #
 from __future__ import division, absolute_import
 from six.moves import range
+import numbers
 from multiprocessing.sharedctypes import SynchronizedArray
 from multiprocessing import Process, Manager
 from joblib import cpu_count
@@ -68,7 +69,7 @@ class TriangularMatrix(object):
         self.size = size
         if loadfile:
             self.loadz(loadfile)
-        elif isinstance(size, int):
+        elif isinstance(size, numbers.Integral):
             self.size = size
             self._elements = np.zeros((size + 1) * size // 2, dtype=np.float64)
         elif isinstance(size, SynchronizedArray):

--- a/package/MDAnalysis/auxiliary/XVG.py
+++ b/package/MDAnalysis/auxiliary/XVG.py
@@ -228,8 +228,12 @@ class XVGReader(base.AuxReader):
 
         Parameters
         ----------
-        i : int
+        i: int
             Step number (0-indexed) to move to
+
+        Returns
+        -------
+        :class:`XVGStep`
 
         Raises
         ------

--- a/package/MDAnalysis/auxiliary/XVG.py
+++ b/package/MDAnalysis/auxiliary/XVG.py
@@ -69,6 +69,7 @@ from __future__ import absolute_import
 
 from six.moves import range
 
+import numbers
 import os
 import numpy as np
 from . import base
@@ -134,7 +135,7 @@ class XVGStep(base.AuxStep):
         if key is None:
             # here so that None is a valid value; just return
             return
-        if isinstance(key, int):
+        if isinstance(key, numbers.Integral):
             return self._select_data(key)
         else:
              raise ValueError('Time selector must be single index')
@@ -143,7 +144,7 @@ class XVGStep(base.AuxStep):
         if key is None:
             # here so that None is a valid value; just return
             return
-        if isinstance(key, int):
+        if isinstance(key, numbers.Integral):
             try:
                 return self._data[key]
             except IndexError:

--- a/package/MDAnalysis/auxiliary/XVG.py
+++ b/package/MDAnalysis/auxiliary/XVG.py
@@ -25,14 +25,14 @@ XVG auxiliary reader --- :mod:`MDAnalysis.auxiliary.XVG`
 ========================================================
 
 xvg files are produced by Gromacs during simulation or analysis, formatted
-for plotting data with Grace. 
+for plotting data with Grace.
 
-Data is column-formatted; time/data selection is enabled by providing column 
-indices. 
+Data is column-formatted; time/data selection is enabled by providing column
+indices.
 
 Note
 ----
-By default, the time of each step is assumed to be stored in the first column, 
+By default, the time of each step is assumed to be stored in the first column,
 in units of ps.
 
 
@@ -42,17 +42,17 @@ in units of ps.
 
 XVG Readers
 -----------
-The default :class:`XVGReader` reads and stores the full contents of the .xvg 
-file on initialisation, while a second reader (:class:`XVGFileReader`) that 
-reads steps one at a time as required is also provided for when a lower memory 
+The default :class:`XVGReader` reads and stores the full contents of the .xvg
+file on initialisation, while a second reader (:class:`XVGFileReader`) that
+reads steps one at a time as required is also provided for when a lower memory
 footprint is desired.
 
 Note
 ----
 Data is assumed to be time-ordered.
 
-Multiple datasets, separated in the .xvg file by '&', are currently not 
-supported (the readers will stop at the first line starting '&'). 
+Multiple datasets, separated in the .xvg file by '&', are currently not
+supported (the readers will stop at the first line starting '&').
 
 
 .. autoclass:: XVGReader
@@ -106,8 +106,8 @@ def uncomment(lines):
 class XVGStep(base.AuxStep):
     """ AuxStep class for .xvg file format.
 
-    Extends the base AuxStep class to allow selection of time and 
-    data-of-interest fields (by column index) from the full set of data read 
+    Extends the base AuxStep class to allow selection of time and
+    data-of-interest fields (by column index) from the full set of data read
     each step.
 
     Parameters
@@ -156,15 +156,15 @@ class XVGStep(base.AuxStep):
 class XVGReader(base.AuxReader):
     """ Auxiliary reader to read data from an .xvg file.
 
-    Detault reader for .xvg files. All data from the file will be read and stored 
+    Detault reader for .xvg files. All data from the file will be read and stored
     on initialisation.
-    
+
     Parameters
     ----------
     filename : str
         Location of the file containing the auxiliary data.
     **kwargs
-       Other AuxReader options.    
+       Other AuxReader options.
 
     See Also
     --------
@@ -172,7 +172,7 @@ class XVGReader(base.AuxReader):
 
     Note
     ----
-    The file is assumed to be of a size such that reading and storing the full 
+    The file is assumed to be of a size such that reading and storing the full
     contents is practical.
     """
 
@@ -193,7 +193,7 @@ class XVGReader(base.AuxReader):
            # check the number of columns is consistent
            if len(auxdata_values[i]) != len(auxdata_values[0]):
                 raise ValueError('Step {0} has {1} columns instead of '
-                                 '{2}'.format(i, auxdata_values[i], 
+                                 '{2}'.format(i, auxdata_values[i],
                                               auxdata_values[0]))
         self._auxdata_values = np.array(auxdata_values)
         self._n_steps = len(self._auxdata_values)
@@ -223,7 +223,7 @@ class XVGReader(base.AuxReader):
             raise StopIteration
 
     def _go_to_step(self, i):
-        """ Move to and read i-th auxiliary step. 
+        """ Move to and read i-th auxiliary step.
 
         Parameters
         ----------
@@ -256,16 +256,16 @@ class XVGReader(base.AuxReader):
 class XVGFileReader(base.AuxFileReader):
     """ Auxiliary reader to read (step at a time) from an .xvg file.
 
-    An alternative XVG reader which reads each step from the .xvg file as 
-    needed (rather than reading and storing all from the start), for a lower 
-    memory footprint.     
-    
+    An alternative XVG reader which reads each step from the .xvg file as
+    needed (rather than reading and storing all from the start), for a lower
+    memory footprint.
+
     Parameters
     ----------
     filename : str
        Location of the file containing the auxiliary data.
     **kwargs
-       Other AuxReader options.    
+       Other AuxReader options.
 
     See Also
     --------
@@ -336,7 +336,7 @@ class XVGFileReader(base.AuxFileReader):
             try:
                 return len(self._times)
             except AttributeError:
-                # might as well build _times now, since we'll need to iterate 
+                # might as well build _times now, since we'll need to iterate
                 # through anyway
                 self._times = self.read_all_times()
                 return len(self.read_all_times())

--- a/package/MDAnalysis/auxiliary/base.py
+++ b/package/MDAnalysis/auxiliary/base.py
@@ -47,8 +47,9 @@ import numbers
 import math
 import warnings
 
-from ..lib.util import asiterable, anyopen
 import numpy as np
+
+from ..lib.util import asiterable, anyopen
 
 from . import _AUXREADERS
 

--- a/package/MDAnalysis/auxiliary/base.py
+++ b/package/MDAnalysis/auxiliary/base.py
@@ -157,7 +157,7 @@ class AuxStep(object):
         Will be passed to ``_select_time()``, defined separately for each
         auxiliary format, when returning the time of the current step.
         Format will depend on the auxiliary format. e.g. for the XVGReader,
-        this is an index and `_select_time()` returns the value in that column
+        this is an index and ``_select_time()`` returns the value in that column
         of the current step data.
 
         Defaults to 'None' if time selection is not enabled.

--- a/package/MDAnalysis/coordinates/CRD.py
+++ b/package/MDAnalysis/coordinates/CRD.py
@@ -99,11 +99,14 @@ class CRDReader(base.SingleFrameReaderBase):
     def Writer(self, filename, **kwargs):
         """Returns a CRDWriter for *filename*.
 
-        :Arguments:
-          *filename*
-              filename of the output CRD file
+        Parameters
+        ----------
+        filename: str
+            filename of the output CRD file
 
-        :Returns: :class:`CRDWriter`
+        Returns
+        -------
+        :class:`CRDWriter`
 
         """
         return CRDWriter(filename, **kwargs)

--- a/package/MDAnalysis/coordinates/CRD.py
+++ b/package/MDAnalysis/coordinates/CRD.py
@@ -1,5 +1,5 @@
 # -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
-# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
 #
 # MDAnalysis --- http://www.mdanalysis.org
 # Copyright (c) 2006-2016 The MDAnalysis Development Team and contributors
@@ -45,8 +45,8 @@ class CRDReader(base.SingleFrameReaderBase):
     """CRD reader that implements the standard and extended CRD coordinate formats
 
     .. versionchanged:: 0.11.0
-       Now returns a ValueError instead of FormatError
-       Frames now 0-based instead of 1-based
+       Now returns a ValueError instead of FormatError.
+       Frames now 0-based instead of 1-based.
     """
     format = 'CRD'
     units = {'time': None, 'length': 'Angstrom'}
@@ -118,7 +118,7 @@ class CRDWriter(base.WriterBase):
     It automatically writes the CHARMM EXT extended format if there
     are more than 99,999 atoms.
 
-    Requires the following attributes:
+    Requires the following attributes to be present:
     - resids
     - resnames
     - names
@@ -148,16 +148,27 @@ class CRDWriter(base.WriterBase):
     }
 
     def __init__(self, filename, **kwargs):
+        """
+        Parameters
+        ----------
+        filename : str or :class:`~MDAnalysis.lib.util.NamedStream`
+             name of the output file or a stream
+        """
+
         self.filename = util.filename(filename, ext='crd')
         self.crd = None
 
     def write(self, selection, frame=None):
         """Write selection at current trajectory frame to file.
 
-        write(selection,frame=FRAME)
+        Parameters
+        ----------
+        selection : AtomGroup
+             group of atoms to be written
+        frame : int (optional)
+             Move the trajectory to frame `frame`; by default, write
+             the current frame.
 
-        selection         MDAnalysis AtomGroup
-        frame             optionally move to frame FRAME
         """
         u = selection.universe
         if frame is not None:

--- a/package/MDAnalysis/coordinates/DCD.py
+++ b/package/MDAnalysis/coordinates/DCD.py
@@ -124,6 +124,7 @@ class Timestep(base.Timestep):
         it is assumed it is a new-style CHARMM unitcell (at least since c36b2)
         in which box vectors were recorded.
 
+
         .. warning:: The DCD format is not well defined. Check your unit cell
            dimensions carefully, especially when using triclinic
            boxes. Different software packages implement different conventions
@@ -176,26 +177,26 @@ class DCDWriter(base.WriterBase):
 
     Parameters
     ----------
-    filename: str
+    filename : str
         name of output file
-    n_atoms: int (optional)
+    n_atoms : int (optional)
         number of atoms in dcd file
-    start: int (optional)
+    start : int (optional)
         starting frame number
-    step: int (optional)
+    step : int (optional)
         skip between subsequent timesteps (indicate that `step` **MD
         integrator steps (!)** make up one trajectory frame); default is 1.
-    delta: float (optional)
+    delta : float (optional)
         timestep (**MD integrator time step (!)**, in AKMA units); default is
         20.45482949774598 (corresponding to 1 ps).
-    remarks: str (optional)
+    remarks : str (optional)
         comments to annotate dcd file
-    dt: float (optional)
+    dt : float (optional)
         **Override** `step` and `delta` so that the DCD records that
         `dt` ps lie between two frames. (It sets `step` = 1 and
         `delta` ``= AKMA(dt)``.) The default is ``None``, in which case
         `step` and `delta` are used.
-    convert_units: bool (optional)
+    convert_units : bool (optional)
         units are converted to the MDAnalysis base format; ``None`` selects
         the value of :data:`MDAnalysis.core.flags` ['convert_lengths'].
         (see :ref:`flags-label`)
@@ -403,13 +404,13 @@ class DCDReader(base.ReaderBase):
 
     Note
     ----
-
     The DCD file format is not well defined. In particular, NAMD and CHARMM use
     it differently. Currently, MDAnalysis tries to guess the correct format for
     the unitcell representation but it can be wrong. **Check the unitcell
     dimensions**, especially for triclinic unitcells (see `Issue 187`_ and
     :attr:`Timestep.dimensions`). A second potential issue are the units of
     time (TODO).
+
 
     .. versionchanged:: 0.9.0
        The underlying DCD reader (written in C and derived from the
@@ -529,7 +530,7 @@ class DCDReader(base.ReaderBase):
 
         Parameters
         ----------
-        asel: :class:`~MDAnalysis.core.groups.AtomGroup`
+        asel : :class:`~MDAnalysis.core.groups.AtomGroup`
             The :class:`~MDAnalysis.core.groups.AtomGroup` to read the
             coordinates from. Defaults to None, in which case the full set of
             coordinate data is returned.
@@ -543,7 +544,7 @@ class DCDReader(base.ReaderBase):
         step : int (optional)
              Step size for reading; the default ``None`` is equivalent to 1 and means to
              read every frame.
-        format: str (optional)
+        format : str (optional)
             the order/shape of the return data array, corresponding
             to (a)tom, (f)rame, (c)oordinates all six combinations
             of 'a', 'f', 'c' are allowed ie "fac" - return array
@@ -578,7 +579,11 @@ class DCDReader(base.ReaderBase):
         return self._read_timeseries(atom_numbers, start, stop, step, format)
 
     def correl(self, timeseries, start=None, stop=None, step=None, skip=None):
-        """Populate a `TimeseriesCollection` object with timeseries computed from the trajectory.
+        """Populate a :class:`~MDAnalysis.core.Timeseries.TimeseriesCollection` object
+        with time series computed from the trajectory.
+
+        Calling this method will iterate through the whole trajectory and
+        perform the calculations prescribed in `timeseries`.
 
         Parameters
         ----------
@@ -595,6 +600,11 @@ class DCDReader(base.ReaderBase):
         step : int (optional)
              Step size for reading; the default ``None`` is equivalent to 1 and means to
              read every frame.
+
+        Note
+        ----
+        The `correl` functionality is only implemented for DCD trajectories and
+        the :class:`DCDReader`.
 
 
         .. deprecated:: 0.16.0
@@ -631,17 +641,17 @@ class DCDReader(base.ReaderBase):
 
         Parameters
         ----------
-        filename: str
+        filename : str
             filename of the output DCD trajectory
-        n_atoms: int (optional)
+        n_atoms : int (optional)
             number of atoms
-        start: int (optional)
+        start : int (optional)
             number of the first recorded MD step
-        step: int (optional)
+        step : int (optional)
             indicate that `step` **MD steps (!)** make up one trajectory frame
-        delta: float (optional)
+        delta : float (optional)
             **MD integrator time step (!)**, in AKMA units
-        dt: float (optional)
+        dt : float (optional)
             **Override** `step` and `delta` so that the DCD records that
             `dt` ps lie between two frames. (It sets `step` `` = 1`` and
             `delta` `` = AKMA(dt)``.) The default is ``None``, in which case
@@ -654,17 +664,17 @@ class DCDReader(base.ReaderBase):
         -------
         :class:`DCDWriter`
 
-        .. Note::
 
-           The keyword arguments set the low-level attributes of the DCD
-           according to the CHARMM format. The time between two frames would be
-           `delta` * `step` !
+        Note
+        ----
+        The keyword arguments set the low-level attributes of the DCD according
+        to the CHARMM format. The time between two frames would be `delta` *
+        `step`!
 
-           Here `step` is really the number of MD integrator time
-           steps that occured after this frame, including the frame
-           itself that is the coordinate snapshot and `delta` is the
-           integrator stime step.  The DCD file format contains this
-           information so it needs to be provided here.
+        Here `step` is really the number of MD integrator time steps that
+        occured after this frame, including the frame itself that is the
+        coordinate snapshot and `delta` is the integrator stime step.  The DCD
+        file format contains this information so it needs to be provided here.
 
 
         See Also

--- a/package/MDAnalysis/coordinates/DCD.py
+++ b/package/MDAnalysis/coordinates/DCD.py
@@ -213,29 +213,31 @@ class DCDWriter(base.WriterBase):
                  remarks="Created by DCDWriter", convert_units=None):
         """Create a new DCDWriter
 
-        :Arguments:
-         *filename*
-           name of output file
-         *n_atoms*
-           number of atoms in dcd file
-         *start*
-           starting timestep
-         *step*
-           skip between subsequent timesteps (indicate that *step* MD
-           integrator steps (!) make up one trajectory frame); default is 1.
-         *delta*
-           timestep (MD integrator time step (!), in AKMA units); default is
-           20.45482949774598 (corresponding to 1 ps).
-         *remarks*
-           comments to annotate dcd file
-         *dt*
-           **Override** *step* and *delta* so that the DCD records that *dt* ps
-           lie between two frames. (It sets *step* = 1 and *delta* = ``AKMA(dt)``.)
-           The default is ``None``, in which case *step* and *delta* are used.
-         *convert_units*
-           units are converted to the MDAnalysis base format; ``None`` selects
-           the value of :data:`MDAnalysis.core.flags` ['convert_lengths'].
-           (see :ref:`flags-label`)
+        Parameters
+        ----------
+        filename: str
+            name of output file
+        n_atoms: int
+            number of atoms in dcd file
+        start: int
+            starting timestep
+        step: int
+            skip between subsequent timesteps (indicate that *step* MD
+            integrator steps (!) make up one trajectory frame); default is 1.
+        delta: float
+            timestep (MD integrator time step (!), in AKMA units); default is
+            20.45482949774598 (corresponding to 1 ps).
+        remarks: str
+            comments to annotate dcd file
+        dt: float
+            **Override** *step* and *delta* so that the DCD records that
+            *dt* ps lie between two frames. (It sets *step* = 1 and
+            *delta* = ``AKMA(dt)``.) The default is ``None``, in which case
+            *step* and *delta* are used.
+        convert_units: bool
+            units are converted to the MDAnalysis base format; ``None`` selects
+            the value of :data:`MDAnalysis.core.flags` ['convert_lengths'].
+            (see :ref:`flags-label`)
 
        .. Note::
 
@@ -516,23 +518,24 @@ class DCDReader(base.ReaderBase):
                    format='afc'):
         """Return a subset of coordinate data for an AtomGroup
 
-        :Arguments:
-            *asel*
-               :class:`~MDAnalysis.core.groups.AtomGroup` object
-               Defaults to None, in which case the full set of coordinate data
-               is returned.
-            *start*, *stop*, *step*
-               A range of the trajectory to access, with start being inclusive
-               and stop being exclusive.
-            *format*
-               the order/shape of the return data array, corresponding
-               to (a)tom, (f)rame, (c)oordinates all six combinations
-               of 'a', 'f', 'c' are allowed ie "fac" - return array
-               where the shape is (frame, number of atoms,
-               coordinates)
-        :Deprecated:
-            *skip*
-                Skip has been deprecated in favor of the standard keyword step.
+        Parameters
+        ----------
+        asel: :class:`~MDAnalysis.core.groups.AtomGroup`
+            The :class:`~MDAnalysis.core.groups.AtomGroup` to read the
+            coordinates from. Defaults to None, in which case the full set of
+            coordinate data is returned.
+        start, stop, step: int
+            A range of the trajectory to access, with start being inclusive
+            and stop being exclusive.
+        format: str
+            the order/shape of the return data array, corresponding
+            to (a)tom, (f)rame, (c)oordinates all six combinations
+            of 'a', 'f', 'c' are allowed ie "fac" - return array
+            where the shape is (frame, number of atoms,
+            coordinates)
+
+        .. deprecated:: 0.016.0
+            *skip* has been deprecated in favor of the standard keyword step.
         """
         if skip is not None:
             step = skip
@@ -559,15 +562,15 @@ class DCDReader(base.ReaderBase):
     def correl(self, timeseries, start=None, stop=None, step=None, skip=None):
         """Populate a TimeseriesCollection object with timeseries computed from the trajectory
 
-        :Arguments:
-            *timeseries*
-               :class:`MDAnalysis.core.Timeseries.TimeseriesCollection`
-            *start, stop, step*
-               A subset of the trajectory to use, with start being inclusive
-               and stop being exclusive.
-        :Deprecated:
-            *skip*
-                Skip has been deprecated in favor of the standard keyword step.
+        Parameters
+        ----------
+        timeseries: :class:`MDAnalysis.core.Timeseries.TimeseriesCollection`
+        start, stop, step: int
+            A subset of the trajectory to use, with start being inclusive and
+            stop being exclusive.
+
+        .. deprecated:: 0.16.0
+            *skip* has been deprecated in favor of the standard keyword step.
         """
         if skip is not None:
             step = skip
@@ -596,26 +599,28 @@ class DCDReader(base.ReaderBase):
 
         All values can be changed through keyword arguments.
 
-        :Arguments:
-          *filename*
-              filename of the output DCD trajectory
-        :Keywords:
-          *n_atoms*
-              number of atoms
-          *start*
-              number of the first recorded MD step
-          *step*
-              indicate that *step* MD steps (!) make up one trajectory frame
-          *delta*
-              MD integrator time step (!), in AKMA units
-          *dt*
-             **Override** *step* and *delta* so that the DCD records that *dt* ps
-             lie between two frames. (It sets *step* = 1 and *delta* = ``AKMA(dt)``.)
-             The default is ``None``, in which case *step* and *delta* are used.
-          *remarks*
-              string that is stored in the DCD header [XXX -- max length?]
+        Parameters
+        ----------
+        filename: str
+            filename of the output DCD trajectory
+        n_atoms: int
+            number of atoms
+        start: int
+            number of the first recorded MD step
+        step: int
+            indicate that *step* MD steps (!) make up one trajectory frame
+        delta: float
+            MD integrator time step (!), in AKMA units
+        dt: float
+            **Override** *step* and *delta* so that the DCD records that
+            *dt* ps lie between two frames. (It sets *step* = 1 and
+            *delta* = ``AKMA(dt)``.) The default is ``None``, in which case
+            *step* and *delta* are used.  *remarks* string that is stored in
+            the DCD header
 
-        :Returns: :class:`DCDWriter`
+        Returns
+        -------
+        :class:`DCDWriter`
 
         .. Note::
 
@@ -626,6 +631,8 @@ class DCDReader(base.ReaderBase):
         See Also
         --------
         :class:`DCDWriter`
+
+
         """
         n_atoms = kwargs.pop('n_atoms', self.n_atoms)
         kwargs.setdefault('start', self.start_timestep)

--- a/package/MDAnalysis/coordinates/DCD.py
+++ b/package/MDAnalysis/coordinates/DCD.py
@@ -172,8 +172,57 @@ class Timestep(base.Timestep):
 
 
 class DCDWriter(base.WriterBase):
-    """Writes to a DCD file
+    """Write to a CHARMM/NAMD DCD trajectory file.
 
+    Parameters
+    ----------
+    filename: str
+        name of output file
+    n_atoms: int (optional)
+        number of atoms in dcd file
+    start: int (optional)
+        starting frame number
+    step: int (optional)
+        skip between subsequent timesteps (indicate that `step` **MD
+        integrator steps (!)** make up one trajectory frame); default is 1.
+    delta: float (optional)
+        timestep (**MD integrator time step (!)**, in AKMA units); default is
+        20.45482949774598 (corresponding to 1 ps).
+    remarks: str (optional)
+        comments to annotate dcd file
+    dt: float (optional)
+        **Override** `step` and `delta` so that the DCD records that
+        `dt` ps lie between two frames. (It sets `step` = 1 and
+        `delta` ``= AKMA(dt)``.) The default is ``None``, in which case
+        `step` and `delta` are used.
+    convert_units: bool (optional)
+        units are converted to the MDAnalysis base format; ``None`` selects
+        the value of :data:`MDAnalysis.core.flags` ['convert_lengths'].
+        (see :ref:`flags-label`)
+
+    Note
+    ----
+    The keyword arguments set the **low-level attributes of the DCD** according
+    to the CHARMM format. The time between two frames would be `delta` *
+    `step`!  For convenience, one can alternatively supply the `dt` keyword
+    (see above) to just tell the writer that it should record "There are `dt`
+    ps between each frame".
+
+    The Writer will write the **unit cell information** to the DCD in a format
+    compatible with NAMD and older CHARMM versions, namely the unit cell
+    lengths in Angstrom and the angle cosines (see :class:`Timestep`). Newer
+    versions of CHARMM (at least c36b2) store the matrix of the box
+    vectors. Writing this matrix to a DCD is currently not supported (although
+    reading is supported with the :class:`DCDReader`); instead the angle
+    cosines are written, which *might make the DCD file unusable in CHARMM
+    itself*. See `Issue 187`_ for further information.
+
+    The writing behavior of the :class:`DCDWriter` is identical to that of the
+    DCD molfile plugin of VMD with the exception that by default it will use
+    AKMA time units.
+
+    Example
+    -------
     Typical usage::
 
        with DCDWriter("new.dcd", u.atoms.n_atoms) as w:
@@ -182,26 +231,8 @@ class DCDWriter(base.WriterBase):
 
     Keywords are available to set some of the low-level attributes of the DCD.
 
-    :Methods:
-       ``d = DCDWriter(dcdfilename, n_atoms, start, step, delta, remarks)``
-
-    .. Note::
-
-       The Writer will write the **unit cell information** to the DCD in a
-       format compatible with NAMD and older CHARMM versions, namely the unit
-       cell lengths in Angstrom and the angle cosines (see
-       :class:`Timestep`). Newer versions of CHARMM (at least c36b2) store the
-       matrix of the box vectors. Writing this matrix to a DCD is currently not
-       supported (although reading is supported with the
-       :class:`DCDReader`); instead the angle cosines are written,
-       which *might make the DCD file unusable in CHARMM itself*. See
-       `Issue 187`_ for further information.
-
-       The writing behavior of the :class:`DCDWriter` is identical to
-       that of the DCD molfile plugin of VMD with the exception that
-       by default it will use AKMA time units.
-
     .. _Issue 187: https://github.com/MDAnalysis/mdanalysis/issues/187
+
     """
     format = 'DCD'
     multiframe = True
@@ -211,43 +242,6 @@ class DCDWriter(base.WriterBase):
     def __init__(self, filename, n_atoms, start=0, step=1,
                  delta=mdaunits.convert(1., 'ps', 'AKMA'), dt=None,
                  remarks="Created by DCDWriter", convert_units=None):
-        """Create a new DCDWriter
-
-        Parameters
-        ----------
-        filename: str
-            name of output file
-        n_atoms: int
-            number of atoms in dcd file
-        start: int
-            starting timestep
-        step: int
-            skip between subsequent timesteps (indicate that *step* MD
-            integrator steps (!) make up one trajectory frame); default is 1.
-        delta: float
-            timestep (MD integrator time step (!), in AKMA units); default is
-            20.45482949774598 (corresponding to 1 ps).
-        remarks: str
-            comments to annotate dcd file
-        dt: float
-            **Override** *step* and *delta* so that the DCD records that
-            *dt* ps lie between two frames. (It sets *step* = 1 and
-            *delta* = ``AKMA(dt)``.) The default is ``None``, in which case
-            *step* and *delta* are used.
-        convert_units: bool
-            units are converted to the MDAnalysis base format; ``None`` selects
-            the value of :data:`MDAnalysis.core.flags` ['convert_lengths'].
-            (see :ref:`flags-label`)
-
-       .. Note::
-
-          The keyword arguments set the low-level attributes of the DCD
-          according to the CHARMM format. The time between two frames would be
-          *delta* * *step* ! For convenience, one can alternatively supply the
-          *dt* keyword (see above) to just tell the writer that it should
-          record "There are dt ps between each frame".
-
-        """
         if n_atoms == 0:
             raise ValueError("DCDWriter: no atoms in output trajectory")
         elif n_atoms is None:
@@ -314,15 +308,29 @@ class DCDWriter(base.WriterBase):
         return dict(zip(desc, struct.unpack("LLiiiiidiPPiiii", self._dcd_C_str)))
 
     def write_next_timestep(self, ts=None):
-        ''' write a new timestep to the dcd file
+        """Write a new timestep to the DCD file.
 
-        *ts* - timestep object containing coordinates to be written to dcd file
+        Parameters
+        ----------
+        ts : `Timestep` (optional)
+            `Timestep` object containing coordinates to be written to DCD file;
+            by default it uses the current `Timestep` associated with the
+            Writer.
+
+        Raises
+        ------
+        :exc:`ValueError`
+           if wrong number of atoms supplied
+        :exc:`~MDAnalysis.NoDataError`
+           if no coordinates to be written.
+
 
         .. versionchanged:: 0.7.5
            Raises :exc:`ValueError` instead of generic :exc:`Exception`
            if wrong number of atoms supplied and :exc:`~MDAnalysis.NoDataError`
            if no coordinates to be written.
-        '''
+
+        """
         if ts is None:
             try:
                 ts = self.ts
@@ -393,15 +401,15 @@ class DCDReader(base.ReaderBase):
         ``data = dcd.correl(...)``
            populate a :class:`MDAnalysis.core.Timeseries.Collection` object with computed timeseries
 
-    .. Note::
+    Note
+    ----
 
-       The DCD file format is not well defined. In particular, NAMD
-       and CHARMM use it differently. Currently, MDAnalysis tries to
-       guess the correct format for the unitcell representation but it
-       can be wrong. **Check the unitcell dimensions**, especially for
-       triclinic unitcells (see `Issue 187`_ and
-       :attr:`Timestep.dimensions`). A second potential issue are the
-       units of time (TODO).
+    The DCD file format is not well defined. In particular, NAMD and CHARMM use
+    it differently. Currently, MDAnalysis tries to guess the correct format for
+    the unitcell representation but it can be wrong. **Check the unitcell
+    dimensions**, especially for triclinic unitcells (see `Issue 187`_ and
+    :attr:`Timestep.dimensions`). A second potential issue are the units of
+    time (TODO).
 
     .. versionchanged:: 0.9.0
        The underlying DCD reader (written in C and derived from the
@@ -412,9 +420,10 @@ class DCDReader(base.ReaderBase):
     .. _Issue 187: https://github.com/MDAnalysis/mdanalysis/issues/187
 
     .. versionchanged:: 0.11.0
-       Frames now 0-based instead of 1-based
-       Native frame number read into ts._frame
-       Removed skip keyword and functionality
+       Frames now 0-based instead of 1-based.
+       Native frame number read into `ts._frame`.
+       Removed `skip` keyword and functionality.
+
     """
     format = 'DCD'
     flavor = 'CHARMM'
@@ -524,18 +533,27 @@ class DCDReader(base.ReaderBase):
             The :class:`~MDAnalysis.core.groups.AtomGroup` to read the
             coordinates from. Defaults to None, in which case the full set of
             coordinate data is returned.
-        start, stop, step: int
-            A range of the trajectory to access, with start being inclusive
-            and stop being exclusive.
-        format: str
+        start :  int (optional)
+             Begin reading the trajectory at frame index `start` (where 0 is the index
+             of the first frame in the trajectory); the default ``None`` starts
+             at the beginning.
+        stop : int (optional)
+             End reading the trajectory at frame index `stop`-1, i.e, `stop` is excluded.
+             The trajectory is read to the end with the default ``None``.
+        step : int (optional)
+             Step size for reading; the default ``None`` is equivalent to 1 and means to
+             read every frame.
+        format: str (optional)
             the order/shape of the return data array, corresponding
             to (a)tom, (f)rame, (c)oordinates all six combinations
             of 'a', 'f', 'c' are allowed ie "fac" - return array
             where the shape is (frame, number of atoms,
             coordinates)
 
-        .. deprecated:: 0.016.0
-            *skip* has been deprecated in favor of the standard keyword step.
+
+        .. deprecated:: 0.16.0
+           `skip` has been deprecated in favor of the standard keyword `step`.
+
         """
         if skip is not None:
             step = skip
@@ -560,17 +578,28 @@ class DCDReader(base.ReaderBase):
         return self._read_timeseries(atom_numbers, start, stop, step, format)
 
     def correl(self, timeseries, start=None, stop=None, step=None, skip=None):
-        """Populate a TimeseriesCollection object with timeseries computed from the trajectory
+        """Populate a `TimeseriesCollection` object with timeseries computed from the trajectory.
 
         Parameters
         ----------
-        timeseries: :class:`MDAnalysis.core.Timeseries.TimeseriesCollection`
-        start, stop, step: int
-            A subset of the trajectory to use, with start being inclusive and
-            stop being exclusive.
+        timeseries : :class:`MDAnalysis.core.Timeseries.TimeseriesCollection`
+             The :class:`MDAnalysis.core.Timeseries.TimeseriesCollection` that defines what kind
+             of computations should be performed on the data in this trajectory.
+        start :  int (optional)
+             Begin reading the trajectory at frame index `start` (where 0 is the index
+             of the first frame in the trajectory); the default ``None`` starts
+             at the beginning.
+        stop : int (optional)
+             End reading the trajectory at frame index `stop`-1, i.e, `stop` is excluded.
+             The trajectory is read to the end with the default ``None``.
+        step : int (optional)
+             Step size for reading; the default ``None`` is equivalent to 1 and means to
+             read every frame.
+
 
         .. deprecated:: 0.16.0
-            *skip* has been deprecated in favor of the standard keyword step.
+           `skip` has been deprecated in favor of the standard keyword `step`.
+
         """
         if skip is not None:
             step = skip
@@ -595,28 +624,31 @@ class DCDReader(base.ReaderBase):
             self.dcdfile = None
 
     def Writer(self, filename, **kwargs):
-        """Returns a DCDWriter for *filename* with the same parameters as this DCD.
+        """Returns a DCDWriter for `filename` with the same parameters as this DCD.
 
-        All values can be changed through keyword arguments.
+        Defaults for all values are obtained from the `DCDReader` itself but
+        all values can be changed through keyword arguments.
 
         Parameters
         ----------
         filename: str
             filename of the output DCD trajectory
-        n_atoms: int
+        n_atoms: int (optional)
             number of atoms
-        start: int
+        start: int (optional)
             number of the first recorded MD step
-        step: int
-            indicate that *step* MD steps (!) make up one trajectory frame
-        delta: float
-            MD integrator time step (!), in AKMA units
-        dt: float
-            **Override** *step* and *delta* so that the DCD records that
-            *dt* ps lie between two frames. (It sets *step* = 1 and
-            *delta* = ``AKMA(dt)``.) The default is ``None``, in which case
-            *step* and *delta* are used.  *remarks* string that is stored in
-            the DCD header
+        step: int (optional)
+            indicate that `step` **MD steps (!)** make up one trajectory frame
+        delta: float (optional)
+            **MD integrator time step (!)**, in AKMA units
+        dt: float (optional)
+            **Override** `step` and `delta` so that the DCD records that
+            `dt` ps lie between two frames. (It sets `step` `` = 1`` and
+            `delta` `` = AKMA(dt)``.) The default is ``None``, in which case
+            `step` and `delta` are used.
+
+        remarks : str (optional)
+            string that is stored in the DCD header
 
         Returns
         -------
@@ -626,12 +658,18 @@ class DCDReader(base.ReaderBase):
 
            The keyword arguments set the low-level attributes of the DCD
            according to the CHARMM format. The time between two frames would be
-           *delta* * *step* !
+           `delta` * `step` !
+
+           Here `step` is really the number of MD integrator time
+           steps that occured after this frame, including the frame
+           itself that is the coordinate snapshot and `delta` is the
+           integrator stime step.  The DCD file format contains this
+           information so it needs to be provided here.
+
 
         See Also
         --------
         :class:`DCDWriter`
-
 
         """
         n_atoms = kwargs.pop('n_atoms', self.n_atoms)

--- a/package/MDAnalysis/coordinates/GMS.py
+++ b/package/MDAnalysis/coordinates/GMS.py
@@ -30,7 +30,11 @@ GAMESS distributions: US-GAMESS, Firefly (PC-GAMESS) and GAMESS-UK.
 Current version was approbated with US-GAMESS & Firefly only.
 
 There appears to be no rigid format definition so it is likely users
-will need to tweak this Class.
+will need to tweak the :class:`GMSReader`.
+
+.. autoclass:: GMSReader
+   :members:
+
 """
 from __future__ import absolute_import
 
@@ -55,13 +59,17 @@ class GMSReader(base.ReaderBase):
         ``for ts in out:``
           iterate through trajectory
 
-    .. Note: this can read both compressed (foo.out) and compressed
-          (foo.out.bz2 or foo.out.gz) files; uncompression is handled
-          on the fly
+    Note
+    ----
+    :class:`GMSReader` can read both uncompressed (``foo.out``) and
+    compressed (``foo.out.bz2`` or ``foo.out.gz``) files;
+    decompression is handled on the fly
+
 
     .. versionchanged:: 0.11.0
-       Frames now 0-based instead of 1-based
-       Added dt and time_offset keywords (passed to Timestep)
+       Frames now 0-based instead of 1-based.
+       Added `dt` and `time_offset` keywords (passed to :class:`Timestep`).
+
     """
 
     format = "GMS"
@@ -171,7 +179,7 @@ class GMSReader(base.ReaderBase):
         self.outfile.seek(self._offsets[frame])
         self.ts.frame = frame - 1  # gets +1'd in _read_next
         return self._read_next_timestep()
-    
+
     def _read_next_timestep(self, ts=None):
         # check that the timestep object exists
         if ts is None:

--- a/package/MDAnalysis/coordinates/GRO.py
+++ b/package/MDAnalysis/coordinates/GRO.py
@@ -1,5 +1,5 @@
 # -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
-# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
 #
 # MDAnalysis --- http://www.mdanalysis.org
 # Copyright (c) 2006-2016 The MDAnalysis Development Team and contributors
@@ -121,7 +121,7 @@ class Timestep(base.Timestep):
 
 class GROReader(base.SingleFrameReaderBase):
     """Reader for the Gromacs GRO structure format.
-    
+
     .. versionchanged:: 0.11.0
        Frames now 0-based instead of 1-based
     """
@@ -190,11 +190,14 @@ class GROReader(base.SingleFrameReaderBase):
     def Writer(self, filename, n_atoms=None, **kwargs):
         """Returns a CRDWriter for *filename*.
 
-        :Arguments:
-          *filename*
+        Parameters
+        ----------
+        filename: str
             filename of the output GRO file
 
-        :Returns: :class:`GROWriter`
+        Returns
+        -------
+        :class:`GROWriter`
 
         """
         if n_atoms is None:
@@ -251,6 +254,9 @@ class GROWriter(base.WriterBase):
         n_atoms : int (optional)
             number of atoms
 
+        convert_units: str (optional)
+            units are converted to the MDAnalysis base format; ``None`` selects
+            the value of :data:`MDAnalysis.core.flags` ['convert_lengths']
         """
         self.filename = util.filename(filename, ext='gro')
         self.n_atoms = n_atoms

--- a/package/MDAnalysis/coordinates/GRO.py
+++ b/package/MDAnalysis/coordinates/GRO.py
@@ -27,30 +27,50 @@ GRO file format --- :mod:`MDAnalysis.coordinates.GRO`
 Classes to read and write Gromacs_ GRO_ coordinate files; see the notes on the
 `GRO format`_ which includes a conversion routine for the box.
 
-GROWriter format strings
-------------------------
 
-The GROWriter class has a .fmt attribute, which is a dictionary of different
-strings for writing lines in .gro files.  These are as follows:
+Classes
+-------
 
-n_atoms
+.. autoclass:: Timestep
+   :members:
+
+.. autoclass:: GROReader
+   :members:
+
+.. autoclass:: GROWriter
+   :members:
+
+
+Developer notes: ``GROWriter`` format strings
+---------------------------------------------
+
+The :class:`GROWriter` class has a :attr:`GROWriter.fmt` attribute, which is a dictionary of different
+strings for writing lines in ``.gro`` files.  These are as follows:
+
+``n_atoms``
   For the first line of the gro file, supply the number of atoms in the system.
-  Eg: fmt['n_atoms'].format(42)
+  E.g.::
 
-xyz
+      fmt['n_atoms'].format(42)
+
+``xyz``
   An atom line without velocities.  Requires that the 'resid', 'resname',
   'name', 'index' and 'pos' keys be supplied.
-  Eg: fmt['xyz'].format(resid=1, resname='SOL', name='OW2', index=2, pos=(0.0, 1.0, 2.0))
+  E.g.::
 
-xyz_v
+     fmt['xyz'].format(resid=1, resname='SOL', name='OW2', index=2, pos=(0.0, 1.0, 2.0))
+
+``xyz_v``
   As above, but with velocities.  Needs an additional keyword 'vel'.
 
-box_orthorhombic
+``box_orthorhombic``
   The final line of the gro file which gives box dimensions.  Requires
   the box keyword to be given, which should be the three cartesian dimensions.
-  Eg: fmt['box_orthorhombic'].format(box=(10.0, 10.0, 10.0))
+  E.g.::
 
-box_triclinic
+     fmt['box_orthorhombic'].format(box=(10.0, 10.0, 10.0))
+
+``box_triclinic``
   As above, but for a non orthorhombic box. Requires the box keyword, but this
   time as a length 9 vector.  This is a flattened version of the (3,3) triclinic
   vector representation of the unit cell.  The rearrangement into the odd
@@ -60,6 +80,7 @@ box_triclinic
 .. _Gromacs: http://www.gromacs.org
 .. _GRO: http://manual.gromacs.org/current/online/gro.html
 .. _GRO format: http://chembytes.wikidot.com/g-grofile
+
 """
 from __future__ import absolute_import
 
@@ -213,18 +234,19 @@ class GROWriter(base.WriterBase):
      - resnames (defaults to 'UNK')
      - resids (defaults to '1')
 
-    .. Note::
+    Note
+    ----
+    The precision is hard coded to three decimal places
 
-       The precision is hard coded to three decimal places
 
     .. versionchanged:: 0.11.0
        Frames now 0-based instead of 1-based
     .. versionchanged:: 0.13.0
-       Now strictly writes positions with 3dp precision
-       and velocities with 4dp
+       Now strictly writes positions with 3dp precision.
+       and velocities with 4dp.
        Removed the `convert_dimensions_to_unitcell` method,
-       use `Timestep.triclinic_dimensions` instead
-       Now now writes velocities where possible
+       use `Timestep.triclinic_dimensions` instead.
+       Now now writes velocities where possible.
     """
 
     format = 'GRO'
@@ -254,7 +276,7 @@ class GROWriter(base.WriterBase):
         n_atoms : int (optional)
             number of atoms
 
-        convert_units: str (optional)
+        convert_units : str (optional)
             units are converted to the MDAnalysis base format; ``None`` selects
             the value of :data:`MDAnalysis.core.flags` ['convert_lengths']
         """
@@ -270,19 +292,19 @@ class GROWriter(base.WriterBase):
 
         Parameters
         -----------
-        obj : AtomGroup / Universe / Timestep
+        obj : AtomGroup or Universe or :class:`Timestep`
 
         Note
         ----
-        The GRO format only allows 5 digits for resid and atom
-        number. If these number become larger than 99,999 then this
+        The GRO format only allows 5 digits for *resid* and *atom
+        number*. If these numbers become larger than 99,999 then this
         routine will chop off the leading digits.
 
 
         .. versionchanged:: 0.7.6
-           resName and atomName are truncated to a maximum of 5 characters
+           *resName* and *atomName* are truncated to a maximum of 5 characters
         .. versionchanged:: 0.16.0
-           frame kwarg has been removed
+           `frame` kwarg has been removed
         """
         # write() method that complies with the Trajectory API
 

--- a/package/MDAnalysis/coordinates/INPCRD.py
+++ b/package/MDAnalysis/coordinates/INPCRD.py
@@ -1,5 +1,5 @@
 # -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
-# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
 #
 # MDAnalysis --- http://www.mdanalysis.org
 # Copyright (c) 2006-2016 The MDAnalysis Development Team and contributors
@@ -24,10 +24,17 @@
 """INPCRD structure files in MDAnalysis --- :mod:`MDAnalysis.coordinates.INPCRD`
 ================================================================================
 
-Read and write coordinates in Amber_ coordinate/restart file (suffix
-"inpcrd").
+Read coordinates in Amber_ coordinate/restart file (suffix "inpcrd").
 
 .. _Amber: http://ambermd.org/formats.html#restart
+
+
+Classes
+-------
+
+.. autoclass:: INPReader
+   :members:
+
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 
@@ -36,6 +43,8 @@ from six.moves import range
 from . import base
 
 class INPReader(base.SingleFrameReaderBase):
+    """Reader for Amber restart files."""
+
     format = ['INPCRD', 'RESTRT']
     units = {'length': 'Angstrom'}
 
@@ -61,7 +70,7 @@ class INPReader(base.SingleFrameReaderBase):
                 for i, dest in enumerate([(2*p, 0), (2*p, 1), (2*p, 2),
                                           (2*p + 1, 0), (2*p + 1, 1), (2*p + 1, 2)]):
                     self.ts._pos[dest] = float(line[i*12:(i+1)*12])
-            # Read last coordinate if necessary            
+            # Read last coordinate if necessary
             if self.n_atoms % 2:
                 line = inf.readline()
                 for i in range(3):

--- a/package/MDAnalysis/coordinates/LAMMPS.py
+++ b/package/MDAnalysis/coordinates/LAMMPS.py
@@ -1,5 +1,5 @@
 # -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
-# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
 #
 # MDAnalysis --- http://www.mdanalysis.org
 # Copyright (c) 2006-2016 The MDAnalysis Development Team and contributors
@@ -45,7 +45,8 @@ keywords *timeunit* and/or *lengthunit* to :class:`DCDWriter` and
 :class:`~MDAnalysis.core.universe.Universe` (which then calls
 :class:`DCDReader`).
 
-.. Rubric:: Example: Loading a LAMMPS simulation
+Example: Loading a LAMMPS simulation
+------------------------------------
 
 To load a LAMMPS simulation from a LAMMPS data file (using the
 :class:`~MDAnalysis.topology.LAMMPSParser.DATAParser`) together with a
@@ -70,10 +71,9 @@ data file,
 
 Note
 ----
-
-   Lennard-Jones units are not implemented. See :mod:`MDAnalysis.units` for
-   other recognized values and the documentation for the LAMMPS `units
-   command`_.
+Lennard-Jones units are not implemented. See :mod:`MDAnalysis.units`
+for other recognized values and the documentation for the LAMMPS
+`units command`_.
 
 See Also
 --------
@@ -104,6 +104,7 @@ Classes
 .. autoclass:: DATAWriter
    :members:
    :inherited-members:
+
 """
 from __future__ import absolute_import
 
@@ -249,7 +250,7 @@ class DATAWriter(base.WriterBase):
         self.units = {'time': 'fs', 'length': 'Angstrom'}
         self.units['length'] = kwargs.pop('lengthunit', self.units['length'])
         self.units['time'] = kwargs.pop('timeunit', self.units['time'])
-        self.units['velocity'] = kwargs.pop('velocityunit', 
+        self.units['velocity'] = kwargs.pop('velocityunit',
                                  self.units['length']+'/'+self.units['time'])
 
     def _write_atoms(self, atoms):
@@ -344,11 +345,13 @@ class DATAWriter(base.WriterBase):
 
     @requires('types', 'masses')
     def write(self, selection, frame=None):
-        """Write selection at current trajectory frame to file, including
-        sections Atoms, Masses, Velocities, Bonds, Angles, Dihedrals, and
-        Impropers (if these are defined). Atoms section is written in the
-        "full" sub-style if charges are available or "molecular" sub-style if
-        they are not. Molecule id in atoms section is set to to 0.
+        """Write selection at current trajectory frame to file.
+
+        The sections for Atoms, Masses, Velocities, Bonds, Angles,
+        Dihedrals, and Impropers (if these are defined) are
+        written. The Atoms section is written in the "full" sub-style
+        if charges are available or "molecular" sub-style if they are
+        not. Molecule id in atoms section is set to to 0.
 
         No other sections are written to the DATA file.
         As of this writing, other sections are not parsed into the topology
@@ -356,15 +359,17 @@ class DATAWriter(base.WriterBase):
 
         Note
         ----
-           If the selection includes a partial fragment, then only the bonds, angles,
-           etc. whose atoms are contained within the selection will be included.
+        If the selection includes a partial fragment, then only the bonds,
+        angles, etc. whose atoms are contained within the selection will be
+        included.
 
         Parameters
         ----------
-        selection : AtomGroup
+        selection : AtomGroup or Universe
             MDAnalysis AtomGroup (selection or Universe.atoms) or also Universe
-        frame : Optional[int]
-            optionally move to frame number *frame*
+        frame : int (optional)
+            optionally move to frame number `frame`
+
         """
         u = selection.universe
         if frame is not None:

--- a/package/MDAnalysis/coordinates/MMTF.py
+++ b/package/MDAnalysis/coordinates/MMTF.py
@@ -54,9 +54,7 @@ def _parse_mmtf(fn):
 
 
 class MMTFReader(base.SingleFrameReaderBase):
-    """Topology parser for the Macromolecular Transmission Format format (MMTF_).
-
-    """
+    """Coordinate reader for the Macromolecular Transmission Format format (MMTF_)."""
     format = 'MMTF'
 
     def _read_first_frame(self):
@@ -88,7 +86,8 @@ def fetch_mmtf(pdb_id):
 
     Returns
     -------
-    MDAnalysis Universe of the corresponding PDB system
+    Universe
+        MDAnalysis Universe of the corresponding PDB system
 
 
     See Also

--- a/package/MDAnalysis/coordinates/MOL2.py
+++ b/package/MDAnalysis/coordinates/MOL2.py
@@ -1,5 +1,5 @@
 # -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
-# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
 #
 # MDAnalysis --- http://www.mdanalysis.org
 # Copyright (c) 2006-2016 The MDAnalysis Development Team and contributors
@@ -20,20 +20,19 @@
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
 
-"""
-MOL2 file format --- :mod:`MDAnalysis.coordinates.MOL2`
+"""MOL2 file format --- :mod:`MDAnalysis.coordinates.MOL2`
 ========================================================
 
-Classes to read Tripos_ molecule structure format (MOL2_)
-coordinate and topology files. Used by the DOCK_ docking
-code.
+Classes to work with Tripos_ molecule structure format (MOL2_) coordinate and
+topology files. Used, for instance, by the DOCK_ docking code.
 
-Examples
-~~~~~~~~
+
+Example for working with mol2 files
+-----------------------------------
 
 To open a mol2, remove all hydrogens and save as a new file, use the following::
 
-  u = Universe("MDAnalysis/testsuite/MDAnalysisTests/data/mol2/Molecule.mol2")
+  u = Universe("Molecule.mol2")
   gr = u.select_atoms("not name H*")
   print(len(u.atoms), len(gr))
   gr.write("Molecule_noh.mol2")
@@ -41,6 +40,75 @@ To open a mol2, remove all hydrogens and save as a new file, use the following::
 .. _MOL2: http://www.tripos.com/data/support/mol2.pdf
 .. _Tripos: http://www.tripos.com/
 .. _DOCK: http://dock.compbio.ucsf.edu/
+
+
+See Also
+--------
+rdkit: rdkit_ is an open source cheminformatics toolkit with more mol2
+       functionality
+
+.. _rdkit: http://www.rdkit.org/docs/GettingStartedInPython.html
+
+
+Classes
+-------
+
+.. autoclass:: MOL2Reader
+   :members:
+
+.. autoclass:: MOL2Writer
+   :members:
+
+
+MOL2 format notes
+-----------------
+
+* MOL2 Format Specification:  (http://www.tripos.com/data/support/mol2.pdf)
+* Example file (http://www.tripos.com/mol2/mol2_format3.html)::
+
+    #    Name: benzene
+    #    Creating user name: tom
+    #    Creation time: Wed Dec 28 00:18:30 1988
+
+    #    Modifying user name: tom
+    #    Modification time: Wed Dec 28 00:18:30 1988
+
+    @<TRIPOS>MOLECULE
+    benzene
+    12 12 1  0   0
+    SMALL
+    NO_CHARGES
+
+
+    @<TRIPOS>ATOM
+    1   C1  1.207   2.091   0.000   C.ar    1   BENZENE 0.000
+    2   C2  2.414   1.394   0.000   C.ar    1   BENZENE 0.000
+    3   C3  2.414   0.000   0.000   C.ar    1   BENZENE 0.000
+    4   C4  1.207   -0.697  0.000   C.ar    1   BENZENE 0.000
+    5   C5  0.000   0.000   0.000   C.ar    1   BENZENE 0.000
+    6   C6  0.000   1.394   0.000   C.ar    1   BENZENE 0.000
+    7   H1  1.207   3.175   0.000   H   1   BENZENE 0.000
+    8   H2  3.353   1.936   0.000   H   1   BENZENE 0.000
+    9   H3  3.353   -0.542  0.000   H   1   BENZENE 0.000
+    10  H4  1.207   -1.781  0.000   H   1   BENZENE 0.000
+    11  H5  -0.939  -0.542  0.000   H   1   BENZENE 0.000
+    12  H6  -0.939  1.936   0.000   H   1   BENZENE 0.000
+    @<TRIPOS>BOND
+    1   1   2   ar
+    2   1   6   ar
+    3   2   3   ar
+    4   3   4   ar
+    5   4   5   ar
+    6   5   6   ar
+    7   1   7   1
+    8   2   8   1
+    9   3   9   1
+    10  4   10  1
+    11  5   11  1
+    12  6   12  1
+   @<TRIPOS>SUBSTRUCTURE
+    1   BENZENE 1   PERM    0   ****    ****    0   ROOT
+
 """
 from __future__ import absolute_import
 
@@ -55,15 +123,22 @@ class MOL2Reader(base.ReaderBase):
     """Reader for MOL2 structure format.
 
     .. versionchanged:: 0.11.0
-       Frames now 0-based instead of 1-based
-       MOL2 now resuses the same Timestep object for every frame
-       previously created a new instance of Timestep each frame
+       Frames now 0-based instead of 1-based.
+       MOL2 now reuses the same Timestep object for every frame,
+       previously created a new instance of Timestep each frame.
     """
     format = 'MOL2'
     units = {'time': None, 'length': 'Angstrom'}
 
     def __init__(self, filename, **kwargs):
-        """Read coordinates from *filename*."""
+        """Read coordinates from `filename`.
+
+
+        Parameters
+        ----------
+        filename : str or NamedStream
+             name of the mol2 file or stream
+        """
         super(MOL2Reader, self).__init__(filename, **kwargs)
 
         self.n_atoms = None
@@ -166,16 +241,18 @@ class MOL2Reader(base.ReaderBase):
 
 
 class MOL2Writer(base.WriterBase):
-    """
+    """mol2 format writer
 
-    MOL2Writer Limitations
-    ----------------------
-    MOL2Writer can only be used to write out previously loaded MOL2 files.
+    Write a file in the Tripos_ molecule structure format (MOL2_).
+
+    Note
+    ----
+    :class:`MOL2Writer` can only be used to write out previously loaded MOL2 files.
     If you're trying to convert, for example, a PDB file to MOL you should
-    use other tools, like rdkit (http://www.rdkit.org/docs/GettingStartedInPython.html).
+    use other tools, like rdkit_.
 
-    Here is an example how to use rdkit to convert a PDB to MOL::
-    
+    Here is an example how to use rdkit_ to convert a PDB to MOL::
+
       from rdkit import Chem
       mol = Chem.MolFromPDBFile("molecule.pdb", removeHs=False)
       Chem.MolToMolFile(mol, "molecule.mol" )
@@ -185,51 +262,8 @@ class MOL2Writer(base.WriterBase):
     See page 7 for list of SYBYL atomtypes
     (http://tripos.com/tripos_resources/fileroot/pdfs/mol2_format2.pdf).
 
-    * MOL2 Format Specification:  (http://www.tripos.com/data/support/mol2.pdf)
-    * Example file (http://www.tripos.com/mol2/mol2_format3.html)::
 
-              #    Name: benzene 
-              #    Creating user name: tom 
-              #    Creation time: Wed Dec 28 00:18:30 1988 
-            
-              #    Modifying user name: tom 
-              #    Modification time: Wed Dec 28 00:18:30 1988 
-            
-              @<TRIPOS>MOLECULE 
-              benzene 
-              12 12 1  0   0 
-              SMALL 
-              NO_CHARGES 
-             
-             
-              @<TRIPOS>ATOM 
-              1   C1  1.207   2.091   0.000   C.ar    1   BENZENE 0.000 
-              2   C2  2.414   1.394   0.000   C.ar    1   BENZENE 0.000 
-              3   C3  2.414   0.000   0.000   C.ar    1   BENZENE 0.000 
-              4   C4  1.207   -0.697  0.000   C.ar    1   BENZENE 0.000 
-              5   C5  0.000   0.000   0.000   C.ar    1   BENZENE 0.000 
-              6   C6  0.000   1.394   0.000   C.ar    1   BENZENE 0.000 
-              7   H1  1.207   3.175   0.000   H   1   BENZENE 0.000 
-              8   H2  3.353   1.936   0.000   H   1   BENZENE 0.000 
-              9   H3  3.353   -0.542  0.000   H   1   BENZENE 0.000 
-              10  H4  1.207   -1.781  0.000   H   1   BENZENE 0.000 
-              11  H5  -0.939  -0.542  0.000   H   1   BENZENE 0.000 
-              12  H6  -0.939  1.936   0.000   H   1   BENZENE 0.000 
-              @<TRIPOS>BOND 
-              1   1   2   ar 
-              2   1   6   ar 
-              3   2   3   ar 
-              4   3   4   ar 
-              5   4   5   ar 
-              6   5   6   ar 
-              7   1   7   1 
-              8   2   8   1 
-              9   3   9   1 
-              10  4   10  1 
-              11  5   11  1 
-              12  6   12  1 
-             @<TRIPOS>SUBSTRUCTURE 
-              1   BENZENE 1   PERM    0   ****    ****    0   ROOT
+    .. _rdkit: http://www.rdkit.org/docs/GettingStartedInPython.html
 
     .. versionchanged:: 0.11.0
        Frames now 0-based instead of 1-based
@@ -239,15 +273,14 @@ class MOL2Writer(base.WriterBase):
     multiframe = True
     units = {'time': None, 'length': 'Angstrom'}
 
-    def __init__(self, filename, n_atoms=None,
-                 convert_units=None):
+    def __init__(self, filename, n_atoms=None, convert_units=None):
         """Create a new MOL2Writer
 
         Parameters
         ----------
         filename: str
             name of output file
-        convert_units: bool
+        convert_units: bool (optional)
             units are converted to the MDAnalysis base format; ``None`` selects
             the value of :data:`MDAnalysis.core.flags` ['convert_lengths']
         """

--- a/package/MDAnalysis/coordinates/MOL2.py
+++ b/package/MDAnalysis/coordinates/MOL2.py
@@ -243,12 +243,13 @@ class MOL2Writer(base.WriterBase):
                  convert_units=None):
         """Create a new MOL2Writer
 
-        :Arguments:
-         *filename*
-           name of output file
-         *convert_units*
-           units are converted to the MDAnalysis base format; ``None`` selects
-           the value of :data:`MDAnalysis.core.flags` ['convert_lengths']
+        Parameters
+        ----------
+        filename: str
+            name of output file
+        convert_units: bool
+            units are converted to the MDAnalysis base format; ``None`` selects
+            the value of :data:`MDAnalysis.core.flags` ['convert_lengths']
         """
         self.filename = filename
         if convert_units is None:

--- a/package/MDAnalysis/coordinates/PDB.py
+++ b/package/MDAnalysis/coordinates/PDB.py
@@ -326,11 +326,14 @@ class PDBReader(base.ReaderBase):
     def Writer(self, filename, **kwargs):
         """Returns a PDBWriter for *filename*.
 
-        :Arguments:
-          *filename*
-              filename of the output PDB file
+        Parameters
+        ----------
+        filename: str
+            filename of the output PDB file
 
-        :Returns: :class:`PDBWriter`
+        Returns
+        -------
+        :class:`PDBWriter`
 
         """
         kwargs.setdefault('multiframe', self.n_frames > 1)
@@ -423,11 +426,12 @@ class PDBWriter(base.WriterBase):
     .. _ENDMDL: http://www.wwpdb.org/documentation/format32/sect9.html#ENDMDL
     .. _CONECT: http://www.wwpdb.org/documentation/format32/sect10.html#CONECT
 
+
     Note
     ----
     This class is identical to :class:`MultiPDBWriter` with the one
     exception that it defaults to writing single-frame PDB files as if
-    *multiframe* = ``False`` was selected.
+    `multiframe` = ``False`` was selected.
 
 
     .. versionchanged:: 0.7.5
@@ -530,7 +534,6 @@ class PDBWriter(base.WriterBase):
            ``False``: write a single frame to the file; ``True``: create a
            multi frame PDB file in which frames are written as MODEL_ ... ENDMDL_
            records. If ``None``, then the class default is chosen.    [``None``]
-
 
         Note
         ----
@@ -729,10 +732,11 @@ class PDBWriter(base.WriterBase):
         used as the PDB chainID (but see :meth:`~PDBWriter.ATOM` for
         details).
 
-        :Arguments:
-          *obj*
-            :class:`~MDAnalysis.core.groups.AtomGroup` or
-            :class:`~MDAnalysis.core.universe.Universe`
+        Parameters
+        ----------
+        obj
+            The :class:`~MDAnalysis.core.groups.AtomGroup` or
+            :class:`~MDAnalysis.core.universe.Universe` to write.
         """
 
         self._update_frame(obj)

--- a/package/MDAnalysis/coordinates/PDBQT.py
+++ b/package/MDAnalysis/coordinates/PDBQT.py
@@ -1,5 +1,5 @@
 # -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
-# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
 #
 # MDAnalysis --- http://www.mdanalysis.org
 # Copyright (c) 2006-2016 The MDAnalysis Development Team and contributors
@@ -55,7 +55,7 @@ class PDBQTReader(base.SingleFrameReaderBase):
      - CRYST1 for unitcell A,B,C, alpha,beta,gamm
      - ATOM. HETATM for x,y,z
 
-    Original `PDB format documentation`_    with  `AutoDOCK extensions`_
+    Original `PDB format documentation`_ with `AutoDOCK extensions`_
 
 
     .. _PDB format documentation:
@@ -221,14 +221,13 @@ class PDBQTWriter(base.WriterBase):
     def write(self, selection, frame=None):
         """Write selection at current trajectory frame to file.
 
-        write(selection, frame=FRAME)
-
         Parameters
         ----------
         selection : AtomGroup
             The selection to be written
-        frame : int, optional
-            optionally move to *frame* before writing
+        frame : int (optional)
+            optionally move to frame index `frame` before writing; the default
+            is to write the current trajectory frame
 
         Note
         ----
@@ -239,6 +238,7 @@ class PDBQTWriter(base.WriterBase):
 
         .. versionchanged:: 0.11.0
            Frames now 0-based instead of 1-based
+
         """
         u = selection.universe
         if frame is not None:

--- a/package/MDAnalysis/coordinates/PQR.py
+++ b/package/MDAnalysis/coordinates/PQR.py
@@ -1,5 +1,5 @@
 # -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
-# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
 #
 # MDAnalysis --- http://www.mdanalysis.org
 # Copyright (c) 2006-2016 The MDAnalysis Development Team and contributors
@@ -145,7 +145,7 @@ class PQRReader(base.SingleFrameReaderBase):
 
         Parameters
         ----------
-        filename: str
+        filename : str
             filename of the output PQR file
 
         Returns
@@ -188,7 +188,7 @@ class PQRWriter(base.WriterBase):
         ----------
         filename : str
              output filename
-        remarks : str, optionak
+        remarks : str (optional)
              remark lines (list of strings) or single string to be added to the
              top of the PQR file
         """
@@ -207,12 +207,14 @@ class PQRWriter(base.WriterBase):
         ----------
         selection : AtomGroup or Universe
             MDAnalysis AtomGroup or Universe
-        frame : int, optional
-            optionally move to frame number *frame*
+        frame : int (optional)
+            optionally move to frame index `frame`; by default, write the
+            current frame
 
 
         .. versionchanged:: 0.11.0
            Frames now 0-based instead of 1-based
+
         """
         # write() method that complies with the Trajectory API
         u = selection.universe

--- a/package/MDAnalysis/coordinates/PQR.py
+++ b/package/MDAnalysis/coordinates/PQR.py
@@ -143,11 +143,14 @@ class PQRReader(base.SingleFrameReaderBase):
     def Writer(self, filename, **kwargs):
         """Returns a PQRWriter for *filename*.
 
-        :Arguments:
-           *filename*
-              filename of the output PQR file
+        Parameters
+        ----------
+        filename: str
+            filename of the output PQR file
 
-        :Returns: :class:`PQRWriter`
+        Returns
+        -------
+        :class:`PQRWriter`
         """
         return PQRWriter(filename, **kwargs)
 

--- a/package/MDAnalysis/coordinates/TRJ.py
+++ b/package/MDAnalysis/coordinates/TRJ.py
@@ -19,26 +19,28 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-"""
-AMBER trajectories --- :mod:`MDAnalysis.coordinates.TRJ`
+"""AMBER trajectories --- :mod:`MDAnalysis.coordinates.TRJ`
 ========================================================
 
 AMBER_ can write :ref:`ASCII trajectories<ascii-trajectories>` ("traj") and
 :ref:`binary trajectories<netcdf-trajectories>` ("netcdf"). MDAnalysis supports
 reading of both formats and writing for the binary trajectories.
 
-.. Note::
+Note
+----
+Support for AMBER is still somewhat *experimental* and feedback and
+contributions are highly appreciated. Use the `Issue Tracker`_ or get in touch
+on the `MDAnalysis mailinglist`_.
 
-   Support for AMBER is *experimental* and feedback and contributions
-   are highly appreciated. Use the `Issue Tracker`_ or get in touch on
-   the `MDAnalysis mailinglist`_.
 
 .. rubric:: Units
+
+AMBER trajectories are assumed to be in the following units:
 
 * lengths in Angstrom (Å)
 * time in ps (but see below)
 
-AMBER trajectory coordinate frames are based on a :class:`Timestep`
+AMBER trajectory coordinate frames are based on a custom :class:`Timestep`
 object.
 
 .. autoclass:: Timestep
@@ -127,8 +129,6 @@ those and will raise a :exc:`NotImplementedError` if anything else is detected.
 .. _Issue Tracker: https://github.com/MDAnalysis/mdanalysis/issues
 .. _MDAnalysis mailinglist: http://groups.google.com/group/mdnalysis-discussion
 
-
-
 """
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
@@ -161,8 +161,8 @@ except ImportError:
 class Timestep(base.Timestep):
     """AMBER trajectory Timestep.
 
-    The Timestep can be initialized with *arg* being an integer
-    (the number of atoms) and an optional keyword argument *velocities* to
+    The Timestep can be initialized with `arg` being an integer
+    (the number of atoms) and an optional keyword argument `velocities` to
     allocate space for both coordinates and velocities;
 
     .. versionchanged:: 0.10.0
@@ -192,8 +192,8 @@ class TRJReader(base.ReaderBase):
     .. _AMBER TRJ format: http://ambermd.org/formats.html#trajectory
 
     .. versionchanged:: 0.11.0
-       Frames now 0-based instead of 1-based
-       kwarg 'delta' renamed to 'dt', for uniformity with other Readers
+       Frames now 0-based instead of 1-based.
+       kwarg `delta` renamed to `dt`, for uniformity with other Readers
     """
     format = ['TRJ', 'MDCRD', 'CRDBOX']
     units = {'time': 'ps', 'length': 'Angstrom'}
@@ -293,7 +293,8 @@ class TRJReader(base.ReaderBase):
          - this WILL fail if we have exactly 1 atom in the trajectory because
            there's no way to distinguish the coordinates from the box
            so for 1 atom we always assume no box
-         XXX: needs a Timestep that knows about AMBER unitcells!
+
+        .. TODO:: needs a Timestep that knows about AMBER unitcells!
         """
         if self.n_atoms == 1:
             # for 1 atom we cannot detect the box with the current approach
@@ -385,7 +386,7 @@ class NCDFReader(base.ReaderBase):
     AMBER binary trajectories are automatically recognised by the
     file extension ".ncdf".
 
-    The number of atoms (*n_atoms*) does not have to be provided as it can
+    The number of atoms (`n_atoms`) does not have to be provided as it can
     be read from the trajectory. The trajectory reader can randomly access
     frames and therefore supports direct indexing (with 0-based frame
     indices) and full-feature trajectory iteration, including slicing.
@@ -412,12 +413,13 @@ class NCDFReader(base.ReaderBase):
     --------
     :class:`NCDFWriter`
 
+
     .. versionadded: 0.7.6
     .. versionchanged:: 0.10.0
        Added ability to read Forces
     .. versionchanged:: 0.11.0
-       Frame labels now 0-based instead of 1-based
-       kwarg 'delta' renamed to 'dt', for uniformity with other Readers
+       Frame labels now 0-based instead of 1-based.
+       kwarg `delta` renamed to `dt`, for uniformity with other Readers.
     """
 
     format = ['NCDF', 'NC']
@@ -568,19 +570,19 @@ class NCDFReader(base.ReaderBase):
             self.trjfile = None
 
     def Writer(self, filename, **kwargs):
-        """Returns a NCDFWriter for *filename* with the same parameters as this NCDF.
+        """Returns a NCDFWriter for `filename` with the same parameters as this NCDF.
 
         All values can be changed through keyword arguments.
 
         Parameters
         ----------
-        filename: str
+        filename : str
             filename of the output NCDF trajectory
-        n_atoms: int
+        n_atoms : int (optional)
             number of atoms
-        dt: float
+        dt : float (optional)
             length of one timestep in picoseconds
-        remarks: str
+        remarks : str (optional)
             string that is stored in the title field
 
         Returns
@@ -612,12 +614,13 @@ class NCDFWriter(base.WriterBase):
     --------
     :class:`NCDFReader`
 
+
     .. versionadded: 0.7.6
 
     .. versionchanged:: 0.10.0
        Added ability to write velocities and forces
     .. versionchanged:: 0.11.0
-       kwarg 'delta' renamed to 'dt', for uniformity with other Readers
+       kwarg `delta` renamed to `dt`, for uniformity with other Readers
     """
 
     format = 'NCDF'
@@ -643,27 +646,27 @@ class NCDFWriter(base.WriterBase):
 
         Parameters
         ----------
-        filename: str
+        filename : str
             name of output file
-        n_atoms: int
+        n_atoms : int
             number of atoms in trajectory file
-        start: int
+        start : int (optional)
             starting timestep
-        step: int
+        step : int (optional)
             skip between subsequent timesteps
-        dt: float
+        dt : float (optional)
             timestep
-        convert_units: bool
+        convert_units : bool (optional)
             ``True``: units are converted to the AMBER base format; ``None``
             selects the value of :data:`MDAnalysis.core.flags`
             ['convert_lengths'] (see :ref:`flags-label`).
-        zlib: bool
+        zlib : bool (optional)
             compress data [``False``]
-        cmplevel: int
+        cmplevel : int (optional)
             compression level (1-9) [1]
-        velocities: bool
+        velocities : bool (optional)
             Write velocities into the trajectory [``False``]
-        forces: bool
+        forces : bool (optional)
             Write forces into the trajectory [``False``]
         """
         self.filename = filename
@@ -807,18 +810,33 @@ class NCDFWriter(base.WriterBase):
         self.trjfile = ncfile
 
     def is_periodic(self, ts=None):
-        """Return ``True`` if :class:`Timestep` *ts* contains a valid
-        simulation box
+        """Test if `Timestep` contains a periodic trajectory.
+
+        Parameters
+        ----------
+        ts : :class:`Timestep`
+             :class:`Timestep` instance containing coordinates to
+             be written to trajectory file; default is the current
+             timestep
+
+        Returns
+        -------
+        bool
+            Return ``True`` if `ts` contains a valid simulation box
         """
         ts = ts if ts is not None else self.ts
         return np.all(ts.dimensions > 0)
 
     def write_next_timestep(self, ts=None):
-        '''write a new timestep to the trj file
+        """write a new timestep to the trj file
 
-        *ts* is a :class:`Timestep` instance containing coordinates to
-        be written to trajectory file
-        '''
+        Parameters
+        ----------
+        ts : :class:`Timestep`
+             :class:`Timestep` instance containing coordinates to
+             be written to trajectory file; default is the current
+             timestep
+        """
         if ts is None:
             ts = self.ts
         if ts is None:

--- a/package/MDAnalysis/coordinates/TRJ.py
+++ b/package/MDAnalysis/coordinates/TRJ.py
@@ -572,18 +572,20 @@ class NCDFReader(base.ReaderBase):
 
         All values can be changed through keyword arguments.
 
-        :Arguments:
-          *filename*
-              filename of the output NCDF trajectory
-        :Keywords:
-          *n_atoms*
-              number of atoms
-          *dt*
-              length of one timestep in picoseconds
-          *remarks*
-              string that is stored in the title field
+        Parameters
+        ----------
+        filename: str
+            filename of the output NCDF trajectory
+        n_atoms: int
+            number of atoms
+        dt: float
+            length of one timestep in picoseconds
+        remarks: str
+            string that is stored in the title field
 
-        :Returns: :class:`NCDFWriter`
+        Returns
+        -------
+        :class:`NCDFWriter`
         """
         n_atoms = kwargs.pop('n_atoms', self.n_atoms)
         kwargs.setdefault('remarks', self.remarks)
@@ -639,30 +641,29 @@ class NCDFWriter(base.WriterBase):
                  **kwargs):
         """Create a new NCDFWriter
 
-        :Arguments:
-         *filename*
+        Parameters
+        ----------
+        filename: str
             name of output file
-         *n_atoms*
+        n_atoms: int
             number of atoms in trajectory file
-
-        :Keywords:
-          *start*
+        start: int
             starting timestep
-          *step*
+        step: int
             skip between subsequent timesteps
-          *dt*
+        dt: float
             timestep
-          *convert_units*
+        convert_units: bool
             ``True``: units are converted to the AMBER base format; ``None``
             selects the value of :data:`MDAnalysis.core.flags`
             ['convert_lengths'] (see :ref:`flags-label`).
-          *zlib*
+        zlib: bool
             compress data [``False``]
-          *cmplevel*
+        cmplevel: int
             compression level (1-9) [1]
-          *velocities*
+        velocities: bool
             Write velocities into the trajectory [``False``]
-          *forces*
+        forces: bool
             Write forces into the trajectory [``False``]
         """
         self.filename = filename

--- a/package/MDAnalysis/coordinates/TRR.py
+++ b/package/MDAnalysis/coordinates/TRR.py
@@ -38,14 +38,17 @@ from ..lib.mdamath import triclinic_vectors, triclinic_box
 
 
 class TRRWriter(XDRBaseWriter):
-    """The Gromacs TRR trajectory format is a lossless format. The TRR format can
+    """Writer for the Gromacs TRR format.
+
+    The Gromacs TRR trajectory format is a lossless format. The TRR format can
     store *velocoties* and *forces* in addition to the coordinates. It is also
     used by other Gromacs tools to store and process other data such as modes
     from a principal component analysis.
 
-    If the data dictionary of a TimeStep contains the key 'lambda' the
-    corresponding value will be used as the lambda value for written TRR file.
-    If None is found the lambda is set to 0.
+    If the data dictionary of a :class:`Timestep` contains the key
+    'lambda' the corresponding value will be used as the lambda value
+    for written TRR file.  If ``None`` is found the lambda is set to 0.
+
     """
 
     format = 'TRR'
@@ -59,7 +62,7 @@ class TRRWriter(XDRBaseWriter):
 
         Parameters
         ----------
-        ts : TimeStep
+        ts : :class:`~base.Timestep`
 
         See Also
         --------
@@ -101,12 +104,15 @@ class TRRWriter(XDRBaseWriter):
 
 
 class TRRReader(XDRBaseReader):
-    """The Gromacs TRR trajectory format is a lossless format. The TRR format can
+    """Reader for the Gromacs TRR format.
+
+    The Gromacs TRR trajectory format is a lossless format. The TRR format can
     store *velocoties* and *forces* in addition to the coordinates. It is also
     used by other Gromacs tools to store and process other data such as modes
     from a principal component analysis.
 
-    The lambda value is written in the data dictionary of the returned TimeStep
+    The lambda value is written in the data dictionary of the returned
+    :class:`Timestep`
 
     Notes
     -----

--- a/package/MDAnalysis/coordinates/TRZ.py
+++ b/package/MDAnalysis/coordinates/TRZ.py
@@ -32,6 +32,9 @@ Reads coordinates, velocities and more (see attributes of the
 .. _IBIsCO: http://www.theo.chemie.tu-darmstadt.de/ibisco/IBISCO.html
 .. _YASP: http://www.theo.chemie.tu-darmstadt.de/group/services/yaspdoc/yaspdoc.html
 
+Classes
+-------
+
 .. autoclass:: MDAnalysis.coordinates.TRZ.Timestep
    :members:
 
@@ -153,11 +156,11 @@ class TRZReader(base.ReaderBase):
 
         Parameters
         ----------
-        trzfilename: str
+        trzfilename : str
             name of input file
-        n_atoms: int
+        n_atoms : int
             number of atoms in trajectory, must be taken from topology file!
-        convert_units: bool
+        convert_units : bool (optional)
             converts units to MDAnalysis defaults
         """
         super(TRZReader, self).__init__(trzfilename,  **kwargs)
@@ -445,14 +448,14 @@ class TRZWriter(base.WriterBase):
 
         Parameters
         ----------
-        filename: str
+        filename : str
             name of output file
-        n_atoms: int
+        n_atoms : int
             number of atoms in trajectory
-        title: str
+        title : str (optional)
             title of the trajectory; the title must be 80 characters or
             shorter, a longer title raises a ValueError exception.
-        convert_units: bool
+        convert_units : bool (optional)
             units are converted to the MDAnalysis base format; ``None`` selects
             the value of :data:`MDAnalysis.core.flags` ['convert_lengths'].
             (see :ref:`flags-label`)

--- a/package/MDAnalysis/coordinates/TRZ.py
+++ b/package/MDAnalysis/coordinates/TRZ.py
@@ -151,12 +151,13 @@ class TRZReader(base.ReaderBase):
     def __init__(self, trzfilename, n_atoms=None, **kwargs):
         """Creates a TRZ Reader
 
-        :Arguments:
-          *trzfilename*
+        Parameters
+        ----------
+        trzfilename: str
             name of input file
-          *n_atoms*
-            number of atoms in trajectory, must taken from topology file!
-          *convert_units*
+        n_atoms: int
+            number of atoms in trajectory, must be taken from topology file!
+        convert_units: bool
             converts units to MDAnalysis defaults
         """
         super(TRZReader, self).__init__(trzfilename,  **kwargs)
@@ -442,20 +443,19 @@ class TRZWriter(base.WriterBase):
     def __init__(self, filename, n_atoms, title='TRZ', convert_units=None):
         """Create a TRZWriter
 
-        :Arguments:
-         *filename*
-          name of output file
-         *n_atoms*
-          number of atoms in trajectory
-
-        :Keywords:
-         *title*
-          title of the trajectory; the title must be 80 characters or shorter,
-          a longer title raises a ValueError exception.
-         *convert_units*
-          units are converted to the MDAnalysis base format; ``None`` selects
-          the value of :data:`MDAnalysis.core.flags` ['convert_lengths'].
-          (see :ref:`flags-label`)
+        Parameters
+        ----------
+        filename: str
+            name of output file
+        n_atoms: int
+            number of atoms in trajectory
+        title: str
+            title of the trajectory; the title must be 80 characters or
+            shorter, a longer title raises a ValueError exception.
+        convert_units: bool
+            units are converted to the MDAnalysis base format; ``None`` selects
+            the value of :data:`MDAnalysis.core.flags` ['convert_lengths'].
+            (see :ref:`flags-label`)
         """
         self.filename = filename
         if n_atoms is None:

--- a/package/MDAnalysis/coordinates/XDR.py
+++ b/package/MDAnalysis/coordinates/XDR.py
@@ -112,7 +112,8 @@ class XDRBaseReader(base.ReaderBase):
     """
     def __init__(self, filename, convert_units=True, sub=None,
                  refresh_offsets=False, **kwargs):
-        """Parameters
+        """
+        Parameters
         ----------
         filename : str
             trajectory filename

--- a/package/MDAnalysis/coordinates/XTC.py
+++ b/package/MDAnalysis/coordinates/XTC.py
@@ -38,7 +38,9 @@ from ..lib.mdamath import triclinic_vectors, triclinic_box
 
 
 class XTCWriter(XDRBaseWriter):
-    """XTC is a compressed trajectory format from Gromacs. The trajectory is saved
+    """Writer for the Gromacs XTC trajectory format.
+
+    XTC is a compressed trajectory format from Gromacs. The trajectory is saved
     with reduced precision (3 decimal places by default) compared to other
     lossless formarts like TRR and DCD. The main advantage of XTC files is that
     they require significantly less disk space and the loss of precision is
@@ -51,7 +53,8 @@ class XTCWriter(XDRBaseWriter):
 
     def __init__(self, filename, n_atoms, convert_units=True,
                  precision=3, **kwargs):
-        """Parameters
+        """
+        Parameters
         ----------
         filename : str
             filename of the trajectory
@@ -71,7 +74,7 @@ class XTCWriter(XDRBaseWriter):
 
         Parameters
         ----------
-        ts: TimeStep
+        ts : :class:`~base.Timestep`
 
         See Also
         --------
@@ -96,7 +99,9 @@ class XTCWriter(XDRBaseWriter):
 
 
 class XTCReader(XDRBaseReader):
-    """XTC is a compressed trajectory format from Gromacs. The trajectory is saved
+    """Reader for the Gromacs XTC trajectory format.
+
+    XTC is a compressed trajectory format from Gromacs. The trajectory is saved
     with reduced precision (3 decimal places) compared to other lossless
     formarts like TRR and DCD. The main advantage of XTC files is that they
     require significantly less disk space and the loss of precision is usually

--- a/package/MDAnalysis/coordinates/XYZ.py
+++ b/package/MDAnalysis/coordinates/XYZ.py
@@ -185,10 +185,11 @@ class XYZWriter(base.WriterBase):
         to the value of the *atoms* keyword supplied to the
         :class:`XYZWriter` constructor.
 
-        :Arguments:
-          *obj*
-            :class:`~MDAnalysis.core.groups.AtomGroup` or
-            :class:`~MDAnalysis.core.universe.Universe`
+        Parameters
+        ----------
+        obj:
+            The :class:`~MDAnalysis.core.groups.AtomGroup` or
+            :class:`~MDAnalysis.core.universe.Universe` to write.
         """
         # prepare the Timestep and extract atom names if possible
         # (The way it is written it should be possible to write

--- a/package/MDAnalysis/coordinates/XYZ.py
+++ b/package/MDAnalysis/coordinates/XYZ.py
@@ -1,5 +1,5 @@
 # -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
-# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
 #
 # MDAnalysis --- http://www.mdanalysis.org
 # Copyright (c) 2006-2016 The MDAnalysis Development Team and contributors
@@ -64,15 +64,20 @@ the `VMD xyzplugin`_ from whence the definition was taken)::
     ...
     atomN x y z [ ...         ]                                                 line N+2
 
-.. Note::
-   * comment lines not implemented (do not include them)
-   * molecule name: the line is required but the content is ignored
-     at the moment
-   * optional data (after the coordinates) are presently ignored
+
+Note
+----
+* comment lines not implemented (do not include them)
+* molecule name: the line is required but the content is ignored
+  at the moment
+* optional data (after the coordinates) are presently ignored
 
 
 .. Links
 .. _`VMD xyzplugin`: http://www.ks.uiuc.edu/Research/vmd/plugins/molfile/xyzplugin.html
+
+Classes
+-------
 
 """
 from __future__ import division, absolute_import
@@ -176,18 +181,15 @@ class XYZWriter(base.WriterBase):
         self._xyz = None
 
     def write(self, obj):
-        """Write object *obj* at current trajectory frame to file.
+        """Write object `obj` at current trajectory frame to file.
 
-        *obj* can be a :class:`~MDAnalysis.core.groups.AtomGroup`)
-        or a whole :class:`~MDAnalysis.core.universe.Universe`.
-
-        Atom names in the output are taken from the *obj* or default
-        to the value of the *atoms* keyword supplied to the
+        Atom names in the output are taken from the `obj` or default
+        to the value of the `atoms` keyword supplied to the
         :class:`XYZWriter` constructor.
 
         Parameters
         ----------
-        obj:
+        obj : Universe or AtomGroup
             The :class:`~MDAnalysis.core.groups.AtomGroup` or
             :class:`~MDAnalysis.core.universe.Universe` to write.
         """

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -1150,9 +1150,11 @@ class ProtoReader(six.with_metaclass(_Readermeta, IOBase)):
         Sets the default keywords *start*, *step* and *dt* (if
         available). *n_atoms* is always set from :attr:`Reader.n_atoms`.
 
+
         See Also
         --------
         :meth:`Reader.Writer` and :func:`MDAnalysis.Writer`
+
         """
         kwargs['n_atoms'] = self.n_atoms  # essential
         kwargs.setdefault('start', self.frame)
@@ -1753,12 +1755,16 @@ class WriterBase(six.with_metaclass(_Writermeta, IOBase)):
 
            min < x <= max
 
-        :Arguments:
-            *criteria*
-               dictionary containing the *max* and *min* values in native units
-            *x*
-               :class:`np.ndarray` of ``(x, y, z)`` coordinates of atoms selected to be written out.
-        :Returns: boolean
+        Parameters
+        ----------
+        criteria: dict
+            dictionary containing the *max* and *min* values in native units
+            *x* :class:`np.ndarray` of ``(x, y, z)`` coordinates of atoms
+            selected to be written out.
+
+        Returns
+        -------
+        bool
         """
         x = np.ravel(x)
         return np.all(criteria["min"] < x) and np.all(x <= criteria["max"])

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -363,7 +363,7 @@ class Timestep(object):
            correspond to atom indices,
            :attr:`MDAnalysis.core.groups.Atom.index` (0-based)
         """
-        if isinstance(atoms, int):
+        if isinstance(atoms, numbers.Integral):
             return self._pos[atoms]
         elif isinstance(atoms, (slice, np.ndarray)):
             return self._pos[atoms]
@@ -1205,7 +1205,7 @@ class ProtoReader(six.with_metaclass(_Readermeta, IOBase)):
                                  "".format(frame, len(self)))
             return frame
 
-        if isinstance(frame, int):
+        if isinstance(frame, numbers.Integral):
             frame = apply_limits(frame)
             return self._read_frame_with_aux(frame)
         elif isinstance(frame, (list, np.ndarray)):
@@ -1217,7 +1217,7 @@ class ProtoReader(six.with_metaclass(_Readermeta, IOBase)):
 
             def listiter(frames):
                 for f in frames:
-                    if not isinstance(f, (int, np.integer)):
+                    if not isinstance(f, numbers.Integral):
                         raise TypeError("Frames indices must be integers")
                     yield self._read_frame_with_aux(apply_limits(f))
 

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -29,6 +29,13 @@ Derive other Timestep, Reader and Writer classes from the classes in
 this module. The derived classes must follow the :ref:`Trajectory API`
 in :mod:`MDAnalysis.coordinates.__init__`.
 
+Timestep
+--------
+
+A :class:`Timestep` holds information for the current time frame in
+the trajectory. It is one of the central data structures in
+MDAnalysis.
+
 .. class:: Timestep
 
    .. automethod:: __init__
@@ -107,19 +114,62 @@ in :mod:`MDAnalysis.coordinates.__init__`.
    .. automethod:: copy
    .. automethod:: copy_slice
 
-.. autoclass:: IOBase
-   :members:
 
-.. autoclass:: ProtoReader
-   :members:
+Readers
+-------
+
+Readers know how to take trajectory data in a given format and present it in a
+common API to the user in MDAnalysis. There are two types of readers:
+
+1. Readers for *multi frame trajectories*, i.e., file formats that typically
+   contain many frames. These readers are typically derived from
+   :class:`ReaderBase`.
+
+2. Readers for *single frame formats*: These file formats only contain a single
+   coordinate set. These readers are derived from
+   :class`:SingleFrameReaderBase`.
+
+The underlying low-level readers handle closing of files in different
+ways. Typically, the MDAnalysis readers try to ensure that files are always
+closed when a reader instance is garbage collected, which relies on
+implementing a :meth:`~ReaderBase.__del__` method. However, in some cases, this
+is not necessary (for instance, for the single frame formats) and then such a
+method can lead to undesirable side effects (such as memory leaks). In this
+case, :class:`ProtoReader` should be used.
+
 
 .. autoclass:: ReaderBase
    :members:
    :inherited-members:
 
+.. autoclass:: SingleFrameReaderBase
+   :members:
+   :inherited-members:
+
+.. autoclass:: ProtoReader
+   :members:
+
+
+
+Writers
+-------
+
+Writers know how to write information in a :class:`Timestep` to a trajectory
+file.
+
 .. autoclass:: WriterBase
    :members:
    :inherited-members:
+
+
+Helper classes
+--------------
+
+The following classes contain basic functionality that all readers and
+writers share.
+
+.. autoclass:: IOBase
+   :members:
 
 """
 from __future__ import absolute_import
@@ -158,10 +208,10 @@ class Timestep(object):
     .. versionchanged:: 0.11.0
        Added :meth:`from_timestep` and :meth:`from_coordinates` constructor
        methods.
-       :class:`Timestep` init now only accepts integer creation
-       :attr:`n_atoms` now a read only property
-       :attr:`frame` now 0-based instead of 1-based
-       Attributes status and step removed
+       :class:`Timestep` init now only accepts integer creation.
+       :attr:`n_atoms` now a read only property.
+       :attr:`frame` now 0-based instead of 1-based.
+       Attributes `status` and `step` removed.
     """
     order = 'F'
 
@@ -174,23 +224,24 @@ class Timestep(object):
           The total number of atoms this Timestep describes
         positions : bool, optional
           Whether this Timestep has position information [``True``]
-        velocities : bool, optional
+        velocities : bool (optional)
           Whether this Timestep has velocity information [``False``]
-        forces : bool, optional
+        forces : bool (optional)
           Whether this Timestep has force information [``False``]
-        reader : Reader, optional
+        reader : Reader (optional)
           A weak reference to the owning Reader.  Used for
           when attributes require trajectory manipulation (e.g. dt)
-        dt : float, optional
+        dt : float (optional)
           The time difference between frames (ps).  If :attr:`time`
           is set, then `dt` will be ignored.
-        time_offset : float, optional
-          The starting time from which to calculate time (ps)
+        time_offset : float (optional)
+          The starting time from which to calculate time (in ps)
 
-          .. versionchanged:: 0.11.0
-             Added keywords for `positions`, `velocities` and `forces`.
-             Can add and remove position/velocity/force information by using
-             the ``has_*`` attribute.
+
+        .. versionchanged:: 0.11.0
+           Added keywords for `positions`, `velocities` and `forces`.
+           Can add and remove position/velocity/force information by using
+           the ``has_*`` attribute.
         """
         # readers call Reader._read_next_timestep() on init, incrementing
         # self.frame to 0
@@ -399,25 +450,41 @@ class Timestep(object):
         return self.from_timestep(self)
 
     def copy_slice(self, sel):
-        """Make a new Timestep containing a subset of the original Timestep.
+        """Make a new `Timestep` containing a subset of the original `Timestep`.
 
-        ``ts.copy_slice(slice(start, stop, skip))``
-        ``ts.copy_slice([list of indices])``
+        Parameters
+        ----------
+        sel : array_like or slice
+            The underlying position, velocity, and force arrays are sliced
+            using a :class:`list`, :class:`slice`, or any array-like.
 
         Returns
         -------
-        A Timestep object of the same type containing all header
-        information and all atom information relevant to the selection.
+        :class:`Timestep`
+            A `Timestep` object of the same type containing all header
+            information and all atom information relevant to the selection.
 
         Note
         ----
-        The selection must be a 0 based slice or array of the atom indices
-        in this Timestep
+        The selection must be a 0 based :class:`slice` or array of the atom indices
+        in this :class:`Timestep`
+
+        Example
+        -------
+        Using a Python :class:`slice` object::
+
+           new_ts = ts.copy_slice(slice(start, stop, step))
+
+        Using a list of indices::
+
+           new_ts = ts.copy_slice([0, 2, 10, 20, 23])
+
 
         .. versionadded:: 0.8
         .. versionchanged:: 0.11.0
            Reworked to follow new Timestep API.  Now will strictly only
            copy official attributes of the Timestep.
+
         """
         # Detect the size of the Timestep by doing a dummy slice
         try:
@@ -511,16 +578,17 @@ class Timestep(object):
 
         Returns
         -------
-          A numpy.ndarray of shape (n_atoms, 3) of position data for each
-          atom
+        positions : numpy.ndarray with dtype numpy.float32
+               position data of shape ``(n_atoms, 3)`` for all atoms
 
         Raises
         ------
-          :class:`MDAnalysis.exceptions.NoDataError`
-          If the Timestep has no position data
+        :exc:`MDAnalysis.exceptions.NoDataError`
+               if the Timestep has no position data
+
 
         .. versionchanged:: 0.11.0
-           Now can raise NoDataError when no position data present
+           Now can raise :exc`NoDataError` when no position data present
         """
         if self.has_positions:
             return self._pos
@@ -588,13 +656,14 @@ class Timestep(object):
 
         Returns
         -------
-          A numpy.ndarray of shape (n_atoms, 3) of velocity data for each
-          atom
+        velocities : numpy.ndarray with dtype numpy.float32
+               velocity data of shape ``(n_atoms, 3)`` for all atoms
 
         Raises
         ------
-          :class:`MDAnalysis.exceptions.NoDataError`
-          When the Timestep does not contain velocity information
+        :exc:`MDAnalysis.exceptions.NoDataError`
+               if the Timestep has no velocity data
+
 
         .. versionadded:: 0.11.0
         """
@@ -637,13 +706,14 @@ class Timestep(object):
 
         Returns
         -------
-        A numpy.ndarray of shape (n_atoms, 3) of force data for each
-        atom
+        forces : numpy.ndarray with dtype numpy.float32
+               force data of shape ``(n_atoms, 3)`` for all atoms
 
         Raises
         ------
-        :class:`MDAnalysis.NoDataError`
-        When the Timestep does not contain force information
+        :exc:`MDAnalysis.exceptions.NoDataError`
+               if the Timestep has no force data
+
 
         .. versionadded:: 0.11.0
         """
@@ -688,7 +758,8 @@ class Timestep(object):
 
         Returns
         -------
-        A (3, 3) numpy.ndarray of unit cell vectors
+        numpy.ndarray
+             A (3, 3) numpy.ndarray of unit cell vectors
 
         Examples
         --------
@@ -734,6 +805,7 @@ class Timestep(object):
         Note
         ----
         This defaults to 1.0 ps in the absence of time data
+
 
         .. versionadded:: 0.11.0
         """
@@ -804,17 +876,20 @@ class IOBase(object):
         ----------
         x : array_like
           Positions to transform
-        inplace : bool, optional
+        inplace : bool (optional)
           Whether to modify the array inplace, overwriting previous data
 
         Note
         ----
-        By default, the input *x* is modified in place and also returned.
+        By default, the input `x` is modified in place and also returned.
+        In-place operations improve performance because allocating new arrays
+        is avoided.
+
 
         .. versionchanged:: 0.7.5
-           Keyword *inplace* can be set to ``False`` so that a
+           Keyword `inplace` can be set to ``False`` so that a
            modified copy is returned *unless* no conversion takes
-           place, in which case the reference to the unmodified *x* is
+           place, in which case the reference to the unmodified `x` is
            returned.
 
         """
@@ -834,12 +909,15 @@ class IOBase(object):
         ----------
         v : array_like
           Velocities to transform
-        inplace : bool, optional
+        inplace : bool (optional)
           Whether to modify the array inplace, overwriting previous data
 
         Note
         ----
         By default, the input *v* is modified in place and also returned.
+        In-place operations improve performance because allocating new arrays
+        is avoided.
+
 
         .. versionadded:: 0.7.5
         """
@@ -859,12 +937,14 @@ class IOBase(object):
         ----------
         force : array_like
           Forces to transform
-        inplace : bool, optional
+        inplace : bool (optional)
           Whether to modify the array inplace, overwriting previous data
 
         Note
         ----
         By default, the input *force* is modified in place and also returned.
+        In-place operations improve performance because allocating new arrays
+        is avoided.
 
         .. versionadded:: 0.7.7
         """
@@ -884,20 +964,22 @@ class IOBase(object):
         ----------
         t : array_like
           Time values to transform
-        inplace : bool, optional
+        inplace : bool (optional)
           Whether to modify the array inplace, overwriting previous data
 
         Note
         ----
-        By default, the input *t* is modified in place and also
-        returned (although note that scalar values *t* are passed by
-        value in Python and hence an in-place modification has no
-        effect on the caller.)
+        By default, the input `t` is modified in place and also returned
+        (although note that scalar values `t` are passed by value in Python and
+        hence an in-place modification has no effect on the caller.)  In-place
+        operations improve performance because allocating new arrays is
+        avoided.
+
 
         .. versionchanged:: 0.7.5
-           Keyword *inplace* can be set to ``False`` so that a
+           Keyword `inplace` can be set to ``False`` so that a
            modified copy is returned *unless* no conversion takes
-           place, in which case the reference to the unmodified *x* is
+           place, in which case the reference to the unmodified `x` is
            returned.
 
         """
@@ -911,23 +993,26 @@ class IOBase(object):
         return t
 
     def convert_pos_to_native(self, x, inplace=True):
-        """Conversion of coordinate array x from base units to native units.
+        """Conversion of coordinate array `x` from base units to native units.
 
         Parameters
         ----------
         x : array_like
           Positions to transform
-        inplace : bool, optional
+        inplace : bool (optional)
           Whether to modify the array inplace, overwriting previous data
 
         Note
         ----
-        By default, the input *x* is modified in place and also returned.
+        By default, the input `x` is modified in place and also returned.
+        In-place operations improve performance because allocating new arrays
+        is avoided.
+
 
         .. versionchanged:: 0.7.5
-           Keyword *inplace* can be set to ``False`` so that a
+           Keyword `inplace` can be set to ``False`` so that a
            modified copy is returned *unless* no conversion takes
-           place, in which case the reference to the unmodified *x* is
+           place, in which case the reference to the unmodified `x` is
            returned.
 
         """
@@ -941,18 +1026,21 @@ class IOBase(object):
         return x
 
     def convert_velocities_to_native(self, v, inplace=True):
-        """Conversion of coordinate array *v* from base to native units
+        """Conversion of coordinate array `v` from base to native units
 
         Parameters
         ----------
         v : array_like
           Velocities to transform
-        inplace : bool, optional
+        inplace : bool (optional)
           Whether to modify the array inplace, overwriting previous data
 
         Note
         ----
-        By default, the input *v* is modified in place and also returned.
+        By default, the input `v` is modified in place and also returned.
+        In-place operations improve performance because allocating new arrays
+        is avoided.
+
 
         .. versionadded:: 0.7.5
         """
@@ -972,12 +1060,15 @@ class IOBase(object):
         ----------
         force : array_like
           Forces to transform
-        inplace : bool, optional
+        inplace : bool (optional)
           Whether to modify the array inplace, overwriting previous data
 
         Note
         ----
-        By default, the input *force* is modified in place and also returned.
+        By default, the input `force` is modified in place and also returned.
+        In-place operations improve performance because allocating new arrays
+        is avoided.
+
 
         .. versionadded:: 0.7.7
         """
@@ -1065,6 +1156,7 @@ class ProtoReader(six.with_metaclass(_Readermeta, IOBase)):
     See Also
     --------
     :class:`ReaderBase`
+
 
     .. versionchanged:: 0.11.0
        Frames now 0-based instead of 1-based
@@ -1188,7 +1280,7 @@ class ProtoReader(six.with_metaclass(_Readermeta, IOBase)):
     def __getitem__(self, frame):
         """Return the Timestep corresponding to *frame*.
 
-        If *frame* is a integer then the corresponding frame is
+        If `frame` is a integer then the corresponding frame is
         returned. Negative numbers are counted from the end.
 
         If frame is a :class:`slice` then an iterator is returned that
@@ -1273,33 +1365,51 @@ class ProtoReader(six.with_metaclass(_Readermeta, IOBase)):
                             "".format(self.__class__.__name__))
 
     def check_slice_indices(self, start, stop, step):
-        """Check frame indices are valid and clip to fit trajectory
+        """Check frame indices are valid and clip to fit trajectory.
+
+        The usage follows standard Python conventions for :func:`range` but see
+        the warning below.
 
         Parameters
         ----------
-        start, stop, step : int or None
-          Values representing the slice indices.
-          Can use `None` to use defaults of (0, n_frames, and 1)
-          respectively.
+        start : int or None
+          Starting frame index (inclusive). ``None`` corresponds to the default
+          of 0, i.e., the initial frame.
+        stop : int or None
+          Last frame index (exclusive). ``None`` corresponds to the default
+          of n_frames, i.e., it includes the last frame of the trajectory.
+        step : int or None
+          step size of the slice, ``None`` corresponds to the default of 1, i.e,
+          include every frame in the range `start`, `stop`.
 
         Returns
         -------
-        start, stop, step : int
+        start, stop, step : tuple (int, int, int)
           Integers representing the slice
 
         Warning
         -------
-        The returned values start, stop and step give the expected result when passed
-        in range() but gives unexpected behaviour when passed in a slice when stop=None
-        and step=-1
+        The returned values `start`, `stop` and `step` give the expected result
+        when passed in :func:`range` but gives unexpected behavior when passed
+        in a :class:`slice` when ``stop=None`` and ``step=-1``
 
-        This is because when we slice the trajectory (u.trajectory[::-1]), the values
-        returned by check_slice_indices are passed to range. Instead, in AnalysisBase
-        the values returned by check_slice_indices are used to splice the trajectory.
-        This creates a discrepancy because these two lines are not equivalent:
+        This can be a problem for downstream processing of the output from this
+        method. For example, slicing of trajectories is implemented by passing
+        the values returned by :meth:`check_slice_indices` to :func:`range` ::
 
-            range(10, -1, -1)  # [10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
-            range(10)[10:-1:-1]  # []
+          range(start, stop, step)
+
+        and using them as the indices to randomly seek to. On the other hand,
+        in :class:`MDAnalysis.analysis.base.AnalysisBase` the values returned
+        by :meth:`check_slice_indices` are used to splice the trajectory by
+        creating a :class:`slice` instance ::
+
+          slice(start, stop, step)
+
+        This creates a discrepancy because these two lines are not equivalent::
+
+            range(10, -1, -1)             # [10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
+            range(10)[slice(10, -1, -1)]  # []
 
         """
 
@@ -1359,7 +1469,7 @@ class ProtoReader(six.with_metaclass(_Readermeta, IOBase)):
         :class:`~MDAnalysis.auxiliary.base.AuxReader` instance, or the data
         itself as e.g. a filename; in the latter case an appropriate
         :class:`~MDAnalysis.auxiliary.base.AuxReader` is guessed from the
-        data/file format. An appropriate *format* may also be directly provided
+        data/file format. An appropriate `format` may also be directly provided
         as a key word argument.
 
         On adding, the AuxReader is initially matched to the current timestep
@@ -1630,6 +1740,7 @@ class ReaderBase(ProtoReader):
     --------
     :class:`ProtoReader`
 
+
     .. versionchanged:: 0.11.0
        Most of the base Reader class definitions were offloaded to
        :class:`ProtoReader` so as to allow the subclassing of ReaderBases without a
@@ -1714,15 +1825,17 @@ class WriterBase(six.with_metaclass(_Writermeta, IOBase)):
         return np.concatenate([lengths, angles])
 
     def write(self, obj):
-        """Write current timestep, using the supplied *obj*.
+        """Write current timestep, using the supplied `obj`.
 
-        The argument should be a :class:`~MDAnalysis.core.groups.AtomGroup` or
-        a :class:`~MDAnalysis.core.universe.Universe` or a :class:`Timestep` instance.
+        Parameters
+        ----------
+        obj : :class:`~MDAnalysis.core.groups.AtomGroup` or :class:`~MDAnalysis.core.universe.Universe` or a :class:`Timestep`
+            write coordinate information associate with `obj`
 
-        .. Note::
-
-           The size of the *obj* must be the same as the number of atom
-           provided when setting up the trajectory.
+        Note
+        ----
+        The size of the `obj` must be the same as the number of atoms provided
+        when setting up the trajectory.
         """
         if isinstance(obj, Timestep):
             ts = obj
@@ -1757,10 +1870,10 @@ class WriterBase(six.with_metaclass(_Writermeta, IOBase)):
 
         Parameters
         ----------
-        criteria: dict
+        criteria : dict
             dictionary containing the *max* and *min* values in native units
-            *x* :class:`np.ndarray` of ``(x, y, z)`` coordinates of atoms
-            selected to be written out.
+        x : numpy.ndarray
+            ``(x, y, z)`` coordinates of atoms selected to be written out
 
         Returns
         -------

--- a/package/MDAnalysis/coordinates/chain.py
+++ b/package/MDAnalysis/coordinates/chain.py
@@ -69,6 +69,7 @@ class ChainReader(base.ProtoReader):
     :attr:`ChainReader.n_atoms`, and :attr:`ChainReader.fixed` are properly
     set, though
 
+
     .. versionchanged:: 0.11.0
        Frames now 0-based instead of 1-based
     .. versionchanged:: 0.13.0
@@ -94,17 +95,17 @@ class ChainReader(base.ProtoReader):
            names in either plain file names format or ``(filename, format)``
            tuple combination. This allows explicit setting of the format for
            each individual trajectory file.
-        skip : int, optional
+        skip : int (optional)
            skip step (also passed on to the individual trajectory readers);
            must be same for all trajectories
-        dt : float, optional
+        dt : float (optional)
           Passed to individual trajectory readers to enforce a common time
           difference between frames, in MDAnalysis time units. If not set, each
           reader's `dt` will be used (either inferred from the trajectory
           files, or set to the reader's default) when reporting frame times;
           note that this might lead an inconsistent time difference between
           frames.
-        **kwargs : dict, optional
+        **kwargs : dict (optional)
           all other keyword arguments are passed on to each trajectory reader
           unchanged
 
@@ -173,7 +174,7 @@ class ChainReader(base.ProtoReader):
         Returns
         -------
         (i, f) : tuple
-            **local frame** tuple `
+            **local frame** tuple
 
         Raises
         ------

--- a/package/MDAnalysis/coordinates/core.py
+++ b/package/MDAnalysis/coordinates/core.py
@@ -65,7 +65,8 @@ def reader(filename, **kwargs):
 
     Returns
     -------
-    A Reader object
+    :class:`~base.Reader`
+        A trajectory Reader instance
 
     See Also
     --------
@@ -90,10 +91,10 @@ def writer(filename, n_atoms=None, **kwargs):
     filename : str
         Output filename of the trajectory; the extension determines the
         format.
-    n_atoms : int, optional
+    n_atoms : int (optional)
         The number of atoms in the output trajectory; can be ommitted
         for single-frame writers.
-    multiframe : bool, optional
+    multiframe : bool (optional)
         ``True``: write a trajectory with multiple frames; ``False``
         only write a single frame snapshot; ``None`` first try to get
         a multiframe writer and then fall back to single frame [``None``]
@@ -106,7 +107,8 @@ def writer(filename, n_atoms=None, **kwargs):
 
     Returns
     -------
-    A Writer object
+    :class:`~base.Writer`
+        A trajectory Writer instance
 
     See Also
     --------
@@ -114,7 +116,7 @@ def writer(filename, n_atoms=None, **kwargs):
 
 
     .. versionchanged:: 0.7.6
-       Added *multiframe* keyword. See also :func:`get_writer_for`.
+       Added `multiframe` keyword. See also :func:`get_writer_for`.
 
     """
     Writer = get_writer_for(filename, format=kwargs.pop('format', None),

--- a/package/MDAnalysis/coordinates/core.py
+++ b/package/MDAnalysis/coordinates/core.py
@@ -72,10 +72,6 @@ def reader(filename, **kwargs):
     :ref:`Supported coordinate formats`
 
 
-    .. deprecated:: 0.15.0
-       The "permissive" flag is not used anymore (and effectively
-       defaults to True); it will be completely removed in 0.16.0.
-
     """
     if isinstance(filename, tuple):
         Reader = get_reader_for(filename[0],

--- a/package/MDAnalysis/coordinates/memory.py
+++ b/package/MDAnalysis/coordinates/memory.py
@@ -217,6 +217,9 @@ class MemoryReader(base.ProtoReader):
     A trajectory reader interface to a numpy array of the coordinates.
     For compatibility with the timeseries interface, support is provided for
     specifying the order of columns through the format option.
+
+    .. versionadded:: 0.16.0
+
     """
 
     format = 'MEMORY'
@@ -225,27 +228,34 @@ class MemoryReader(base.ProtoReader):
     def __init__(self, coordinate_array, order='fac',
                  dimensions=None, dt=1, filename=None, **kwargs):
         """
-
         Parameters
         ----------
-        coordinate_array : :class:`~numpy.ndarray` object
+        coordinate_array : numpy.ndarray
             The underlying array of coordinates
-        order : str, optional
+        order : {"afc", "acf", "caf", "fac", "fca", "cfa"} (optional)
             the order/shape of the return data array, corresponding
             to (a)tom, (f)rame, (c)oordinates all six combinations
             of 'a', 'f', 'c' are allowed ie "fac" - return array
             where the shape is (frame, number of atoms,
-            coordinates)
-        dimensions: (*A*, *B*, *C*, *alpha*, *beta*, *gamma*), optional
+            coordinates).
+        dimensions: [A, B, C, alpha, beta, gamma] (optional)
             unitcell dimensions (*A*, *B*, *C*, *alpha*, *beta*, *gamma*)
             lengths *A*, *B*, *C* are in the MDAnalysis length unit (Å), and
             angles are in degrees.
-        dt: float, optional
+        dt: float (optional)
             The time difference between frames (ps).  If :attr:`time`
             is set, then `dt` will be ignored.
-        filename: string, optional
-            The name of the file from which this instance is created. Set to None
+        filename: string (optional)
+            The name of the file from which this instance is created. Set to ``None``
             when created from an array
+
+        Note
+        ----
+        At the moment, only a fixed `dimension` is supported, i.e., the same
+        unit cell for all frames in `coordinate_array`. See issue `#1041`_.
+
+        .. _`#1041`: https://github.com/MDAnalysis/mdanalysis/issues/1041
+
         """
 
         super(MemoryReader, self).__init__()
@@ -282,12 +292,12 @@ class MemoryReader(base.ProtoReader):
         ----------
         coordinate_array : :class:`~numpy.ndarray` object
             The underlying array of coordinates
-        order
-            The order/shape of the return data array, corresponding
+        order : {"afc", "acf", "caf", "fac", "fca", "cfa"} (optional)
+            the order/shape of the return data array, corresponding
             to (a)tom, (f)rame, (c)oordinates all six combinations
             of 'a', 'f', 'c' are allowed ie "fac" - return array
             where the shape is (frame, number of atoms,
-            coordinates)
+            coordinates).
         """
         # Only make copy if not already in float32 format
         self.coordinate_array = coordinate_array.astype('float32', copy=False)
@@ -307,29 +317,36 @@ class MemoryReader(base.ProtoReader):
     def timeseries(self, asel=None, start=0, stop=-1, step=1, format='afc'):
         """Return a subset of coordinate data for an AtomGroup in desired
         column order/format. If no selection is given, it will return a view of
-        the underlying array, while a copy is returned otherwise. 
+        the underlying array, while a copy is returned otherwise.
 
         Parameters
         ---------
-        asel : :class:`~MDAnalysis.core.groups.AtomGroup` object
-            Atom selection. Defaults to None, in which case the full set of
+        asel : AtomGroup (optional)
+            Atom selection. Defaults to ``None``, in which case the full set of
             coordinate data is returned. Note that in this case, a view
             of the underlying numpy array is returned, while a copy of the
-            data is returned whenever asel is different from None.
-        start, stop, skip : int
-            range of trajectory to access, start and stop are inclusive
-        format : str
+            data is returned whenever `asel` is different from ``None``.
+        start : int (optional)
+        stop : int (optional)
+        step : int (optional)
+            range of trajectory to access, `start` and `stop` are *inclusive*
+        format : {"afc", "acf", "caf", "fac", "fca", "cfa"} (optional)
             the order/shape of the return data array, corresponding
             to (a)tom, (f)rame, (c)oordinates all six combinations
             of 'a', 'f', 'c' are allowed ie "fac" - return array
             where the shape is (frame, number of atoms,
-            coordinates). 
-        """
+            coordinates).
 
-        # The "format" name is used for compliance with DCD.timeseries
-        # Renaming it to order here for internal consistency in this class
+        Note
+        ----
+        The `format` parameter name is used to mimic the
+        :class:`MDAnalysis.coordinates.DCD.timeseries` interface. It is
+        identical to the `order` parameter for :class:`MemoryReader`. In a
+        future version, `format` will be renamed to `order`.
+        """
+        # Renaming 'format' to 'order' here for internal consistency in this class
         order = format
-        
+
         array = self.get_array()
         if order == self.stored_order:
             pass

--- a/package/MDAnalysis/coordinates/null.py
+++ b/package/MDAnalysis/coordinates/null.py
@@ -29,6 +29,12 @@ any output files. This is similar to writing to ``/dev/null``.
 
 This class exists to allow developers writing generic code and tests.
 
+Classes
+-------
+
+.. autoclass:: NullWriter
+   :members:
+
 """
 from __future__ import absolute_import
 
@@ -41,7 +47,6 @@ class NullWriter(base.WriterBase):
     The NullWriter is the equivalent to ``/dev/null``: it behaves like
     a Writer but ignores all input. It can be used in order to
     suppress output.
-
     """
     format = 'NULL'
     multiframe = True

--- a/package/MDAnalysis/core/__init__.py
+++ b/package/MDAnalysis/core/__init__.py
@@ -21,21 +21,20 @@
 #
 
 
-"""
-Core functions of MDAnalysis
+"""Core functions of MDAnalysis
 ============================
 
-The basic class is an :class:`~MDAnalysis.core.groups.AtomGroup`;
-the whole simulation is called the
-:class:`~MDAnalysis.core.universe.Universe`. Selections are computed
-on an :class:`~MDAnalysis.core.groups.AtomGroup` and return another
+The basic class is an :class:`~MDAnalysis.core.groups.AtomGroup`; the whole
+simulation is called the
+:class:`~MDAnalysis.core.universe.Universe`. Selections are computed on an
+:class:`~MDAnalysis.core.groups.AtomGroup` and return another
 :class:`~MDAnalysis.core.groups.AtomGroup`.
 
 :mod:`~MDAnalysis.Timeseries` are a convenient way to analyse trajectories.
 
 To get started, load the Universe::
 
-  u = Universe(psffilename,dcdfilename)
+  u = Universe(topology_file, trajectory_file)
 
 A simple selection of all water oxygens within 4 A of the protein::
 
@@ -43,9 +42,9 @@ A simple selection of all water oxygens within 4 A of the protein::
   water_shell.n_atoms           # how many waters were selected
   water_shell.total_mass()       # their total mass
 
-:class:`AtomGroup` instances have various methods that allow
-calculation of simple properties. For more complicated analysis,
-obtain the coordinates as a numpy array ::
+:class:`~MDAnalysis.core.groups.AtomGroup` instances have various methods that
+allow calculation of simple properties. For more complicated analysis, obtain
+the coordinates as a numpy array ::
 
   coords = water_shell.positions
 
@@ -84,7 +83,6 @@ Classes
 
 .. autoclass:: Flag
    :members:
-
 
 """
 from __future__ import absolute_import
@@ -189,15 +187,15 @@ class Flag(object):
 
         Parameters
         ----------
-        name: str
+        name : str
             name of the flag, must be a legal python name
         default
             default value
-        mapping: dict
+        mapping : dict
             dict that maps allowed input values to canonical values;
             if ``None`` then no argument checking will be performed and
             all values are directly set.
-        doc: str
+        doc : str
             doc string; may contain string interpolation mappings for::
 
                     %%(name)s        name of the flag

--- a/package/MDAnalysis/core/__init__.py
+++ b/package/MDAnalysis/core/__init__.py
@@ -185,15 +185,13 @@ class Flag(object):
     """A Flag, essentially a variable that knows its default and legal values."""
 
     def __init__(self, name, default, mapping=None, doc=None):
-        """Create a new flag which will be registered with FLags.
-
-          newflag = Flag(name,default,mapping,doc)
+        """Create a new flag which will be registered with Flags.
 
         Parameters
         ----------
         name: str
             name of the flag, must be a legal python name
-         default
+        default
             default value
         mapping: dict
             dict that maps allowed input values to canonical values;
@@ -208,6 +206,14 @@ class Flag(object):
                     %%(mapping)r     mapping
 
             Doc strings are generated dynamically and reflect the current state.
+
+
+        Example
+        -------
+        Create a new flag::
+
+            newflag = Flag(name, default, mapping, doc)
+
         """
         self.name = name
         self.value = default
@@ -266,8 +272,8 @@ _flags = [
         'use_KDTree_routines',
         'fast',
         {True: 'fast', 'fast': 'fast',  # only KDTree if advantageous
-            'always': 'always',  # always even if slower (for testing)
-            False: 'never', 'never': 'never'},  # never, only use (slower) alternatives
+         'always': 'always',  # always even if slower (for testing)
+         False: 'never', 'never': 'never'},  # never, only use (slower) alternatives
         """
            Determines which KDTree routines are used for distance selections
 

--- a/package/MDAnalysis/core/__init__.py
+++ b/package/MDAnalysis/core/__init__.py
@@ -189,16 +189,17 @@ class Flag(object):
 
           newflag = Flag(name,default,mapping,doc)
 
-        :Arguments:
-         *name*
+        Parameters
+        ----------
+        name: str
             name of the flag, must be a legal python name
-         *default*
+         default
             default value
-         *mapping*
+        mapping: dict
             dict that maps allowed input values to canonical values;
             if ``None`` then no argument checking will be performed and
             all values are directly set.
-         *doc*
+        doc: str
             doc string; may contain string interpolation mappings for::
 
                     %%(name)s        name of the flag

--- a/package/MDAnalysis/core/_get_readers.py
+++ b/package/MDAnalysis/core/_get_readers.py
@@ -39,7 +39,7 @@ def get_reader_for(filename, format=None):
     filename
         filename of the input trajectory or coordinate file.  Also can
         handle a few special cases, see notes below.
-    format
+    format : str or :class:`Reader` (optional)
         Define the desired format.  Can be a string to request a given
         Reader.
         If a class is passed, it will be assumed that this is
@@ -47,7 +47,8 @@ def get_reader_for(filename, format=None):
 
     Returns
     -------
-    A Reader object
+    :class:`Reader`
+        A Reader object
 
 
     Raises
@@ -59,13 +60,19 @@ def get_reader_for(filename, format=None):
     Notes
     -----
     There are a number of special cases that can be handled:
-      If `filename` is a numpy array, MemoryReader is returned.
-      If `filename` is an MMTF object, MMTFReader is returned.
-      If `filename` is an iterable of filenames, ChainReader is returned.
 
-    Automatic detection is disabled when an explicit `format` is
-    provided, unless a list of filenames is given, in which case
-    ChainReader is returned and `format` passed to the ChainReader.
+    - If `filename` is a numpy array,
+      :class:`~MDAnalysis.coordinates.memory.MemoryReader` is returned.
+    - If `filename` is an MMTF object,
+      :class:`~MDAnalysis.coordinates.MMTF.MMTFReader` is returned.
+    - If `filename` is an iterable of filenames,
+      :class:`~MDAnalysis.coordinates.chain.ChainReader` is returned.
+
+    Automatic detection is disabled when an explicit `format` is provided,
+    unless a list of filenames is given, in which case
+    :class:`~MDAnalysis.coordinates.chain.ChainReader` is returned and `format`
+    passed to the :class:`~MDAnalysis.coordinates.chain.ChainReader`.
+
     """
     # check if format is actually a Reader
     if inspect.isclass(format):
@@ -105,7 +112,7 @@ def get_writer_for(filename, format=None, multiframe=None):
     """Return an appropriate trajectory or frame writer class for `filename`.
 
     The format is determined by the `format` argument or the extension of
-    `filename`. If `format` is provided, it takes precedence over The
+    `filename`. If `format` is provided, it takes precedence over the
     extension of `filename`.
 
     Parameters
@@ -113,18 +120,20 @@ def get_writer_for(filename, format=None, multiframe=None):
     filename : str or ``None``
         If no *format* is supplied, then the filename for the trajectory is
         examined for its extension and the Writer is chosen accordingly.
-        If ``None`` is provided, the
-        :class:`~MDAnalysis.coordinates.null.NullWriter` is selected.
-    format : str, optional
+        If ``None`` is provided, then
+        :class:`~MDAnalysis.coordinates.null.NullWriter` is selected (and
+        all output is discarded silently).
+    format : str (optional)
         Explicitly set a format.
-    multiframe : bool, optional
+    multiframe : bool (optional)
         ``True``: write multiple frames to the trajectory; ``False``: only
         write a single coordinate frame; ``None``: first try trajectory (multi
         frame writers), then the single frame ones. Default is ``None``.
 
     Returns
     -------
-    A Writer object
+    :class:`Writer`
+        A Writer object
 
     Raises
     ------
@@ -169,7 +178,7 @@ def get_writer_for(filename, format=None, multiframe=None):
         errmsg = "No trajectory or frame writer for format '{0}'"
     elif multiframe is True:
         options = _MULTIFRAME_WRITERS
-        errmsg = "No trajectory writer for format '{0}'" 
+        errmsg = "No trajectory writer for format '{0}'"
     elif multiframe is False:
         options = _SINGLEFRAME_WRITERS
         errmsg = "No single frame writer for format '{0}'"
@@ -190,10 +199,19 @@ def get_parser_for(filename, format=None):
     Automatic detection is disabled when an explicit `format` is
     provided.
 
+    Parameters
+    ----------
+    filename : str or mmtf.MMTFDecoder
+        name of the topology file; if this is an instance of
+        :class:`mmtf.MMTFDecoder` then directly use the MMTF format.
+    format : str
+        description of the file format
+
     Raises
     ------
     ValueError
         If no appropriate parser could be found.
+
     """
     if inspect.isclass(format):
         return format

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -97,6 +97,7 @@ from collections import namedtuple
 import numpy as np
 import functools
 import itertools
+import numbers
 import os
 import warnings
 
@@ -433,7 +434,7 @@ class GroupBase(_MutableBase):
         # because our _ix attribute is a numpy array
         # it can be sliced by all of these already,
         # so just return ourselves sliced by the item
-        if isinstance(item, (int, np.int_)):
+        if isinstance(item, numbers.Integral):
             return self.level.singular(self.ix[item], self.universe)
         else:
             if isinstance(item, list) and item:  # check for empty list

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -39,6 +39,7 @@ import Bio.Alphabet
 from collections import defaultdict
 import functools
 import itertools
+import numbers
 import numpy as np
 
 from . import flags
@@ -607,7 +608,7 @@ class Masses(AtomAttr):
     def get_residues(self, rg):
         resatoms = self.top.tt.residues2atoms_2d(rg._ix)
 
-        if isinstance(rg._ix, int):
+        if isinstance(rg._ix, numbers.Integral):
             # for a single residue
             masses = self.values[resatoms].sum()
         else:
@@ -621,7 +622,7 @@ class Masses(AtomAttr):
     def get_segments(self, sg):
         segatoms = self.top.tt.segments2atoms_2d(sg._ix)
 
-        if isinstance(sg._ix, int):
+        if isinstance(sg._ix, numbers.Integral):
             # for a single segment
             masses = self.values[segatoms].sum()
         else:
@@ -933,7 +934,7 @@ class Charges(AtomAttr):
     def get_residues(self, rg):
         resatoms = self.top.tt.residues2atoms_2d(rg._ix)
 
-        if isinstance(rg._ix, int):
+        if isinstance(rg._ix, numbers.Integral):
             charges = self.values[resatoms].sum()
         else:
             charges = np.empty(len(rg))
@@ -945,7 +946,7 @@ class Charges(AtomAttr):
     def get_segments(self, sg):
         segatoms = self.top.tt.segments2atoms_2d(sg._ix)
 
-        if isinstance(sg._ix, int):
+        if isinstance(sg._ix, numbers.Integral):
             # for a single segment
             charges = self.values[segatoms].sum()
         else:

--- a/package/MDAnalysis/core/topologyobjects.py
+++ b/package/MDAnalysis/core/topologyobjects.py
@@ -30,6 +30,7 @@ The building blocks for MDAnalysis' description of topology
 from __future__ import print_function, absolute_import, division
 
 from six.moves import zip
+import numbers
 import numpy as np
 import functools
 
@@ -749,7 +750,7 @@ class TopologyGroup(object):
            Allows indexing via boolean numpy array
         """
         # Grab a single Item, similar to Atom/AtomGroup relationship
-        if isinstance(item, int):
+        if isinstance(item, numbers.Integral):
             outclass = {'bond': Bond,
                         'angle': Angle,
                         'dihedral': Dihedral,

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -859,7 +859,9 @@ def as_Universe(*args, **kwargs):
          as_Universe(PSF, DCD, **kwargs) --> Universe(PSF, DCD, **kwargs)
          as_Universe(*args, **kwargs) --> Universe(*args, **kwargs)
 
-    :Returns: an instance of :class:`~MDAnalysis.core.groups.Universe`
+    Returns
+    -------
+    :class:`~MDAnalysis.core.groups.Universe`
     """
     if len(args) == 0:
         raise TypeError("as_Universe() takes at least one argument (%d given)" % len(args))
@@ -881,9 +883,12 @@ def Merge(*args):
     -------
     universe : :class:`Universe`
 
-    :Raises: :exc:`ValueError` for too few arguments or if an AtomGroup is
-             empty and :exc:`TypeError` if arguments are not
-             :class:`AtomGroup` instances.
+    Raises
+    ------
+    ValueError
+        Too few arguments or an AtomGroup is empty and
+    TypeError
+        Arguments are not :class:`AtomGroup` instances.
 
     Notes
     -----

--- a/package/MDAnalysis/lib/mdamath.py
+++ b/package/MDAnalysis/lib/mdamath.py
@@ -57,7 +57,7 @@ def norm(v):
 
     Parameters
     ----------
-    v: array_like
+    v : array_like
         1D array of shape (N) for a vector of length N
 
     Returns
@@ -188,21 +188,20 @@ def triclinic_vectors(dimensions):
 
     Parameters
     ----------
-    dimensions: list of floats
+    dimensions : [A, B, C, alpha, beta, gamma]
         list of box lengths and angles (in degrees) such as
-        [A,B,C,alpha,beta,gamma]
+        ``[A,B,C,alpha,beta,gamma]``
 
     Returns
     -------
     numpy.array
-        numpy 3x3 array B, with B[0] = first box vector,
-        B[1] = second vector, B[2] third box vector.
+        numpy 3x3 array B, with ``B[0]`` as first box vector,
+        ``B[1]``as second vector, ``B[2]`` as third box vector.
 
     Notes
     -----
-
-    The first vector is always pointing along the X-axis
-    i.e. parallel to (1,0,0).
+    The first vector is always pointing along the X-axis,
+    i.e., parallel to (1, 0, 0).
 
 
     .. versionchanged:: 0.7.6
@@ -239,15 +238,13 @@ def box_volume(dimensions):
 
     Parameters
     ----------
-    dimensions: list of floats
+    dimensions : [A, B, C, alpha, beta, gamma]
         list of box lengths and angles (in degrees) such as
         [A,B,C,alpha,beta,gamma]
 
     Returns
     -------
-    numpy.array
-        numpy 3x3 array B, with B[0] = first box vector,
-        B[1] = second vector, B[2] third box vector.
+    volume : float
     """
     return np.linalg.det(triclinic_vectors(dimensions))
 
@@ -305,11 +302,11 @@ def make_whole(atomgroup, reference_atom=None):
 
     Parameters
     ----------
-    atomgroup
+    atomgroup : AtomGroup
         The :class:`MDAnalysis.core.groups.AtomGroup` to work with.
         The positions of this are modified in place.  All these atoms
         must belong in the same molecule or fragment.
-    reference_atom: :class:`~MDAnalysis.core.groups.Atom`
+    reference_atom : :class:`~MDAnalysis.core.groups.Atom`
         The atom around which all other atoms will be moved.
         Defaults to atom 0 in the atomgroup.
 
@@ -326,7 +323,7 @@ def make_whole(atomgroup, reference_atom=None):
 
     Note
     ----
-    Only orthogonal boxes are currently supported
+    Only orthogonal boxes are currently supported.
 
     Example
     -------
@@ -437,13 +434,19 @@ def one_to_many_pointers(Ni, Nj, i2j):
 
     Arguments
     ---------
-    Ni, Nj - number of i and j components
-    i2j - the array relating i to parent js
+    Ni : int
+       number of i  components
+    Nj : int
+       number of j components
+    i2j : numpy.ndarray
+       relates i to parent js
 
     Returns
     -------
-    ordered - an ordered list of i indices [size (i,)]
-    ptrs - the start and end index for each j [size (Nj, 2)]
+    ordered : list
+       an ordered list of i indices [size (i,)]
+    ptrs : list
+       the start and end index for each j [size (Nj, 2)]
 
     Example
     -------

--- a/package/MDAnalysis/lib/mdamath.py
+++ b/package/MDAnalysis/lib/mdamath.py
@@ -1,5 +1,5 @@
 # -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
-# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
 #
 # MDAnalysis --- http://www.mdanalysis.org
 # Copyright (c) 2006-2016 The MDAnalysis Development Team and contributors
@@ -186,13 +186,17 @@ def triclinic_vectors(dimensions):
     .. _code by Tsjerk Wassenaar:
        http://www.mail-archive.com/gmx-users@gromacs.org/msg28032.html
 
-    :Arguments:
-      *dimensions*
+    Parameters
+    ----------
+    dimensions: list of floats
         list of box lengths and angles (in degrees) such as
         [A,B,C,alpha,beta,gamma]
 
-    :Returns: numpy 3x3 array B, with B[0] = first box vector,
-              B[1] = second vector, B[2] third box vector.
+    Returns
+    -------
+    numpy.array
+        numpy 3x3 array B, with B[0] = first box vector,
+        B[1] = second vector, B[2] third box vector.
 
     .. note::
 
@@ -231,13 +235,17 @@ def box_volume(dimensions):
     The volume is computed as `det(x1,x2,x2)` where the xi are the
     triclinic box vectors from :func:`triclinic_vectors`.
 
-    :Arguments:
-       *dimensions*
-          list of box lengths and angles (in degrees) such as
-          [A,B,C,alpha,beta,gamma]
+    Parameters
+    ----------
+    dimensions: list of floats
+        list of box lengths and angles (in degrees) such as
+        [A,B,C,alpha,beta,gamma]
 
-    :Returns: numpy 3x3 array B, with B[0] = first box vector,
-              B[1] = second vector, B[2] third box vector.
+    Returns
+    -------
+    numpy.array
+        numpy 3x3 array B, with B[0] = first box vector,
+        B[1] = second vector, B[2] third box vector.
     """
     return np.linalg.det(triclinic_vectors(dimensions))
 
@@ -245,10 +253,12 @@ def box_volume(dimensions):
 def _is_contiguous(atomgroup, atom):
     """Walk through atomgroup, starting with atom.
 
-    :Returns:
-       ``True`` if all of *atomgroup* is accessible through walking
+    Returns
+    -------
+    bool
+        ``True`` if all of *atomgroup* is accessible through walking
         along bonds.
-       ``False`` otherwise.
+        ``False`` otherwise.
     """
     seen = set([atom])
     walked = set()
@@ -273,29 +283,28 @@ def _is_contiguous(atomgroup, atom):
 def make_whole(atomgroup, reference_atom=None):
     """Move all atoms in a single molecule so that bonds don't split over images
 
-    :Arguments:
-      *atomgroup*
+    Atoms are modified in place.
+
+    Parameters
+    ----------
+    atomgroup
         The :class:`MDAnalysis.core.groups.AtomGroup` to work with.
         The positions of this are modified in place.  All these atoms
         must belong in the same molecule or fragment.
-
-    :Keywords:
-      *reference_atom*
+    reference_atom: :class:`~MDAnalysis.core.groups.Atom`
         The atom around which all other atoms will be moved.
         Defaults to atom 0 in the atomgroup.
 
-    :Returns:
-       ``None``.  Atom positions are modified in place
+    Raises
+    ------
+    NoDataError
+        There are no bonds present.
+        (See :func:`~MDAnalysis.topology.core.guess_bonds`)
 
-    :Raises:
-      `NoDataError`
-         if there are no bonds present.
-         (See :func:`~MDAnalysis.topology.core.guess_bonds`)
-
-      `ValueError`
-         if the algorithm fails to work.  This is usually
-         caused by the atomgroup not being a single fragment.
-         (ie the molecule can't be traversed by following bonds)
+    ValueError
+        The algorithm fails to work.  This is usually
+        caused by the atomgroup not being a single fragment.
+        (ie the molecule can't be traversed by following bonds)
 
     This function is most useful when atoms have been packed into the primary
     unit cell, causing breaks mid molecule, with the molecule then appearing
@@ -312,25 +321,26 @@ def make_whole(atomgroup, reference_atom=None):
        |           |     |           |
        +-----------+     +-----------+
 
-    Usage::
+    Example
+    -------
 
-      from MDAnalysis.util.mdamath import make_whole
+        from MDAnalysis.util.mdamath import make_whole
 
-      # This algorithm requires bonds, these can be guessed!
-      u = mda.Universe(......, guess_bonds=True)
+        # This algorithm requires bonds, these can be guessed!
+        u = mda.Universe(......, guess_bonds=True)
 
-      # MDAnalysis can split molecules into their fragments
-      # based on bonding information.
-      # Note that this function will only handle a single fragment
-      # at a time, necessitating a loop.
-      for frag in u.fragments:
+        # MDAnalysis can split molecules into their fragments
+        # based on bonding information.
+        # Note that this function will only handle a single fragment
+        # at a time, necessitating a loop.
+        for frag in u.fragments:
           make_whole(frag)
 
     Alternatively, to keep a single atom in place as the anchor::
 
-      # This will mean that atomgroup[10] will NOT get moved,
-      # and all other atoms will move (if necessary).
-      make_whole(atomgroup, reference_atom=atomgroup[10])
+        # This will mean that atomgroup[10] will NOT get moved,
+        # and all other atoms will move (if necessary).
+        make_whole(atomgroup, reference_atom=atomgroup[10])
 
     .. Note::
 
@@ -437,7 +447,7 @@ def one_to_many_pointers(Ni, Nj, i2j):
 
     # Returns an array of the atom indices that are in resid 7
     atoms = ordered[ptrs[7,0]:ptrs[7,1]]
-    
+
     """
     ordered = i2j.argsort()
     sorted_idx = i2j[ordered]

--- a/package/MDAnalysis/lib/mdamath.py
+++ b/package/MDAnalysis/lib/mdamath.py
@@ -198,10 +198,12 @@ def triclinic_vectors(dimensions):
         numpy 3x3 array B, with B[0] = first box vector,
         B[1] = second vector, B[2] third box vector.
 
-    .. note::
+    Notes
+    -----
 
-       The first vector is always pointing along the X-axis
-       i.e. parallel to (1,0,0).
+    The first vector is always pointing along the X-axis
+    i.e. parallel to (1,0,0).
+
 
     .. versionchanged:: 0.7.6
        Null-vectors are returned for non-periodic (or missing) unit cell.
@@ -445,11 +447,13 @@ def one_to_many_pointers(Ni, Nj, i2j):
 
     Example
     -------
-    # Residx - the resid of each Atom
-    ordered, ptrs = one_to_many_pointers(Natoms, Nres, Residx)
+    .. code:: python
 
-    # Returns an array of the atom indices that are in resid 7
-    atoms = ordered[ptrs[7,0]:ptrs[7,1]]
+        # Residx - the resid of each Atom
+        ordered, ptrs = one_to_many_pointers(Natoms, Nres, Residx)
+
+        # Returns an array of the atom indices that are in resid 7
+        atoms = ordered[ptrs[7,0]:ptrs[7,1]]
 
     """
     ordered = i2j.argsort()

--- a/package/MDAnalysis/lib/mdamath.py
+++ b/package/MDAnalysis/lib/mdamath.py
@@ -285,6 +285,22 @@ def make_whole(atomgroup, reference_atom=None):
 
     Atoms are modified in place.
 
+    This function is most useful when atoms have been packed into the primary
+    unit cell, causing breaks mid molecule, with the molecule then appearing
+    on either side of the unit cell. This is problematic for operations
+    such as calculating the center of mass of the molecule. ::
+
+       +-----------+     +-----------+
+       |           |     |           |
+       | 6       3 |     |         3 | 6
+       | !       ! |     |         ! | !
+       |-5-8   1-2-| ->  |       1-2-|-5-8
+       | !       ! |     |         ! | !
+       | 7       4 |     |         4 | 7
+       |           |     |           |
+       +-----------+     +-----------+
+
+
     Parameters
     ----------
     atomgroup
@@ -306,23 +322,13 @@ def make_whole(atomgroup, reference_atom=None):
         caused by the atomgroup not being a single fragment.
         (ie the molecule can't be traversed by following bonds)
 
-    This function is most useful when atoms have been packed into the primary
-    unit cell, causing breaks mid molecule, with the molecule then appearing
-    on either side of the unit cell. This is problematic for operations
-    such as calculating the center of mass of the molecule. ::
-
-       +-----------+     +-----------+
-       |           |     |           |
-       | 6       3 |     |         3 | 6
-       | !       ! |     |         ! | !
-       |-5-8   1-2-| ->  |       1-2-|-5-8
-       | !       ! |     |         ! | !
-       | 7       4 |     |         4 | 7
-       |           |     |           |
-       +-----------+     +-----------+
+    Note
+    ----
+    Only orthogonal boxes are currently supported
 
     Example
     -------
+    Make fragments whole::
 
         from MDAnalysis.util.mdamath import make_whole
 
@@ -342,9 +348,6 @@ def make_whole(atomgroup, reference_atom=None):
         # and all other atoms will move (if necessary).
         make_whole(atomgroup, reference_atom=atomgroup[10])
 
-    .. Note::
-
-       Only orthogonal boxes are currently supported
 
     .. versionadded:: 0.11.0
     """

--- a/package/MDAnalysis/lib/qcprot.pyx
+++ b/package/MDAnalysis/lib/qcprot.pyx
@@ -93,9 +93,10 @@ matrix [Liu2010]_.
 A full description of the method, along with the original C implementation can
 be found at http://theobald.brandeis.edu/qcp/
 
-.. SeeAlso:: The :func:`CalcRMSDRotationalMatrix` function is used in
-             :mod:`MDAnalysis.analysis.align` and
-             :mod:`MDAnalysis.analysis.rmsd`.
+See Also
+--------
+The :func:`CalcRMSDRotationalMatrix` function is used in
+:mod:`MDAnalysis.analysis.align` and :mod:`MDAnalysis.analysis.rmsd`.
 
 .. versionchanged:: 0.16.0
    Call signatures were changed to directly interface with MDAnalysis

--- a/package/MDAnalysis/lib/qcprot.pyx
+++ b/package/MDAnalysis/lib/qcprot.pyx
@@ -95,8 +95,12 @@ be found at http://theobald.brandeis.edu/qcp/
 
 See Also
 --------
-The :func:`CalcRMSDRotationalMatrix` function is used in
-:mod:`MDAnalysis.analysis.align` and :mod:`MDAnalysis.analysis.rmsd`.
+MDAnalysis.analysis.align:
+    Align structures using :func:`CalcRMSDRotationalMatrix`
+MDAnalysis.analysis.rms.rmsd:
+    Calculate the RMSD between two structures using
+    :func:`CalcRMSDRotationalMatrix`
+
 
 .. versionchanged:: 0.16.0
    Call signatures were changed to directly interface with MDAnalysis

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -26,6 +26,10 @@ Helper functions --- :mod:`MDAnalysis.lib.util`
 
 Small helper functions that don't fit anywhere else.
 
+.. versionchanged:: 0.11.0
+   Moved mathematical functions into lib.mdamath
+
+
 Files and directories
 ---------------------
 
@@ -147,8 +151,6 @@ Class decorators
    close it.
 
 
-.. versionchanged:: 0.11.0
-   Moved mathematical functions into lib.mdamath
 """
 from __future__ import division, absolute_import
 import six
@@ -192,13 +194,13 @@ def filename(name, ext=None, keep=False):
 
     Parameters
     ----------
-    name: str or :class:`NamedStream`
+    name : str or NamedStream
         filename; extension is replaced unless ``keep=True``;
         `name` can also be a :class:`NamedStream` (and its
         :attr:`NamedStream.name` will be changed accordingly)
-    ext: None or str
+    ext : None or str
         extension to use in the new filename
-    keep: bool
+    keep : bool
         - ``False``: replace existing extension with `ext`;
         - ``True``: keep old extension if one existed
 
@@ -223,10 +225,10 @@ def filename(name, ext=None, keep=False):
 def openany(datasource, mode='r', reset=True):
     """Context manager for :func:`anyopen`.
 
-    Open the *datasource* and close it when the context of the :keyword:`with`
+    Open the `datasource` and close it when the context of the :keyword:`with`
     statement exits.
 
-    *datasource* can be a filename or a stream (see :func:`isstream`). A stream
+    `datasource` can be a filename or a stream (see :func:`isstream`). A stream
     is reset to its start if possible (via :meth:`~io.IOBase.seek` or
     :meth:`~cString.StringIO.reset`).
 
@@ -238,9 +240,9 @@ def openany(datasource, mode='r', reset=True):
     Parameters
     ----------
     datasource : a file or a stream
-    mode : str
-        `r` or `w`
-    reset : bool
+    mode : {'r', 'w'} (optional)
+        open in r(ead) or w(rite) mode
+    reset : bool (optional)
         try to read (`mode` 'r') the stream from the start [``True``]
 
     Examples
@@ -292,7 +294,7 @@ else:
 def anyopen(datasource, mode='r', reset=True):
     """Open datasource (gzipped, bzipped, uncompressed) and return a stream.
 
-    *datasource* can be a filename or a stream (see :func:`isstream`). By
+    `datasource` can be a filename or a stream (see :func:`isstream`). By
     default, a stream is reset to its start if possible (via
     :meth:`~io.IOBase.seek` or :meth:`~cString.StringIO.reset`).
 
@@ -304,11 +306,12 @@ def anyopen(datasource, mode='r', reset=True):
     datasource
         a file (from :class:`file` or :func:`open`) or a stream (e.g. from
         :func:`urllib2.urlopen` or :class:`cStringIO.StringIO`)
-    mode: str
-        'r' or 'w' or 'a', more complicated modes ('r+', 'w+' are not supported
-        because only the first letter is looked at)
-    reset: bool
-        try to read (*mode* 'r') the stream from the start
+    mode: {'r', 'w', 'a'} (optional)
+        Open in r(ead), w(rite) or a(ppen) mode. More complicated
+        modes ('r+', 'w+', ...) are not supported; only the first letter of
+        `mode` is used and thus any additional modifiers are silently ignored.
+    reset: bool (optional)
+        try to read (`mode` 'r') the stream from the start
 
     Returns
     -------
@@ -323,6 +326,7 @@ def anyopen(datasource, mode='r', reset=True):
     .. versionchanged:: 0.9.0
        Only returns the ``stream`` and tries to set ``stream.name = filename`` instead of the previous
        behavior to return a tuple ``(stream, filename)``.
+
     """
     handlers = {'bz2': bz2_open, 'gz': gzip.open, '': open}
 
@@ -416,18 +420,21 @@ def greedy_splitext(p):
 
     Arguments
     ---------
-    p : path, string
+    p : str
+       path
 
     Returns
     -------
-    Tuple ``(root, extension)`` where ``root`` is the full path and
-    filename with all extensions removed whereas ``extension`` is the
-    string of all extensions.
+    (root, extension) : tuple
+          where ``root`` is the full path and filename with all
+          extensions removed whereas ``extension`` is the string of
+          all extensions.
 
     Example
     -------
     >>> greedy_splitext("/home/joe/protein.pdb.bz2")
     ('/home/joe/protein', '.pdb.bz2')
+
     """
     path, root = os.path.split(p)
     extension = ''
@@ -445,7 +452,7 @@ def hasmethod(obj, m):
 
 
 def isstream(obj):
-    """Detect if *obj* is a stream.
+    """Detect if `obj` is a stream.
 
     We consider anything a stream that has the methods
 
@@ -456,19 +463,19 @@ def isstream(obj):
     - ``read()``, ``readline()``, ``readlines()``
     - ``write()``, ``writeline()``, ``writelines()``
 
-    See Also
-    --------
-    :mod:`io`
-
-
     Parameters
     ----------
-    obj: stream or string
+    obj : stream or str
 
     Returns
     -------
     bool
-        ``True`` is *obj* is a stream, ``False`` otherwise
+        ``True`` if `obj` is a stream, ``False`` otherwise
+
+    See Also
+    --------
+    :mod:`io`
+
 
     .. versionadded:: 0.9.0
     """
@@ -489,9 +496,20 @@ def isstream(obj):
 
 
 def which(program):
-    """Determine full path of executable *program* on :envvar:`PATH`.
+    """Determine full path of executable `program` on :envvar:`PATH`.
 
     (Jay at http://stackoverflow.com/questions/377017/test-if-executable-exists-in-python)
+
+    Parameters
+    ----------
+    programe : str
+       name of the executable
+
+    Returns
+    -------
+    path : str or None
+       absolute path to the executable if it can be found, else ``None``
+
     """
 
     def is_exe(fpath):
@@ -514,7 +532,7 @@ def which(program):
 class NamedStream(io.IOBase):
     """Stream that also provides a (fake) name.
 
-    By wrapping a stream *stream* in this class, it can be passed to
+    By wrapping a stream `stream` in this class, it can be passed to
     code that uses inspection of the filename to make decisions. For
     instance. :func:`os.path.split` will work correctly on a
     :class:`NamedStream`.
@@ -528,8 +546,8 @@ class NamedStream(io.IOBase):
     and :func:`os.path.expanduser`, which will return the :class:`NamedStream`
     itself instead of a string if no substitutions were made.
 
-    .. rubric:: Example
-
+    Example
+    -------
     Wrap a :func:`cStringIO.StringIO` instance to write to::
 
       import cStringIO
@@ -552,26 +570,26 @@ class NamedStream(io.IOBase):
          # ...
       print f.closed     # --> True
 
-    .. Note::
+    Note
+    ----
+    This class uses its own :meth:`__getitem__` method so if `stream`
+    implements :meth:`stream.__getitem__` then that will be masked and
+    this class should not be used.
 
-       This class uses its own :meth:`__getitem__` method so if *stream*
-       implements :meth:`stream.__getitem__` then that will be masked and this
-       class should not be used.
-
-    .. Warning::
-
-       By default, :meth:`NamedStream.close` will **not close the
-       stream** but instead :meth:`~NamedStream.reset` it to the
-       beginning. [#NamedStreamClose]_ Provide the ``force=True`` keyword
-       to :meth:`NamedStream.close` to always close the stream.
+    Warning
+    -------
+    By default, :meth:`NamedStream.close` will **not close the
+    stream** but instead :meth:`~NamedStream.reset` it to the
+    beginning. [#NamedStreamClose]_ Provide the ``force=True`` keyword
+    to :meth:`NamedStream.close` to always close the stream.
 
     """
 
     def __init__(self, stream, filename, reset=True, close=False):
-        """Initialize the :class:`NamedStream` from a *stream* and give it a *name*.
+        """Initialize the :class:`NamedStream` from a `stream` and give it a `name`.
 
         The constructor attempts to rewind the stream to the beginning unless
-        the keyword *reset* is set to ``False``. If rewinding fails, a
+        the keyword `reset` is set to ``False``. If rewinding fails, a
         :class:`MDAnalysis.StreamWarning` is issued.
 
         Parameters
@@ -580,10 +598,10 @@ class NamedStream(io.IOBase):
             an open stream (e.g. :class:`file` or :func:`cStringIO.StringIO`)
         filename : str
             the filename that should be associated with the stream
-        reset : bool
+        reset : bool (optional)
             start the stream from the beginning (either :meth:`reset` or :meth:`seek`)
             when the class instance is constructed
-        close : bool
+        close : bool (optional)
             close the stream when a :keyword:`with` block exits or when
             :meth:`close` is called; note that the default is **not to close
             the stream**
@@ -677,22 +695,28 @@ class NamedStream(io.IOBase):
             return super(NamedStream, self).closed
 
     def seek(self, offset, whence=os.SEEK_SET):
-        """Change the stream position to the given byte *offset* .
+        """Change the stream position to the given byte `offset` .
 
-        *offset* is interpreted relative to the position indicated by
-        *whence*. Values for *whence* are:
+        Parameters
+        ----------
+        offset : int
+             `offset` is interpreted relative to the position
+             indicated by `whence`.
+        whence : {0, 1, 2} (optional)
+             Values for `whence` are:
 
-        - :data:`io.SEEK_SET` or 0 – start of the stream (the default); *offset*
-          should be zero or positive
-        - :data:`io.SEEK_CUR` or 1 – current stream position; *offset* may be
-          negative
-        - :data:`io.SEEK_END` or 2 – end of the stream; *offset* is usually
-          negative
+               - :data:`io.SEEK_SET` or 0 – start of the stream (the default); `offset`
+                 should be zero or positive
+               - :data:`io.SEEK_CUR` or 1 – current stream position; `offset` may be
+                 negative
+               - :data:`io.SEEK_END` or 2 – end of the stream; `offset` is usually
+                 negative
 
         Returns
         -------
         int
-            the new absolute position.
+            the new absolute position in bytes.
+
         """
         try:
             return self.stream.seek(offset, whence)  # file.seek: no kw
@@ -707,10 +731,14 @@ class NamedStream(io.IOBase):
             return super(NamedStream, self).tell()
 
     def truncate(self, *size):
-        """Truncate the stream's size to *size*.
+        """Truncate the stream's size to `size`.
 
-        The size defaults to the current position (if no *size* argument is
-        supplied). The current file position is not changed.
+        Parameters
+        ----------
+        size : int (optional)
+             The `size` defaults to the current position (if no `size` argument
+             is supplied). The current file position is not changed.
+
         """
         try:
             return self.stream.truncate(*size)
@@ -720,7 +748,9 @@ class NamedStream(io.IOBase):
     def seekable(self):
         """Return ``True`` if the stream supports random access.
 
-        If ``False``, :meth:`seek`, :meth:`tell` and :meth:`truncate` will raise :exc:`IOError`.
+        If ``False``, :meth:`seek`, :meth:`tell` and :meth:`truncate` will
+        raise :exc:`IOError`.
+
         """
         try:
             return self.stream.seekable()
@@ -809,9 +839,9 @@ class NamedStream(io.IOBase):
 
 
 def realpath(*args):
-    """Join all args and return the real path, rooted at /.
+    """Join all args and return the real path, rooted at ``/``.
 
-    Expands '~', '~user', and environment variables such as :envvar`$HOME`.
+    Expands '~', '~user', and environment variables such as :envvar:`$HOME`.
 
     Returns ``None`` if any of the args is ``None``.
     """
@@ -821,12 +851,16 @@ def realpath(*args):
 
 
 def get_ext(filename):
-    """Return the lower-cased extension of *filename* without a leading dot.
+    """Return the lower-cased extension of `filename` without a leading dot.
+
+    Parameters
+    ----------
+    filename : str
 
     Returns
     -------
-    root: str
-    ext: str
+    root : str
+    ext : str
     """
     root, ext = os.path.splitext(filename)
     if ext.startswith(os.extsep):
@@ -835,7 +869,27 @@ def get_ext(filename):
 
 
 def check_compressed_format(root, ext):
-    """Check if this is a supported gzipped/bzip2ed file format and return UPPERCASE format."""
+    """Check if this is a supported gzipped/bzip2ed file format and return UPPERCASE format.
+
+    Parameters
+    ----------
+    root : str
+       path of a file, without extension `ext`
+    ext : str
+       extension (currently only "bz2" and "gz" are recognized as compressed formats)
+
+    Returns
+    -------
+    format : str
+       upper case format extension *if* the compression can be handled by
+       :func:`openany`
+
+    See Also
+    --------
+    openany : function that is used to open and decompress formats on the fly; only
+              compression formats implemented in :func:`openany` are recognized
+
+    """
     # XYZReader&others are setup to handle both plain and compressed (bzip2, gz) files
     # ..so if the first file extension is bzip2 or gz, look at the one to the left of it
     if ext.lower() in ("bz2", "gz"):
@@ -849,7 +903,21 @@ def check_compressed_format(root, ext):
 
 
 def format_from_filename_extension(filename):
-    """Guess file format from the file extension"""
+    """Guess file format from the file extension.
+
+    Parameters
+    ----------
+    filename : str
+
+    Returns
+    -------
+    format : str
+
+    Raises
+    ------
+    TypeError
+        if the file format cannot be determined
+    """
     try:
         root, ext = get_ext(filename)
     except:
@@ -862,20 +930,31 @@ def format_from_filename_extension(filename):
 
 
 def guess_format(filename):
-    """Return the format of *filename*
+    """Return the format of `filename`
 
-    The current heuristic simply looks at the filename extension
-    and can work around compressed format extensions
+    The current heuristic simply looks at the filename extension and can work
+    around compressed format extensions.
 
-    *filename* can also be a stream, in which case
-    *filename.name* is looked at for a hint to the format
+    Parameters
+    ----------
+    filename : str or stream
+        path to the file or a stream, in which case ``filename.name`` is looked
+        at for a hint to the format
+
+    Returns
+    -------
+    format : str
+        format specifier (upper case)
 
     Raises
     ------
     ValueError
+        if the heuristics are insufficient to guess a supported format
+
 
     .. versionadded:: 0.11.0
        Moved into lib.util
+
     """
     if isstream(filename):
         # perhaps StringIO or open stream
@@ -897,7 +976,7 @@ def guess_format(filename):
 
 
 def iterable(obj):
-    """Returns ``True`` if *obj* can be iterated over and is *not* a  string
+    """Returns ``True`` if `obj` can be iterated over and is *not* a  string
     nor a :class:`NamedStream`"""
     if isinstance(obj, (six.string_types, NamedStream)):
         return False  # avoid iterating over characters of a string
@@ -912,7 +991,16 @@ def iterable(obj):
 
 
 def asiterable(obj):
-    """Returns obj so that it can be iterated over; a string is *not* treated as iterable"""
+    """Returns `obj` so that it can be iterated over.
+
+    A string is *not* detected as and iterable and is wrapped into a :class:`list`
+    with a single element.
+
+    See Also
+    --------
+    iterable
+
+    """
     if not iterable(obj):
         obj = [obj]
     return obj
@@ -926,7 +1014,7 @@ _FORTRAN_format_pattern = re.compile(FORTRAN_format_regex)
 
 
 def strip(s):
-    """Convert *s* to a string and return it white-space stripped."""
+    """Convert `s` to a string and return it white-space stripped."""
     return str(s).strip()
 
 
@@ -942,11 +1030,11 @@ class FixedcolumnEntry(object):
         """
         Parameters
         ----------
-        start: int
+        start : int
             first column
-        stop: int
+        stop : int
             last column + 1
-        typespecifier: str
+        typespecifier : str
             'I': int, 'F': float, 'E': float, 'A': stripped string
 
         The start/stop arguments follow standard Python convention in that
@@ -958,7 +1046,7 @@ class FixedcolumnEntry(object):
         self.convertor = self.convertors[typespecifier]
 
     def read(self, line):
-        """Read the entry from *line* and convert to appropriate type."""
+        """Read the entry from `line` and convert to appropriate type."""
         try:
             return self.convertor(line[self.start:self.stop])
         except ValueError:
@@ -975,13 +1063,8 @@ class FixedcolumnEntry(object):
 class FORTRANReader(object):
     """FORTRANReader provides a method to parse FORTRAN formatted lines in a file.
 
-    Usage::
-
-       atomformat = FORTRANReader('2I10,2X,A8,2X,A8,3F20.10,2X,A8,2X,A8,F20.10')
-       for line in open('coordinates.crd'):
-           serial,TotRes,resName,name,x,y,z,chainID,resSeq,tempFactor = atomformat.read(line)
-
-    Fortran format edit descriptors; see `Fortran Formats`_ for the syntax.
+    The contents of lines in a file can be parsed according to FORTRAN format
+    edit descriptors (see `Fortran Formats`_ for the syntax).
 
     Only simple one-character specifiers supported here: *I F E A X* (see
     :data:`FORTRAN_format_regex`).
@@ -991,12 +1074,28 @@ class FORTRANReader(object):
     .. _`Fortran Formats`: http://www.webcitation.org/5xbaWMV2x
     .. _`Fortran Formats (URL)`:
        http://www.cs.mtu.edu/~shene/COURSES/cs201/NOTES/chap05/format.html
+
     """
 
     def __init__(self, fmt):
         """Set up the reader with the FORTRAN format string.
 
-        The string *fmt* should look like '2I10,2X,A8,2X,A8,3F20.10,2X,A8,2X,A8,F20.10'.
+        The string `fmt` should look like '2I10,2X,A8,2X,A8,3F20.10,2X,A8,2X,A8,F20.10'.
+
+        Parameters
+        ----------
+        fmt : str
+           FORTRAN format edit descriptor for a line as described in `Fortran
+           Formats`_
+
+        Example
+        -------
+        Parsing of a standard CRD file::
+
+           atomformat = FORTRANReader('2I10,2X,A8,2X,A8,3F20.10,2X,A8,2X,A8,F20.10')
+           for line in open('coordinates.crd'):
+               serial,TotRes,resName,name,x,y,z,chainID,resSeq,tempFactor = atomformat.read(line)
+
         """
         self.fmt = fmt.split(',')
         descriptors = [self.parse_FORTRAN_format(descriptor) for descriptor in self.fmt]
@@ -1012,9 +1111,13 @@ class FORTRANReader(object):
                 start += d['totallength']
 
     def read(self, line):
-        """Parse *line* according to the format string and return list of values.
+        """Parse `line` according to the format string and return list of values.
 
         Values are converted to Python types according to the format specifier.
+
+        Parameters
+        ----------
+        line : str
 
         Returns
         -------
@@ -1047,7 +1150,11 @@ class FORTRANReader(object):
     def parse_FORTRAN_format(self, edit_descriptor):
         """Parse the descriptor.
 
-          parse_FORTRAN_format(edit_descriptor) --> dict
+
+        Parameters
+        ----------
+        edit_descriptor : str
+            FORTRAN format edit descriptor
 
         Returns
         -------
@@ -1057,13 +1164,13 @@ class FORTRANReader(object):
         Raises
         ------
         ValueError
-            The *edit_descriptor* is not recognized and cannot be parsed
+            The `edit_descriptor` is not recognized and cannot be parsed
 
-        .. Note::
+        Note
+        ----
+        Specifiers: *L ES EN T TL TR / r S SP SS BN BZ* are *not* supported,
+        and neither are the scientific notation *Ew.dEe* forms.
 
-           Specifiers: *L ES EN T TL TR / r S SP SS BN BZ* are *not*
-           supported, and neither are the scientific notation *Ew.dEe*
-           forms.
         """
 
         m = _FORTRAN_format_pattern.match(edit_descriptor.upper())
@@ -1098,11 +1205,38 @@ class FORTRANReader(object):
 
 
 def fixedwidth_bins(delta, xmin, xmax):
-    """Return bins of width delta that cover xmin,xmax (or a larger range).
+    """Return bins of width `delta` that cover `xmin`, `xmax` (or a larger range).
 
-    dict = fixedwidth_bins(delta,xmin,xmax)
+    The bin parameters are computed such that the bin size `delta` is
+    guaranteed. In order to achieve this, the range `[xmin, xmax]` can be
+    increased.
 
-    The dict contains 'Nbins', 'delta', 'min', and 'max'.
+    Bins can be calculated for 1D data (then all parameters are simple floats)
+    or nD data (then parameters are supplied as arrays, with each entry
+    correpsonding to one dimension).
+
+    Parameters
+    ----------
+    delta : float or array_like
+        desired spacing of the bins
+    xmin : float or array_like
+        lower bound (left boundary of first bin)
+    xmax : float or array_like
+        upper bound (right boundary of last bin)
+
+    Returns
+    -------
+    dict
+        The dict contains 'Nbins', 'delta', 'min', and 'max'; these are either
+        floats or arrays, depending on the input.
+
+    Example
+    -------
+    Use with :func:`numpy.histogram`::
+
+       B = fixedwidth_bins(delta, xmin, xmax)
+       h, e = np.histogram(data, bins=B['Nbins'], range=(B['min'], B['max']))
+
     """
     if not np.all(xmin < xmax):
         raise ValueError('Boundaries are not sane: should be xmin < xmax.')
@@ -1151,6 +1285,21 @@ inverse_aa_codes.update(alternative_inverse_aa_codes)
 def convert_aa_code(x):
     """Converts between 3-letter and 1-letter amino acid codes.
 
+    Parameters
+    ----------
+    x : str
+        1-letter or 3-letter amino acid code
+
+    Returns
+    -------
+    str
+        3-letter or 1-letter amino acid code
+
+    Raises
+    ------
+    ValueError
+        No conversion can be made; the amino acid code is not defined.
+
     Note
     ----
     Data are defined in :data:`amino_acid_codes` and :data:`inverse_aa_codes`.
@@ -1187,13 +1336,6 @@ RESIDUE = re.compile("""
 def parse_residue(residue):
     """Process residue string.
 
-    Examples:
-     - "LYS300:HZ1" --> ("LYS", 300, "HZ1")
-     - "K300:HZ1" --> ("LYS", 300, "HZ1")
-     - "K300" --> ("LYS", 300, None)
-     - "4GB300:H6O" --> ("4GB", 300, "H6O")
-     - "4GB300" --> ("4GB", 300, None)
-
     Parameters
     ----------
     residue: str
@@ -1208,6 +1350,15 @@ def parse_residue(residue):
     tuple
         `(3-letter aa string, resid, atomname)`; known 1-letter
         aa codes are converted to 3-letter codes
+
+    Examples
+    --------
+     - "LYS300:HZ1" --> ("LYS", 300, "HZ1")
+     - "K300:HZ1" --> ("LYS", 300, "HZ1")
+     - "K300" --> ("LYS", 300, None)
+     - "4GB300:H6O" --> ("4GB", 300, "H6O")
+     - "4GB300" --> ("4GB", 300, None)
+
     """
 
     # XXX: use _translate_residue() ....
@@ -1225,7 +1376,7 @@ def parse_residue(residue):
 
 
 def conv_float(s):
-    """Convert an object *s* to float if possible.
+    """Convert an object `s` to float if possible.
 
     Function to be passed into :func:`map` or a list comprehension. If
     the argument can be interpreted as a float it is converted,
@@ -1238,11 +1389,14 @@ def conv_float(s):
 
 
 def cached(key):
-    """Cache a property within a class
+    """Cache a property within a class.
 
     Requires the Class to have a cache dict called ``_cache``.
 
-    Usage::
+    Example
+    -------
+    How to add a cache for a variable to a class by using the `@cached`
+    decorator::
 
        class A(object):
            def__init__(self):
@@ -1256,7 +1410,9 @@ def cached(key):
                # _cache with the key: 'keyname'
                size = 10.0
 
+
     .. versionadded:: 0.9.0
+
     """
 
     def cached_lookup(func):
@@ -1280,11 +1436,15 @@ def unique_rows(arr, return_index=False):
     ---------
     arr : np.array of shape (n1, m)
     return_index : bool, optional
-      If True, returns indices of arr that formed answer (see np.unique)
+      If ``True``, returns indices of array that formed answer (see
+      :func:`numpy.unique`)
 
     Returns
     -------
-    unique_rows (n2, m)
+    unique_rows : numpy.array
+         shape (n2, m)
+    r_idx : numpy.array (optional)
+          index (if `return_index` was ``True``)
 
     Examples
     --------
@@ -1293,6 +1453,11 @@ def unique_rows(arr, return_index=False):
     >>> b = unique_rows(a)
     >>> b
     array([[0, 1], [1, 2], [2, 3]])
+
+    See Also
+    --------
+    numpy.unique
+
     """
     # From here, but adapted to handle any size rows
     # https://mail.scipy.org/pipermail/scipy-user/2011-December/031200.html
@@ -1329,15 +1494,15 @@ def blocks_of(a, n, m):
     m : int
         size of block in second dimension
 
-
     Returns
     -------
-      (nblocks, n, m) view of the original array.
-      Where nblocks is the number of times the miniblock fits in the original.
+    (nblocks, n, m) : tuple
+          view of the original array, where nblocks is the number of times the
+          miniblock fits in the original.
 
     Raises
     ------
-      ValueError
+    ValueError
         If the supplied `n` and `m` don't divide `a` into an integer number
         of blocks.
 
@@ -1354,13 +1519,15 @@ def blocks_of(a, n, m):
 
     Notes
     -----
-      n, m must divide a into an identical integer number of blocks.
+    n, m must divide a into an identical integer number of blocks.
 
-      Uses strides so probably requires that the array is C contiguous
+    Uses strides so probably requires that the array is C contiguous.
 
-      Returns a view, so editing this modifies the original array
+    Returns a view, so editing this modifies the original array.
+
 
     .. versionadded:: 0.12.0
+
     """
     # based on:
     # http://stackoverflow.com/a/10862636

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -190,16 +190,17 @@ except NameError:
 def filename(name, ext=None, keep=False):
     """Return a new name that has suffix attached; replaces other extensions.
 
-    :Arguments:
-      *name*
-           filename; extension is replaced unless keep=True;
-           *name* can also be a :class:`NamedStream` (and its
-           :attr:`NamedStream.name` will be changed accordingly)
-      *ext*
-           extension
-      *keep*
-           - ``False``: replace existing extension with *ext*;
-           - ``True``: keep old extension if one existed
+    Parameters
+    ----------
+    name: str or :class:`NamedStream`
+        filename; extension is replaced unless keep=True;
+        *name* can also be a :class:`NamedStream` (and its
+        :attr:`NamedStream.name` will be changed accordingly)
+    ext: None or str
+        extension to use in the new filename
+    keep: bool
+        - ``False``: replace existing extension with *ext*;
+        - ``True``: keep old extension if one existed
 
     .. versionchanged:: 0.9.0
        Also permits :class:`NamedStream` to pass through.
@@ -239,7 +240,7 @@ def openany(datasource, mode='r', reset=True):
     mode : str
         `r` or `w`
     reset : bool
-        try to read (*mode* 'r') the stream from the start [``True``]
+        try to read (`mode` 'r') the stream from the start [``True``]
 
     Examples
     --------
@@ -253,7 +254,7 @@ def openany(datasource, mode='r', reset=True):
     Open a URL and read it::
 
        import urllib2
-       with openany(urllib2.urlopen("http://www.MDAnalysis.org/")) as html:
+       with openany(urllib2.urlopen("http://www.mdanalysis.org/")) as html:
            print(html.read())
 
 
@@ -297,17 +298,20 @@ def anyopen(datasource, mode='r', reset=True):
     If possible, the attribute ``stream.name`` is set to the filename or
     "<stream>" if no filename could be associated with the *datasource*.
 
-    :Arguments:
-     *datasource*
+    Parameters
+    ----------
+    datasource
         a file (from :class:`file` or :func:`open`) or a stream (e.g. from
         :func:`urllib2.urlopen` or :class:`cStringIO.StringIO`)
-     *mode*
-        'r' or 'w' or 'a', more complicated modes ('r+', 'w+' are not supported because
-        only the first letter is looked at) [``'r'``]
-     *reset*
-        try to read (*mode* 'r') the stream from the start [``True``]
+    mode: str
+        'r' or 'w' or 'a', more complicated modes ('r+', 'w+' are not supported
+        because only the first letter is looked at)
+    reset: bool
+        try to read (*mode* 'r') the stream from the start
 
-    :Returns: tuple ``stream`` which is a file-like object
+    Returns
+    -------
+    file-like object
 
     See Also
     --------
@@ -456,11 +460,14 @@ def isstream(obj):
     :mod:`io`
 
 
-    :Arguments:
-      *obj*
-          stream or string
+    Parameters
+    ----------
+    obj: stream or string
 
-    :Returns: ``True`` is *obj* is a stream, ``False`` otherwise
+    Returns
+    -------
+    bool
+        ``True`` is *obj* is a stream, ``False`` otherwise
 
     .. versionadded:: 0.9.0
     """
@@ -681,7 +688,10 @@ class NamedStream(io.IOBase):
         - :data:`io.SEEK_END` or 2 – end of the stream; *offset* is usually
           negative
 
-        :Returns: the new absolute position.
+        Returns
+        -------
+        int
+            the new absolute position.
         """
         try:
             return self.stream.seek(offset, whence)  # file.seek: no kw
@@ -812,7 +822,10 @@ def realpath(*args):
 def get_ext(filename):
     """Return the lower-cased extension of *filename* without a leading dot.
 
-    :Returns: root, ext
+    Returns
+    -------
+    root: str
+    ext: str
     """
     root, ext = os.path.splitext(filename)
     if ext.startswith(os.extsep):
@@ -856,8 +869,9 @@ def guess_format(filename):
     *filename* can also be a stream, in which case
     *filename.name* is looked at for a hint to the format
 
-    :Raises:
-       *ValueError*
+    Raises
+    ------
+    ValueError
 
     .. versionadded:: 0.11.0
        Moved into lib.util
@@ -925,12 +939,13 @@ class FixedcolumnEntry(object):
 
     def __init__(self, start, stop, typespecifier):
         """
-        :Arguments:
-         *start*
+        Parameters
+        ----------
+        start: int
             first column
-         *stop*
+        stop: int
             last column + 1
-         *typespecifier*
+        typespecifier: str
             'I': int, 'F': float, 'E': float, 'A': stripped string
 
         The start/stop arguments follow standard Python convention in that
@@ -1000,9 +1015,15 @@ class FORTRANReader(object):
 
         Values are converted to Python types according to the format specifier.
 
-        :Returns: list of entries with appropriate types
-        :Raises: :exc:`ValueError` if any of the conversions cannot be made
-                 (e.g. space for an int)
+        Returns
+        -------
+        list
+            list of entries with appropriate types
+
+        Raises
+        ------
+        ValueError
+            Any of the conversions cannot be made (e.g. space for an int)
 
         See Also
         --------
@@ -1027,10 +1048,15 @@ class FORTRANReader(object):
 
           parse_FORTRAN_format(edit_descriptor) --> dict
 
-        :Returns: dict with totallength (in chars), repeat, length,
-                  format, decimals
-        :Raises: :exc:`ValueError` if the *edit_descriptor* is not recognized
-                 and cannot be parsed
+        Returns
+        -------
+        dict
+            dict with totallength (in chars), repeat, length, format, decimals
+
+        Raises
+        ------
+        ValueError
+            The *edit_descriptor* is not recognized and cannot be parsed
 
         .. Note::
 
@@ -1167,14 +1193,20 @@ def parse_residue(residue):
      - "4GB300:H6O" --> ("4GB", 300, "H6O")
      - "4GB300" --> ("4GB", 300, None)
 
-    :Argument: The *residue* must contain a 1-letter or 3-letter or
-               4-letter residue string, a number (the resid) and
-               optionally an atom identifier, which must be separate
-               from the residue with a colon (":"). White space is
-               allowed in between.
+    Parameters
+    ----------
+    residue: str
+        The *residue* must contain a 1-letter or 3-letter or
+        4-letter residue string, a number (the resid) and
+        optionally an atom identifier, which must be separate
+        from the residue with a colon (":"). White space is
+        allowed in between.
 
-    :Returns: `(3-letter aa string, resid, atomname)`; known 1-letter
-              aa codes are converted to 3-letter codes
+    Returns
+    -------
+    tuple
+        `(3-letter aa string, resid, atomname)`; known 1-letter
+        aa codes are converted to 3-letter codes
     """
 
     # XXX: use _translate_residue() ....
@@ -1269,7 +1301,7 @@ def unique_rows(arr, return_index=False):
     # eg: idx = np.array([1, 2])[None, :]
     if not arr.flags['OWNDATA']:
         arr = arr.copy()
-    
+
     m = arr.shape[1]
 
     if return_index:

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -193,14 +193,15 @@ def filename(name, ext=None, keep=False):
     Parameters
     ----------
     name: str or :class:`NamedStream`
-        filename; extension is replaced unless keep=True;
-        *name* can also be a :class:`NamedStream` (and its
+        filename; extension is replaced unless ``keep=True``;
+        `name` can also be a :class:`NamedStream` (and its
         :attr:`NamedStream.name` will be changed accordingly)
     ext: None or str
         extension to use in the new filename
     keep: bool
-        - ``False``: replace existing extension with *ext*;
+        - ``False``: replace existing extension with `ext`;
         - ``True``: keep old extension if one existed
+
 
     .. versionchanged:: 0.9.0
        Also permits :class:`NamedStream` to pass through.

--- a/package/MDAnalysis/topology/GROParser.py
+++ b/package/MDAnalysis/topology/GROParser.py
@@ -34,6 +34,7 @@ See Also
 :mod:`MDAnalysis.coordinates.GRO`
 
 
+
 Classes
 -------
 
@@ -132,7 +133,7 @@ class GROParser(TopologyReaderBase):
         # Guess types and masses
         atomtypes = guessers.guess_types(names)
         masses = guessers.guess_masses(atomtypes)
-        
+
         residx, (new_resids, new_resnames) = change_squash(
                                 (resids, resnames), (resids, resnames))
 

--- a/package/MDAnalysis/topology/PDBQTParser.py
+++ b/package/MDAnalysis/topology/PDBQTParser.py
@@ -1,5 +1,5 @@
 # -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
-# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
 #
 # MDAnalysis --- http://www.mdanalysis.org
 # Copyright (c) 2006-2016 The MDAnalysis Development Team and contributors

--- a/package/MDAnalysis/topology/PQRParser.py
+++ b/package/MDAnalysis/topology/PQRParser.py
@@ -1,5 +1,5 @@
 # -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
-# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
 #
 # MDAnalysis --- http://www.mdanalysis.org
 # Copyright (c) 2006-2016 The MDAnalysis Development Team and contributors

--- a/package/MDAnalysis/topology/TPRParser.py
+++ b/package/MDAnalysis/topology/TPRParser.py
@@ -202,7 +202,7 @@ class TPRParser(TopologyReaderBase):
             raise IOError(msg)
 
         tpr_top.add_TopologyAttr(Resnums(tpr_top.resids.values.copy()))
-        
+
         return tpr_top
 
     # THE FOLLOWING CODE IS WORKING FOR TPX VERSION 58, BUT SINCE THESE INFO IS

--- a/package/MDAnalysis/topology/guessers.py
+++ b/package/MDAnalysis/topology/guessers.py
@@ -247,8 +247,10 @@ def guess_angles(bonds):
 
     Returns
     -------
-    List of tuples defining the angles.
-    Suitable for use in u._topology
+    list of tuples
+        List of tuples defining the angles.
+        Suitable for use in u._topology
+
 
     See Also
     --------

--- a/package/MDAnalysis/topology/guessers.py
+++ b/package/MDAnalysis/topology/guessers.py
@@ -79,10 +79,12 @@ def guess_atom_type(atomname):
     At the moment, this function simply returns the element, as
     guessed by :func:`guess_atom_element`.
 
+
     See Also
     --------
     :func:`guess_atom_element`
     :mod:`MDAnalysis.topology.tables`
+
 
     """
     return guess_atom_element(atomname)
@@ -277,9 +279,11 @@ def guess_dihedrals(angles):
     Works by assuming that if (1,2,3) is an angle, and 3 & 4 are bonded,
     then (1,2,3,4) must be a dihedral.
 
-    :Returns:
-      List of tuples defining the dihedrals.
-      Suitable for use in u._topology
+    Returns
+    -------
+    list of tuples
+        List of tuples defining the dihedrals.
+        Suitable for use in u._topology
 
     .. versionadded 0.9.0
     """
@@ -311,9 +315,10 @@ def guess_improper_dihedrals(angles):
     ie the improper dihedral is the angle between the planes formed by
     (1, 2, 3) and (1, 3, 4)
 
-    :Returns:
-      List of tuples defining the improper dihedrals.
-      Suitable for use in u._topology
+    Returns
+    -------
+        List of tuples defining the improper dihedrals.
+        Suitable for use in u._topology
 
     .. versionadded 0.9.0
     """

--- a/package/MDAnalysis/units.py
+++ b/package/MDAnalysis/units.py
@@ -114,7 +114,8 @@ concentration:
 
 Note
 ----
-Maybe we should simply use Quantities_ or :mod:`scipy.constants`?
+In the future me might move towards using the Quantities_ package or
+:mod:`scipy.constants`.
 
 
 .. _Quantities: http://packages.python.org/quantities/
@@ -347,11 +348,16 @@ def get_conversion_factor(unit_type, u1, u2):
 def convert(x, u1, u2):
     """Convert value *x* in unit *u1* to new value in *u2*.
 
-    :Returns: Converted value.
+    Returns
+    -------
+    float
+        Converted value.
 
-    :Raises: :Exc:`ValueError` if the units are not known or if
-             one attempts to convert between incompatible
-             units.
+    Raises
+    ------
+    ValueError
+        The units are not known or if one attempts to convert between
+        incompatible units.
     """
     try:
         ut1 = unit_types[u1]

--- a/package/doc/sphinx/Makefile
+++ b/package/doc/sphinx/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
-SPHINXBUILD   = sphinx-build
+SPHINXBUILD   = sphinx-build -v -W
 PAPER         =
 BUILDDIR      = ..
 

--- a/package/doc/sphinx/source/documentation_pages/coordinates/GRO.rst
+++ b/package/doc/sphinx/source/documentation_pages/coordinates/GRO.rst
@@ -1,2 +1,2 @@
 .. automodule:: MDAnalysis.coordinates.GRO
-   :members:
+


### PR DESCRIPTION
This PR is the result of some heavy procrastination. It fixes some minor issues in the package:
* Remove the windows end of line in the XVG aux reader
* Replace all occurences of `isinstance(something, int)` by the more generic and safe `isinstance(something, numbers.Integral)`
* Update most docstrings to the numpy format; only the docstrings from the analysis are left.

Please, do not squash the commits as they are unrelated logical units.