### PR TITLE
update version number to 0.17.0

### DIFF
--- a/maintainer/conda/MDAnalysis/meta.yaml
+++ b/maintainer/conda/MDAnalysis/meta.yaml
@@ -1,7 +1,7 @@
 package:
   name: mdanalysis
   # This has to be changed after a release
-  version: "0.16.1dev"
+  version: "0.17.0dev"
 
 source:
    git_url: https://github.com/MDAnalysis/mdanalysis

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,6 +13,17 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
+mm/dd/17 richardjgowers, rathann, jbarnoud, orbeckst
+
+  * 0.17.0
+
+Enhancements
+
+Deprecations
+
+Fixes
+
+Changes
 
 
 mm/dd/17 richardjgowers, rathann, jbarnoud, orbeckst

--- a/package/MDAnalysis/version.py
+++ b/package/MDAnalysis/version.py
@@ -66,4 +66,4 @@ Data
 # e.g. with lib.log
 
 #: Release of MDAnalysis as a string, using `semantic versioning`_.
-__version__ = "0.16.2-dev0"  # NOTE: keep in sync with RELEASE in setup.py
+__version__ = "0.17.0-dev"  # NOTE: keep in sync with RELEASE in setup.py

--- a/package/setup.py
+++ b/package/setup.py
@@ -75,7 +75,7 @@ except ImportError:
     cmdclass = {}
 
 # NOTE: keep in sync with MDAnalysis.__version__ in version.py
-RELEASE = "0.16.2-dev0"
+RELEASE = "0.17.0-dev"
 
 is_release = 'dev' not in RELEASE
 

--- a/testsuite/MDAnalysisTests/__init__.py
+++ b/testsuite/MDAnalysisTests/__init__.py
@@ -116,7 +116,7 @@ from __future__ import absolute_import
 import logging
 logger = logging.getLogger("MDAnalysisTests.__init__")
 
-__version__ = "0.16.2-dev0"  # keep in sync with RELEASE in setup.py
+__version__ = "0.17.0-dev"  # keep in sync with RELEASE in setup.py
 try:
     from MDAnalysisTests.authors import __authors__
 except ImportError:

--- a/testsuite/setup.py
+++ b/testsuite/setup.py
@@ -131,7 +131,7 @@ if __name__ == '__main__':
     except (OSError, IOError):
         warnings.warn('Cannot write the list of authors.')
 
-    RELEASE = "0.16.2-dev0"  # this must be in-sync with MDAnalysis
+    RELEASE = "0.17.0-dev"  # this must be in-sync with MDAnalysis
     LONG_DESCRIPTION = \
         """MDAnalysis is a tool for analyzing molecular dynamics trajectories.
 


### PR DESCRIPTION
If we agree that #1421 is the 0.16.2 release branch I think we can start to track new changes in develop under 0.17.0. 

@richardjgowers I leave it to you to merge this or scream at me if I made a mistake. 
