### PR TITLE
Test log fix warnings

### DIFF
--- a/testsuite/MDAnalysisTests/utils/test_log.py
+++ b/testsuite/MDAnalysisTests/utils/test_log.py
@@ -147,24 +147,32 @@ class TestSetVerbose(object):
 
     @pytest.mark.parametrize('verbose, quiet, default, result', [
         (True, False, True, True),  # Everything agrees verbose should be True
-        (False, True, False, False),  # Everything agrees verbose should be False
-        (True, False, False, True),  # Make sure the default does not overwrite the user choice
-        (False, True, True, False),  # Make sure the default does not overwrite the user choice
+        (False, True, False, False),# Everything agrees verbose should be False
+        (True, False, False, True), # Make sure the default does not overwrite the user choice
+        (False, True, True, False), # Make sure the default does not overwrite the user choice
+        (None, True, False, False), # Verbose is not provided
+        (None, False, False, True), # Verbose is not provided
+    ])
+    def test__set_verbose_deprecated(self, verbose, quiet, default, result):
+        with pytest.deprecated_call():
+            assert _set_verbose(verbose=verbose, quiet=quiet, default=default) == result
+
+    @pytest.mark.parametrize('verbose, quiet, default, result', [
         (True, None, False, True),  # Quiet is not provided
-        (False, None, False, False),  # Quiet is not provided
-        (None, True, False, False),  # Verbose is not provided
-        (None, False, False, True),  # Verbose is not provided
-        (None, None, True, True),  # Nothing is provided
-        (None, None, False, False),  # Nothing is provided
+        (False, None, False, False),# Quiet is not provided
+        (None, None, True, True),   # Nothing is provided
+        (None, None, False, False), # Nothing is provided
     ])
     def test__set_verbose(self, verbose, quiet, default, result):
         assert _set_verbose(verbose=verbose, quiet=quiet, default=default) == result
 
     @pytest.mark.parametrize('verbose', (True, False))
     def test__set_verbose_invalid_args(self, verbose):
-        with pytest.raises(ValueError):
-            # setting quiet==verbose is a contradiction
-            _set_verbose(verbose=verbose, quiet=verbose, default=None)
+        # can't combine the two context managers
+        with pytest.deprecated_call():
+            with pytest.raises(ValueError):
+                # setting quiet==verbose is a contradiction
+                _set_verbose(verbose=verbose, quiet=verbose, default=None)
 
 
     @pytest.mark.parametrize('verbose, quiet', [

--- a/testsuite/MDAnalysisTests/utils/test_log.py
+++ b/testsuite/MDAnalysisTests/utils/test_log.py
@@ -94,7 +94,8 @@ def test_custom_ProgressMeter(buffer, n=51, interval=7):
         pm = MDAnalysis.lib.log.ProgressMeter(n, interval=interval,
                                               format=template, offset=1)
         for frame in range(n):
-            rmsd = 0.02 * frame * (n+1)/float(n)  # n+1/n correction for 0-based frame vs 1-based counting
+            # n+1/n correction for 0-based frame vs 1-based counting
+            rmsd = 0.02 * frame * (n+1)/ n
             pm.echo(frame, rmsd=rmsd)
     buffer.seek(0)
     output = "".join(buffer.readlines())
@@ -114,7 +115,8 @@ def test_legacy_ProgressMeter(buffer, n=51, interval=7):
         pm = MDAnalysis.lib.log.ProgressMeter(n, interval=interval,
                                               format=template, offset=1)
         for frame in range(n):
-            rmsd = 0.02 * frame * (n+1)/float(n)  # n+1/n correction for 0-based frame vs 1-based counting
+            # n+1/n correction for 0-based frame vs 1-based counting
+            rmsd = 0.02 * frame * (n+1)/ n
             pm.echo(frame, rmsd=rmsd)
     buffer.seek(0)
     output = "".join(buffer.readlines())


### PR DESCRIPTION
This marks all the deprecated calls accordingly. This is a pretty nice since pytest also has a warnings summary at the end we can slowly start using. That will be pretty nice once we have removed all the yield test to check that our own testsuite doesn't use deprecated calls.
