### PR TITLE
[WIP] early work adding asv benchmark suite to MDA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ env:
     - PYTEST_COVERAGE_FILE="pytest_coverage"
     - MAIN_CMD="pytest ${PYTEST_LIST}"
     - SETUP_CMD="${PYTEST_FLAGS}"
-    - BUILD_CMD="pip install -v package/ && pip install testsuite/"
+    - BUILD_CMD="pip install -v . && pip install testsuite/"
     - CONDA_DEPENDENCIES="mmtf-python nose=1.3.7 mock six biopython networkx cython joblib nose-timer matplotlib scipy griddataformats hypothesis"
     - CONDA_ALL_DEPENDENCIES="mmtf-python nose=1.3.7 mock six biopython networkx cython joblib nose-timer matplotlib netcdf4 scikit-learn scipy griddataformats seaborn coveralls clustalw=2.1  hypothesis"
     # Install griddataformats from PIP so that scipy is only installed in the full build (#1147)
@@ -51,10 +51,10 @@ matrix:
 
     - os: linux
       env: NAME="Doc"
-           MAIN_CMD="cd package && python setup.py"
+           MAIN_CMD="python setup.py && cd package"
            SETUP_CMD="build_sphinx"
            BUILD_DOCS=true
-           BUILD_CMD="cd ${TRAVIS_BUILD_DIR}/package && python setup.py build_ext --inplace"
+           BUILD_CMD="cd ${TRAVIS_BUILD_DIR} && python setup.py build_ext --inplace && cd ${TRAVIS_BUILD_DIR}/package"
            CONDA_DEPENDENCIES=${CONDA_ALL_DEPENDENCIES}
 
     - os: linux

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -1,0 +1,60 @@
+{
+    // The version of the config file format.  Do not change, unless
+    // you know what you are doing.
+    "version": 1,
+
+    // The name of the project being benchmarked
+    "project": "mdanalysis",
+
+    // The project's homepage
+    "project_url": "http://www.mdanalysis.org/",
+
+    // The URL of the source code repository for the project being
+    // benchmarked
+    "repo": "..",
+    "dvcs": "git",
+    "branches": ["develop"],
+
+    // The base URL to "how a commit for the project.
+    //"show_commit_url": "http://github.com/scipy/scipy/commit/",
+
+    // The Pythons you'd like to test against.  If not provided, defaults
+    // to the current version of Python used to run `asv`.
+    "pythons": ["2.7"],
+    // The matrix of dependencies to test.  Each key is the name of a
+    // package (in PyPI) and the values are version numbers.  An empty
+    // list indicates to just test against the default (latest)
+    // version.
+    "matrix": {
+        "numpy": ["1.8.2"],
+        "Tempita": ["0.5.2"],
+        "Cython": ["0.23.4"],
+	"six": [],
+    },
+    // The directory (relative to the current directory) that benchmarks are
+    // stored in.  If not provided, defaults to "benchmarks"
+    "benchmark_dir": "benchmarks",
+    // The directory (relative to the current directory) to cache the Python
+    // environments in.  If not provided, defaults to "env"
+    "env_dir": "env",
+    "environment_type": "virtualenv",
+    "wheel_cache_size": 10,
+    // The directory (relative to the current directory) that raw benchmark
+    // results are stored in.  If not provided, defaults to "results".
+    "results_dir": "results",
+    // The directory (relative to the current directory) that the html tree
+    // should be written to.  If not provided, defaults to "html".
+    "html_dir": "html",
+    // The number of characters to retain in the commit hashes.
+    "hash_length": 8,
+    // The commits after which the regression search in `asv publish`
+    // should start looking for regressions. Dictionary whose keys are
+    // regexps matching to benchmark names, and values corresponding to
+    // the commit (exclusive) after which to start looking for
+    // regressions.  The default is to start from the first commit
+    // with results. If the commit is `null`, regression detection is
+    // skipped for the matching benchmark.
+    "regressions_first_commits": {
+       "io_matlab\\.StructArr\\..*": "67c089a6",  //  structarrs weren't properly implemented before this
+    }
+}

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -13,7 +13,7 @@
     // benchmarked
     "repo": "..",
     "dvcs": "git",
