### PR TITLE
Fixed Issue #1347

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -42,6 +42,8 @@ Fixes
   * Fixed incorrect handling of residue names with trailing numbers in
     HydrogenBondAnalysis (issue #801)
   * Fixed AnalysisBase class provides numerical start,stop,step values (PR #1340)
+  * Fixed PSFParser not creating multiple residues for identical resids in
+    different segments. (Issue #1347, PR #1348)
 
 Changes
   * Enable various pylint warnings to increase python 3 compatibility

--- a/package/MDAnalysis/topology/PSFParser.py
+++ b/package/MDAnalysis/topology/PSFParser.py
@@ -52,7 +52,7 @@ import numpy as np
 
 from ..lib.util import openany
 from . import guessers
-from .base import TopologyReaderBase, squash_by
+from .base import TopologyReaderBase, squash_by, change_squash
 from ..core.topologyattrs import (
     Atomids,
     Atomnames,
@@ -311,8 +311,9 @@ class PSFParser(TopologyReaderBase):
 
         # Residue
         # resids, resnames
-        residx, new_resids, (new_resnames, perres_segids) = squash_by(
-            resids, resnames, segids)
+        residx, (new_resids, new_resnames, perres_segids) = change_squash(
+            (resids, resnames, segids),
+            (resids, resnames, segids))
         # transform from atom:Rid to atom:Rix
         residueids = Resids(new_resids)
         residuenums = Resnums(new_resids.copy())

--- a/testsuite/MDAnalysisTests/topology/test_psf.py
+++ b/testsuite/MDAnalysisTests/topology/test_psf.py
@@ -32,6 +32,7 @@ from MDAnalysisTests.datafiles import (
     PSF,
     PSF_nosegid,
     PSF_NAMD,
+    XYZ_psf, XYZ,
 )
 
 
@@ -108,6 +109,28 @@ class TestNAMDPSFParser(ParserBase):
     expected_n_atoms = 130
     expected_n_residues = 6
     expected_n_segments = 1
+
+
+class TestPSFParser2(ParserBase):
+    parser = mda.topology.PSFParser.PSFParser
+    filename = XYZ_psf
+    expected_attrs = ['ids', 'names', 'types', 'masses',
+                      'charges',
+                      'resids', 'resnames',
+                      'segids',
+                      'bonds', 'angles', 'dihedrals', 'impropers']
+    expected_n_atoms = 1284
+    expected_n_residues = 152
+    expected_n_segments = 4
+
+    def test_as_universe_resids(self):
+        u = mda.Universe(XYZ_psf, XYZ)
+
+        # each segment has [380, 381, 382, 383] as the first
+        # 4 residues
+        for seg in u.segments:
+            assert_equal(seg.residues.resids[:4],
+                         [380, 381, 382, 383])
 
 
 def test_psf_nosegid():


### PR DESCRIPTION
PSFParser now considers segid and resname when splitting into residues

Fixes #1347

PR Checklist
------------
 - [x] Tests?
 - ~[ ] Docs?~
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
