### PR TITLE
Remove parsernotfound

### DIFF
--- a/package/MDAnalysis/__init__.py
+++ b/package/MDAnalysis/__init__.py
@@ -198,14 +198,3 @@ from .coordinates.core import writer as Writer
 from .coordinates.MMTF import fetch_mmtf
 
 from .migration.ten2eleven import ten2eleven
-
-import six
-if six.PY3:
-    warnings.warn('''\
-#####
-MDAnalysis on python 3 is highly experimental!
-It is mostly non functional and dramatically untested.
-Use at your own risks!!!
-''')
-
-

--- a/package/MDAnalysis/coordinates/__init__.py
+++ b/package/MDAnalysis/coordinates/__init__.py
@@ -702,11 +702,13 @@ from . import base
 from .core import reader, writer
 from . import chain
 from . import CRD
+from . import DCD
 from . import DLPoly
 from . import DMS
 from . import GMS
 from . import GRO
 from . import INPCRD
+from . import LAMMPS
 from . import MOL2
 from . import PDB
 from . import PDBQT
@@ -719,13 +721,3 @@ from . import XYZ
 from . import memory
 from . import MMTF
 from . import null
-
-
-try:
-    from . import DCD
-    from . import LAMMPS
-except ImportError as e:
-    # The import is expected to fail under Python 3.
-    # It should not fail on Python 2, however.
-    if six.PY2:
-        raise e

--- a/testsuite/MDAnalysisTests/__init__.py
+++ b/testsuite/MDAnalysisTests/__init__.py
@@ -114,7 +114,6 @@ from MDAnalysisTests.util import (
     block_import,
     executable_not_found,
     module_not_found,
-    parser_not_found,
     in_dir,
     assert_nowarns,
 )

