### PR TITLE
Travis build times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ env:
     - CONDA_CHANNELS='biobuilds conda-forge'
     - CONDA_CHANNEL_PRIORITY=True
     - NUMPY_VERSION=stable
+    - DEBUG=True
 
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,13 +31,12 @@ env:
     - SETUP_CMD=""
     - BUILD_CMD="pip install -v package/ && pip install testsuite/"
     - CONDA_DEPENDENCIES="mmtf-python nose=1.3.7 mock six biopython networkx cython joblib nose-timer"
-    - CONDA_ALL_DEPENDENCIES="mmtf-python nose=1.3.7 mock six biopython networkx cython joblib nose-timer matplotlib netcdf4 scikit-learn scipy seaborn coveralls clustalw=2.1"
+    - CONDA_ALL_DEPENDENCIES="mmtf-python nose=1.3.7 mock six biopython networkx cython joblib nose-timer matplotlib scikit-learn scipy seaborn coveralls clustalw=2.1"
     # Install griddataformats from PIP so that scipy is only installed in the full build (#1147)
     - PIP_DEPENDENCIES='griddataformats'
     - CONDA_CHANNELS='biobuilds conda-forge'
     - CONDA_CHANNEL_PRIORITY=True
     - NUMPY_VERSION=stable
-    - DEBUG=True
 
 
 
@@ -57,6 +56,7 @@ matrix:
            BUILD_DOCS=true
            BUILD_CMD="cd ${TRAVIS_BUILD_DIR}/package && python setup.py build_ext --inplace"
            CONDA_DEPENDENCIES=${CONDA_ALL_DEPENDENCIES}
+           PIP_DEPENDENCIES="griddataformats netcdf4"
 
     - os: linux
       env: NAME="Lint"
@@ -70,21 +70,25 @@ matrix:
            COVERAGE='--with-coverage --cover-package MDAnalysis'
            MAIN_CMD='export COVERAGE_FILE=$NOSE_COVERAGE1; python ./testsuite/MDAnalysisTests/mda_nosetests ${NOSE_TEST_LIST1} ${NOSE_FLAGS} ${COVERAGE}; export COVERAGE_FILE=$NOSE_COVERAGE2; python ./testsuite/MDAnalysisTests/mda_nosetests ${NOSE_TEST_LIST2} ${NOSE_FLAGS} ${COVERAGE}'
            CONDA_DEPENDENCIES=${CONDA_ALL_DEPENDENCIES}
+           PIP_DEPENDENCIES="griddataformats netcdf4"
            COVERALLS='true'
 
     - os: osx
       env: NAME='osx'
            CONDA_DEPENDENCIES=${CONDA_ALL_DEPENDENCIES}
+           PIP_DEPENDENCIES="griddataformats netcdf4"
 
     - os: linux
       env: NAME='old numpy'
            NUMPY_VERSION=1.10.4
            CONDA_DEPENDENCIES=${CONDA_ALL_DEPENDENCIES}
+           PIP_DEPENDENCIES="griddataformats netcdf4"
 
     - os: linux
       env: NAME='numpy dev'
            NUMPY_VERSION=dev
            CONDA_DEPENDENCIES=${CONDA_ALL_DEPENDENCIES}
+           PIP_DEPENDENCIES="griddataformats netcdf4"
            EVENT_TYPE='cron'
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,29 +11,14 @@ os:
 
 env:
   global:
-    - secure: "f8EMSWeYC38elhpB4B/ddxlklEvQoycaxnt90Xw2tH/+ThdP1qteQ2vdgNFy1KL7Am/xnbrRhavI5K+ayfxJ93NoE2adaJ9f9aljXK+Oeu+buv5MVo2E2HhN9mX9opSSxiqGmnHIVYcdLP+1soIsDD78SGL7hB/u5nQ1aTzkbaM="
-    - GH_DOC_BRANCH=develop
-    - GH_REPOSITORY=github.com/MDAnalysis/mdanalysis.git
-    - GIT_CI_USER=TravisCI
-    - GIT_CI_EMAIL=TravisCI@mdanalysis.org
-    - MDA_DOCDIR=${TRAVIS_BUILD_DIR}/package/doc/html/html
-    - MDA_OPTPACKAGES=opt/packages
     # Set default python version to avoid repetition later
     - BUILD_DOCS=false
     - PYTHON_VERSION=2.7
-    - COVERALLS=false
-    - NOSE_FLAGS="--processes=2 --process-timeout=400 --no-open-files --with-timer --timer-top-n 50"
-    - NOSE_TEST_LIST1="analysis auxiliary coordinates core formats topology utils"
-    - NOSE_TEST_LIST2="lib"
-    - NOSE_COVERAGE1="coverage1"
-    - NOSE_COVERAGE2="coverage2"
-    - MAIN_CMD="python ./testsuite/MDAnalysisTests/mda_nosetests ${NOSE_TEST_LIST1} ${NOSE_FLAGS}; python ./testsuite/MDAnalysisTests/mda_nosetests ${NOSE_TEST_LIST2} ${NOSE_FLAGS}"
+    - MAIN_CMD="python ./testsuite/MDAnalysisTests/mda_nosetests --processes=2 --process-timeout=400 --no-open-files --with-timer --timer-top-n 50"
     - SETUP_CMD=""
