### PR TITLE
Explicitly define __hash__ for groups

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,15 +13,18 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-mm/dd/17
 
-  * 0.16.2 richardjgowers, rathann
+
+mm/dd/17 richardjgowers, rathann, jbarnoud
+
+  * 0.16.2
 
 Enhancements
 
 Fixes
   * fixed GROWriter truncating long resids from the wrong end (Issue #1395)
   * Fixed dtype of numpy arrays to accomodate 32 bit architectures (Issue #1362)
+  * Groups are hashable on python 3 (Issue #1397)
 
 Changes
 

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -423,6 +423,9 @@ class GroupBase(_MutableBase):
         self._u = u
         self._cache = dict()
 
+    def __hash__(self):
+        return hash((self._u, self.__class__, tuple(self.ix.tolist())))
+
     def __len__(self):
         return len(self._ix)
 


### PR DESCRIPTION
Groups (AtomGroup, ResidueGroup, SegmentGroup) cannot be stored in sets
or used as dict key if they are not hashable. In python 3, the __hash__
method is not defined implicitly anymore when a class has a __eq__ method.

Fixes #1397 

PR Checklist
------------
 - [X] Tests?
 - ~~[ ] Docs?~~
 - [X] CHANGELOG updated?
 - [X] Issue raised/referenced?
