### PR TITLE
add debug information to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,6 +68,12 @@ matrix:
            NUMPY_VERSION=1.10.4
            CONDA_DEPENDENCIES=${CONDA_ALL_DEPENDENCIES}
 
+    - os: linux
+      env: NAME='numpy dev'
+           NUMPY_VERSION=dev
+           CONDA_DEPENDENCIES=${CONDA_ALL_DEPENDENCIES}
+           EVENT_TYPE='cron'
+
 install:
   - git clone git://github.com/astropy/ci-helpers.git
   - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh


### PR DESCRIPTION
The cron job build seems to fail currently. I'm not sure why that is there is also no indication in the travis log. So lets see what information we get if we add more debug info in the logs.