### PR TITLE
FIX: rmsf.run should return itself

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -45,6 +45,7 @@ Fixes
   * Fixed PSFParser not creating multiple residues for identical resids in
     different segments. (Issue #1347, PR #1348)
   * Add the OC1 and OC2 from amber99sb-ildn to hydrogen bond acceptors (issue #1342)
+  * Fix RMSF run return value (PR #1354)
 
 
 Changes

--- a/package/MDAnalysis/analysis/rms.py
+++ b/package/MDAnalysis/analysis/rms.py
@@ -646,7 +646,7 @@ class RMSF(AnalysisBase):
             super(RMSF, self).__init__(self.atomgroup.universe.trajectory,
                                        start=start, stop=stop, step=step,
                                        verbose=verbose)
-        super(RMSF, self).run()
+        return super(RMSF, self).run()
 
     def _prepare(self):
         self.sumsquares = np.zeros((self.atomgroup.n_atoms, 3))

--- a/testsuite/MDAnalysisTests/analysis/test_rms.py
+++ b/testsuite/MDAnalysisTests/analysis/test_rms.py
@@ -276,15 +276,13 @@ class TestRMSF(TestCase):
                             "values")
 
     def test_rmsf_single_frame(self):
-        rmsfs = rms.RMSF(self.universe.select_atoms('name CA'), start=5, stop=6)
-        rmsfs.run()
+        rmsfs = rms.RMSF(self.universe.select_atoms('name CA'), start=5, stop=6).run()
 
         assert_almost_equal(rmsfs.rmsf, 0, 5,
                             err_msg="error: rmsfs should all be zero")
 
     def test_rmsf_old_run(self):
-        rmsfs = rms.RMSF(self.universe.select_atoms('name CA'))
-        rmsfs.run(start=5, stop=6)
+        rmsfs = rms.RMSF(self.universe.select_atoms('name CA')).run(start=5, stop=6)
 
         assert_almost_equal(rmsfs.rmsf, 0, 5,
                             err_msg="error: rmsfs should all be zero")


### PR DESCRIPTION
This is the standard for normal analysis today

PR Checklist
------------
 - [x] Tests?
 ~- [ ] Docs?~
 - [x] CHANGELOG updated?
~ - [ ] Issue raised/referenced?~
