### PR TITLE
Fix python 3 imcompatibilities in core

### DIFF
--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -644,6 +644,9 @@ class NamedStream(io.IOBase):
     def __iter__(self):
         return iter(self.stream)
 
+    def __next__(self):
+        return self.stream.__next__()
+
     def __enter__(self):
         # do not call the stream's __enter__ because the stream is already open
         return self
@@ -799,6 +802,12 @@ class NamedStream(io.IOBase):
         except AttributeError:
             # IOBase.fileno does not raise IOError as advertised so we do this here
             raise IOError("This NamedStream does not use a file descriptor.")
+
+    def readline(self):
+        try:
+            return self.stream.readline()
+        except AttributeError:
+            return super(NamedStream, self).readline()
 
     # fake the important parts of the string API
     # (other methods such as rfind() are automatically dealt with via __getattr__)

--- a/package/MDAnalysis/topology/GROParser.py
+++ b/package/MDAnalysis/topology/GROParser.py
@@ -84,8 +84,8 @@ class GROParser(TopologyReaderBase):
         # Gro has the following columns
         # resid, resname, name, index, (x,y,z)
         with openany(self.filename, 'rt') as inf:
-            inf.readline()
-            n_atoms = int(inf.readline())
+            next(inf)
+            n_atoms = int(next(inf))
 
             # Allocate shizznizz
             resids = np.zeros(n_atoms, dtype=np.int32)

--- a/package/MDAnalysis/topology/PDBParser.py
+++ b/package/MDAnalysis/topology/PDBParser.py
@@ -150,7 +150,7 @@ class PDBParser(TopologyReaderBase):
 
         self._wrapped_serials = False  # did serials go over 100k?
         last_wrapped_serial = 100000  # if serials wrap, start from here
-        with util.openany(self.filename) as f:
+        with util.openany(self.filename, mode='rt') as f:
             for line in f:
                 line = line.strip()  # Remove extra spaces
                 if not line:  # Skip line if empty

--- a/package/MDAnalysis/topology/TOPParser.py
+++ b/package/MDAnalysis/topology/TOPParser.py
@@ -153,24 +153,24 @@ class TOPParser(TopologyReaderBase):
         # Open and check top validity
         # Reading header info POINTERS
         with openany(self.filename) as self.topfile:
-            header = self.topfile.next()
+            header = next(self.topfile)
             if not header.startswith("%VE"):
                 raise ValueError(
                     "{0} is not a valid TOP file. %VE Missing in header"
                     "".format(self.filename))
-            title = self.topfile.next().split()
+            title = next(self.topfile).split()
             if not (title[1] == "TITLE"):
                 raise ValueError(
                     "{0} is not a valid TOP file. 'TITLE' missing in header"
                     "".format(self.filename))
             while not header.startswith('%FLAG POINTERS'):
-                header = self.topfile.next()
-            self.topfile.next()
+                header = next(self.topfile)
+            next(self.topfile)
 
-            topremarks = [self.topfile.next().strip() for i in range(4)]
+            topremarks = [next(self.topfile).strip() for i in range(4)]
             sys_info = [int(k) for i in topremarks for k in i.split()]
 
-            header = self.topfile.next()
+            header = next(self.topfile)
             # grab the next section title
             next_section = header.split("%FLAG")[1].strip()
 
@@ -179,7 +179,8 @@ class TOPParser(TopologyReaderBase):
                     (atoms_per, per_line,
                      func, name, sect_num) = sections[next_section]
                 except KeyError:
