### PR TITLE
pip install without extra deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ install:
   - conda create -q -n pyenv python=$PYTHON_VERSION
   - source activate pyenv
   # Minimal installation!
-  - conda install numpy mmtf-python nose=1.3.7 mock six biopython networkx cython joblib pylint psutil
+  - conda install numpy mmtf-python nose mock six biopython networkx cython joblib pylint psutil
   # Install griddataformats from PIP so that scipy is only installed in the full build (#1147)
   - pip install griddataformats nose-timer
   # Add missing packages for the full build

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
     - MAIN_CMD="./testsuite/MDAnalysisTests/mda_nosetests --with-coverage --cover-package MDAnalysis --processes=2 --process-timeout=400 --with-memleak --with-timer --timer-top-n 50 --no-open-files"
     - SETUP=minimal
     - COVERALLS=false
-    - BUILD_CMD="pip install -v package/ && pip install testsuite/"
+    - BUILD_CMD="pip install -v package/ --no-deps && pip install testsuite/ --no-deps"
   matrix:
     - SETUP=minimal PYTHON_VERSION=2.7
     - SETUP=full PYTHON_VERSION=2.7 COVERALLS=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ install:
   - conda create -q -n pyenv python=$PYTHON_VERSION
   - source activate pyenv
   # Minimal installation!
-  - conda install numpy mmtf-python nose=1.3.7 mock six biopython networkx cython joblib pylint
+  - conda install numpy mmtf-python nose=1.3.7 mock six biopython networkx cython joblib pylint psutil
   # Install griddataformats from PIP so that scipy is only installed in the full build (#1147)
   - pip install griddataformats nose-timer
   # Add missing packages for the full build


### PR DESCRIPTION
This is a check to compare against my local conda builds which currently fail the tests.

The basic change is that pip isn't allowed to install missing dependencies anymore.