+    - COVERALLS=false
     - BUILD_CMD="pip install -v package/ && pip install testsuite/"
-    - CONDA_DEPENDENCIES="mmtf-python nose=1.3.7 mock six biopython networkx cython joblib nose-timer"
-    - CONDA_ALL_DEPENDENCIES="mmtf-python nose=1.3.7 mock six biopython networkx cython joblib nose-timer matplotlib scikit-learn scipy seaborn coveralls clustalw=2.1"
     # Install griddataformats from PIP so that scipy is only installed in the full build (#1147)
-    - PIP_DEPENDENCIES='griddataformats'
     - CONDA_CHANNELS='biobuilds conda-forge'
     - CONDA_CHANNEL_PRIORITY=True
     - NUMPY_VERSION=stable
@@ -43,80 +28,76 @@ env:
 matrix:
   fast_finish: true
   include:
-    - os : linux
-      env: NAME='minimal'
-           PYTHON_VERSION=2.7
-           MEMLEAK='--with-memleak'
-           MAIN_CMD='python ./testsuite/MDAnalysisTests/mda_nosetests ${NOSE_TEST_LIST1} ${NOSE_FLAGS} ${MEMLEAK}; python ./testsuite/MDAnalysisTests/mda_nosetests  ${NOSE_TEST_LIST2} ${NOSE_FLAGS} ${MEMLEAK}'
-
-    - os: linux
-      env: NAME="Doc"
-           MAIN_CMD="cd package && python setup.py"
-           SETUP_CMD="build_sphinx"
-           BUILD_DOCS=true
-           BUILD_CMD="cd ${TRAVIS_BUILD_DIR}/package && python setup.py build_ext --inplace"
-           CONDA_DEPENDENCIES=${CONDA_ALL_DEPENDENCIES}
-           PIP_DEPENDENCIES="griddataformats netcdf4"
-
-    - os: linux
-      env: NAME="Lint"
-           MAIN_CMD="pylint --rcfile=package/.pylintrc package/MDAnalysis && pylint --rcfile=package/.pylintrc testsuite/MDAnalysisTests"
-           BUILD_CMD=""
-           CONDA_DEPENDENCIES="pylint backports.functools_lru_cache"
-           PIP_DEPENDENCIES=""
-
-    - os: linux
-      env: NAME='full'
-           COVERAGE='--with-coverage --cover-package MDAnalysis'
-           MAIN_CMD='export COVERAGE_FILE=$NOSE_COVERAGE1; python ./testsuite/MDAnalysisTests/mda_nosetests ${NOSE_TEST_LIST1} ${NOSE_FLAGS} ${COVERAGE}; export COVERAGE_FILE=$NOSE_COVERAGE2; python ./testsuite/MDAnalysisTests/mda_nosetests ${NOSE_TEST_LIST2} ${NOSE_FLAGS} ${COVERAGE}'
-           CONDA_DEPENDENCIES=${CONDA_ALL_DEPENDENCIES}
-           PIP_DEPENDENCIES="griddataformats netcdf4"
-           COVERALLS='true'
-
-    - os: osx
-      env: NAME='osx'
-           CONDA_DEPENDENCIES=${CONDA_ALL_DEPENDENCIES}
-           PIP_DEPENDENCIES="griddataformats netcdf4"
-
-    - os: linux
-      env: NAME='old numpy'
-           NUMPY_VERSION=1.10.4
-           CONDA_DEPENDENCIES=${CONDA_ALL_DEPENDENCIES}
-           PIP_DEPENDENCIES="griddataformats netcdf4"
-
-    - os: linux
-      env: NAME='numpy dev'
-           NUMPY_VERSION=dev
-           CONDA_DEPENDENCIES=${CONDA_ALL_DEPENDENCIES}
-           PIP_DEPENDENCIES="griddataformats netcdf4"
-           EVENT_TYPE='cron'
+    - env: CONDA_DEPENDENCIES="mmtf-python"
+      os: linux
+    - env: CONDA_DEPENDENCIES="nose=1.3.7"
+      os: linux
+    - env: CONDA_DEPENDENCIES="mock"
+      os: linux
+    - env: CONDA_DEPENDENCIES="six"
+      os: linux
+    - env: CONDA_DEPENDENCIES="biopython"
+      os: linux
+    - env: CONDA_DEPENDENCIES="networkx"
+      os: linux
+    - env: CONDA_DEPENDENCIES="cython"
+      os: linux
+    - env: CONDA_DEPENDENCIES="joblib"
+      os: linux
+    - env: CONDA_DEPENDENCIES="nose-timer"
+      os: linux
+    - env: CONDA_DEPENDENCIES="matplotlib"
+      os: linux
+    - env: CONDA_DEPENDENCIES="scikit-learn"
+      os: linux
+    - env: CONDA_DEPENDENCIES="scipy"
+      os: linux
+    - env: CONDA_DEPENDENCIES="seaborn"
+      os: linux
+    - env: CONDA_DEPENDENCIES="coveralls"
+      os: linux
+    - env: CONDA_DEPENDENCIES="clustalw=2.1"
+      os: linux
+    - env: CONDA_DEPENDENCIES="griddataformats"
+      os: linux
+    - env: CONDA_DEPENDENCIES="mmtf-python"
+      os: linux
+    - env: CONDA_DEPENDENCIES="mmtf-python nose=1.3.7"
+      os: linux
+    - env: CONDA_DEPENDENCIES="mmtf-python nose=1.3.7 mock"
+      os: linux
+    - env: CONDA_DEPENDENCIES="mmtf-python nose=1.3.7 mock six"
+      os: linux
+    - env: CONDA_DEPENDENCIES="mmtf-python nose=1.3.7 mock six biopython"
+      os: linux
+    - env: CONDA_DEPENDENCIES="mmtf-python nose=1.3.7 mock six biopython networkx"
+      os: linux
+    - env: CONDA_DEPENDENCIES="mmtf-python nose=1.3.7 mock six biopython networkx cython"
+      os: linux
+    - env: CONDA_DEPENDENCIES="mmtf-python nose=1.3.7 mock six biopython networkx cython joblib"
+      os: linux
+    - env: CONDA_DEPENDENCIES="mmtf-python nose=1.3.7 mock six biopython networkx cython joblib nose-timer"
+      os: linux
+    - env: CONDA_DEPENDENCIES="mmtf-python nose=1.3.7 mock six biopython networkx cython joblib nose-timer matplotlib"
+      os: linux
+    - env: CONDA_DEPENDENCIES="mmtf-python nose=1.3.7 mock six biopython networkx cython joblib nose-timer matplotlib scikit-learn"
+      os: linux
+    - env: CONDA_DEPENDENCIES="mmtf-python nose=1.3.7 mock six biopython networkx cython joblib nose-timer matplotlib scikit-learn scipy"
+      os: linux
+    - env: CONDA_DEPENDENCIES="mmtf-python nose=1.3.7 mock six biopython networkx cython joblib nose-timer matplotlib scikit-learn scipy seaborn"
+      os: linux
+    - env: CONDA_DEPENDENCIES="mmtf-python nose=1.3.7 mock six biopython networkx cython joblib nose-timer matplotlib scikit-learn scipy seaborn coveralls"
+      os: linux
+    - env: CONDA_DEPENDENCIES="mmtf-python nose=1.3.7 mock six biopython networkx cython joblib nose-timer matplotlib scikit-learn scipy seaborn coveralls clustalw=2.1"
+      os: linux
+    - env: CONDA_DEPENDENCIES="mmtf-python nose=1.3.7 mock six biopython networkx cython joblib nose-timer matplotlib scikit-learn scipy seaborn coveralls clustalw=2.1 griddataformats"
+      os: linux
 
 install:
   - git clone git://github.com/astropy/ci-helpers.git
   - source ci-helpers/travis/setup_conda.sh
