### PR TITLE
Input argument type checking in dist_mat_to_vec

### DIFF
--- a/package/MDAnalysis/analysis/psa.py
+++ b/package/MDAnalysis/analysis/psa.py
@@ -721,8 +721,8 @@ def dist_mat_to_vec(N, i, j):
 
     """
 
-    if not (isinstance(N, numbers.Integral) or isinstance(i, numbers.Integral)
-            or isinstance(j, numbers.Integral)):
+    if not (isinstance(N, numbers.Integral) and isinstance(i, numbers.Integral)
+            and isinstance(j, numbers.Integral)):
         err_str = "N, i, j all must be of type int"
         raise ValueError(err_str)
 

--- a/testsuite/MDAnalysisTests/analysis/test_psa.py
+++ b/testsuite/MDAnalysisTests/analysis/test_psa.py
@@ -30,6 +30,7 @@ from numpy.testing import (TestCase, dec, assert_array_less,
 import numpy as np
 import scipy
 import scipy.spatial
+import pytest
 
 from MDAnalysisTests.datafiles import PSF, DCD, DCD2
 from MDAnalysisTests import parser_not_found, tempdir, module_not_found
@@ -173,8 +174,9 @@ class TestPSAExceptions(TestCase):
         """Test that ValueError is raised when i or j are
         not Integers"""
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError) as err:
             PSA.dist_mat_to_vec(5, '6', '7')
+        assert 'all must be of type int' in str(err.value)
 
         with self.assertRaises(ValueError):
             PSA.dist_mat_to_vec(5, float(6), 7)


### PR DESCRIPTION
Related issue: #1498 

Summary: `dist_mat_to_vec` function should have all input types as integers but the `or` statements in the input checking logic were allowing a single integer and two non-integers; replacing with `and` statements should patch this to require all integers.

Also, switched to pytest style and increased the stringency of the corresponding unit test (now checks error message as well).

The more detailed and correct input checking & unit testing appears to pass on both py2/3 builds now.