### PR TITLE
Fix confusion in transfer_to_memory

### DIFF
--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -487,7 +487,7 @@ class Universe(object):
                 coordinates,
                 dimensions=self.trajectory.ts.dimensions,
                 dt=self.trajectory.ts.dt,
-                filename=self.filename)
+                filename=self.trajectory.filename)
 
     # python 2 doesn't allow an efficient splitting of kwargs in function
     # argument signatures.

--- a/testsuite/MDAnalysisTests/coordinates/test_memory.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_memory.py
@@ -67,7 +67,7 @@ class TestMemoryReader(BaseReaderTest):
         # MemoryReader should have a filename attribute set to the trajaectory filename
         universe = mda.Universe(PSF, DCD)
         universe.transfer_to_memory()
-        assert_equal(universe.trajectory.filename, PSF)
+        assert_equal(universe.trajectory.filename, DCD)
 
     def test_filename_array(self):
         # filename attribute of MemoryReader should be None when generated from an array


### PR DESCRIPTION
I reviewed #1252 too fast and missed a mixup in the filename passed
to the memory reader. The topology filename was passed instead of the
trajectory one. This commit fixes the confusion.