### PR TITLE
Use generic travis install script rather than OS specific ones

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ matrix:
 
 install:
   - git clone git://github.com/astropy/ci-helpers.git
-  - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh
+  - source ci-helpers/travis/setup_conda.sh
   # additional external tools (Issue #898) -- HOLE
   - |
     if [[ $NAME == 'full' ]]; then \


### PR DESCRIPTION
This should address the issue @kain88-de mentioned about the cron builds in https://github.com/astropy/ci-helpers/pull/199#issuecomment-309222119