-    "branches": ["asv_bench"],
+    "branches": ["develop"],
 
     // The base URL to "how a commit for the project.
     //"show_commit_url": "http://github.com/scipy/scipy/commit/",

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -13,23 +13,24 @@
     // benchmarked
     "repo": "..",
     "dvcs": "git",
-    "branches": ["develop"],
+    "branches": ["asv_bench"],
 
     // The base URL to "how a commit for the project.
     //"show_commit_url": "http://github.com/scipy/scipy/commit/",
 
     // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.
-    "pythons": ["2.7"],
+    "pythons": ["2.7", "3.6"],
     // The matrix of dependencies to test.  Each key is the name of a
     // package (in PyPI) and the values are version numbers.  An empty
     // list indicates to just test against the default (latest)
     // version.
     "matrix": {
-        "numpy": ["1.8.2"],
-        "Tempita": ["0.5.2"],
-        "Cython": ["0.23.4"],
+        "Cython": [],
+        "numpy": [],
+	"scipy":[],
 	"six": [],
+	"pytest": [],
     },
     // The directory (relative to the current directory) that benchmarks are
     // stored in.  If not provided, defaults to "benchmarks"
@@ -37,7 +38,7 @@
     // The directory (relative to the current directory) to cache the Python
     // environments in.  If not provided, defaults to "env"
     "env_dir": "env",
-    "environment_type": "virtualenv",
+    "environment_type": "conda",
     "wheel_cache_size": 10,
     // The directory (relative to the current directory) that raw benchmark
     // results are stored in.  If not provided, defaults to "results".

--- a/benchmarks/benchmarks/GRO.py
+++ b/benchmarks/benchmarks/GRO.py
@@ -1,0 +1,13 @@
+from __future__ import division, absolute_import, print_function
+
+import numpy as np
+from MDAnalysis.coordinates.GRO import GROReader
+from MDAnalysisTests.datafiles import GRO
+
+class GROReadBench(object):
+
+    def time_read_GRO_file(self):
+        """Benchmark reading of standard test
+        suite GRO file.
+        """
+        GROReader(GRO)

