### PR TITLE
fixed Python 3 errors in analysis.hole and tests

### DIFF
--- a/testsuite/MDAnalysisTests/analysis/test_hole.py
+++ b/testsuite/MDAnalysisTests/analysis/test_hole.py
@@ -74,11 +74,11 @@ class TestHOLE(TestCase):
 
     @dec.skipif(executable_not_found("hole"), msg="Test skipped because HOLE not found")
     def test_HOLE(self):
-        profiles = self.H.profiles.values()
-        assert_equal(len(profiles), 1,
+        profiles_values = list(self.H.profiles.values())
+        assert_equal(len(profiles_values), 1,
                      err_msg="HOLE.profile should contain exactly 1 profile")
 
-        p = profiles[0]
+        p = profiles_values[0]
 
         assert_equal(len(p), 425,
                      err_msg="wrong number of points in HOLE profile")


### PR DESCRIPTION
Changes made in this Pull Request:
 - encoding in analysis.hole
 - fixed a bunch of "dict stuff is now iterator"
 - use OrderedDict()

I only noticed because tests failed locally (macOS) with `hole` installed by default. I suspect that the hole tests are not running properly on travis.

PR Checklist
------------
 - [ ] Tests?
 - na Docs?
 - [ ]  CHANGELOG updated?
 - [ ] Issue raised/referenced?