-  # additional external tools (Issue #898) -- HOLE
-  - |
-    if [[ $NAME == 'full' ]]; then \
-        bash ./maintainer/install_hole.sh $TRAVIS_OS_NAME "${HOME}/${MDA_OPTPACKAGES}"; \
-        HOLE_BINDIR="${HOME}/${MDA_OPTPACKAGES}/hole2/exe"; \
-        export PATH=${PATH}:${HOLE_BINDIR}; \
-    fi
-  - eval $BUILD_CMD
 
 script:
   - cd ${TRAVIS_BUILD_DIR}
   - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then ulimit -S -n 2048; fi
   - echo $MAIN_CMD $SETUP_CMD
-  - eval $MAIN_CMD $SETUP_CMD
-
-
-after_success:
-  - |
-    if [[ $COVERALLS == 'true' ]]; then \
-      coverage combine $NOSE_COVERAGE1 $NOSE_COVERAGE2; \
-      coveralls; \
-    fi
-  # can't use test here since this leads to travis fails even though the build passes
-  - if [[ ${TRAVIS_PULL_REQUEST} == "false" ]] && [[ ${BUILD_DOCS} == "true" ]] && [[ ${TRAVIS_BRANCH} == ${GH_DOC_BRANCH} ]]; then
-            bash ${TRAVIS_BUILD_DIR}/maintainer/deploy_docs.sh;
-    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,6 @@ env:
     - CONDA_CHANNELS='biobuilds conda-forge'
     - CONDA_CHANNEL_PRIORITY=True
     - NUMPY_VERSION=stable
-    - DEBUG=True
 
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: generic
 
+sudo: false
+dist: trusty
+
 # Only build for develop and master (and PRs)
 branches:
   only:


### PR DESCRIPTION
installing netcdf4 from pip should fix the build times. I still see a lot of issues on the normal branches when installing netcdf4 that it can't be installed with the mkl version of numpy. 