### PR TITLE
ENH: Added basic asv benchmark suite to MDAnalysis

### DIFF
--- a/benchmarks/README.rst
+++ b/benchmarks/README.rst
@@ -1,0 +1,120 @@
+=====================
+MDAnalysis benchmarks
+=====================
+
+Benchmarking MDAnalysis with Airspeed Velocity.
+
+Usage with MDAnalysis
+---------------------
+
+Airspeed Velocity builds clean conda environments to
+benchmark the performance of MDAnalysis at different
+time points in its history (for different git commit
+hashes).
+
+At the time of writing, Airspeed Velocity expects the
+project ``setup.py`` to be in the root directory of
+the git repository. MDAnalysis has had ``setup.py``
+for the main package in a subdirectory for quite some
+time now, so for the time being we are using a modified
+branch (``flexible_build``) of Airspeed Velocity in our `fork of their
+package`_, which enables Airspeed Velocity to build
+MDAnalysis despite the location of ``setup.py``. A WIP
+PR is open to enable more flexible Airspeed Velocity
+build mechanics, but for now we will use our fork.
+
+To build / install our fork of Airspeed Velocity it should
+suffice to clone the git repo, checkout the ``flexible_build``
+branch, and run::
+
+    python setup.py install --user
+
+`Airspeed Velocity commands`_ are described in detail in their
+documentation. A common usage example for evaluating the
+performance of a feature branch / pull request would be::
+
+    asv continuous --bench GROReadBench d76c9348 e0bc303 -e
+
+In the above, ``GROReadBench`` is handled as a regular
+expression for the specific benchmark test to run between
+the provided git commit hashes.
+
+To evaluate a benchmark test over the course of project
+history one would commonly use ``asv run``. For example,
+to probe performance for trajectory readers at 20 commit
+hashes evenly spread over a few years of the project one
+might run::
+
+     asv run -e -s 20 ddb57592..e0bc3034 --bench TrajReaderBench -j
+
+It is also possible to specify ``ALL`` to space the performance
+tests over the entire lifetime of the project, but exercise
+caution as very early commits may represent a state of the
+project where many features are not available and / or
+files are not in the expected locations.
+
+The ``asv run`` command will store detailed benchmark data locally
+as ``JSON`` files, which can be converted into interactive website
+data and hosted locally with::
+
+    asv publish
+    asv preview
+
+.. _fork of their package: https://github.com/MDAnalysis/asv
+.. _Airspeed Velocity commands: http://asv.readthedocs.io/en/latest/commands.html
+
+Writing benchmarks
+------------------
+
+The Airspeed Velocity `documentation for writing benchmarks`_ is a
+suitable reference. As a quick summary of guidelines:
+
+- wrap imports from MDAnalysis in the test modules because older
+  commit hashes may not have the name imported for various reasons::
+
+     try:
+        from MDAnalysis.coordinates.DCD import DCDReader
+     except ImportError:
+        pass
+
+  The benchmarks themselves will automatically handle the missing
+  features if the above is done.
+
+- leave the timing code to ASV -- don't implement your own
+
+- the benchmarks are written as Python modules in the `benchmark`
+  directory (and subdirectories thereof). There are no formal
+  naming requirements for these modules. Benchmarks are generally
+  written as functions of the form `time_feature()` with the `time`
+  prefix, sometimes within a broader class object. A `setup` method
+  or attribute may be used to perform operations that are required
+  for the test suite, but should not be included in the performance
+  timing.
+
+- parametrized benchmarks can be quite powerful for testing several
+  inputs to a test; note that all possible combinations will be tested,
+  and it is very useful to label the parameters with names as these
+  will be nicely summarized in the output::
+
+       params = (['XTC', 'TRR', 'DCD'],
+                 [10, 20, 30])
+       param_names = ['traj_format', 'num_atoms']
+
+- memory usage can also be profiled with test prefixes including `mem`
+  and `peakmem`
+
+.. _documentation for writing benchmarks: http://asv.readthedocs.io/en/latest/writing_benchmarks.html
+
+Advanced Notes
+--------------
+
+- the depedencies installed in the clean conda benchmarking environments,
+  and indeed the decision to use conda over virtualenv, can be controlled
+  in the ``asv.conf.json`` file, as can which versions of Python are probed
+
+- the above file also controls which branch of MDAnalysis is used for a
+  first-pass check of the benchmarks that are written--regardless of where you
+  run the benchmarks from, the current ``JSON`` file indicates that ASV
+  will check your benchmark code against the latest commit hash on develop
+  branch first, before running the actual benchmarks for the specified commit
+  hashes

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -1,0 +1,60 @@
+{
+    // The version of the config file format.  Do not change, unless
+    // you know what you are doing.
+    "version": 1,
+
+    // The name of the project being benchmarked
+    "project": "mdanalysis",
+
+    // The project's homepage
+    "project_url": "http://www.mdanalysis.org/",
+
+    // The URL of the source code repository for the project being
+    // benchmarked
+    "repo": "..",
+    "dvcs": "git",
+    "branches": ["develop"],
+
+    // The base URL to "how a commit for the project.
+    //"show_commit_url": "http://github.com/scipy/scipy/commit/",
+
+    // The Pythons you'd like to test against.  If not provided, defaults
+    // to the current version of Python used to run `asv`.
+    "pythons": ["2.7"],
+    // The matrix of dependencies to test.  Each key is the name of a
+    // package (in PyPI) and the values are version numbers.  An empty
+    // list indicates to just test against the default (latest)
+    // version.
+    "matrix": {
+        "numpy": ["1.8.2"],
+        "Tempita": ["0.5.2"],
+        "Cython": ["0.23.4"],
+	"six": [],
+    },
+    // The directory (relative to the current directory) that benchmarks are
+    // stored in.  If not provided, defaults to "benchmarks"
+    "benchmark_dir": "benchmarks",
+    // The directory (relative to the current directory) to cache the Python
+    // environments in.  If not provided, defaults to "env"
+    "env_dir": "env",
+    "environment_type": "virtualenv",
+    "wheel_cache_size": 10,
+    // The directory (relative to the current directory) that raw benchmark
+    // results are stored in.  If not provided, defaults to "results".
+    "results_dir": "results",
+    // The directory (relative to the current directory) that the html tree
+    // should be written to.  If not provided, defaults to "html".
+    "html_dir": "html",
+    // The number of characters to retain in the commit hashes.
+    "hash_length": 8,
+    // The commits after which the regression search in `asv publish`
+    // should start looking for regressions. Dictionary whose keys are
+    // regexps matching to benchmark names, and values corresponding to
+    // the commit (exclusive) after which to start looking for
+    // regressions.  The default is to start from the first commit
+    // with results. If the commit is `null`, regression detection is
+    // skipped for the matching benchmark.
+    "regressions_first_commits": {
+       "io_matlab\\.StructArr\\..*": "67c089a6",  //  structarrs weren't properly implemented before this
+    }
+}

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -26,10 +26,14 @@
     // list indicates to just test against the default (latest)
     // version.
     "matrix": {
-        "numpy": ["1.8.2"],
-        "Tempita": ["0.5.2"],
-        "Cython": ["0.23.4"],
-	"six": [],
+        "Cython": [],
+        "numpy": [],
+        "scipy": [],
+	    "six": [],
+	    "pytest": [],
+	    "nose": [],
+	    "psutil": [],
+	    "mock": [],
     },
     // The directory (relative to the current directory) that benchmarks are
     // stored in.  If not provided, defaults to "benchmarks"
