### PR TITLE
Issue 1555 moltype

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -22,7 +22,8 @@ Enhancements
   * Python versions 3.4 and upwards are now supported (Issue #260)
   * add low level lib.formats.libdcd module for reading/writing DCD (PR #1372)
   * replace old DCD reader with a Python 3 ready DCD reader (Issue #659)
-  * The TPR parser populate the `moltype` topology attribute (Issue #1555)
+  * The TPR parser populate the `moltypes` topology attribute and
+    the `moltype` selection keyword is added (Issue #1555)
 
 Deprecations
 

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -22,6 +22,7 @@ Enhancements
   * Python versions 3.4 and upwards are now supported (Issue #260)
   * add low level lib.formats.libdcd module for reading/writing DCD (PR #1372)
   * replace old DCD reader with a Python 3 ready DCD reader (Issue #659)
+  * The TPR parser populate the `moltype` topology attribute (Issue #1555)
 
 Deprecations
 

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -1826,6 +1826,9 @@ class AtomGroup(GroupBase):
                 which is often the case with high-resolution crystal structures
                 e.g. `resid 4 and resname ALA and altloc B` selects only the
                 atoms of ALA-4 that have an altloc B record.
+            moltype *molecule-type*
+                select by molecule type, e.g. ``moltype Protein_A``. At the
+                moment, only the TPR format defines the molecule type.
 
         **Boolean**
 
@@ -1944,6 +1947,8 @@ class AtomGroup(GroupBase):
            Resid selection now takes icodes into account where present.
         .. versionadded:: 0.16.0
            Updating selections now possible by setting the ``updating`` argument.
+        .. versionadded:: 0.17.0
+           Added *moltype* selection.
 
         """
         updating = selgroups.pop('updating', False)

--- a/package/MDAnalysis/core/selection.py
+++ b/package/MDAnalysis/core/selection.py
@@ -611,6 +611,12 @@ class ResidueNameSelection(StringSelection):
     field = 'resnames'
 
 
+class MoleculeTypeSelection(StringSelection):
+    """Select atoms based on 'moltypes' attribute"""
+    token = 'moltype'
+    field = 'moltypes'
+
+
 class SegmentNameSelection(StringSelection):
     """Select atoms based on 'segids' attribute"""
     token = 'segid'

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -1225,6 +1225,16 @@ class ICodes(ResidueAttr):
     singular = 'icode'
 
 
+class Moltypes(ResidueAttr):
+    """Name of the molecule type
+
+    Two molecules that share a molecule type share a common template topology.
+    """
+    attrname = 'moltypes'
+    singular = 'moltype'
+    target_classes = [Atom, Residue]
+
+
 # segment attributes
 
 class SegmentAttr(TopologyAttr):

--- a/package/MDAnalysis/topology/TPRParser.py
+++ b/package/MDAnalysis/topology/TPRParser.py
@@ -104,7 +104,7 @@ The TPR reader is a pure-python implementation of a basic TPR
 parser. Currently the following sections of the topology are parsed:
 
 * Atoms: number, name, type, resname, resid, segid, mass, charge,
-  [residue, segment, radius, bfactor, resnum]
+  [residue, segment, radius, bfactor, resnum, moltype]
 * Bonds
 * Angels
 * Dihedrals

--- a/package/MDAnalysis/topology/__init__.py
+++ b/package/MDAnalysis/topology/__init__.py
@@ -105,7 +105,7 @@ the attributes they provide.
    TPR [#b]_         tpr       names, types,     Gromacs portable run input reader (limited
                                resids, resnames, experimental support for some of the more recent
                                charges, bonds,   versions of the file format);
-                               masses,           :mod:`MDAnalysis.topology.TPRParser`
+                               masses, moltypes  :mod:`MDAnalysis.topology.TPRParser`
 
    MOL2 [#a]_        mol2      ids, names,       Tripos MOL2 molecular structure format;
                                types, resids,    :mod:`MDAnalysis.topology.MOL2Parser`

--- a/package/MDAnalysis/topology/tpr/utils.py
+++ b/package/MDAnalysis/topology/tpr/utils.py
@@ -62,6 +62,7 @@ from ...core.topologyattrs import (
     Charges,
     Resids,
     Resnames,
+    Moltypes,
     Segids,
     Bonds,
     Angles,
@@ -213,6 +214,7 @@ def do_mtop(data, fver):
     resnames = []
     atomnames = []
     atomtypes = []
+    moltypes = []
     charges = []
     masses = []
 
@@ -234,6 +236,7 @@ def do_mtop(data, fver):
                 resnames.append(atomkind.resname.decode())
                 atomnames.append(atomkind.name.decode())
                 atomtypes.append(atomkind.type.decode())
+                moltypes.append(molblock)
                 charges.append(atomkind.charge)
                 masses.append(atomkind.mass)
 
@@ -261,13 +264,18 @@ def do_mtop(data, fver):
     charges = Charges(np.array(charges, dtype=np.float32))
     masses = Masses(np.array(masses, dtype=np.float32))
 
+    moltypes = np.array(moltypes, dtype=object)
     segids = np.array(segids, dtype=object)
     resids = np.array(resids, dtype=np.int32)
     resnames = np.array(resnames, dtype=object)
     (residx, new_resids,
-     (new_resnames, perres_segids)) = squash_by(resids, resnames, segids)
+     (new_resnames, new_moltypes, perres_segids)) = squash_by(resids,
+                                                              resnames,
+                                                              moltypes,
+                                                              segids)
     residueids = Resids(new_resids)
     residuenames = Resnames(new_resnames)
+    residue_moltypes = Moltypes(new_moltypes)
 
     segidx, perseg_segids = squash_by(perres_segids)[:2]
     segids = Segids(perseg_segids)
@@ -275,7 +283,7 @@ def do_mtop(data, fver):
     top = Topology(len(atomids), len(new_resids), len(perseg_segids),
                    attrs=[atomids, atomnames, atomtypes,
                           charges, masses,
-                          residueids, residuenames,
+                          residueids, residuenames, residue_moltypes,
                           segids],
                    atom_resindex=residx,
                    residue_segindex=segidx)

--- a/testsuite/MDAnalysisTests/core/test_atomselections.py
+++ b/testsuite/MDAnalysisTests/core/test_atomselections.py
@@ -415,7 +415,7 @@ class TestSelectionsGRO(TestCase):
         assert_equal(len(sel), 1556)
 
 
-class TestSelectionsXTC(TestCase):
+class TestSelectionsTPR(TestCase):
     def setUp(self):
         self.universe = MDAnalysis.Universe(TPR,XTC)
 
@@ -430,6 +430,11 @@ class TestSelectionsXTC(TestCase):
         assert_array_equal(
             sel.indices, self.universe.atoms[0].fragment.indices,
             "Found a different set of atoms when using the 'same fragment as' construct vs. the .fragment prperty")
+
+    def test_moltype(self):
+        sel = self.universe.select_atoms("moltype NA+")
+        ref = np.array([47677, 47678, 47679, 47680], dtype=np.int32)
+        assert_array_equal(sel.ids, ref)
 
 
 class TestSelectionsNucleicAcids(TestCase):

--- a/testsuite/MDAnalysisTests/topology/test_topology_str_types.py
+++ b/testsuite/MDAnalysisTests/topology/test_topology_str_types.py
@@ -44,6 +44,7 @@ from MDAnalysis.tests.datafiles import (
  'resname',
  'type',
  'segid',
+ 'moltype',
 ]
 )
 # topology formats curated from values available in

--- a/testsuite/MDAnalysisTests/topology/test_tprparser.py
+++ b/testsuite/MDAnalysisTests/topology/test_tprparser.py
@@ -20,8 +20,10 @@
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
 from __future__ import absolute_import
-from numpy.testing import assert_
+from numpy.testing import assert_, assert_array_equal
 import functools
+
+import numpy as np
 
 from MDAnalysis.tests.datafiles import (
     TPR,
@@ -36,8 +38,14 @@ import MDAnalysis.topology.TPRParser
 
 class TPRAttrs(ParserBase):
     parser = MDAnalysis.topology.TPRParser.TPRParser
-    expected_attrs = ['ids', 'names', 'resids', 'resnames']
+    expected_attrs = ['ids', 'names', 'resids', 'resnames', 'moltypes']
     guessed_attrs = ['elements']
+
+    def test_moltypes(self):
+        moltypes = self.top.moltypes.values
+        assert_array_equal(moltypes, self.ref_moltypes)
+
+
 
 
 class TestTPR(TPRAttrs):
@@ -51,6 +59,8 @@ class TestTPR(TPRAttrs):
     expected_n_atoms = 47681
     expected_n_residues = 11302
     expected_n_segments = 3
+    ref_moltypes = np.array(['AKeco'] * 214 + ['SOL'] * 11084 + ['NA+'] * 4,
+                            dtype=object)
 
 
 # The follow test the same system grompped by different version of gromacs
@@ -61,6 +71,7 @@ class TPRBase(TPRAttrs):
     expected_n_atoms = 2263
     expected_n_residues = 230
     expected_n_segments = 2
+    ref_moltypes = np.array(['Protein_A'] * 129 + ['SOL'] * 101, dtype=object)
 
 
 # All these classes should be generated in a loop.
@@ -146,6 +157,10 @@ class TPRDouble(TPRAttrs):
     expected_n_atoms = 21692
     expected_n_residues = 4352
     expected_n_segments = 7
+    ref_moltypes = np.array(['DOPC'] * 21 + ['DPPC'] * 10 + ['CHOL'] * 3
+                            + ['DOPC'] * 21 + ['DPPC'] * 10 + ['CHOL'] * 3
+                            + ['SOL'] * 4284,
+                            dtype=object)
 
 class TestTPR455Double(TPRDouble):
 
@@ -158,6 +173,11 @@ class TPR46xBase(TPRAttrs):
     expected_n_atoms = 44052
     expected_n_residues = 10712
     expected_n_segments = 8
+    ref_moltypes = np.array(['Protein_A'] * 27 + ['Protein_B'] * 27
+                            + ['Protein_C'] * 27 + ['Protein_D'] * 27
+                            + ['Protein_E'] * 27
+                            + ['SOL'] * 10530 + ['NA+'] * 26 + ['CL-'] * 21,
+                            dtype=object)
 
 
 class TestTPR460(TPR46xBase):


### PR DESCRIPTION
Fixes #1555

The TPR parser now exposes the molecule type as the moltypes topology
attribute. The moltypes attribute is defined at the residue level, but
can be accessed at the atom level as well; it behave in the same way as
the resnames attribute.

The molecule type is the name of the molecule to which the atom/residue
belongs. Two molecules that share a molecule type has the same topology
template, so by definition they will have the same number of atoms,
residue, bonds, angles ... On the contrary to segments, moltypes do not
have to be contiguous so multiple occurrences of the same moltype can be
defined in a topology with other molecule types in between; this happens
for instance in lipid bilayer simulations where the lipids are sorted by
leaflet.

In the specific case of gromacs, the molecule type is defined as the
first field in the `[moleculetype]` section of an ITP file. Only the TPR
parser implements the moltype attribute, though the attribute is generic
in principle and can be implemented in any other parser assuming the
format can name molecules.

This PR adds the `moltypes` attribute when reading TPR files, and defines the `moltype` selection keyword.


PR Checklist
------------
 - [X] Tests?
 - [X] Docs?
 - [X] CHANGELOG updated?
 - [X] Issue raised/referenced?
