### PR TITLE
Issue a deprecation warning for Universe.<segid>

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -31,6 +31,8 @@ Fixes
   ENCORE analysis package (issue #1390)
   * Fix extra deprecation warnings for instant segment and residue selectors
     (Issue #1476)
+  * Accessing segments from a universe with an instant selector now issues a
+    deprecation warning as expected (Issue #1478)
 
 Changes
   * remove deprecated TimeSeriesCollection

--- a/testsuite/MDAnalysisTests/core/test_topologyattrs.py
+++ b/testsuite/MDAnalysisTests/core/test_topologyattrs.py
@@ -512,8 +512,7 @@ class TestInstantSelectorDeprecation(object):
         'universe.atoms.CA',
         'universe.residues.LYS',
         'universe.segments.s4AKE',
-        pytest.param('universe.s4AKE',
-                     marks=pytest.mark.xfail(reason="Issue #1478")),
+        'universe.s4AKE',
     ))
     def test_deprecation(self, universe, instruction):
         """Test that the warnings are issued when required.


### PR DESCRIPTION
Fixes #1478

The `Universe.<segid>` is now accessed through a `__getattr__` method. This changes slightly the behaviour of this instant selector. Indeed, previously, a segment could have overloaded an attribute of `Universe`. This is not possible anymore as `__getattr__` is only called if the attribute name is not found in the object.

PR Checklist
------------
 - [X] Tests?
 - ~~[ ] Docs?~~
 - [X] CHANGELOG updated?
 - [X] Issue raised/referenced?