@@ -37,7 +41,7 @@
     // The directory (relative to the current directory) to cache the Python
     // environments in.  If not provided, defaults to "env"
     "env_dir": "env",
-    "environment_type": "virtualenv",
+    "environment_type": "conda",
     "wheel_cache_size": 10,
     // The directory (relative to the current directory) that raw benchmark
     // results are stored in.  If not provided, defaults to "results".
@@ -47,14 +51,4 @@
     "html_dir": "html",
     // The number of characters to retain in the commit hashes.
     "hash_length": 8,
-    // The commits after which the regression search in `asv publish`
-    // should start looking for regressions. Dictionary whose keys are
-    // regexps matching to benchmark names, and values corresponding to
-    // the commit (exclusive) after which to start looking for
-    // regressions.  The default is to start from the first commit
-    // with results. If the commit is `null`, regression detection is
-    // skipped for the matching benchmark.
-    "regressions_first_commits": {
-       "io_matlab\\.StructArr\\..*": "67c089a6",  //  structarrs weren't properly implemented before this
-    }
 }

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -15,9 +15,6 @@
     "dvcs": "git",
     "branches": ["develop"],
 
-    // The base URL to "how a commit for the project.
-    //"show_commit_url": "http://github.com/scipy/scipy/commit/",
-
     // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.
     "pythons": ["2.7"],

