### PR TITLE
Make topology pass tests in python 3

### DIFF
--- a/package/MDAnalysis/topology/TOPParser.py
+++ b/package/MDAnalysis/topology/TOPParser.py
@@ -152,7 +152,7 @@ class TOPParser(TopologyReaderBase):
 
         # Open and check top validity
         # Reading header info POINTERS
-        with openany(self.filename) as self.topfile:
+        with openany(self.filename, mode='rt') as self.topfile:
             header = next(self.topfile)
             if not header.startswith("%VE"):
                 raise ValueError(

--- a/package/MDAnalysis/topology/TPRParser.py
+++ b/package/MDAnalysis/topology/TPRParser.py
@@ -145,7 +145,7 @@ __copyright__ = "GNU Public Licence, v2"
 import xdrlib
 
 from . import guessers
-from ..lib.util import anyopen
+from ..lib.util import openany
 from .tpr import utils as tpr_utils
 from .base import TopologyReaderBase
 from ..core.topologyattrs import Resnums
@@ -169,7 +169,8 @@ class TPRParser(TopologyReaderBase):
         -------
         structure : dict
         """
-        tprf = anyopen(self.filename, mode='rb').read()
+        with openany(self.filename, mode='rb') as infile:
+            tprf = infile.read()
         data = xdrlib.Unpacker(tprf)
         try:
             th = tpr_utils.read_tpxheader(data)                    # tpxheader

--- a/package/MDAnalysis/topology/XYZParser.py
+++ b/package/MDAnalysis/topology/XYZParser.py
@@ -78,7 +78,7 @@ class XYZParser(TopologyReaderBase):
         -------
         MDAnalysis Topology object
         """
-        with openany(self.filename, 'r') as inf:
+        with openany(self.filename, 'rt') as inf:
             natoms = int(inf.readline().strip())
             inf.readline()
 

--- a/package/MDAnalysis/topology/tpr/utils.py
+++ b/package/MDAnalysis/topology/tpr/utils.py
@@ -230,9 +230,9 @@ def do_mtop(data, fver):
                 atomids.append(atomkind.id + atom_start_ndx)
                 segids.append(segid)
                 resids.append(atomkind.resid + res_start_ndx)
-                resnames.append(atomkind.resname)
-                atomnames.append(atomkind.name)
-                atomtypes.append(atomkind.type)
+                resnames.append(atomkind.resname.decode())
+                atomnames.append(atomkind.name.decode())
+                atomtypes.append(atomkind.type.decode())
                 charges.append(atomkind.charge)
                 masses.append(atomkind.mass)
 

--- a/testsuite/MDAnalysisTests/topology/test_lammpsdata.py
+++ b/testsuite/MDAnalysisTests/topology/test_lammpsdata.py
@@ -27,7 +27,10 @@ from numpy.testing import (
 )
 import numpy as np
 
+import pytest
+
 import MDAnalysis as mda
+from MDAnalysisTests import parser_not_found
 from MDAnalysisTests.topology.base import ParserBase
 from MDAnalysis.tests.datafiles import (
     LAMMPSdata,
@@ -188,6 +191,8 @@ class TestLAMMPSDeletedAtoms(LammpsBase):
         assert_equal(u.atoms.ids,
                      [1, 10, 1002, 2003, 2004, 2005, 2006, 2007, 2008, 2009])
 
+    @pytest.mark.skipif(parser_not_found('LAMMPS'),
+                        reason='LAMMPS parser not available. Are you using python 3?')
     def test_traj(self):
         u = mda.Universe(self.filename)
 


### PR DESCRIPTION
Tests for the topology module now pass on python 3. This especially fix
the issue of topology attribute types (bytes/string) for TOP, XVG, and
TPR (see #1363).