### PR TITLE
Fixed analysis_class warning. Fixes #1511.

### DIFF
--- a/package/MDAnalysis/analysis/base.py
+++ b/package/MDAnalysis/analysis/base.py
@@ -306,13 +306,21 @@ def _filter_baseanalysis_kwargs(function, kwargs):
     ------
     ValueError : if ``function`` has the same kwargs as ``BaseAnalysis``
     """
-    base_argspec = inspect.getargspec(AnalysisBase.__init__)
+    try:
+        base_argspec = inspect.getfullargspec(AnalysisBase.__init__)
+    except AttributeError:
+        base_argspec = inspect.getargspec(AnalysisBase.__init__)
+
     n_base_defaults = len(base_argspec.defaults)
     base_kwargs = {name: val
                    for name, val in zip(base_argspec.args[-n_base_defaults:],
                                         base_argspec.defaults)}
 
-    argspec = inspect.getargspec(function)
+    try:
+        argspec = inspect.getfullargspec(function)
+    except AttributeError:
+        argspec = inspect.getargspec(function)
+
     for base_kw in six.iterkeys(base_kwargs):
         if base_kw in argspec.args:
             raise ValueError(

--- a/testsuite/MDAnalysisTests/analysis/test_base.py
+++ b/testsuite/MDAnalysisTests/analysis/test_base.py
@@ -177,10 +177,12 @@ def test_analysis_class_decorator():
     # Issue #1511
     # analysis_class should not raise
     # a DeprecationWarning
-    with no_deprecated_call():
-        u = mda.Universe(PSF, DCD)
-        def distance(a, b):
-            return np.linalg.norm((a.centroid() - b.centroid()))
+    u = mda.Universe(PSF, DCD)
 
-        Distances = base.analysis_class(distance)
+    def distance(a, b):
+        return np.linalg.norm((a.centroid() - b.centroid()))
+
+    Distances = base.analysis_class(distance)
+
+    with no_deprecated_call():
         d = Distances(u.atoms[:10], u.atoms[10:20]).run()

--- a/testsuite/MDAnalysisTests/analysis/test_base.py
+++ b/testsuite/MDAnalysisTests/analysis/test_base.py
@@ -33,6 +33,7 @@ import MDAnalysis as mda
 from MDAnalysis.analysis import base
 
 from MDAnalysisTests.datafiles import PSF, DCD
+from MDAnalysisTests.util import no_deprecated_call
 
 
 class FrameAnalysis(base.AnalysisBase):
@@ -171,3 +172,15 @@ def test_analysis_class():
     assert_array_equal(results, ana.results)
 
     assert_raises(ValueError, ana_class, 2)
+
+def test_analysis_class_decorator():
+    # Issue #1511
+    # analysis_class should not raise
+    # a DeprecationWarning
+    with no_deprecated_call():
+        u = mda.Universe(PSF, DCD)
+        def distance(a, b):
+            return np.linalg.norm((a.centroid() - b.centroid()))
+
+        Distances = base.analysis_class(distance)
+        d = Distances(u.atoms[:10], u.atoms[10:20]).run()


### PR DESCRIPTION
Fixes #1511 

Unit testing for the fix of this issue is more complicated than the fix itself:

- a number of possible fixes were discussed; since the underlying code was recently refactored in pytest I decided not to risk pytest version dependency and copy / paste / modify the relevant MIT-licensed portions of the pytest code for handling `DeprecationWarning` so that we can check that such a warning is NOT raised after the fix applied here
- an alternative approach would be to write some kind of i.e., decorator that inverts the functionality of the normal `pytest.deprecated_call` which normally checks that such a warning IS raised, but this was proving annoying in my hands
- ideally I could just inherit from stable pytest code and redefine the `__exit__` method in `_DeprecatedCallContext` class, but this class didn't even exist until version `3.1.3` so we can't really consider that stable and require a pytest version pin-down for the inheritance (note that this does work if you pin down the version though)

The fix for the issue itself:
- is based on [previously patched github code](https://github.com/lmfit/lmfit-py/pull/410/files)

