### PR TITLE
remove * imports in align docs

### DIFF
--- a/package/MDAnalysis/analysis/align.py
+++ b/package/MDAnalysis/analysis/align.py
@@ -63,8 +63,8 @@ The example uses files provided as part of the MDAnalysis test suite
 :data:`~MDAnalysis.tests.datafiles.PDB_small`). For all further
 examples execute first ::
 
-   >>> from MDAnalysis import *
-   >>> from MDAnalysis.analysis.align import *
+   >>> import MDAnalysis as mda
+   >>> from MDAnalysis.analysis import align
    >>> from MDAnalysis.analysis.rms import rmsd
    >>> from MDAnalysis.tests.datafiles import PSF, DCD, PDB_small
 
@@ -72,8 +72,8 @@ examples execute first ::
 In the simplest case, we can simply calculate the C-alpha RMSD between
 two structures, using :func:`rmsd`::
 
-   >>> ref = Universe(PDB_small)
-   >>> mobile = Universe(PSF,DCD)
+   >>> ref = mda.Universe(PDB_small)
+   >>> mobile = mda.Universe(PSF,DCD)
    >>> rmsd(mobile.atoms.CA.positions, ref.atoms.CA.positions)
    16.282308620224068
 
@@ -98,7 +98,7 @@ function ::
 
    >>> mobile0 = mobile.atoms.CA.positions - mobile.atoms.center_of_mass()
    >>> ref0 = ref.atoms.CA.positions - ref.atoms.center_of_mass()
-   >>> R, rmsd = rotation_matrix(mobile0, ref0)
+   >>> R, rmsd = align.rotation_matrix(mobile0, ref0)
    >>> print rmsd
    6.8093965864717951
    >>> print R
@@ -119,9 +119,9 @@ Common usage
 
 To **fit a single structure** with :func:`alignto`::
 
-   >>> ref = Universe(PSF, PDB_small)
-   >>> mobile = Universe(PSF, DCD)     # we use the first frame
-   >>> alignto(mobile, ref, select="protein and name CA", mass_weighted=True)
+   >>> ref = mda.Universe(PSF, PDB_small)
+   >>> mobile = mda.Universe(PSF, DCD)     # we use the first frame
+   >>> align.alignto(mobile, ref, select="protein and name CA", mass_weighted=True)
 
 This will change *all* coordinates in *mobile* so that the protein
 C-alpha atoms are optimally superimposed (translation and rotation).
@@ -129,10 +129,10 @@ C-alpha atoms are optimally superimposed (translation and rotation).
 To **fit a whole trajectory** to a reference structure with the
 :class:`AlignTraj` class::
 
-   >>> ref = Universe(PSF, PDB_small)   # reference structure 1AKE
-   >>> trj = Universe(PSF, DCD)         # trajectory of change 1AKE->4AKE
-   >>> align =  AlignTraj(trj, ref, filename='rmsfit.dcd')
-   >>> align.run()
+   >>> ref = mda.Universe(PSF, PDB_small)   # reference structure 1AKE
+   >>> trj = mda.Universe(PSF, DCD)         # trajectory of change 1AKE->4AKE
+   >>> alignment = align.AlignTraj(trj, ref, filename='rmsfit.dcd')
+   >>> alignment.run()
 
 It is also possible to align two arbitrary structures by providing a
 mapping between atoms based on a sequence alignment. This allows
@@ -142,9 +142,9 @@ If a alignment was provided as "sequences.aln" one would first produce
 the appropriate MDAnalysis selections with the :func:`fasta2select`
 function and then feed the resulting dictionary to :class:`AlignTraj`::
 
-   >>> seldict = fasta2select('sequences.aln')
-   >>> align = AlignTraj(trj, ref, filename='rmsfit.dcd', select=seldict)
-   >>> align.run()
+   >>> seldict = align.fasta2select('sequences.aln')
+   >>> alignment = align.AlignTraj(trj, ref, filename='rmsfit.dcd', select=seldict)
+   >>> alignment.run()
 
 (See the documentation of the functions for this advanced usage.)
 


### PR DESCRIPTION
Fixes #180

Changes made in this Pull Request:
 - docs strings don't use global import anymore.


PR Checklist
------------
~~- [ ] Tests?~~
 - [x] Docs?
 ~~- [ ] CHANGELOG updated?~~
 - [x] Issue raised/referenced?