--- a/benchmarks/benchmarks/GRO.py
+++ b/benchmarks/benchmarks/GRO.py
@@ -1,0 +1,13 @@
+from __future__ import division, absolute_import, print_function
+
+import numpy as np
+from MDAnalysis.coordinates.GRO import GROReader
+from MDAnalysisTests.datafiles import GRO
+
+class GROReadBench(object):
+
+    def time_read_GRO_file(self):
+        """Benchmark reading of standard test
+        suite GRO file.
+        """
+        GROReader(GRO)

--- a/benchmarks/benchmarks/traj_reader.py
+++ b/benchmarks/benchmarks/traj_reader.py
@@ -1,0 +1,26 @@
+from __future__ import division, absolute_import, print_function
+
+try:
+    from MDAnalysis.coordinates.DCD import DCDReader
+    from MDAnalysis.coordinates.XTC import XTCReader
+    from MDAnalysis.coordinates.TRR import TRRReader
+    from MDAnalysisTests.datafiles import XTC, TRR, DCD
+except ImportError:
+    pass
+
+class TrajReaderBench(object):
+    """Benchmarks for trajectory file format reading."""
+    params = (['XTC', 'TRR', 'DCD'])
+    param_names = ['traj_format']
+
+    def setup(self, traj_format):
+        self.traj_dict = {'XTC': [XTC, XTCReader],
+                          'TRR': [TRR, TRRReader],
+                          'DCD': [DCD, DCDReader]}
+        self.traj_file, self.traj_reader = self.traj_dict[traj_format]
+
+    def time_reads(self, traj_format):
+        """Simple benchmark for reading traj file formats
+        from our standard test files.
+        """
+        self.traj_reader(self.traj_file)


### PR DESCRIPTION
This feature branch allows `asv` benchmarks to run for the MDAnalysis project with no modification to the location of our `setup.py` (yay !!).

A minimal set of enabling modifications (to handle `setup.py` in a subdirectory instead of expected project root) in a branch of our fork of `asv` can be seen in the [PR to asv itself](https://github.com/spacetelescope/asv/pull/535). For the near term, I suspect we'll be using our custom fork of `asv`, but longer term I think there are definitely prospects to generalize for `asv` itself so we don't have to maintain the fork indefinitely.

This PR supersedes #1399.

Here is an example of MDAnalysis being benchmarked with our fork of asv (execute from the `benchmarks` folder):
`asv continuous --bench GROReadBench d76c9348 e0bc303 -e`

Output (scroll right for bench times):
```
· Creating environments
· Discovering benchmarks
·· Uninstalling from conda-py2.7-Cython-mock-nose-numpy-psutil-pytest-scipy-six..
·· Installing into conda-py2.7-Cython-mock-nose-numpy-psutil-pytest-scipy-six..
· Running 2 total benchmarks (2 commits * 1 environments * 1 benchmarks)
[  0.00%] · For mdanalysis commit hash e0bc3034:
[  0.00%] ·· Building for conda-py2.7-Cython-mock-nose-numpy-psutil-pytest-scipy-six....
[  0.00%] ·· Benchmarking conda-py2.7-Cython-mock-nose-numpy-psutil-pytest-scipy-six
[ 50.00%] ··· Running GRO.GROReadBench.time_read_GRO_file                                                                                                                                                                            156±0ms
[ 50.00%] · For mdanalysis commit hash d76c9348:
[ 50.00%] ·· Building for conda-py2.7-Cython-mock-nose-numpy-psutil-pytest-scipy-six....
[ 50.00%] ·· Benchmarking conda-py2.7-Cython-mock-nose-numpy-psutil-pytest-scipy-six
[100.00%] ··· Running GRO.GROReadBench.time_read_GRO_file                                                                                                                                                                            156±0ms
BENCHMARKS NOT SIGNIFICANTLY CHANGED.
```

As expected, GRO file reading performance did not change between those two recent commit hashes that didn't touch gro file reading. Of course, far more powerful commands are also possible, and since this solution doesn't relocate `setup.py` I'll see if I can find time to run a nice retroactive analysis of performance this evening. 

I encourage those reviewing this PR to try this out as well.  `asv` commands are [documented online](http://asv.readthedocs.io/en/latest/commands.html).  Don't forget to build `asv` from source using our fork / branch named `flexible_build`.