### PR TITLE
print slowest tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,8 @@ env:
     - MAIN_CMD="pytest ${PYTEST_LIST} ${PYTEST_FLAGS}"
     - SETUP_CMD=""
     - BUILD_CMD="pip install -v package/ && pip install testsuite/"
-    - CONDA_DEPENDENCIES="mmtf-python nose=1.3.7 mock six biopython networkx cython joblib nose-timer matplotlib scipy griddataformats pytest-cov pytest-xdist hypothesis"
-    - CONDA_ALL_DEPENDENCIES="mmtf-python nose=1.3.7 mock six biopython networkx cython joblib nose-timer matplotlib netcdf4 scikit-learn scipy griddataformats seaborn coveralls clustalw=2.1 pytest-cov pytest-xdist hypothesis"
+    - CONDA_DEPENDENCIES="mmtf-python nose=1.3.7 mock six biopython networkx cython joblib nose-timer matplotlib scipy griddataformats hypothesis"
+    - CONDA_ALL_DEPENDENCIES="mmtf-python nose=1.3.7 mock six biopython networkx cython joblib nose-timer matplotlib netcdf4 scikit-learn scipy griddataformats seaborn coveralls clustalw=2.1  hypothesis"
     # Install griddataformats from PIP so that scipy is only installed in the full build (#1147)
     - PIP_DEPENDENCIES='pytest-raises'
     - CONDA_CHANNELS='biobuilds conda-forge'

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
     - COVERALLS=false
     - NOSE_FLAGS="--processes=2 --process-timeout=400 --no-open-files --with-timer --timer-top-n 50"
     - NOSE_TEST_LIST=""
-    - PYTEST_FLAGS="--disable-pytest-warnings -n 2"
+    - PYTEST_FLAGS="--disable-pytest-warnings --numprocesses 2 --durations=50"
     - PYTEST_LIST="testsuite/MDAnalysisTests/lib testsuite/MDAnalysisTests/formats testsuite/MDAnalysisTests/coordinates testsuite/MDAnalysisTests/utils testsuite/MDAnalysisTests/topology testsuite/MDAnalysisTests/auxiliary testsuite/MDAnalysisTests/core testsuite/MDAnalysisTests/analysis"
     - NOSE_COVERAGE_FILE="nose_coverage"
     - PYTEST_COVERAGE_FILE="pytest_coverage"

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,8 @@ env:
     - PYTEST_LIST="testsuite/MDAnalysisTests/lib testsuite/MDAnalysisTests/formats testsuite/MDAnalysisTests/coordinates testsuite/MDAnalysisTests/utils testsuite/MDAnalysisTests/topology testsuite/MDAnalysisTests/auxiliary testsuite/MDAnalysisTests/core testsuite/MDAnalysisTests/analysis"
     - NOSE_COVERAGE_FILE="nose_coverage"
     - PYTEST_COVERAGE_FILE="pytest_coverage"
-    - MAIN_CMD="pytest ${PYTEST_LIST} ${PYTEST_FLAGS}"
-    - SETUP_CMD=""
+    - MAIN_CMD="pytest ${PYTEST_LIST}"
+    - SETUP_CMD="${PYTEST_FLAGS}"
     - BUILD_CMD="pip install -v package/ && pip install testsuite/"
     - CONDA_DEPENDENCIES="mmtf-python nose=1.3.7 mock six biopython networkx cython joblib nose-timer matplotlib scipy griddataformats hypothesis"
     - CONDA_ALL_DEPENDENCIES="mmtf-python nose=1.3.7 mock six biopython networkx cython joblib nose-timer matplotlib netcdf4 scikit-learn scipy griddataformats seaborn coveralls clustalw=2.1  hypothesis"
@@ -60,6 +60,7 @@ matrix:
     - os: linux
       env: NAME="Lint"
            MAIN_CMD="pylint --rcfile=package/.pylintrc package/MDAnalysis && pylint --rcfile=package/.pylintrc testsuite/MDAnalysisTests"
+           SETUP_CMD=''
            BUILD_CMD=""
            CONDA_DEPENDENCIES="pylint backports.functools_lru_cache"
            PIP_DEPENDENCIES=""
@@ -68,7 +69,7 @@ matrix:
       env: NAME='full'
            NOSE_COVERAGE='--with-coverage --cover-package MDAnalysis'
            PYTEST_COVERAGE='--cov=MDAnalysis'
-           MAIN_CMD='pytest ${PYTEST_LIST} ${PYTEST_FLAGS} ${PYTEST_COVERAGE}'
+           SETUP_CMD="${PYTEST_FLAGS} ${PYTEST_COVERAGE}"
            CONDA_DEPENDENCIES=${CONDA_ALL_DEPENDENCIES}
            COVERALLS='true'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ env:
     - CONDA_DEPENDENCIES="mmtf-python nose=1.3.7 mock six biopython networkx cython joblib nose-timer matplotlib scipy griddataformats hypothesis"
     - CONDA_ALL_DEPENDENCIES="mmtf-python nose=1.3.7 mock six biopython networkx cython joblib nose-timer matplotlib netcdf4 scikit-learn scipy griddataformats seaborn coveralls clustalw=2.1  hypothesis"
     # Install griddataformats from PIP so that scipy is only installed in the full build (#1147)