-                    next_getter = self.skipper
+                    def next_getter():
+                        return self.skipper()
                 else:
                     num = sys_info[sect_num]
                     numlines = (num // per_line)
@@ -188,7 +189,8 @@ class TOPParser(TopologyReaderBase):
 
                     attrs[name] = func(atoms_per, numlines)
 
-                    next_getter = self.topfile.next
+                    def next_getter():
+                        return next(self.topfile)
 
                 try:
                     line = next_getter()
@@ -221,7 +223,7 @@ class TOPParser(TopologyReaderBase):
         attrs['segids'] = Segids(np.array(['SYSTEM'], dtype=object))
 
         top = Topology(n_atoms, n_res, 1,
-                       attrs=attrs.values(),
+                       attrs=list(attrs.values()),
                        atom_resindex=residx,
                        residue_segindex=None)
 
@@ -229,9 +231,9 @@ class TOPParser(TopologyReaderBase):
 
     def skipper(self):
         """Skip until we find the next %FLAG entry and return that"""
-        line = self.topfile.next()
+        line = next(self.topfile)
         while not line.startswith("%FLAG"):
-            line = self.topfile.next()
+            line = next(self.topfile)
         return line
 
     def parse_names(self, atoms_per, numlines):
@@ -284,10 +286,10 @@ class TOPParser(TopologyReaderBase):
         return vals
 
     def parsebond(self, atoms_per, numlines):
-        y = self.topfile.next().strip("%FORMAT(")
+        y = next(self.topfile).strip("%FORMAT(")
         section = []
         for i in range(numlines):
-            l = self.topfile.next()
+            l = next(self.topfile)
             # Subtract 1 from each number to ensure zero-indexing for the atoms
             fields = np.int64(l.split()) - 1
             for j in range(0, len(fields), atoms_per):
@@ -296,11 +298,11 @@ class TOPParser(TopologyReaderBase):
 
     def parsesection_mapper(self, atoms_per, numlines, mapper):
         section = []
-        y = self.topfile.next().strip("%FORMAT(")
+        y = next(self.topfile).strip("%FORMAT(")
         y.strip(")")
         x = FORTRANReader(y)
         for i in range(numlines):
-            l = self.topfile.next()
+            l = next(self.topfile)
             for j in range(len(x.entries)):
                 val = l[x.entries[j].start:x.entries[j].stop].strip()
                 if val:

--- a/testsuite/MDAnalysisTests/core/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/core/test_atomgroup.py
@@ -62,6 +62,8 @@ warnings.simplefilter('always')
 
 class TestDeprecationWarnings(object):
     @staticmethod
+    @dec.skipif(parser_not_found('DCD'),
+                'DCD parser not available. Are you using python 3?')
     def test_AtomGroupUniverse_usage_warning():
         with warnings.catch_warnings(record=True) as warn:
             warnings.simplefilter('always')
@@ -69,6 +71,8 @@ class TestDeprecationWarnings(object):
         assert_equal(len(warn), 1)
 
     @staticmethod
+    @dec.skipif(parser_not_found('DCD'),
+                'DCD parser not available. Are you using python 3?')
     def test_old_AtomGroup_init_warns():
         u = make_Universe(('names',))
         at_list = list(u.atoms[:10])
@@ -78,6 +82,8 @@ class TestDeprecationWarnings(object):
         assert_equal(len(warn), 1)
 
     @staticmethod
+    @dec.skipif(parser_not_found('DCD'),
+                'DCD parser not available. Are you using python 3?')
     def test_old_AtomGroup_init_works():
         u = make_Universe(('names',))
         at_list = list(u.atoms[:10])
@@ -88,6 +94,8 @@ class TestDeprecationWarnings(object):
         assert_equal(ag.names, u.atoms[:10].names)
 
     @staticmethod
+    @dec.skipif(parser_not_found('DCD'),
+                'DCD parser not available. Are you using python 3?')
     def test_old_ResidueGroup_init_warns():
         u = make_Universe(('resnames',))
         res_list = list(u.residues[:10])
@@ -97,6 +105,8 @@ class TestDeprecationWarnings(object):
         assert_equal(len(warn), 1)
 
     @staticmethod
+    @dec.skipif(parser_not_found('DCD'),
+                'DCD parser not available. Are you using python 3?')
     def test_old_ResidueGroup_init_works():
         u = make_Universe(('resnames',))
         res_list = list(u.residues[:10])
@@ -107,6 +117,8 @@ class TestDeprecationWarnings(object):
         assert_equal(rg.resnames, u.residues[:10].resnames)
 
     @staticmethod
+    @dec.skipif(parser_not_found('DCD'),
+                'DCD parser not available. Are you using python 3?')
     def test_old_SegmentGroup_init_warns():
         u = make_Universe(('segids',))
         seg_list = list(u.segments[:3])
@@ -116,6 +128,8 @@ class TestDeprecationWarnings(object):
         assert_equal(len(warn), 1)
 
     @staticmethod
+    @dec.skipif(parser_not_found('DCD'),
+                'DCD parser not available. Are you using python 3?')
     def test_old_SegmentGroup_init_works():
         u = make_Universe(('segids',))
         seg_list = list(u.segments[:3])
@@ -128,6 +142,8 @@ class TestDeprecationWarnings(object):
 
 class TestAtomGroupToTopology(object):
     """Test the conversion of AtomGroup to TopologyObjects"""
+    @dec.skipif(parser_not_found('DCD'),
+                'DCD parser not available. Are you using python 3?')
     def setUp(self):
         self.u = mda.Universe(PSF, DCD)
 
@@ -165,6 +181,8 @@ class TestAtomGroupToTopology(object):
 
 
 class TestAtomGroupWriting(object):
+    @dec.skipif(parser_not_found('DCD'),
+                'DCD parser not available. Are you using python 3?')
     def setUp(self):
         self.u = mda.Universe(PSF, DCD)
 
@@ -311,6 +329,8 @@ class TestWriteGRO(_WriteAtoms):
 
 
 class TestAtomGroupTransformations(object):
+    @dec.skipif(parser_not_found('DCD'),
+                'DCD parser not available. Are you using python 3?')
     def setUp(self):
         self.u = mda.Universe(PSF, DCD)
         self.coords = self.u.atoms.positions.copy()
@@ -468,6 +488,8 @@ class TestCenter(object):
 
 
 class TestSplit(object):
+    @dec.skipif(parser_not_found('DCD'),
+                'DCD parser not available. Are you using python 3?')
     def setUp(self):
         self.universe = mda.Universe(PSF, DCD)
 

--- a/testsuite/MDAnalysisTests/core/test_residuegroup.py
+++ b/testsuite/MDAnalysisTests/core/test_residuegroup.py
@@ -47,6 +47,8 @@ class TestSequence(object):
         "YYSKEAEAGNTKYAKVDGTKPVAEVRADLEKILG"
     )
 
