### PR TITLE
Aux cleaning

### DIFF
--- a/package/MDAnalysis/auxiliary/XVG.py
+++ b/package/MDAnalysis/auxiliary/XVG.py
@@ -359,3 +359,4 @@ class XVGFileReader(base.AuxFileReader):
         for step in self:
             times.append(self.time)
         return np.array(times)
+

--- a/package/MDAnalysis/auxiliary/XVG.py
+++ b/package/MDAnalysis/auxiliary/XVG.py
@@ -71,6 +71,7 @@ from six.moves import range
 import os
 import numpy as np
 from . import base
+from ..lib.util import anyopen
 
 def uncomment(lines):
     """ Remove comments from lines in an .xvg file
@@ -179,7 +180,7 @@ class XVGReader(base.AuxReader):
 
     def __init__(self, filename, **kwargs):
         self._auxdata = os.path.abspath(filename)
-        with open(filename) as xvg_file:
+        with anyopen(filename) as xvg_file:
             lines = xvg_file.readlines()
         auxdata_values = []
         # remove comments before storing
@@ -294,7 +295,7 @@ class XVGFileReader(base.AuxFileReader):
         StopIteration
             When end of file or end of first data set is reached.
         """
-        line = self.auxfile.readline()
+        line = next(self.auxfile)
         while True:
             if not line or (line.strip() and line.strip()[0] == '&'):
                 # at end of file or end of first set of data (multiple sets
@@ -319,7 +320,7 @@ class XVGFileReader(base.AuxFileReader):
                                                   auxstep._n_cols))
                 return auxstep
             # line is comment only - move to next
-            line = self.auxfile.readline()
+            line = next(self.auxfile)
 
     def _count_n_steps(self):
         """ Iterate through all steps to count total number.

--- a/package/MDAnalysis/auxiliary/base.py
+++ b/package/MDAnalysis/auxiliary/base.py
@@ -46,7 +46,7 @@ import numpy as np
 import math
 import warnings
 
-from ..lib.util import asiterable
+from ..lib.util import asiterable, anyopen
 
 from . import _AUXREADERS
 
@@ -881,7 +881,7 @@ class AuxFileReader(AuxReader):
     """
     
     def __init__(self, filename, **kwargs):
-        self.auxfile = open(filename)
+        self.auxfile = anyopen(filename)
         self._auxdata = os.path.abspath(filename)
         super(AuxFileReader, self).__init__(**kwargs)
 

--- a/testsuite/MDAnalysisTests/auxiliary/test_xvg.py
+++ b/testsuite/MDAnalysisTests/auxiliary/test_xvg.py
@@ -1,10 +1,12 @@
 from numpy.testing import (assert_equal, assert_raises, assert_almost_equal,
-                           raises)
+                           assert_array_equal, raises)
+import numpy as np
+
 import os
 
 import MDAnalysis as mda
 
-from MDAnalysisTests.datafiles import AUX_XVG, XVG_BAD_NCOL
+from MDAnalysisTests.datafiles import AUX_XVG, XVG_BAD_NCOL, XVG_BZ2
 from MDAnalysisTests.auxiliary.base import (BaseAuxReaderTest, BaseAuxReference)
 
 class XVGReference(BaseAuxReference):
@@ -73,3 +75,11 @@ class TestXVGFileReader(TestXVGReader):
         # should start us back at before step 0, so next takes us to step 0
         self.reader.next()
         assert_equal(self.reader.step, 0)
+
+def test_xvg_bz2():
+    reader = mda.auxiliary.XVG.XVGReader(XVG_BZ2)
+    assert_array_equal(reader.read_all_times(), np.array([0., 50., 100.]))
+
+def test_xvg_bz2():
+    reader = mda.auxiliary.XVG.XVGFileReader(XVG_BZ2)
+    assert_array_equal(reader.read_all_times(), np.array([0., 50., 100.]))

--- a/testsuite/MDAnalysisTests/datafiles.py
+++ b/testsuite/MDAnalysisTests/datafiles.py
@@ -69,6 +69,7 @@ __all__ = [
     "GRO_residwrap",  # resids wrapping because of 5 digit field (Issue #728)
     "GRO_residwrap_0base",  # corner case of #728 with resid=0 for first atom
     "PDB_xvf", "TPR_xvf", "TRR_xvf",  # Gromacs coords/veloc/forces (cobrotoxin, OPLS-AA, Gromacs 4.5.5 tpr)
+    "XVG_BZ2",  # Compressed xvg file about cobrotoxin
     "PDB_xlserial",
     "TPR400", "TPR402", "TPR403", "TPR404", "TPR405", "TPR406", "TPR407",
     "TPR450", "TPR451", "TPR452", "TPR453", "TPR454", "TPR455", "TPR455Double",
@@ -229,6 +230,7 @@ TRR_multi_frame = resource_filename(
 PDB_xvf = resource_filename(__name__, 'data/cobrotoxin.pdb')
 TPR_xvf = resource_filename(__name__, 'data/cobrotoxin.tpr')
 TRR_xvf = resource_filename(__name__, 'data/cobrotoxin.trr')
+XVG_BZ2 = resource_filename(__name__, 'data/cobrotoxin_protein_forces.xvg.bz2')
 
 XPDB_small = resource_filename(__name__, 'data/5digitResid.pdb')
 # number is the gromacs version


### PR DESCRIPTION
Fixes #1289 

Changes made in this Pull Request:
 - remove the windows end of line in XVG.py
 - make the two XVG aux reader use `anyopen` instead of the built in `open`
 - declare one test file that was already in the repo

**Do not squash the commits! The removal of the windows end of lines make the diff unreadable otherwise.**

Hopefully, this can be merged before the release. It would allow me to use one of the test files in <https://github.com/MDAnalysis/MDAnalysis.github.io/pull/26>.

PR Checklist
------------
 - [X] Tests?
 - ~~[ ] Docs?~~ Fix a bug
 - ~~[ ] CHANGELOG updated?~~ Aux reader is new in 0.16.0
 - [X] Issue raised/referenced?
