### PR TITLE
fix test_streamio python3

### DIFF
--- a/testsuite/MDAnalysisTests/utils/test_streamio.py
+++ b/testsuite/MDAnalysisTests/utils/test_streamio.py
@@ -74,7 +74,7 @@ class TestIsstream(TestCase):
 
     def test_StringIO_read(self):
         with open(datafiles.PSF, "r") as f:
-            obj = StringIO(f)
+            obj = StringIO(f.read())
         assert_equal(util.isstream(obj), True)
         obj.close()
 


### PR DESCRIPTION
StringIO can't be initialized from a file handle

