### PR TITLE
Fix comparison of None with int in auxiliary

### DIFF
--- a/package/MDAnalysis/auxiliary/base.py
+++ b/package/MDAnalysis/auxiliary/base.py
@@ -413,8 +413,10 @@ class AuxReader(six.with_metaclass(_AuxReaderMeta)):
         # the frame being read): the current step should be assigned to a
         # previous frame, and the next step to either the frame being read or a
         # following frame. Move to right position if not.
-        if not (self.step_to_frame(self.step, ts) < ts.frame
-                and self.step_to_frame(self.step+1, ts) >= ts.frame):
+        frame_for_step = self.step_to_frame(self.step, ts)
+        frame_for_next_step = self.step_to_frame(self.step+1, ts)
+        if (self.step != -1
+                and not (frame_for_step < ts.frame <= frame_for_next_step)):
             self.move_to_ts(ts)
 
         self._reset_frame_data() # clear previous frame data

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -1559,7 +1559,7 @@ class ProtoReader(six.with_metaclass(_Readermeta, IOBase)):
         aux = self._check_for_aux(auxname)
         ts = self.ts
         # catch up auxiliary if it starts earlier than trajectory
-        while aux.step_to_frame(aux.step + 1, ts) < 0:
+        while aux.step_to_frame(aux.step + 1, ts) is None:
             next(aux)
         # find the next frame that'll have a representative value
         next_frame = aux.next_nonempty_frame(ts)
@@ -1586,7 +1586,10 @@ class ProtoReader(six.with_metaclass(_Readermeta, IOBase)):
         self._reopen()
         aux._restart()
         while True:
-            yield self.next_as_aux(auxname)
+            try:
+                yield self.next_as_aux(auxname)
+            except StopIteration:
+                return
 
     def iter_auxiliary(self, auxname, start=None, stop=None, step=None,
                        selected=None):


### PR DESCRIPTION
Fixes #1457

In some cases the base class of the aux reader can compare an `int` with `None`. This happens when `AuxReader.step == -1` which means that the aux reader is before the beginning of the set.

This commit avoid the comparison where it was happening.