### PR TITLE
python3  util.filename

### DIFF
--- a/package/MDAnalysis/coordinates/XYZ.py
+++ b/package/MDAnalysis/coordinates/XYZ.py
@@ -302,7 +302,11 @@ class XYZReader(base.ReaderBase):
         # the filename has been parsed to be either be foo.xyz or foo.xyz.bz2 by
         # coordinates::core.py so the last file extension will tell us if it is
         # bzipped or not
-        root, ext = os.path.splitext(self.filename)
+        if util.isstream(self.filename):
+            root = str(self.filename)
+            ext = 'xyz'
+        else:
+            root, ext = os.path.splitext(self.filename)
         self.xyzfile = util.anyopen(self.filename)
         self.compression = ext[1:] if ext[1:] != "xyz" else None
         self._cache = dict()

--- a/package/MDAnalysis/coordinates/XYZ.py
+++ b/package/MDAnalysis/coordinates/XYZ.py
@@ -298,17 +298,7 @@ class XYZReader(base.ReaderBase):
 
     def __init__(self, filename, **kwargs):
         super(XYZReader, self).__init__(filename, **kwargs)
-
-        # the filename has been parsed to be either be foo.xyz or foo.xyz.bz2 by
-        # coordinates::core.py so the last file extension will tell us if it is
-        # bzipped or not
-        if util.isstream(self.filename):
-            root = str(self.filename)
-            ext = 'xyz'
-        else:
-            root, ext = os.path.splitext(self.filename)
         self.xyzfile = util.anyopen(self.filename)
-        self.compression = ext[1:] if ext[1:] != "xyz" else None
         self._cache = dict()
 
         self.ts = self._Timestep(self.n_atoms, **self._ts_kwargs)

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -208,6 +208,8 @@ def filename(name, ext=None, keep=False):
     .. versionchanged:: 0.9.0
        Also permits :class:`NamedStream` to pass through.
     """
+    # save casting of NamedStream to a string. Python3 doesn't like the class
+    name = str(name)
     if ext is not None:
         if not ext.startswith(os.path.extsep):
             ext = os.path.extsep + ext

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -209,7 +209,8 @@ def filename(name, ext=None, keep=False):
        Also permits :class:`NamedStream` to pass through.
     """
     # save casting of NamedStream to a string. Python3 doesn't like the class
-    name = str(name)
+    if isstream(name):
+        return name
     if ext is not None:
         if not ext.startswith(os.path.extsep):
             ext = os.path.extsep + ext
@@ -220,7 +221,7 @@ def filename(name, ext=None, keep=False):
                 name.name = newname
             else:
                 name = newname
-    return name if isstream(name) else str(name)
+    return str(name)
 
 
 @contextmanager

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -204,24 +204,28 @@ def filename(name, ext=None, keep=False):
         - ``False``: replace existing extension with `ext`;
         - ``True``: keep old extension if one existed
 
+    Returns
+    -------
+    name : str or NamedStream
+        new filename with replaced extension if ``keep=True``.
+
 
     .. versionchanged:: 0.9.0
        Also permits :class:`NamedStream` to pass through.
     """
-    # save casting of NamedStream to a string. Python3 doesn't like the class
-    if isstream(name):
-        return name
     if ext is not None:
         if not ext.startswith(os.path.extsep):
             ext = os.path.extsep + ext
-        root, origext = os.path.splitext(name)
+        # save casting of NamedStream to a string. Python3 doesn't like the
+        # class because os.path function do type checking
+        root, origext = os.path.splitext(str(name))
         if not keep or len(origext) == 0:
             newname = root + ext
             if isstream(name):
                 name.name = newname
             else:
                 name = newname
-    return str(name)
+    return name
 
 
 @contextmanager

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -878,7 +878,7 @@ def get_ext(filename):
     root : str
     ext : str
     """
-    root, ext = os.path.splitext(filename)
+    root, ext = os.path.splitext(str(filename))
     if ext.startswith(os.extsep):
         ext = ext[1:]
     return root, ext.lower()

--- a/testsuite/MDAnalysisTests/utils/test_streamio.py
+++ b/testsuite/MDAnalysisTests/utils/test_streamio.py
@@ -74,7 +74,7 @@ class TestIsstream(TestCase):
 
     def test_StringIO_read(self):
         with open(datafiles.PSF, "r") as f:
-            obj = StringIO(f)
+            obj = StringIO(f.read())
         assert_equal(util.isstream(obj), True)
         obj.close()
 


### PR DESCRIPTION
the os module seems to be a little bit stricter under python 3. Since we already use our own `filename` function a small fix like this though should make a lot of problems go away.

Fixes #

Changes made in this Pull Request:
 - 


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