+    @dec.skipif(parser_not_found('DCD'),
+                'DCD parser not available. Are you using python 3?')
     def setUp(self):
         self.u = mda.Universe(PSF, DCD)
 

--- a/testsuite/MDAnalysisTests/core/test_topology.py
+++ b/testsuite/MDAnalysisTests/core/test_topology.py
@@ -601,7 +601,7 @@ class TestAddingResidues(object):
         try:
             u.add_Residue(segment=u.segments[0], resid=42)
         except NoDataError as e:
-            assert_('resname' in e[0])
+            assert_('resname' in str(e))
         else:
             raise AssertionError
 
@@ -612,8 +612,8 @@ class TestAddingResidues(object):
         try:
             u.add_Residue(segment=u.segments[0])
         except NoDataError as e:
-            assert_('resname' in e[0])
-            assert_('resid' in e[0])
+            assert_('resname' in str(e))
+            assert_('resid' in str(e))
         else:
             raise AssertionError
 
@@ -636,7 +636,7 @@ class TestAddingResidues(object):
         try:
             u.add_Segment()
         except NoDataError as e:
-            assert_('segid' in e[0])
+            assert_('segid' in str(e))
         else:
             raise AssertionError
 

--- a/testsuite/MDAnalysisTests/core/test_topologyattrs.py
+++ b/testsuite/MDAnalysisTests/core/test_topologyattrs.py
@@ -26,6 +26,7 @@ from __future__ import division, absolute_import
 import numpy as np
 
 from numpy.testing import (
+    dec,
     assert_,
     assert_array_equal,
     assert_array_almost_equal,
@@ -34,7 +35,7 @@ from numpy.testing import (
 from nose.tools import raises
 from MDAnalysisTests.plugins.knownfailure import knownfailure
 from MDAnalysisTests.datafiles import PSF, DCD
-from MDAnalysisTests import make_Universe
+from MDAnalysisTests import parser_not_found, make_Universe
 
 import MDAnalysis as mda
 import MDAnalysis.core.topologyattrs as tpattrs
@@ -151,6 +152,8 @@ class TestAtomids(TestAtomAttr):
 
 
 class TestIndicesClasses(object):
+    @dec.skipif(parser_not_found('DCD'),
+                'DCD parser not available. Are you using python 3?')
     def setUp(self):
         self.u = mda.Universe(PSF, DCD)
 
@@ -370,6 +373,8 @@ class TestSegmentAttr(TopologyAttrMixin):
 
 
 class TestAttr(object):
+    @dec.skipif(parser_not_found('DCD'),
+                'DCD parser not available. Are you using python 3?')
     def setUp(self):
         self.universe = mda.Universe(PSF, DCD)
         self.ag = self.universe.atoms  # prototypical AtomGroup

--- a/testsuite/MDAnalysisTests/core/test_topologyobjects.py
+++ b/testsuite/MDAnalysisTests/core/test_topologyobjects.py
@@ -23,6 +23,7 @@ from __future__ import absolute_import
 
 import numpy as np
 from numpy.testing import (
+    dec,
     assert_array_equal,
     assert_almost_equal,
     assert_equal,
@@ -40,6 +41,7 @@ from MDAnalysis.core.topologyobjects import (
 
 
 from MDAnalysisTests.datafiles import PSF, DCD, TRZ_psf, TRZ
+from MDAnalysisTests import parser_not_found
 
 
 class TestTopologyObjects(object):
@@ -53,6 +55,8 @@ class TestTopologyObjects(object):
     len
     """
 
+    @dec.skipif(parser_not_found('DCD'),
+                'DCD parser not available. Are you using python 3?')
     def setUp(self):
         self.precision = 3  # rather lenient but see #271
         self.u = mda.Universe(PSF, DCD)
@@ -241,7 +245,7 @@ class TestTopologyGroup(object):
                      False)
 
     def test_angles_reversal(self):
-        bondtypes = self.a_td.keys()
+        bondtypes = list(self.a_td.keys())
         b = bondtypes[1]
         assert_equal(all([b in self.a_td, b[::-1] in self.a_td]), True)
 
@@ -262,7 +266,7 @@ class TestTopologyGroup(object):
                      False)
 
     def test_dihedrals_reversal(self):
-        bondtypes = self.t_td.keys()
+        bondtypes = list(self.t_td.keys())
         b = bondtypes[1]
         assert_equal(all([b in self.t_td, b[::-1] in self.t_td]), True)
 
@@ -556,6 +560,8 @@ class TestTopologyGroup_Cython(object):
      - work (return proper values)
      - catch errors
     """
+    @dec.skipif(parser_not_found('DCD'),
+                'DCD parser not available. Are you using python 3?')
     def setUp(self):
         self.u = mda.Universe(PSF, DCD)
         # topologygroups for testing

--- a/testsuite/MDAnalysisTests/core/test_universe.py
+++ b/testsuite/MDAnalysisTests/core/test_universe.py
@@ -452,6 +452,8 @@ class TestInMemoryUniverse(object):
                      err_msg="Unexpected differences between arrays.")
 
     @staticmethod
+    @dec.skipif(parser_not_found('DCD'),
+                'DCD parser not available. Are you using python 3?')
     def test_slicing_with_start_stop():
         universe = MDAnalysis.Universe(PDB_small, DCD)
         # Skip only the last frame
@@ -461,6 +463,8 @@ class TestInMemoryUniverse(object):
                      err_msg="Unexpected shape of trajectory timeseries")
 
     @staticmethod
+    @dec.skipif(parser_not_found('DCD'),
+                'DCD parser not available. Are you using python 3?')
     def test_slicing_without_start():
         universe = MDAnalysis.Universe(PDB_small, DCD)
         # Skip only the last frame
@@ -470,6 +474,8 @@ class TestInMemoryUniverse(object):
                      err_msg="Unexpected shape of trajectory timeseries")
 
     @staticmethod
+    @dec.skipif(parser_not_found('DCD'),
+                'DCD parser not available. Are you using python 3?')
     def test_slicing_without_stop():
         universe = MDAnalysis.Universe(PDB_small, DCD)
         # Skip only the last frame
@@ -480,6 +486,8 @@ class TestInMemoryUniverse(object):
                      err_msg="Unexpected shape of trajectory timeseries")
 
     @staticmethod
