### PR TITLE
universe built with Merge now use the MemoryReader

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -69,6 +69,7 @@ Enhancements
     step is not one.
   * Groups (atomgroup, residuegroup, and segmentgroup) have more operators,
     included set operators (Issue #726)
+  * Universes built with Merge now use the MemoryReader (Issue #1251)
 
 Fixes
   * Trajectory slicing made completely Pythonic (Issue #918 PR #1195)

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -913,8 +913,12 @@ def Merge(*args):
     The complete system is then written out to a new PDB file.
 
 
-    .. versionchanged 0.9.0::
+    .. versionchanged:: 0.9.0
        Raises exceptions instead of assertion errors.
+
+    .. versionchanged:: 0.16.0
+       The trajectory is now a
+       :class:`~MDAnalysis.coordinates.memory.MemoryReader`.
 
     """
     from ..topology.base import squash_by
@@ -1030,15 +1034,9 @@ def Merge(*args):
                    atom_resindex=residx,
                    residue_segindex=segidx)
 
-    # Create blank Universe only from topology
-    u = Universe(top)
-
-    # Take one frame of coordinates from combined atomgroups
+    # Create and populate a universe
     coords = np.vstack([a.positions for a in args])
-    trajectory = MDAnalysis.coordinates.base.ReaderBase(None)
-    ts = MDAnalysis.coordinates.base.Timestep.from_coordinates(coords)
-    setattr(trajectory, "ts", ts)
-    trajectory.n_frames = 1
-    u.trajectory = trajectory
+    u = Universe(top, coords[None, :, :],
+                 format=MDAnalysis.coordinates.memory.MemoryReader)
 
     return u


### PR DESCRIPTION
Fixes #1251

Universes built with Merge now use the MemoryReader. This slighlty streamline the code of the `Merge` function, and make universes build that way full featured.

PR Checklist
------------
 - ~~[ ] Tests?~~
 - ~~[ ] Docs?~~
 - [X] CHANGELOG updated?
 - [X] Issue raised/referenced?