-    - PIP_DEPENDENCIES='pytest-raises'
+    - PIP_DEPENDENCIES=''
     - CONDA_CHANNELS='biobuilds conda-forge'
     - CONDA_CHANNEL_PRIORITY=True
     - NUMPY_VERSION=stable

--- a/testsuite/MDAnalysisTests/utils/test_distances.py
+++ b/testsuite/MDAnalysisTests/utils/test_distances.py
@@ -701,7 +701,6 @@ class TestDistanceBackendSelection(object):
     @pytest.mark.parametrize('backend', [
         "serial", "Serial", "SeRiAL", "SERIAL",
         "openmp", "OpenMP", "oPENmP", "OPENMP",
-        pytest.mark.raises('not_implemented_stuff', exception=ValueError),
     ])
     def test_case_insensitivity(self, backend, backend_selection_pos):
         positions, result = backend_selection_pos
@@ -710,8 +709,14 @@ class TestDistanceBackendSelection(object):
                                           args=(positions, result),
                                           backend=backend)
         except RuntimeError:
-            raise AssertionError("Failed to understand backend {0}".format(backend))
+            pytest.fail("Failed to understand backend {0}".format(backend))
 
+    def test_wront_backend(self, backend_selection_pos):
+        positions, result = backend_selection_pos
+        with pytest.raises(ValueError):
+            MDAnalysis.lib.distances._run("calc_self_distance_array",
+                                          args=(positions, result),
+                                          backend="not implemented stuff")
 
 def test_used_openmpflag():
     assert_(isinstance(MDAnalysis.lib.distances.USED_OPENMP, bool))

--- a/testsuite/MDAnalysisTests/utils/test_log.py
+++ b/testsuite/MDAnalysisTests/utils/test_log.py
@@ -156,12 +156,17 @@ class TestSetVerbose(object):
         (None, False, False, True),  # Verbose is not provided
         (None, None, True, True),  # Nothing is provided
         (None, None, False, False),  # Nothing is provided
-        pytest.mark.raises((True, True, None, None), exception=ValueError),  # quiet and verbose contradict each other
-        pytest.mark.raises((False, False, None, None), exception=ValueError),  # quiet and verbose contradict each other
     ])
     def test__set_verbose(self, verbose, quiet, default, result):
         assert _set_verbose(verbose=verbose, quiet=quiet, default=default) == result
-        
+
+    @pytest.mark.parametrize('verbose', (True, False))
+    def test__set_verbose_invalid_args(self, verbose):
+        with pytest.raises(ValueError):
+            # setting quiet==verbose is a contradiction
+            _set_verbose(verbose=verbose, quiet=verbose, default=None)
+
+
     @pytest.mark.parametrize('verbose, quiet', [
         (None, True),
         (False, True)

--- a/testsuite/MDAnalysisTests/utils/test_units.py
+++ b/testsuite/MDAnalysisTests/utils/test_units.py
@@ -117,17 +117,14 @@ class TestConversion(object):
     def test_force(self, quantity, unit1, unit2, ref):
         self._assert_almost_equal_convert(quantity, unit1, unit2, ref)
 
-    @pytest.mark.parametrize('quantity, unit1, unit2, ref', (
-        pytest.mark.raises((nm, 'Stone', 'nm', None), exception=ValueError),
-        pytest.mark.raises((nm, 'nm', 'Stone', None), exception=ValueError),
-    ))
-    def test_unit_unknown(self, quantity, unit1, unit2, ref):
-        val = units.convert(quantity, unit1, unit2)
-        assert_almost_equal(val, ref,
-                            err_msg="Conversion {0} --> {1} failed".format(unit1, unit2))
+    @pytest.mark.parametrize('quantity, unit1, unit2', ((nm, 'Stone', 'nm'),
+                                                        (nm, 'nm', 'Stone')))
+    def test_unit_unknown(self, quantity, unit1, unit2):
+        with pytest.raises(ValueError):
+            units.convert(quantity, unit1, unit2)
 
     def test_unit_unconvertable(self):
         nm = 12.34567
         A = nm * 10.
-        assert_raises(ValueError, units.convert, A, 'A', 'ps')
-
+        with pytest.raises(ValueError):
+            units.convert(A, 'A', 'ps')

--- a/testsuite/setup.py
+++ b/testsuite/setup.py
@@ -213,9 +213,8 @@ For details see the report for `Issue 87`_.
           long_description=LONG_DESCRIPTION,
           install_requires=[
               'MDAnalysis=={0!s}'.format(RELEASE),  # same as this release!
-              'numpy>=1.10.4',
+              'nose>=1.3.7',
               'pytest>=3.1.2',
-              'pytest-raises',
               'hypothesis',
               'psutil>=4.0.2',
               'mock>=2.0.0',

--- a/testsuite/setup.py
+++ b/testsuite/setup.py
@@ -214,10 +214,7 @@ For details see the report for `Issue 87`_.
           install_requires=[
               'MDAnalysis=={0!s}'.format(RELEASE),  # same as this release!
               'numpy>=1.10.4',
-              'nose>=1.3.7',
               'pytest>=3.1.2',
-              'pytest-cov',
-              'pytest-xdist',
               'pytest-raises',
               'hypothesis',
               'psutil>=4.0.2',


### PR DESCRIPTION
enable test profiling again. This will show us the slowest tests like we had for nosetest.

pytest really comes with batteries included