--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ class Config(object):
 
     """
 
-    def __init__(self, fname='setup.cfg'):
+    def __init__(self, fname='./package/setup.cfg'):
         if os.path.exists(fname):
             self.config = configparser.SafeConfigParser()
             self.config.read(fname)
@@ -296,60 +296,60 @@ def extensions(config):
     include_dirs = [get_numpy_include]
 
     libdcd = MDAExtension('lib.formats.libdcd',
-                          ['MDAnalysis/lib/formats/libdcd' + source_suffix],
-                          include_dirs=include_dirs + ['MDAnalysis/lib/formats/include'],
+                          ['package/MDAnalysis/lib/formats/libdcd' + source_suffix],
+                          include_dirs=include_dirs + ['package/MDAnalysis/lib/formats/include'],
                           define_macros=define_macros,
                           extra_compile_args=extra_compile_args)
     distances = MDAExtension('lib.c_distances',
-                             ['MDAnalysis/lib/c_distances' + source_suffix],
-                             include_dirs=include_dirs + ['MDAnalysis/lib/include'],
+                             ['package/MDAnalysis/lib/c_distances' + source_suffix],
+                             include_dirs=include_dirs + ['package/MDAnalysis/lib/include'],
                              libraries=['m'],
                              define_macros=define_macros,
                              extra_compile_args=extra_compile_args)
     distances_omp = MDAExtension('lib.c_distances_openmp',
-                                 ['MDAnalysis/lib/c_distances_openmp' + source_suffix],
-                                 include_dirs=include_dirs + ['MDAnalysis/lib/include'],
+                                 ['package/MDAnalysis/lib/c_distances_openmp' + source_suffix],
+                                 include_dirs=include_dirs + ['package/MDAnalysis/lib/include'],
                                  libraries=['m'] + parallel_libraries,
                                  define_macros=define_macros + parallel_macros,
                                  extra_compile_args=parallel_args,
                                  extra_link_args=parallel_args)
     qcprot = MDAExtension('lib.qcprot',
-                          ['MDAnalysis/lib/qcprot' + source_suffix],
+                          ['package/MDAnalysis/lib/qcprot' + source_suffix],
                           include_dirs=include_dirs,
                           extra_compile_args=["-O3", "-ffast-math"])
     transformation = MDAExtension('lib._transformations',
-                                  ['MDAnalysis/lib/src/transformations/transformations.c'],
+                                  ['package/MDAnalysis/lib/src/transformations/transformations.c'],
                                   libraries=['m'],
                                   define_macros=define_macros,
                                   include_dirs=include_dirs,
                                   extra_compile_args=extra_compile_args)
     libmdaxdr = MDAExtension('lib.formats.libmdaxdr',
-                          sources=['MDAnalysis/lib/formats/libmdaxdr' + source_suffix,
-                                   'MDAnalysis/lib/formats/src/xdrfile.c',
-                                   'MDAnalysis/lib/formats/src/xdrfile_xtc.c',
-                                   'MDAnalysis/lib/formats/src/xdrfile_trr.c',
-                                   'MDAnalysis/lib/formats/src/trr_seek.c',
-                                   'MDAnalysis/lib/formats/src/xtc_seek.c',
+                          sources=['package/MDAnalysis/lib/formats/libmdaxdr' + source_suffix,
+                                   'package/MDAnalysis/lib/formats/src/xdrfile.c',
+                                   'package/MDAnalysis/lib/formats/src/xdrfile_xtc.c',
+                                   'package/MDAnalysis/lib/formats/src/xdrfile_trr.c',
+                                   'package/MDAnalysis/lib/formats/src/trr_seek.c',
+                                   'package/MDAnalysis/lib/formats/src/xtc_seek.c',
                                    ],
-                          include_dirs=include_dirs + ['MDAnalysis/lib/formats/include',
-                                                       'MDAnalysis/lib/formats'],
+                          include_dirs=include_dirs + ['package/MDAnalysis/lib/formats/include',
+                                                       'package/MDAnalysis/lib/formats'],
                           define_macros=largefile_macros)
     util = MDAExtension('lib.formats.cython_util',
-                        sources=['MDAnalysis/lib/formats/cython_util' + source_suffix],
+                        sources=['package/MDAnalysis/lib/formats/cython_util' + source_suffix],
                         include_dirs=include_dirs)
 
     encore_utils = MDAExtension('analysis.encore.cutils',
-                            sources = ['MDAnalysis/analysis/encore/cutils' + source_suffix],
+                            sources = ['package/MDAnalysis/analysis/encore/cutils' + source_suffix],
                             include_dirs = include_dirs,
                             extra_compile_args = ["-O3", "-ffast-math"])
     ap_clustering = MDAExtension('analysis.encore.clustering.affinityprop',
-                            sources = ['MDAnalysis/analysis/encore/clustering/affinityprop' + source_suffix, 'MDAnalysis/analysis/encore/clustering/src/ap.c'],
-                            include_dirs = include_dirs+['MDAnalysis/analysis/encore/clustering/include'],
+                            sources = ['package/MDAnalysis/analysis/encore/clustering/affinityprop' + source_suffix, 'package/MDAnalysis/analysis/encore/clustering/src/ap.c'],
+                            include_dirs = include_dirs+['package/MDAnalysis/analysis/encore/clustering/include'],
                             libraries=["m"],
                             extra_compile_args=["-O3", "-ffast-math","-std=c99"])
     spe_dimred = MDAExtension('analysis.encore.dimensionality_reduction.stochasticproxembed',
-                            sources = ['MDAnalysis/analysis/encore/dimensionality_reduction/stochasticproxembed' + source_suffix, 'MDAnalysis/analysis/encore/dimensionality_reduction/src/spe.c'],
-                            include_dirs = include_dirs+['MDAnalysis/analysis/encore/dimensionality_reduction/include'],
+                            sources = ['package/MDAnalysis/analysis/encore/dimensionality_reduction/stochasticproxembed' + source_suffix, 'package/MDAnalysis/analysis/encore/dimensionality_reduction/src/spe.c'],
+                            include_dirs = include_dirs+['package/MDAnalysis/analysis/encore/dimensionality_reduction/include'],
                             libraries=["m"],
                             extra_compile_args=["-O3", "-ffast-math","-std=c99"])
     pre_exts = [libdcd, distances, distances_omp, qcprot,
@@ -388,7 +388,7 @@ def dynamic_author_list():
     "Chronological list of authors" title.
     """
     authors = []
