### PR TITLE
Changed dt to include step in Universe.transfer_to_memory()

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -86,6 +86,7 @@ Chronological list of authors
   - Xiki Tempula
   - Akshay Gupta
   - Juan Eiros Zamora
+  - Jon Kapla
 
 External code
 -------------

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -14,7 +14,7 @@ The rules for this file:
 
 ------------------------------------------------------------------------------
 
-mm/dd/17 utkbansal, kain88-de, xiki-tempula
+mm/dd/17 utkbansal, kain88-de, xiki-tempula, kaplajon
 
 
   * 0.16.1
@@ -25,6 +25,7 @@ Enhancements
     (apply to PDB, GRO) (Issue #1306)
 
 Fixes
+  * In Universe.transfer_to_memory(): dt is now adjusted with step (Issue #1310)
   * Various documentation sphinx errors (PR #1312)
 
 Changes

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -491,10 +491,11 @@ class Universe(object):
             # Overwrite trajectory in universe with an MemoryReader
             # object, to provide fast access and allow coordinates
             # to be manipulated
+            if step is None: step=1 
             self.trajectory = MemoryReader(
                 coordinates,
                 dimensions=self.trajectory.ts.dimensions,
-                dt=self.trajectory.ts.dt,
+                dt=self.trajectory.ts.dt * step,
                 filename=self.trajectory.filename)
 
     # python 2 doesn't allow an efficient splitting of kwargs in function

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -491,7 +491,8 @@ class Universe(object):
             # Overwrite trajectory in universe with an MemoryReader
             # object, to provide fast access and allow coordinates
             # to be manipulated
-            if step is None: step=1 
+            if step is None:
+                step = 1 
             self.trajectory = MemoryReader(
                 coordinates,
                 dimensions=self.trajectory.ts.dimensions,

--- a/testsuite/MDAnalysisTests/core/test_universe.py
+++ b/testsuite/MDAnalysisTests/core/test_universe.py
@@ -498,15 +498,16 @@ class TestInMemoryUniverse(object):
         assert_equal(universe.trajectory.timeseries(universe.atoms).shape,
                      (3341, 10, 3),
                      err_msg="Unexpected shape of trajectory timeseries")
+
     @staticmethod
     def test_slicing_step_dt():
         universe = MDAnalysis.Universe(PDB_small, DCD)
-        times=[ts.time for ts in universe.trajectory]
+        times = [ts.time for ts in universe.trajectory]
         universe.transfer_to_memory(step=2)
-        times2=[ts.time for ts in universe.trajectory]
-        assert_almost_equal(times[::2],times2,
+        times2 = [ts.time for ts in universe.trajectory]
+        assert_almost_equal(times[::2], times2,
                 err_msg="Unexpected in-memory timestep: "
-                        +"dt not updated with step information")
+                        + "dt not updated with step information")
 
     @staticmethod
     def test_slicing_negative_start():

--- a/testsuite/MDAnalysisTests/core/test_universe.py
+++ b/testsuite/MDAnalysisTests/core/test_universe.py
@@ -498,6 +498,15 @@ class TestInMemoryUniverse(object):
         assert_equal(universe.trajectory.timeseries(universe.atoms).shape,
                      (3341, 10, 3),
                      err_msg="Unexpected shape of trajectory timeseries")
+    @staticmethod
+    def test_slicing_step_dt():
+        universe = MDAnalysis.Universe(PDB_small, DCD)
+        times=[ts.time for ts in universe.trajectory]
+        universe.transfer_to_memory(step=2)
+        times2=[ts.time for ts in universe.trajectory]
+        assert_almost_equal(times[::2],times2,
+                err_msg="Unexpected in-memory timestep: "
+                        +"dt not updated with step information")
 
     @staticmethod
     def test_slicing_negative_start():


### PR DESCRIPTION
Fixes #1310 

Changes made in this Pull Request:
- added step to dt in Universe.transfer_to_memory() so that time for each frame corresponds to the original trajectory.
- added a test, test_slicing_step_dt(), to test_universe.py:TestInMemoryUniverse


PR Checklist
------------
 - [x] Tests?
 - n/a Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
