### PR TITLE
Fix deprecation warning missfires

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,7 +13,8 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-mm/dd/17 richardjgowers, rathann, orbeckst, tylerjereddy, mtiberti, kain88-de
+mm/dd/17 richardjgowers, rathann, orbeckst, tylerjereddy, mtiberti, kain88-de,
+         jbarnoud
 
   * 0.17.0
 
@@ -28,6 +29,8 @@ Fixes
     #1424)
   * Fixed type matching and inclusion compilation warnings for the
   ENCORE analysis package (issue #1390)
+  * Fix extra deprecation warnings for instant segment and residue selectors
+    (Issue #1476)
 
 Changes
   * remove deprecated TimeSeriesCollection

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -1070,13 +1070,6 @@ class Resnames(ResidueAttr):
     # This transplant is hardcoded for now to allow for multiple getattr things
     #transplants[Segment].append(('__getattr__', getattr__))
 
-
-    @deprecate(message="Instant selector ResidueGroup.<name> "
-               "or Segment.<name> "
-               "is deprecated and will be removed in 1.0. "
-               "Use ResidueGroup[ResidueGroup.resnames == '<name>'] "
-               "or Segment.residues[Segment.residues == '<name>'] "
-               "instead.")
     def _get_named_residue(group, resname):
         """Get all residues with name *resname* in the current ResidueGroup
         or Segment.
@@ -1104,7 +1097,14 @@ class Resnames(ResidueAttr):
         if len(residues) == 0:
             raise selection.SelectionError(
                 "No residues with resname '{0}'".format(resname))
-        elif len(residues) == 1:
+        warnings.warn("Instant selector ResidueGroup.<name> "
+                      "or Segment.<name> "
+                      "is deprecated and will be removed in 1.0. "
+                      "Use ResidueGroup[ResidueGroup.resnames == '<name>'] "
+                      "or Segment.residues[Segment.residues == '<name>'] "
+                      "instead.",
+                      DeprecationWarning)
+        if len(residues) == 1:
             # XXX: keep this, makes more sense for names
             return residues[0]
         else:
@@ -1273,10 +1273,6 @@ class Segids(SegmentAttr):
     transplants[SegmentGroup].append(
         ('__getattr__', getattr__))
 
-    @deprecate(message="Instant selector SegmentGroup.<name> "
-               "is deprecated and will be removed in 1.0. "
-               "Use SegmentGroup[SegmentGroup.segids == '<name>'] "
-               "instead.")
     def _get_named_segment(group, segid):
         """Get all segments with name *segid* in the current SegmentGroup.
 
@@ -1305,7 +1301,12 @@ class Segids(SegmentAttr):
         if len(segments) == 0:
             raise selection.SelectionError(
                 "No segments with segid '{0}'".format(segid))
-        elif len(segments) == 1:
+        warnings.warn("Instant selector SegmentGroup.<name> "
+                      "is deprecated and will be removed in 1.0. "
+                      "Use SegmentGroup[SegmentGroup.segids == '<name>'] "
+                      "instead.",
+                      DeprecationWarning)
+        if len(segments) == 1:
             # XXX: keep this, makes more sense for names
             return segments[0]
         else:

--- a/testsuite/MDAnalysisTests/core/test_topologyattrs.py
+++ b/testsuite/MDAnalysisTests/core/test_topologyattrs.py
@@ -519,7 +519,7 @@ class TestInstantSelectorDeprecation(object):
         """Test that the warnings are issued when required.
         """
         with pytest.deprecated_call():
-            exec(instruction)
+            exec(instruction)  #pylint: disable=W0122
 
     @pytest.mark.parametrize('instruction', (
         'universe.atoms',
@@ -533,7 +533,7 @@ class TestInstantSelectorDeprecation(object):
         """
         with pytest.warns(None) as record:
             warnings.simplefilter('always')
-            exec(instruction)
+            exec(instruction)  #pylint: disable=W0122
         for warning in record:
             assert not 'Instant selector' in str(warning.message)
             


### PR DESCRIPTION
`u.segments` and `u.residues` should not issue a deprecation warning.
This commit applies the same strategy than
a9f9655a3b45b8486a1aadb5ad903f8bfe68ef3f to avoid the unwanted warning.

Fixes  #1476

PR Checklist
------------
 - [x] Tests?
 - ~[ ] Docs?~
 - [x] CHANGELOG updated?
 - [X] Issue raised/referenced?
