### PR TITLE
install pytest-raises with setup.py for testing and keep dependencies only in MDAnalysisTests setup.py

### DIFF
--- a/package/setup.py
+++ b/package/setup.py
@@ -524,12 +524,7 @@ if __name__ == '__main__':
           },
           test_suite="MDAnalysisTests",
           tests_require=[
-              'nose>=1.3.7',
-              'pytest>=3.1.2',
-              'pytest-cov',
-              'pytest-xdist',
-              'hypothesis',
-              'MDAnalysisTests=={0}'.format(RELEASE),  # same as this release!
+              'MDAnalysisTests=={0!s}'.format(RELEASE),  # same as this release!
           ],
           zip_safe=False,  # as a zipped egg the *.so files are not found (at
                            # least in Ubuntu/Linux)

--- a/testsuite/setup.py
+++ b/testsuite/setup.py
@@ -218,6 +218,7 @@ For details see the report for `Issue 87`_.
               'pytest>=3.1.2',
               'pytest-cov',
               'pytest-xdist',
+              'pytest-raises',
               'hypothesis',
               'psutil>=4.0.2',
               'mock>=2.0.0',


### PR DESCRIPTION
If pytest-raises is not installed, a number of tests fail because
exceptions are not properly caught and recognized.

Removed explicit testing dependencies from package/setup.py except the
MDAnalysisTests package itself; all required dependencies are solely
defined in MDAnalysisTests's setup.py.

