### PR TITLE
Fix a syntax error in MDAnalysis.__init__

### DIFF
--- a/package/MDAnalysis/__init__.py
+++ b/package/MDAnalysis/__init__.py
@@ -143,7 +143,7 @@ the OPLS/AA force field.
 """
 from __future__ import absolute_import
 
-__all__ = ['Universe', 'as_Universe', 'Writer',
+__all__ = ['Universe', 'as_Universe', 'Writer', 'fetch_mmtf']
 
 import logging
 import warnings

--- a/testsuite/MDAnalysisTests/utils/test_deprecated.py
+++ b/testsuite/MDAnalysisTests/utils/test_deprecated.py
@@ -76,13 +76,3 @@ class TestImports(object):
             from MDAnalysis.analysis.x3dna import X3DNA
         except ImportError:
             raise AssertionError("MDAnalysis.analysis.x3dna not available")
-
-def test_collections_NotImplementedError():
-    import MDAnalysis
-    with assert_raises(NotImplementedError):
-        MDAnalysis.collection.clear()
-
-
-
-
-


### PR DESCRIPTION
The PR #1375 introduced a syntax error in MDAnalysis.__init__. This
commit fixes the defective line.

See comment https://github.com/MDAnalysis/mdanalysis/pull/1418#issuecomment-310834754 and bellow.