+    @dec.skipif(parser_not_found('DCD'),
+                'DCD parser not available. Are you using python 3?')
     def test_slicing_step_without_start_stop():
         universe = MDAnalysis.Universe(PDB_small, DCD)
         # Skip only the last frame
@@ -490,6 +498,8 @@ class TestInMemoryUniverse(object):
                      err_msg="Unexpected shape of trajectory timeseries")
 
     @staticmethod
+    @dec.skipif(parser_not_found('DCD'),
+                'DCD parser not available. Are you using python 3?')
     def test_slicing_step_with_start_stop():
         universe = MDAnalysis.Universe(PDB_small, DCD)
         # Skip only the last frame
@@ -500,6 +510,8 @@ class TestInMemoryUniverse(object):
                      err_msg="Unexpected shape of trajectory timeseries")
 
     @staticmethod
+    @dec.skipif(parser_not_found('DCD'),
+                'DCD parser not available. Are you using python 3?')
     def test_slicing_step_dt():
         universe = MDAnalysis.Universe(PDB_small, DCD)
         times = [ts.time for ts in universe.trajectory]
@@ -510,6 +522,8 @@ class TestInMemoryUniverse(object):
                         + "dt not updated with step information")
 
     @staticmethod
+    @dec.skipif(parser_not_found('DCD'),
+                'DCD parser not available. Are you using python 3?')
     def test_slicing_negative_start():
         universe = MDAnalysis.Universe(PDB_small, DCD)
         # Skip only the last frame
@@ -520,6 +534,8 @@ class TestInMemoryUniverse(object):
                      err_msg="Unexpected shape of trajectory timeseries")
 
     @staticmethod
+    @dec.skipif(parser_not_found('DCD'),
+                'DCD parser not available. Are you using python 3?')
     def test_slicing_negative_stop():
         universe = MDAnalysis.Universe(PDB_small, DCD)
         # Skip only the last frame


### PR DESCRIPTION
This PR makes the core module pass the tests on python 3. Note that most of the PR consists on having tests being skipped; 266 tests are skipped because they rely on the DCD reader.

These small fixes should allow our python 3 heroes to focus on the real problems.