### PR TITLE
[WIP] u.transfer_to_memory also transfers the box

### DIFF
--- a/package/MDAnalysis/coordinates/DCD.py
+++ b/package/MDAnalysis/coordinates/DCD.py
@@ -267,7 +267,8 @@ class DCDReader(base.ReaderBase):
                    step=None,
                    skip=None,
                    order='afc',
-                   format=None):
+                   format=None,
+                   dimensions=False):
         """Return a subset of coordinate data for an AtomGroup
 
         Parameters
@@ -328,7 +329,10 @@ class DCDReader(base.ReaderBase):
 
         frames = self._file.readframes(
             start, stop, step, order=order, indices=atom_numbers)
-        return frames.xyz
+        if not dimensions:
+            return frames.xyz
+        else:
+            return frames
 
 
 class DCDWriter(base.WriterBase):

--- a/package/MDAnalysis/coordinates/memory.py
+++ b/package/MDAnalysis/coordinates/memory.py
@@ -279,7 +279,7 @@ class MemoryReader(base.ProtoReader):
                                  "array ({})"
                                  .format(provided_n_atoms, self.n_atoms))
 
-        self.dimensions = dimensions
+        self._dimensions_array = np.asanyarray(dimensions)
         self.ts = self._Timestep(self.n_atoms, **kwargs)
         self.ts.dt = dt
         self.ts.frame = -1
@@ -406,11 +406,11 @@ class MemoryReader(base.ProtoReader):
                        [self.ts.frame] +
                        [slice(None)]*(2-f_index))
         ts.positions = self.coordinate_array[basic_slice]
-        if self.dimensions is not None:
-            if len(self.dimensions) == 1:
-                ts.dimensions = self.dimensions
+        if self._dimensions_array is not None:
+            if len(self._dimensions_array) == 1:
+                ts.dimensions = self._dimensions_array
             else:
-                ts.dimensions = self.dimensions[self.ts.frame]
+                ts.dimensions = self._dimensions_array[self.ts.frame]
 
         ts.time = self.ts.frame*self.dt
         return ts

--- a/package/MDAnalysis/coordinates/memory.py
+++ b/package/MDAnalysis/coordinates/memory.py
@@ -279,10 +279,9 @@ class MemoryReader(base.ProtoReader):
                                  "array ({})"
                                  .format(provided_n_atoms, self.n_atoms))
 
+        self.dimensions = dimensions
         self.ts = self._Timestep(self.n_atoms, **kwargs)
         self.ts.dt = dt
-        if dimensions is not None:
-            self.ts.dimensions = dimensions
         self.ts.frame = -1
         self.ts.time = -1
         self._read_next_timestep()
@@ -407,6 +406,11 @@ class MemoryReader(base.ProtoReader):
                        [self.ts.frame] +
                        [slice(None)]*(2-f_index))
         ts.positions = self.coordinate_array[basic_slice]
+        if self.dimensions is not None:
+            if len(self.dimensions) == 1:
+                ts.dimensions = self.dimensions
+            else:
+                ts.dimensions = self.dimensions[self.ts.frame]
 
         ts.time = self.ts.frame*self.dt
         return ts

--- a/package/MDAnalysis/coordinates/memory.py
+++ b/package/MDAnalysis/coordinates/memory.py
@@ -244,20 +244,15 @@ class MemoryReader(base.ProtoReader):
         dimensions: [A, B, C, alpha, beta, gamma] (optional)
             unitcell dimensions (*A*, *B*, *C*, *alpha*, *beta*, *gamma*)
             lengths *A*, *B*, *C* are in the MDAnalysis length unit (Å), and
-            angles are in degrees.
+            angles are in degrees. If the unit cell dimensions vary with time,
+            then they can be provided as a 2D array whith each row
+            corresponding to one frame.
         dt: float (optional)
             The time difference between frames (ps).  If :attr:`time`
             is set, then `dt` will be ignored.
         filename: string (optional)
             The name of the file from which this instance is created. Set to ``None``
             when created from an array
-
-        Note
-        ----
-        At the moment, only a fixed `dimension` is supported, i.e., the same
-        unit cell for all frames in `coordinate_array`. See issue `#1041`_.
-
-        .. _`#1041`: https://github.com/MDAnalysis/mdanalysis/issues/1041
 
         """
 

--- a/package/MDAnalysis/coordinates/memory.py
+++ b/package/MDAnalysis/coordinates/memory.py
@@ -280,6 +280,24 @@ class MemoryReader(base.ProtoReader):
                                  .format(provided_n_atoms, self.n_atoms))
 
         self._dimensions_array = np.asanyarray(dimensions)
+        if self._dimensions_array is not None:
+            if (len(self._dimensions_array.shape) == 1
+                    and self._dimensions_array.shape[0] != 6):
+                raise ValueError('The *dimensions* array must be formated as '
+                                 '[A B C alpha beta gamma] but your dimensions '
+                                 'have {} elements.'
+                                 .format(self._dimensions_array.shape[0]))
+            if len(self._dimensions_array.shape) > 1:
+                if self._dimensions_array.shape[0] != self.n_frames):
+                    raise ValueError('The *dimensions* array does not have '
+                                     'the same number of frames as the '
+                                     'positions: {} dimensions frame but '
+                                     '{} positions frame.'
+                                     .format(self._dimensions_array.shape[0],
+                                             self.n_frames))
+                if self._dimensions_array.shape[1] != 6:
+                    raise ValueError('The dimensions for each frame must be '
+                                     'of the form [A B C alpha beta gamma].')
         self.ts = self._Timestep(self.n_atoms, **kwargs)
         self.ts.dt = dt
         self.ts.frame = -1


### PR DESCRIPTION
This commit makes the memory reader deal with a non-constant box
dimensions and makes `Universe.transfer_to_memory copy the box in
addition to the positions.

Until now, only one box was stored in the memory reader, making it
impractical for NPT systems.

Fixes #1041

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [X] Issue raised/referenced?