--- a/testsuite/MDAnalysisTests/analysis/test_align.py
+++ b/testsuite/MDAnalysisTests/analysis/test_align.py
@@ -35,7 +35,7 @@ from numpy.testing import (TestCase, dec,
 import numpy as np
 
 from MDAnalysisTests.datafiles import PSF, DCD, FASTA, ALIGN_BOUND, ALIGN_UNBOUND
-from MDAnalysisTests import executable_not_found, parser_not_found, tempdir
+from MDAnalysisTests import executable_not_found, tempdir
 
 # I want to catch all warnings in the tests. If this is not set at the start it
 # could cause test that check for warnings to fail.
@@ -90,8 +90,6 @@ class TestRotationMatrix(TestCase):
 
 
 class TestAlign(TestCase):
-    @dec.skipif(parser_not_found('DCD'),
-                'DCD parser not available. Are you using python 3?')
     def setUp(self):
         self.universe = mda.Universe(PSF, DCD)
         self.reference = mda.Universe(PSF, DCD)

--- a/testsuite/MDAnalysisTests/analysis/test_base.py
+++ b/testsuite/MDAnalysisTests/analysis/test_base.py
@@ -33,7 +33,6 @@ import MDAnalysis as mda
 from MDAnalysis.analysis import base
 
 from MDAnalysisTests.datafiles import PSF, DCD
-from MDAnalysisTests import parser_not_found
 
 
 class FrameAnalysis(base.AnalysisBase):
@@ -62,8 +61,6 @@ class OldAPIAnalysis(base.AnalysisBase):
 
 
 class TestAnalysisBase(TestCase):
-    @dec.skipif(parser_not_found('DCD'),
-                'DCD parser not available. Are you using python 3?')
     def setUp(self):
         # has 98 frames
         self.u = mda.Universe(PSF, DCD)
@@ -138,8 +135,6 @@ def simple_function(mobile):
     return mobile.center_of_geometry()
 
 
-@dec.skipif(parser_not_found('DCD'),
-            'DCD parser not available. Are you using python 3?')
 def test_AnalysisFromFunction():
     u = mda.Universe(PSF, DCD)
     step = 2
@@ -159,8 +154,6 @@ def test_AnalysisFromFunction():
         assert_array_equal(results, ana.results)
 
 
-@dec.skipif(parser_not_found('DCD'),
-            'DCD parser not available. Are you using python 3?')
 def test_analysis_class():
     ana_class = base.analysis_class(simple_function)
     assert_(issubclass(ana_class, base.AnalysisBase))

--- a/testsuite/MDAnalysisTests/analysis/test_contacts.py
+++ b/testsuite/MDAnalysisTests/analysis/test_contacts.py
@@ -39,7 +39,7 @@ from MDAnalysisTests.datafiles import (PSF,
                                        contacts_villin_unfolded,
                                        contacts_file, )
 
-from MDAnalysisTests import parser_not_found, tempdir
+from MDAnalysisTests import tempdir
 
 
 def test_soft_cut_q():
@@ -114,8 +114,6 @@ def test_contact_matrix():
     assert_array_equal(out, [True, True, True, False, False])
 
 
-@dec.skipif(parser_not_found('DCD'),
-            'DCD parser not available. Are you using python 3?')
 def test_new_selection():
     u = mda.Universe(PSF, DCD)
     selections = ('all', )
@@ -154,9 +152,6 @@ def soft_cut(ref, u, selA, selB, radius=4.5, beta=5.0, lambda_constant=1.8):
 
 
 class TestContacts(TestCase):
-    @dec.skipif(
-        parser_not_found('DCD'),
-        'DCD parser not available. Are you using python 3?')
     def setUp(self):
         self.universe = mda.Universe(PSF, DCD)
         self.trajectory = self.universe.trajectory
@@ -300,8 +295,6 @@ class TestContacts(TestCase):
                 assert fin.readline().strip() == '# q1 analysis'
 
 
-@dec.skipif(parser_not_found('DCD'),
-            'DCD parser not available. Are you using python 3?')
 def test_q1q2():
     u = mda.Universe(PSF, DCD)
     q1q2 = contacts.q1q2(u, 'name CA', radius=8)

--- a/testsuite/MDAnalysisTests/analysis/test_encore.py
+++ b/testsuite/MDAnalysisTests/analysis/test_encore.py
@@ -35,7 +35,7 @@ from numpy.testing import (TestCase, dec, assert_equal, assert_almost_equal,
                            assert_warns)
 
 from MDAnalysisTests.datafiles import DCD, DCD2, PSF, TPR, XTC
-from MDAnalysisTests import parser_not_found, module_not_found, block_import
+from MDAnalysisTests import module_not_found, block_import
 
 import MDAnalysis.analysis.rms as rms
 import MDAnalysis.analysis.align as align
@@ -43,9 +43,6 @@ import MDAnalysis.analysis.encore.confdistmatrix as confdistmatrix
 
 
 class TestEncore(TestCase):
-
-    @dec.skipif(parser_not_found('DCD'),
-                'DCD parser not available. Are you using python 3?')
     def setUp(self):
         # Create universe from templates defined in setUpClass
         self.ens1 = mda.Universe(
@@ -63,8 +60,6 @@ class TestEncore(TestCase):
         del self.ens2
 
     @classmethod
-    @dec.skipif(parser_not_found('DCD'),
-                'DCD parser not available. Are you using python 3?')
     def setUpClass(cls):
         # To speed up tests, we read in trajectories from file only once,
         # and then recreate them from their coordinate array for each test
@@ -409,8 +404,6 @@ inconsistent results")
 
 
 class TestEncoreClustering(TestCase):
-    @dec.skipif(parser_not_found('DCD'),
-                'DCD parser not available. Are you using python 3?')
     def setUp(self):
         # Create universe from templates defined in setUpClass
         self.ens1 = mda.Universe(
@@ -428,8 +421,6 @@ class TestEncoreClustering(TestCase):
         del self.ens2
 
     @classmethod
-    @dec.skipif(parser_not_found('DCD'),
-                'DCD parser not available. Are you using python 3?')
     def setUpClass(cls):
         # To speed up tests, we read in trajectories from file only once,
         # and then recreate them from their coordinate array for each test
@@ -682,8 +673,6 @@ class TestEncoreClusteringSklearn(TestCase):
 
 
 class TestEncoreDimensionalityReduction(TestCase):
-    @dec.skipif(parser_not_found('DCD'),
-                'DCD parser not available. Are you using python 3?')
     def setUp(self):
         # Create universe from templates defined in setUpClass
         self.ens1 = mda.Universe(
@@ -701,8 +690,6 @@ class TestEncoreDimensionalityReduction(TestCase):
         del self.ens2
 
     @classmethod
-    @dec.skipif(parser_not_found('DCD'),
-                'DCD parser not available. Are you using python 3?')
     def setUpClass(cls):
         # To speed up tests, we read in trajectories from file only once,
         # and then recreate them from their coordinate array for each test

--- a/testsuite/MDAnalysisTests/analysis/test_helanal.py
+++ b/testsuite/MDAnalysisTests/analysis/test_helanal.py
@@ -33,7 +33,7 @@ import MDAnalysis.analysis.helanal
 from MDAnalysis import FinishTimeException
 from MDAnalysisTests.datafiles import (GRO, XTC, PSF, DCD, PDB_small,
                                        HELANAL_BENDING_MATRIX)
-from MDAnalysisTests import parser_not_found, tempdir
+from MDAnalysisTests import tempdir
 
 # reference data from a single PDB file:
 #   data = MDAnalysis.analysis.helanal.helanal_main(PDB_small,
@@ -111,8 +111,6 @@ def read_bending_matrix(fn):
     return data
 
 
-@dec.skipif(parser_not_found('DCD'),
-            'DCD parser not available. Are you using python 3?')
 def test_helanal_trajectory(reference=HELANAL_BENDING_MATRIX,
                             outfile="helanal_bending_matrix.dat"):
     u = mda.Universe(PSF, DCD)

--- a/testsuite/MDAnalysisTests/analysis/test_psa.py
+++ b/testsuite/MDAnalysisTests/analysis/test_psa.py
@@ -33,12 +33,10 @@ import scipy.spatial
 import pytest
 
 from MDAnalysisTests.datafiles import PSF, DCD, DCD2
-from MDAnalysisTests import parser_not_found, tempdir, module_not_found
+from MDAnalysisTests import tempdir, module_not_found
 
 
 class TestPSAnalysis(TestCase):
-    @dec.skipif(parser_not_found('DCD'),
-                'DCD parser not available. Are you using python 3?')
     def setUp(self):
         self.tmpdir = tempdir.TempDir()
         self.iu1 = np.triu_indices(3, k=1)

--- a/testsuite/MDAnalysisTests/analysis/test_rms.py
+++ b/testsuite/MDAnalysisTests/analysis/test_rms.py
@@ -41,7 +41,7 @@ import numpy as np
 
 from MDAnalysis.exceptions import SelectionError, NoDataError
 from MDAnalysisTests.datafiles import GRO, XTC, rmsfArray, PSF, DCD
-from MDAnalysisTests import tempdir, parser_not_found
+from MDAnalysisTests import tempdir
 
 # I want to catch all warnings in the tests. If this is not set at the start it
 # could cause test that check for warnings to fail.
@@ -49,8 +49,6 @@ warnings.simplefilter('always')
 
 
 class Testrmsd(TestCase):
-    @dec.skipif(parser_not_found('DCD'),
-                'DCD parser not available. Are you using python 3?')
     def setUp(self):
         shape = (5, 3)
         # vectors with length one

--- a/testsuite/MDAnalysisTests/analysis/test_waterdynamics.py
+++ b/testsuite/MDAnalysisTests/analysis/test_waterdynamics.py
@@ -27,12 +27,9 @@ from numpy.testing import TestCase, assert_equal, dec
 import numpy as np
 
 from MDAnalysisTests.datafiles import waterPSF, waterDCD
-from MDAnalysisTests import parser_not_found
 
 
 class TestWaterdynamics(TestCase):
-    @dec.skipif(parser_not_found('DCD'),
-                'DCD parser not available. Are you using python 3?')
     def setUp(self):
         self.universe = MDAnalysis.Universe(waterPSF, waterDCD)
         self.selection1 = "byres name OH2"

--- a/testsuite/MDAnalysisTests/coordinates/test_chainreader.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_chainreader.py
@@ -32,13 +32,11 @@ from unittest import TestCase
 import MDAnalysis as mda
 from MDAnalysisTests.datafiles import (PDB, PSF, CRD, DCD,
                                        GRO, XTC, TRR, PDB_small, PDB_closed)
-from MDAnalysisTests import parser_not_found, tempdir
+from MDAnalysisTests import tempdir
 
 
 
 class TestChainReader(TestCase):
-    @dec.skipif(parser_not_found('DCD'),
-                'DCD parset not available. Are you using python 3?')
     def setUp(self):
         self.universe = mda.Universe(PSF,
                                      [DCD, CRD, DCD, CRD, DCD, CRD, CRD])
@@ -131,8 +129,6 @@ class TestChainReader(TestCase):
 
 
 class TestChainReaderCommonDt(TestCase):
-    @dec.skipif(parser_not_found('DCD'),
-                'DCD parset not available. Are you using python 3?')
     def setUp(self):
         self.common_dt = 100.0
         self.universe = mda.Universe(PSF,
@@ -161,8 +157,6 @@ class TestChainReaderFormats(TestCase):
         assert_equal(universe.trajectory.n_frames, 21)
 
     @staticmethod
-    @dec.skipif(parser_not_found('DCD'),
-                'DCD parset not available. Are you using python 3?')
     def test_set_one_format_tuple():
         universe = mda.Universe(PSF, [(PDB_small, 'pdb'), DCD])
         assert_equal(universe.trajectory.n_frames, 99)

--- a/testsuite/MDAnalysisTests/coordinates/test_memory.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_memory.py
@@ -30,12 +30,9 @@ from MDAnalysisTests.coordinates.base import (BaseReference,
                                               MultiframeReaderTest)
 from MDAnalysis.coordinates.memory import Timestep
 from numpy.testing import assert_equal, dec
-from MDAnalysisTests import parser_not_found
 
 
 class MemoryReference(BaseReference):
-    @dec.skipif(parser_not_found('DCD'),
-                'DCD parser not available. Are you using python 3?')
     def __init__(self):
         super(MemoryReference, self).__init__()
 

--- a/testsuite/MDAnalysisTests/coordinates/test_pdb.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_pdb.py
@@ -27,7 +27,7 @@ from unittest import TestCase
 
 import MDAnalysis as mda
 import numpy as np
-from MDAnalysisTests import parser_not_found, tempdir, make_Universe
+from MDAnalysisTests import tempdir, make_Universe
 from MDAnalysisTests.coordinates.base import _SingleFrameReader
 from MDAnalysisTests.coordinates.reference import (RefAdKSmall, Ref4e43,
                                                    RefAdK)
@@ -150,8 +150,6 @@ class TestExtendedPDBReader(_SingleFrameReader):
 
 
 class TestPDBWriter(TestCase):
-    @dec.skipif(parser_not_found('DCD'),
-                'DCD parser not available. Are you using python 3?')
     def setUp(self):
         self.universe = mda.Universe(PSF, PDB_small)
         self.universe2 = mda.Universe(PSF, DCD)
@@ -461,8 +459,6 @@ class TestMultiPDBReader(TestCase):
 
 
 class TestMultiPDBWriter(TestCase):
-    @dec.skipif(parser_not_found('DCD'),
-                'DCD parser not available. Are you using python 3?')
     def setUp(self):
         self.universe = mda.Universe(PSF, PDB_small)
         self.multiverse = mda.Universe(PDB_multiframe)

--- a/testsuite/MDAnalysisTests/coordinates/test_timestep_api.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_timestep_api.py
@@ -28,7 +28,7 @@ _TestTimestepInterface tests the Readers are correctly using Timesteps
 from __future__ import absolute_import
 
 from numpy.testing import assert_equal, dec
-from MDAnalysisTests import module_not_found, parser_not_found
+from MDAnalysisTests import module_not_found
 
 import MDAnalysis as mda
 from MDAnalysisTests.datafiles import (PSF, XYZ_five, INPCRD, DCD, DLP_CONFIG,
@@ -44,7 +44,6 @@ import pytest
 
 # Can add in custom tests for a given Timestep here!
 class TestBaseTimestep(BaseTimestepTest):
-    @pytest.mark.skipif(parser_not_found('DCD'), reason='DCD parser not available. Are you using python 3?')
     @pytest.mark.parametrize('otherTS', [
         mda.coordinates.TRJ.Timestep,
         mda.coordinates.DMS.Timestep,
@@ -95,8 +94,6 @@ class TestCRD(BaseTimestepInterfaceTest):
 
 class TestDCD(BaseTimestepInterfaceTest):
     __test__ = True
-    @dec.skipif(parser_not_found('DCD'),
-                'DCD parser not available. Are you using python 3?')
     def setUp(self):
         u = self.u = mda.Universe(PSF, DCD)
         self.ts = u.trajectory.ts
@@ -148,8 +145,6 @@ class TestINPCRD(BaseTimestepInterfaceTest):
 class TestLAMMPS(BaseTimestepInterfaceTest):
     __test__ = True
 
-    @dec.skipif(parser_not_found('LAMMPS'),
-                'LAMMPS parser not available. Are you using python 3?')
     def setUp(self):
         u = self.u = mda.Universe(LAMMPSdata)
         self.ts = u.trajectory.ts
@@ -158,8 +153,6 @@ class TestLAMMPS(BaseTimestepInterfaceTest):
 class TestLAMMPSDCD(BaseTimestepInterfaceTest):
     __test__ = True
 
-    @dec.skipif(parser_not_found('LAMMPS'),
-                'LAMMPS parser not available. Are you using python 3?')
     def setUp(self):
         u = self.u = mda.Universe(LAMMPSdata2, LAMMPSdcd2,
                                   format='LAMMPS', topology_format='DATA',
@@ -228,8 +221,6 @@ class TestTRR(BaseTimestepInterfaceTest):
 class TestTRZ(BaseTimestepInterfaceTest):
     __test__ = True
 
-    @dec.skipif(parser_not_found('TRZ'),
-                'TRZ parser not available. Are you using python 3?')
     def setUp(self):
         u = self.u = mda.Universe(TRZ_psf, TRZ)
         self.ts = u.trajectory.ts

--- a/testsuite/MDAnalysisTests/core/test_atom.py
+++ b/testsuite/MDAnalysisTests/core/test_atom.py
@@ -41,15 +41,12 @@ from MDAnalysisTests.datafiles import (
     PSF, DCD,
     XYZ_mini,
 )
-from MDAnalysisTests import parser_not_found
 
 
 class TestAtom(TestCase):
     # Legacy tests from before 363
     """Tests of Atom."""
 
-    @pytest.mark.skipif(parser_not_found('DCD'),
-                'DCD parser not available. Are you using python 3?')
     def setUp(self):
         """Set up the standard AdK system in implicit solvent."""
         self.universe = mda.Universe(PSF, DCD)

--- a/testsuite/MDAnalysisTests/core/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/core/test_atomgroup.py
@@ -55,7 +55,7 @@ from MDAnalysisTests.datafiles import (
     TRZ_psf, TRZ,
     two_water_gro,
 )
-from MDAnalysisTests import parser_not_found, tempdir, make_Universe
+from MDAnalysisTests import tempdir, make_Universe
 
 import pytest
 
@@ -64,15 +64,12 @@ import pytest
 warnings.simplefilter('always')
 
 class TestDeprecationWarnings(object):
-    @pytest.mark.skipif(parser_not_found('DCD'), reason='DCD parser not available. Are you using python 3?')
     def test_AtomGroupUniverse_usage_warning(self):
         with warnings.catch_warnings(record=True) as warn:
             warnings.simplefilter('always')
             mda.core.AtomGroup.Universe(PSF, DCD)
         assert_equal(len(warn), 1)
 
-    @pytest.mark.skipif(parser_not_found('DCD'),
-                reason='DCD parser not available. Are you using python 3?')
     def test_old_AtomGroup_init_warns(self):
         u = make_Universe(('names',))
         at_list = list(u.atoms[:10])
@@ -81,8 +78,6 @@ class TestDeprecationWarnings(object):
             ag = mda.core.groups.AtomGroup(at_list)
         assert_equal(len(warn), 1)
 
-    @pytest.mark.skipif(parser_not_found('DCD'),
-                reason='DCD parser not available. Are you using python 3?')
     def test_old_AtomGroup_init_works(self):
         u = make_Universe(('names',))
         at_list = list(u.atoms[:10])
@@ -92,8 +87,6 @@ class TestDeprecationWarnings(object):
         assert_(len(ag) == 10)
         assert_equal(ag.names, u.atoms[:10].names)
 
-    @pytest.mark.skipif(parser_not_found('DCD'),
-                reason='DCD parser not available. Are you using python 3?')
     def test_old_ResidueGroup_init_warns(self):
         u = make_Universe(('resnames',))
         res_list = list(u.residues[:10])
@@ -102,8 +95,6 @@ class TestDeprecationWarnings(object):
             rg = mda.core.groups.ResidueGroup(res_list)
         assert_equal(len(warn), 1)
 
-    @pytest.mark.skipif(parser_not_found('DCD'),
-                reason='DCD parser not available. Are you using python 3?')
     def test_old_ResidueGroup_init_works(self):
         u = make_Universe(('resnames',))
         res_list = list(u.residues[:10])
@@ -113,8 +104,6 @@ class TestDeprecationWarnings(object):
         assert_(len(rg) == 10)
         assert_equal(rg.resnames, u.residues[:10].resnames)
 
-    @pytest.mark.skipif(parser_not_found('DCD'),
-                reason='DCD parser not available. Are you using python 3?')
     def test_old_SegmentGroup_init_warns(self):
         u = make_Universe(('segids',))
         seg_list = list(u.segments[:3])
@@ -123,8 +112,6 @@ class TestDeprecationWarnings(object):
             sg = mda.core.groups.SegmentGroup(seg_list)
         assert_equal(len(warn), 1)
 
-    @pytest.mark.skipif(parser_not_found('DCD'),
-                reason='DCD parser not available. Are you using python 3?')
     def test_old_SegmentGroup_init_works(self):
         u = make_Universe(('segids',))
         seg_list = list(u.segments[:3])
@@ -137,7 +124,6 @@ class TestDeprecationWarnings(object):
 
 class TestAtomGroupToTopology(object):
     """Test the conversion of AtomGroup to TopologyObjects"""
-    @pytest.mark.skipif(parser_not_found('DCD'),'DCD parser not available. Are you using python 3?')
     @pytest.fixture()
     def u(self):
         return mda.Universe(PSF, DCD)
@@ -175,8 +161,6 @@ class TestAtomGroupToTopology(object):
 
 
 class TestAtomGroupWriting(TestCase):
-    @pytest.mark.skipif(parser_not_found('DCD'),
-                'DCD parser not available. Are you using python 3?')
     def setUp(self):
         self.u = mda.Universe(PSF, DCD)
 
@@ -219,8 +203,6 @@ class _WriteAtoms(TestCase):
     ext = None  # override to test various output writers
     precision = 3
 
-    @pytest.mark.skipif(parser_not_found('DCD'),
-                'DCD parser not available. Are you using python 3?')
     def setUp(self):
         self.universe = mda.Universe(PSF, DCD)
         suffix = '.' + self.ext
@@ -332,8 +314,6 @@ class TestWriteGRO(_WriteAtoms):
 
 
 class TestAtomGroupTransformations(TestCase):
-    @pytest.mark.skipif(parser_not_found('DCD'),
-                'DCD parser not available. Are you using python 3?')
     def setUp(self):
         self.u = mda.Universe(PSF, DCD)
         self.coords = self.u.atoms.positions.copy()
@@ -492,8 +472,6 @@ class TestCenter(TestCase):
 
 
 class TestSplit(TestCase):
-    @pytest.mark.skipif(parser_not_found('DCD'),
-                'DCD parser not available. Are you using python 3?')
     def setUp(self):
         self.universe = mda.Universe(PSF, DCD)
 
@@ -540,8 +518,6 @@ class TestSplit(TestCase):
 
 
 class TestWrap(TestCase):
-    @pytest.mark.skipif(parser_not_found('TRZ'),
-                'TRZ parser not available. Are you using python 3?')
     def setUp(self):
         self.u = mda.Universe(TRZ_psf, TRZ)
         self.ag = self.u.atoms[:100]
@@ -642,8 +618,6 @@ class TestAtomGroupProperties(object):
         assert_equal(vals, other,
                      err_msg="Change to Atoms not reflected in AtomGroup for property: {0}".format(att))
 
-    @pytest.mark.skipif(parser_not_found('DCD'),
-                'DCD parser not available. Are you using python 3?')
     def test_attributes(self):
         u = make_Universe(('names', 'resids', 'segids', 'types', 'altLocs',
                            'charges', 'masses', 'radii', 'bfactors',
@@ -732,8 +706,6 @@ class TestCrossUniverse(object):
 
 
 class TestDihedralSelections(TestCase):
-    @pytest.mark.skipif(parser_not_found('DCD'),
-                'DCD parser not available. Are you using python 3?')
     def setUp(self):
         self.universe = mda.Universe(PSF, DCD)
         self.dih_prec = 2
@@ -804,8 +776,6 @@ class TestDihedralSelections(TestCase):
 
 
 class TestPBCFlag(TestCase):
-    @pytest.mark.skipif(parser_not_found('TRZ'),
-                'TRZ parser not available. Are you using python 3?')
     def setUp(self):
         self.prec = 3
         self.universe = mda.Universe(TRZ_psf, TRZ)
@@ -914,8 +884,6 @@ class TestPBCFlag(TestCase):
         mda.core.flags['use_pbc'] = False
 
 
-@pytest.mark.skipif(parser_not_found('DCD'),
-            reason='DCD parser not available. Are you using python 3?')
 def test_instantselection_termini():
     """Test that instant selections work, even for residues that are also termini (Issue 70)"""
     universe = mda.Universe(PSF, DCD)
@@ -929,8 +897,6 @@ class TestAtomGroup(TestCase):
     These are from before the big topology rework (aka #363) but are still valid.
     There is likely lots of duplication between here and other tests.
     """
-    @pytest.mark.skipif(parser_not_found('DCD'),
-                'DCD parser not available. Are you using python 3?')
     def setUp(self):
         """Set up the standard AdK system in implicit solvent."""
         self.universe = mda.Universe(PSF, DCD)
@@ -1292,8 +1258,6 @@ class TestAtomGroup(TestCase):
 class TestAtomGroupTimestep(TestCase):
     """Tests the AtomGroup.ts attribute (partial timestep)"""
 
-    @pytest.mark.skipif(parser_not_found('TRZ'),
-                'TRZ parser not available. Are you using python 3?')
     def setUp(self):
         self.universe = mda.Universe(TRZ_psf, TRZ)
         self.prec = 6

--- a/testsuite/MDAnalysisTests/core/test_atomselections.py
+++ b/testsuite/MDAnalysisTests/core/test_atomselections.py
@@ -54,14 +54,12 @@ from MDAnalysis.tests.datafiles import (
     PDB_full,
     PDB_icodes,
 )
-from MDAnalysisTests import parser_not_found, make_Universe
+from MDAnalysisTests import make_Universe
 
 import pytest
 
 
 class TestSelectionsCHARMM(TestCase):
-    @pytest.mark.skipif(parser_not_found('DCD'),
-                'DCD parser not available. Are you using python 3?')
     def setUp(self):
         """Set up the standard AdK system in implicit solvent.
 
@@ -586,7 +584,6 @@ class TestOrthogonalDistanceSelections(BaseDistanceSelection):
 
     __test__ = True
 
-    @pytest.mark.skipif(parser_not_found('TRZ'), 'TRZ parser not available. Are you using python 3?')
     @pytest.fixture()
     def u(self):
         return mda.Universe(TRZ_psf, TRZ)
@@ -797,8 +794,6 @@ class TestPropSelection(object):
 
 
 class TestBondedSelection(TestCase):
-    @pytest.mark.skipif(parser_not_found('DCD'),
-                'DCD parser not available. Are you using python 3?')
     def setUp(self):
         self.u = mda.Universe(PSF, DCD)
 

--- a/testsuite/MDAnalysisTests/core/test_groups.py
+++ b/testsuite/MDAnalysisTests/core/test_groups.py
@@ -39,7 +39,7 @@ import operator
 import six
 
 import MDAnalysis as mda
-from MDAnalysisTests import make_Universe, parser_not_found, assert_nowarns
+from MDAnalysisTests import make_Universe, assert_nowarns
 from MDAnalysisTests.datafiles import PSF, DCD
 from MDAnalysis.core import groups
 from MDAnalysis.core.topology import Topology
@@ -582,8 +582,6 @@ class TestGroupBy(TestCase):
 
 
 class TestReprs(TestCase):
-    @pytest.mark.skipif(parser_not_found('DCD'),
-                'DCD parser not available. Are you using python 3?')
     def setUp(self):
         self.u = mda.Universe(PSF, DCD)
 

--- a/testsuite/MDAnalysisTests/core/test_residue.py
+++ b/testsuite/MDAnalysisTests/core/test_residue.py
@@ -32,14 +32,11 @@ import pytest
 
 import MDAnalysis as mda
 
-from MDAnalysisTests import parser_not_found
 from MDAnalysisTests.datafiles import PSF, DCD
 
 
 class TestResidue(TestCase):
     # Legacy tests from before 363
-    @pytest.mark.skipif(parser_not_found('DCD'),
-                'DCD parser not available. Are you using python 3?')
     def setUp(self):
         self.universe = mda.Universe(PSF, DCD)
         self.res = self.universe.residues[100]

--- a/testsuite/MDAnalysisTests/core/test_residuegroup.py
+++ b/testsuite/MDAnalysisTests/core/test_residuegroup.py
@@ -34,7 +34,6 @@ from unittest import skip, TestCase
 import MDAnalysis as mda
 
 from MDAnalysisTests.datafiles import PSF, DCD
-from MDAnalysisTests import parser_not_found
 
 
 class TestSequence(TestCase):
@@ -48,8 +47,6 @@ class TestSequence(TestCase):
         "YYSKEAEAGNTKYAKVDGTKPVAEVRADLEKILG"
     )
 
-    @pytest.mark.skipif(parser_not_found('DCD'),
-                'DCD parser not available. Are you using python 3?')
     def setUp(self):
         self.u = mda.Universe(PSF, DCD)
 
@@ -99,8 +96,6 @@ class TestSequence(TestCase):
 
 class TestResidueGroup(TestCase):
     # Legacy tests from before 363
-    @pytest.mark.skipif(parser_not_found('DCD'),
-                'DCD parser not available. Are you using python 3?')
     def setUp(self):
         """Set up the standard AdK system in implicit solvent."""
         self.universe = mda.Universe(PSF, DCD)

--- a/testsuite/MDAnalysisTests/core/test_segment.py
+++ b/testsuite/MDAnalysisTests/core/test_segment.py
@@ -32,7 +32,7 @@ import pytest
 
 import MDAnalysis as mda
 
-from MDAnalysisTests import parser_not_found, make_Universe
+from MDAnalysisTests import make_Universe
 from MDAnalysis.tests.datafiles import PSF, DCD
 
 
@@ -64,8 +64,6 @@ class TestSegment(TestCase):
         assert_equal(self.universe.segments[0].atoms.indices,
                      sorted(self.universe.segments[0].atoms.indices))
 
-@pytest.mark.skipif(parser_not_found('DCD'),
-            reason='DCD parser not available. Are you using python 3?')
 def test_generated_residueselection():
     """Test that a generated residue group always returns a ResidueGroup (Issue 47)
     unless there is a single residue (Issue 363 change)"""

--- a/testsuite/MDAnalysisTests/core/test_segmentgroup.py
+++ b/testsuite/MDAnalysisTests/core/test_segmentgroup.py
@@ -32,13 +32,10 @@ from unittest import TestCase
 import MDAnalysis as mda
 
 from MDAnalysisTests.datafiles import PSF, DCD
-from MDAnalysisTests import parser_not_found
 
 
 class TestSegmentGroup(TestCase):
     # Legacy tests from before 363
-    @pytest.mark.skipif(parser_not_found('DCD'),
-                'DCD parser not available. Are you using python 3?')
     def setUp(self):
         """Set up the standard AdK system in implicit solvent."""
         self.universe = mda.Universe(PSF, DCD)

--- a/testsuite/MDAnalysisTests/core/test_topologyattrs.py
+++ b/testsuite/MDAnalysisTests/core/test_topologyattrs.py
@@ -36,7 +36,7 @@ from numpy.testing import (
 )
 import pytest
 from MDAnalysisTests.datafiles import PSF, DCD
-from MDAnalysisTests import parser_not_found, make_Universe
+from MDAnalysisTests import make_Universe
 
 import MDAnalysis as mda
 import MDAnalysis.core.topologyattrs as tpattrs
@@ -163,8 +163,6 @@ class TestAtomids(TestAtomAttr):
 
 
 class TestIndicesClasses(TestCase):
-    @pytest.mark.skipif(parser_not_found('DCD'),
-                'DCD parser not available. Are you using python 3?')
     def setUp(self):
         self.u = mda.Universe(PSF, DCD)
 
@@ -410,8 +408,6 @@ class TestSegmentAttr(TopologyAttrMixin):
 
 
 class TestAttr(TestCase):
-    @pytest.mark.skipif(parser_not_found('DCD'),
-                'DCD parser not available. Are you using python 3?')
     def setUp(self):
         self.universe = mda.Universe(PSF, DCD)
         self.ag = self.universe.atoms  # prototypical AtomGroup

--- a/testsuite/MDAnalysisTests/core/test_topologyobjects.py
+++ b/testsuite/MDAnalysisTests/core/test_topologyobjects.py
@@ -44,7 +44,6 @@ from MDAnalysis.core.topologyobjects import (
 
 
 from MDAnalysisTests.datafiles import PSF, DCD, TRZ_psf, TRZ
-from MDAnalysisTests import parser_not_found
 
 
 class TestTopologyObjects(TestCase):
@@ -58,8 +57,6 @@ class TestTopologyObjects(TestCase):
     len
     """
 
-    @pytest.mark.skipif(parser_not_found('DCD'),
-                'DCD parser not available. Are you using python 3?')
     def setUp(self):
         self.precision = 3  # rather lenient but see #271
         self.u = mda.Universe(PSF, DCD)
@@ -563,8 +560,6 @@ class TestTopologyGroup_Cython(TestCase):
      - work (return proper values)
      - catch errors
     """
-    @pytest.mark.skipif(parser_not_found('DCD'),
-                'DCD parser not available. Are you using python 3?')
     def setUp(self):
         self.u = mda.Universe(PSF, DCD)
         # topologygroups for testing

--- a/testsuite/MDAnalysisTests/core/test_universe.py
+++ b/testsuite/MDAnalysisTests/core/test_universe.py
@@ -54,7 +54,6 @@ from MDAnalysisTests.datafiles import (
     two_water_gro, two_water_gro_nonames,
     TRZ, TRZ_psf,
 )
-from MDAnalysisTests import parser_not_found
 
 import MDAnalysis as mda
 import MDAnalysis.coordinates
@@ -207,8 +206,6 @@ class TestUniverseCreation(object):
 
 class TestUniverse(object):
     # older tests, still useful
-    @pytest.mark.skipif(parser_not_found('DCD'),
-                reason='DCD parser not available. Are you using python 3?')
     def test_load_bad_topology(self):
         # tests that Universe builds produce the right error message
         def bad_load():
@@ -216,15 +213,11 @@ class TestUniverse(object):
 
         assert_raises(ValueError, bad_load)
 
-    @pytest.mark.skipif(parser_not_found('DCD'),
-                reason='DCD parser not available. Are you using python 3?')
     def test_load_new(self):
         u = mda.Universe(PSF, DCD)
         u.load_new(PDB_small)
         assert_equal(len(u.trajectory), 1, "Failed to load_new(PDB)")
 
-    @pytest.mark.skipif(parser_not_found('DCD'),
-                reason='DCD parser not available. Are you using python 3?')
     def test_load_new_TypeError(self):
         u = mda.Universe(PSF, DCD)
 
@@ -240,8 +233,6 @@ class TestUniverse(object):
         assert_equal(len(u.atoms), 3341, "Loading universe failed somehow")
         assert_almost_equal(u.atoms.positions, ref.atoms.positions)
 
-    @pytest.mark.skipif(parser_not_found('DCD'),
-                reason='DCD parser not available. Are you using python 3?')
     def test_load_multiple_list(self):
         # Universe(top, [trj, trj, ...])
         ref = mda.Universe(PSF, DCD)
@@ -249,8 +240,6 @@ class TestUniverse(object):
         assert_equal(len(u.atoms), 3341, "Loading universe failed somehow")
         assert_equal(u.trajectory.n_frames, 2 * ref.trajectory.n_frames)
 
-    @pytest.mark.skipif(parser_not_found('DCD'),
-                reason='DCD parser not available. Are you using python 3?')
     def test_load_multiple_args(self):
         # Universe(top, trj, trj, ...)
         ref = mda.Universe(PSF, DCD)
@@ -258,14 +247,10 @@ class TestUniverse(object):
         assert_equal(len(u.atoms), 3341, "Loading universe failed somehow")
         assert_equal(u.trajectory.n_frames, 2 * ref.trajectory.n_frames)
 
-    @pytest.mark.skipif(parser_not_found('DCD'),
-                reason='DCD parser not available. Are you using python 3?')
     def test_pickle_raises_NotImplementedError(self):
         u = mda.Universe(PSF, DCD)
         assert_raises(NotImplementedError, cPickle.dumps, u, protocol=cPickle.HIGHEST_PROTOCOL)
 
-    @pytest.mark.skipif(parser_not_found('DCD'),
-                reason='DCD parser not available. Are you using python 3?')
     def test_set_dimensions(self):
         u = mda.Universe(PSF, DCD)
         box = np.array([10, 11, 12, 90, 90, 90])
@@ -382,8 +367,6 @@ class TestGuessBonds(TestCase):
 
 
 class TestInMemoryUniverse(object):
-    @pytest.mark.skipif(parser_not_found('DCD'),
-               reason='DCD parser not available. Are you using python 3?')
     def test_reader_w_timeseries(self):
         universe = mda.Universe(PSF, DCD, in_memory=True)
         assert_equal(universe.trajectory.timeseries(universe.atoms).shape,
@@ -396,8 +379,6 @@ class TestInMemoryUniverse(object):
                      (47681, 10, 3),
                      err_msg="Unexpected shape of trajectory timeseries")
 
-    @pytest.mark.skipif(parser_not_found('DCD'),
-               reason='DCD parser not available. Are you using python 3?')
     def test_reader_w_timeseries_frame_interval(self):
         universe = mda.Universe(PSF, DCD, in_memory=True,
                                        in_memory_step=10)
@@ -412,8 +393,6 @@ class TestInMemoryUniverse(object):
                      (47681, 4, 3),
                      err_msg="Unexpected shape of trajectory timeseries")
 
-    @pytest.mark.skipif(parser_not_found('DCD'),
-                reason='DCD parser not available. Are you using python 3?')
     def test_existing_universe(self):
         universe = mda.Universe(PDB_small, DCD)
         universe.transfer_to_memory()
@@ -421,8 +400,6 @@ class TestInMemoryUniverse(object):
                      (3341, 98, 3),
                      err_msg="Unexpected shape of trajectory timeseries")
 
-    @pytest.mark.skipif(parser_not_found('DCD'),
-                reason='DCD parser not available. Are you using python 3?')
     def test_frame_interval_convention(self):
         universe1 = mda.Universe(PSF, DCD)
         array1 = universe1.trajectory.timeseries(skip=10)
@@ -432,8 +409,6 @@ class TestInMemoryUniverse(object):
         assert_equal(array1, array2,
                      err_msg="Unexpected differences between arrays.")
 
-    @pytest.mark.skipif(parser_not_found('DCD'),
-                reason='DCD parser not available. Are you using python 3?')
     def test_slicing_with_start_stop(self):
         universe = MDAnalysis.Universe(PDB_small, DCD)
         # Skip only the last frame
@@ -442,8 +417,6 @@ class TestInMemoryUniverse(object):
                      (3341, 10, 3),
                      err_msg="Unexpected shape of trajectory timeseries")
 
-    @pytest.mark.skipif(parser_not_found('DCD'),
-                reason='DCD parser not available. Are you using python 3?')
     def test_slicing_without_start(self):
         universe = MDAnalysis.Universe(PDB_small, DCD)
         # Skip only the last frame
@@ -452,8 +425,6 @@ class TestInMemoryUniverse(object):
                      (3341, 10, 3),
                      err_msg="Unexpected shape of trajectory timeseries")
 
-    @pytest.mark.skipif(parser_not_found('DCD'),
-                reason='DCD parser not available. Are you using python 3?')
     def test_slicing_without_stop(self):
         universe = MDAnalysis.Universe(PDB_small, DCD)
         # Skip only the last frame
@@ -463,8 +434,6 @@ class TestInMemoryUniverse(object):
                      (3341, 88, 3),
                      err_msg="Unexpected shape of trajectory timeseries")
 
-    @pytest.mark.skipif(parser_not_found('DCD'),
-                reason='DCD parser not available. Are you using python 3?')
     def test_slicing_step_without_start_stop(self):
         universe = MDAnalysis.Universe(PDB_small, DCD)
         # Skip only the last frame
@@ -474,8 +443,6 @@ class TestInMemoryUniverse(object):
                      (3341, 49, 3),
                      err_msg="Unexpected shape of trajectory timeseries")
 
-    @pytest.mark.skipif(parser_not_found('DCD'),
-                reason='DCD parser not available. Are you using python 3?')
     def test_slicing_step_with_start_stop(self):
         universe = MDAnalysis.Universe(PDB_small, DCD)
         # Skip only the last frame
@@ -485,8 +452,6 @@ class TestInMemoryUniverse(object):
                      (3341, 10, 3),
                      err_msg="Unexpected shape of trajectory timeseries")
 
-    @pytest.mark.skipif(parser_not_found('DCD'),
-                reason='DCD parser not available. Are you using python 3?')
     def test_slicing_step_dt(self):
         universe = MDAnalysis.Universe(PDB_small, DCD)
         times = [ts.time for ts in universe.trajectory]
@@ -496,8 +461,6 @@ class TestInMemoryUniverse(object):
                 err_msg="Unexpected in-memory timestep: "
                         + "dt not updated with step information")
 
-    @pytest.mark.skipif(parser_not_found('DCD'),
-                reason='DCD parser not available. Are you using python 3?')
     def test_slicing_negative_start(self):
         universe = MDAnalysis.Universe(PDB_small, DCD)
         # Skip only the last frame
@@ -507,8 +470,6 @@ class TestInMemoryUniverse(object):
                      (3341, 10, 3),
                      err_msg="Unexpected shape of trajectory timeseries")
 
-    @pytest.mark.skipif(parser_not_found('DCD'),
-                reason='DCD parser not available. Are you using python 3?')
     def test_slicing_negative_stop(self):
         universe = MDAnalysis.Universe(PDB_small, DCD)
         # Skip only the last frame
@@ -523,8 +484,6 @@ class TestCustomReaders(object):
     """
     Can pass a reader as kwarg on Universe creation
     """
-    @pytest.mark.skipif(parser_not_found('TRZ'),
-                reason='TRZ parser not available. Are you using python 3?')
     def test_custom_reader(self):
         # check that reader passing works
         u = mda.Universe(TRZ_psf, TRZ, format=MDAnalysis.coordinates.TRZ.TRZReader)
@@ -545,15 +504,11 @@ class TestCustomReaders(object):
                                 topology_format=T, format=R)
         assert_equal(len(u.atoms), 6)
 
-    @pytest.mark.skipif(parser_not_found('TRZ'),
-                reason='TRZ parser not available. Are you using python 3?')
     def test_custom_parser(self):
         # topology reader passing works
         u = mda.Universe(TRZ_psf, TRZ, topology_format=MDAnalysis.topology.PSFParser.PSFParser)
         assert_equal(len(u.atoms), 8184)
 
-    @pytest.mark.skipif(parser_not_found('TRZ'),
-                reason='TRZ parser not available. Are you using python 3?')
     def test_custom_both(self):
         # use custom for both
         u = mda.Universe(TRZ_psf, TRZ, format=MDAnalysis.coordinates.TRZ.TRZReader,

--- a/testsuite/MDAnalysisTests/topology/test_lammpsdata.py
+++ b/testsuite/MDAnalysisTests/topology/test_lammpsdata.py
@@ -30,7 +30,6 @@ import numpy as np
 import pytest
 
 import MDAnalysis as mda
-from MDAnalysisTests import parser_not_found
 from MDAnalysisTests.topology.base import ParserBase
 from MDAnalysis.tests.datafiles import (
     LAMMPSdata,
@@ -191,8 +190,6 @@ class TestLAMMPSDeletedAtoms(LammpsBase):
         assert_equal(u.atoms.ids,
                      [1, 10, 1002, 2003, 2004, 2005, 2006, 2007, 2008, 2009])
 
-    @pytest.mark.skipif(parser_not_found('LAMMPS'),
-                        reason='LAMMPS parser not available. Are you using python 3?')
     def test_traj(self):
         u = mda.Universe(self.filename)
 

--- a/testsuite/MDAnalysisTests/util.py
+++ b/testsuite/MDAnalysisTests/util.py
@@ -101,26 +101,6 @@ def module_not_found(module):
         return False
 
 
-def parser_not_found(parser_name):
-    """Return ``True`` if the parser of the given name cannot be found.
-
-    This allows to skip a test when the parser is unavailable (e.g in python 3
-    when the parser is not compatible).
-
-    To be used as the argument of::
-
-    @dec.skipif(parser_not_found('DCD'),
-                'DCD parser is not available. Are you on python 3?')
-    """
-    import MDAnalysis.coordinates
-    try:
-        getattr(MDAnalysis.coordinates, parser_name)
-    except AttributeError:
-        return True
-    else:
-        return False
-
-
 @contextmanager
 def in_dir(dirname):
     """Context manager for safely changing directories.

--- a/testsuite/MDAnalysisTests/utils/test_distances.py
+++ b/testsuite/MDAnalysisTests/utils/test_distances.py
@@ -30,7 +30,6 @@ from numpy.testing import (TestCase, dec, raises, assert_,
 
 from MDAnalysis.tests.datafiles import PSF, DCD, TRIC
 from MDAnalysis.lib import mdamath
-from MDAnalysisTests import parser_not_found
 
 
 @pytest.fixture()
@@ -97,8 +96,6 @@ def DCD_Universe():
 
     return universe, trajectory
 
-@pytest.mark.skipif(parser_not_found('DCD'),
-                    reason='DCD parser not available. Are you using python 3?')
 @pytest.mark.parametrize('backend', ['serial', 'openmp'])
 class TestDistanceArrayDCD(object):
     # reasonable precision so that tests succeed on 32 and 64 bit machines
@@ -154,8 +151,6 @@ class TestDistanceArrayDCD(object):
 
 
 
-@pytest.mark.skipif(parser_not_found('DCD'),
-                    reason='DCD parser not available. Are you using python 3?')
 @pytest.mark.parametrize('backend', ['serial', 'openmp'])
 class TestSelfDistanceArrayDCD(object):
     prec = 5
@@ -577,8 +572,6 @@ class TestCythonFunctions(object):
 class Test_apply_PBC(object):
     prec = 6
 
-    @pytest.mark.skipif(parser_not_found('DCD'),
-                        reason='DCD parser not available. Are you using python 3?')
     def test_ortho_PBC(self, backend):
         from MDAnalysis.lib.distances import apply_PBC
 

--- a/testsuite/MDAnalysisTests/utils/test_selections.py
+++ b/testsuite/MDAnalysisTests/utils/test_selections.py
@@ -32,7 +32,6 @@ import numpy as np
 from numpy.testing import TestCase, assert_equal, assert_array_equal, dec
 
 from MDAnalysis.tests.datafiles import PSF, DCD
-from MDAnalysisTests import parser_not_found
 
 import MDAnalysis
 from MDAnalysis.lib.util import NamedStream


### PR DESCRIPTION
Fixes #1454 

We used to avoid loading some modules in python 3 to make MDAnalysis work, this isn't required now.  This PR removes all the related logic to tiptoeing around modules for python 3.