-    with codecs.open('AUTHORS', encoding='utf-8') as infile:
+    with codecs.open('package/AUTHORS', encoding='utf-8') as infile:
         # An author is a bullet point under the title "Chronological list of
         # authors". We first want move the cursor down to the title of
         # interest.
@@ -427,7 +427,7 @@ def dynamic_author_list():
                + authors + ['Oliver Beckstein'])
 
     # Write the authors.py file.
-    out_path = 'MDAnalysis/authors.py'
+    out_path = 'package/MDAnalysis/authors.py'
     with codecs.open(out_path, 'w', encoding='utf-8') as outfile:
         # Write the header
         header = '''\
@@ -451,7 +451,7 @@ if __name__ == '__main__':
     except (OSError, IOError):
         warnings.warn('Cannot write the list of authors.')
 
-    with open("SUMMARY.txt") as summary:
+    with open("./package/SUMMARY.txt") as summary:
         LONG_DESCRIPTION = summary.read()
     CLASSIFIERS = [
         'Development Status :: 4 - Beta',
@@ -483,8 +483,8 @@ if __name__ == '__main__':
           download_url='https://github.com/MDAnalysis/mdanalysis/releases',
           provides=['MDAnalysis'],
           license='GPL 2',
-          packages=find_packages(),
-          package_dir={'MDAnalysis': 'MDAnalysis'},
+          packages=find_packages('package'),
+          package_dir={'MDAnalysis': 'package/MDAnalysis'},
           ext_package='MDAnalysis',
           ext_modules=exts,
           classifiers=CLASSIFIERS,


### PR DESCRIPTION
This is early work for (potentially) adding the [airspeed velocity](https://github.com/spacetelescope/asv) test suite compatibility to MDAnalysis. It effectively involves adding a config file or two and then writing some tests. The dependencies are typically installed locally for running the actual benchmarks on a given machine, rather than trying to clog up CI or add more dependencies to the project itself.

This is not working correctly yet, and is shamelessly based off the model used by scipy, but I think that is std approach anyway.

Currently, running the following simple GRO file reading benchmark command from the new/ proposed MDAnalysis `benchmark` folder: `asv continuous --bench GROReadBench ebe2b84e64 e3d58188b -e`

 produces the following (truncated) error output:

```
· Creating environments
· Discovering benchmarks
·· Uninstalling from virtualenv-py2.7-Cython0.23.4-Tempita0.5.2-numpy1.8.2-six
·· Building for virtualenv-py2.7-Cython0.23.4-Tempita0.5.2-numpy1.8.2-six
·· Error running /mnt/c/Users/treddy/github_projects/mdanalysis/benchmarks/env/1409c2e6bbaba8e53ec8747e2f93e605/bin/python setup.py build
             STDOUT -------->

             STDERR -------->
             /mnt/c/Users/treddy/github_projects/mdanalysis/benchmarks/env/1409c2e6bbaba8e53ec8747e2f93e605/bin/python: can't open file 'setup.py': [Errno 2] No such file or directory
```
I suspect this is the usual MDAnalysis issue of having `setup.py` in a non-standard location, which presumably we could work around.

I'll try to fix that eventually and write some more interesting benchmarks (and use more sensible commit hashes for major version comparisons, etc.). Obviously, we'll have to discuss if we actually want to do this before any serious effort is put into it.

Typically one would just periodically run the full suite outside of the CI context and update a website somewhere with a summary of the results / machine used to run them/ some useful plots. Probably more common use is to evaluate improvements in PRs with a command like the one I've used above for performance spot checks.

There's still some residual scipy stuff hanging around in the config file & we'd have to check license stuff for asv maybe--BSD-3 it seems.