### PR TITLE
fix int type usage

### DIFF
--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -419,7 +419,7 @@ class GroupBase(_MutableBase):
             ix, u = args
 
         # indices for the objects I hold
-        self._ix = np.asarray(ix, dtype=np.int64)
+        self._ix = np.asarray(ix, dtype=np.intp)
         self._u = u
         self._cache = dict()
 

--- a/package/MDAnalysis/core/topology.py
+++ b/package/MDAnalysis/core/topology.py
@@ -125,12 +125,12 @@ def make_downshift_arrays(upshift, nparents):
         counter += 1
         # If parent is skipped, eg (0, 0, 2, 2, etc)
         while counter != upshift[order[x:y][0]]:
-            downshift.append(np.array([], dtype=np.int))
+            downshift.append(np.array([], dtype=np.int64))
             counter += 1
-        downshift.append(np.sort(np.array(order[x:y], copy=True, dtype=np.int)))
+        downshift.append(np.sort(np.array(order[x:y], copy=True, dtype=np.int64)))
     # Add entries for childless parents at end of range
     while counter < (nparents - 1):
-        downshift.append(np.array([], dtype=np.int))
+        downshift.append(np.array([], dtype=np.int64))
         counter += 1
     # Add None to end of array to force it to be of type Object
     # Without this, a rectangular array gets squashed into a single array

--- a/testsuite/MDAnalysisTests/analysis/test_psa.py
+++ b/testsuite/MDAnalysisTests/analysis/test_psa.py
@@ -221,7 +221,8 @@ class _BaseHausdorffDistance(TestCase):
         for a given Hausdorff metric, h.'''
         forward = self.h(self.path_1, self.path_2)
         reverse = self.h(self.path_2, self.path_1)
-        self.assertEqual(forward, reverse)
+        # lower precision on 32bit
+        assert_almost_equal(forward, reverse, decimal=15)
 
     def test_hausdorff_value(self):
         '''Test that the undirected Hausdorff


### PR DESCRIPTION
Fixes part of #1362 .

Changes made in this Pull Request:
 - int type usage fixes to accommodate 32 bit architectures
 - slight precision relaxation in analysis/test_psa.py:_BaseHausdorffDistance.test_symmetry comparison

PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?
