### PR TITLE
changed URL for docs to new http://docs.mdanalysis.org

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -48,10 +48,12 @@ Fixes
   * Add the OC1 and OC2 from amber99sb-ildn to hydrogen bond acceptors (issue #1342)
   * Fix RMSF run return value (PR #1354)
 
-
 Changes
   * Enable various pylint warnings to increase python 3 compatibility
   * Change Mathjax cdn (Issue #1313)
+  * Docs moved to http://docs.mdanalysis.org (Issue #1315)
+    and made responsive (Alabaster theme with readable-sphinx CSS)
+    (Issue #378)
 
 
 04/10/17 kain88-de, fiona-naughton, richardjgowers, tyler.je.reddy, jdetle

--- a/package/doc/README
+++ b/package/doc/README
@@ -22,9 +22,9 @@ through the standard "python doc strings". Type ::
 
   In ipython you can use the question mark operator ::
 
-       MDAnalysis ?
-       MDAnalysis.Universe ?
-       MDAnalysis.Universs ??
+       MDAnalysis?
+       MDAnalysis.Universe?
+       MDAnalysis.Universe??
 
   (The '??' also shows the source code.)
 
@@ -34,22 +34,18 @@ Online html manual
 
 The documentation for the latest stable release can always be found at
 
-   https://pythonhosted.org/MDAnalysis/
+   http://docs.mdanalysis.org
 
 The docs for the latest development version are also on the internet
 at
 
-   http://www.mdanalysis.org/mdanalysis/package/doc/html/
+   http://devdocs.mdanalysis.org
 
 The manual includes all the doc strings with some additional text; it
 is a work in progress and suggestions to improve it are welcome. File
 them via the Issue Tracker at
 https://github.com/MDAnalysis/mdanalysis/issues/ or mention it on the
 mailing list http://groups.google.com/group/mdnalysis-discussion .
-
-The manual corresponding to the current sources is provided in the
-doc/html directory (start at doc/html/index.html).
-
 
 
 Wiki and online docs

--- a/package/doc/sphinx/source/conf.py
+++ b/package/doc/sphinx/source/conf.py
@@ -227,7 +227,7 @@ html_sidebars = {
 # If true, an OpenSearch description file will be output, and all pages will
 # contain a <link> tag referring to it.  The value of this option must be the
 # base URL from which the finished HTML is served.
-html_use_opensearch = 'http://pythonhosted.org/MDAnalysis'
+html_use_opensearch = 'http://docs.mdanalysis.org'
 
 # This is the file name suffix for HTML files (e.g. ".xhtml").
 #html_file_suffix = None


### PR DESCRIPTION
- closes #1315
- master docs were moved to their own repo https://github.com/MDAnalysis/docs and are
  served as GitHub pages
- replaces obsolete https://pythonhosted.org/MDAnalysis

PR Checklist
------------
 - n/a Tests?
 - n/a Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
