### PR TITLE
changes string.uppercase to string.ascii_uppercase for py3 compatibility

### DIFF
--- a/testsuite/CHANGELOG
+++ b/testsuite/CHANGELOG
@@ -16,7 +16,8 @@ and https://github.com/MDAnalysis/mdanalysis/wiki/UnitTests
 mm/dd/17
 
   * 0.16.1
-
+    - Change core.util string.uppercase to string.ascii_uppercase for py3 
+      compatibility
 
 04/10/17 jbarnoud, orbeckst, fiona-naughton, manuel.nuno.melo, richardjgowers
          tyler.je.reddy, utkbansal, vedantrathore, kash1102

--- a/testsuite/MDAnalysisTests/core/util.py
+++ b/testsuite/MDAnalysisTests/core/util.py
@@ -139,21 +139,21 @@ def make_resnames(size):
     """Creates residues named RsA RsB ... """
     import MDAnalysis.core.topologyattrs as ta
     na, nr, ns = size
-    return ta.Resnames(np.array(['Rs{}'.format(string.uppercase[i])
+    return ta.Resnames(np.array(['Rs{}'.format(string.ascii_uppercase[i])
                                  for i in range(nr)], dtype=object))
 
 def make_segids(size):
     """Segids SegA -> SegY"""
     import MDAnalysis.core.topologyattrs as ta
     na, nr, ns = size
-    return ta.Segids(np.array(['Seg{}'.format(string.uppercase[i])
+    return ta.Segids(np.array(['Seg{}'.format(string.ascii_uppercase[i])
                                for i in range(ns)], dtype=object))
 
 def make_types(size):
     """Atoms are given types TypeA -> TypeE on a loop"""
     import MDAnalysis.core.topologyattrs as ta
     na, nr, ns = size
-    types = itertools.cycle(string.uppercase[:5])
+    types = itertools.cycle(string.ascii_uppercase[:5])
     return ta.Atomtypes(np.array(
         ['Type{}'.format(next(types))
          for _ in range(na)], dtype=object))
@@ -163,7 +163,7 @@ def make_names(size):
     import MDAnalysis.core.topologyattrs as ta
     na, nr, ns = size
     # produces, AAA, AAB, AAC, ABA etc
-    names = itertools.product(*[string.uppercase] * 3)
+    names = itertools.product(*[string.ascii_uppercase] * 3)
     return ta.Atomnames(np.array(
         ['{}'.format(''.join(next(names)))
          for _ in range(na)], dtype=object))


### PR DESCRIPTION
Fixes 

string.uppercase is not supported in py35 so it might be better to substitute it for string.ascii_uppercase as it is supported by both py35 and py27. 

PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
