### PR TITLE
[WIP] The NamedStream class now has the required __fspath__ method

### DIFF
--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -188,6 +188,13 @@ except NameError:
     def callable(obj):
         return isinstance(obj, collections.Callable)
 
+try:
+    from os import PathLike
+except ImportError:
+   class PathLike(object):
+       pass
+
+
 
 def filename(name, ext=None, keep=False):
     """Return a new name that has suffix attached; replaces other extensions.
@@ -529,7 +536,7 @@ def which(program):
 
 
 @functools.total_ordering
-class NamedStream(io.IOBase):
+class NamedStream(io.IOBase, PathLike):
     """Stream that also provides a (fake) name.
 
     By wrapping a stream `stream` in this class, it can be passed to

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -661,6 +661,9 @@ class NamedStream(io.IOBase):
         #    super(NamedStream, self).__exit__(*args)
         self.close()
 
+    def __fspath__(self):
+        return self.name
+
     # override more IOBase methods, as these are provided by IOBase and are not
     # caught with __getattr__ (ugly...)
     def close(self, force=False):


### PR DESCRIPTION
Related to `NamedStream` discussion in #1481.

All 20 failing tests in `test_selections.py` pass if the method described for Python 3.6 [path-like objects](https://docs.python.org/3/library/os.html#os.PathLike) called `__fspath__()` is defined to return the name of the file / path. Tests pass in Python 2.7 & 3.6, but earlier versions of Python 3.x remain to be tested.

@orbeckst Thoughts on this being less band-aid like than original solution? Travis tests may also be revealing if other issues show up.

I also note that I have minor concerns that what we're actually supposed to do is define our own [abstract base class](https://docs.python.org/3/glossary.html#term-abstract-base-class) rather than just dumping the method in like I've done initially here. The path-like object link above describes itself as an abstract base class.