### PR TITLE
Replace the deprecated logger.warn

### DIFF
--- a/package/MDAnalysis/analysis/align.py
+++ b/package/MDAnalysis/analysis/align.py
@@ -1103,14 +1103,12 @@ def get_matching_atoms(ag1, ag2, tol_mass=0.1, strict=False):
             # note: ag[arange(len(ag))[boolean]] is ~2x faster than
             # ag[where[boolean]]
             mismatch_resindex = np.arange(ag1.n_residues)[mismatch_mask]
-            logger.warn("Removed {0} residues with non-matching numbers of atoms".format(
-                mismatch_mask.sum()))
-            logger.debug(
-                "Removed residue ids: group 1: {0}".format(
-                    ag1.resids[mismatch_resindex]))
-            logger.debug(
-                "Removed residue ids: group 2: {0}".format(
-                    ag2.resids[mismatch_resindex]))
+            logger.warning("Removed {0} residues with non-matching numbers of atoms"
+                           .format(mismatch_mask.sum()))
+            logger.debug("Removed residue ids: group 1: {0}"
+                         .format(ag1.resids[mismatch_resindex]))
+            logger.debug("Removed residue ids: group 2: {0}"
+                         .format(ag2.resids[mismatch_resindex]))
             # replace after logging (still need old ag1 and ag2 for
             # diagnostics)
             ag1 = _ag1

--- a/package/MDAnalysis/analysis/density.py
+++ b/package/MDAnalysis/analysis/density.py
@@ -363,7 +363,7 @@ class Density(Grid):
 
         if self.parameters['isDensity']:
             msg = "Running make_density() makes no sense: Grid is already a density. Nothing done."
-            logger.warn(msg)
+            logger.warning(msg)
             warnings.warn(msg)
             return
 
@@ -931,7 +931,7 @@ class BfactorDensityCreator(object):
             # with the appropriate B-factor
             if np.any(group.bfactors == 0.0):
                 wmsg = "Some B-factors are Zero (will be skipped)."
-                logger.warn(wmsg)
+                logger.warning(wmsg)
                 warnings.warn(wmsg, category=MissingDataWarning)
             rmsf = Bfactor2RMSF(group.bfactors)
             grid *= 0.0  # reset grid

--- a/package/MDAnalysis/analysis/encore/clustering/ClusteringMethod.py
+++ b/package/MDAnalysis/analysis/encore/clustering/ClusteringMethod.py
@@ -49,7 +49,7 @@ except ImportError:
     msg = "sklearn.cluster could not be imported: some functionality will " \
           "not be available in encore.fit_clusters()"
     warnings.warn(msg, category=ImportWarning)
-    logging.warn(msg)
+    logging.warning(msg)
     del msg
 
 

--- a/package/MDAnalysis/analysis/hbonds/hbond_analysis.py
+++ b/package/MDAnalysis/analysis/hbonds/hbond_analysis.py
@@ -661,7 +661,7 @@ class HydrogenBondAnalysis(object):
             else:
                 errmsg += " Selection will update so continuing with fingers crossed."
                 warnings.warn(errmsg, category=SelectionWarning)
-                logger.warn(errmsg)
+                logger.warning(errmsg)
 
     def _log_parameters(self):
         """Log important parameters to the logfile."""
@@ -807,7 +807,8 @@ class HydrogenBondAnalysis(object):
         self._s1 = self.u.select_atoms(self.selection1)
         self.logger_debug("Size of selection 1: {0} atoms".format(len(self._s1)))
         if not self._s1:
-            logger.warn("Selection 1 '{0}' did not select any atoms.".format(str(self.selection1)[:80]))
+            logger.warning("Selection 1 '{0}' did not select any atoms."
+                           .format(str(self.selection1)[:80]))
         self._s1_donors = {}
         self._s1_donors_h = {}
         self._s1_acceptors = {}
@@ -835,8 +836,8 @@ class HydrogenBondAnalysis(object):
             self._s2 = ns_selection_2.search(self._s1, 3. * self.distance)
         self.logger_debug('Size of selection 2: {0} atoms'.format(len(self._s2)))
         if not self._s2:
-            logger.warn('Selection 2 "{0}" did not select any atoms.'.format(
-                str(self.selection2)[:80]))
+            logger.warning('Selection 2 "{0}" did not select any atoms.'
+                           .format(str(self.selection2)[:80]))
         self._s2_donors = {}
         self._s2_donors_h = {}
         self._s2_acceptors = {}
@@ -913,7 +914,7 @@ class HydrogenBondAnalysis(object):
 
         remove_duplicates = kwargs.pop('remove_duplicates', True)  # False: old behaviour
         if not remove_duplicates:
-            logger.warn("Hidden feature remove_duplicates=False activated: you will probably get duplicate H-bonds.")
+            logger.warning("Hidden feature remove_duplicates=False activated: you will probably get duplicate H-bonds.")
 
         debug = kwargs.pop('debug', None)
         if debug is not None and debug != self.debug:
@@ -948,7 +949,7 @@ class HydrogenBondAnalysis(object):
             # chained reader or xyz(?) cannot do time yet
             def _get_timestep():
                 return self.u.trajectory.frame
-            logger.warn("HBond analysis is recording frame number instead of time step")
+            logger.warning("HBond analysis is recording frame number instead of time step")
 
         logger.info("Starting analysis (frame index start=%d stop=%d, step=%d)",
                     (self.traj_slice.start or 0),
@@ -1142,7 +1143,7 @@ class HydrogenBondAnalysis(object):
         if self._timeseries is None:
             msg = "No timeseries computed, do run() first."
             warnings.warn(msg, category=MissingDataWarning)
-            logger.warn(msg)
+            logger.warning(msg)
             return
 
         num_records = np.sum([len(hframe) for hframe in self._timeseries])
@@ -1197,7 +1198,7 @@ class HydrogenBondAnalysis(object):
         if not has_timeseries:
             msg = "No timeseries computed, do run() first."
             warnings.warn(msg, category=MissingDataWarning)
-            logger.warn(msg)
+            logger.warning(msg)
         return has_timeseries
 
     def count_by_time(self):

--- a/package/MDAnalysis/analysis/helanal.py
+++ b/package/MDAnalysis/analysis/helanal.py
@@ -731,7 +731,7 @@ def rotation_angle(helix_vector, axis_vector, rotation_vector):
             logger.debug("Big Screw Up: screw_angle=%g degrees", np.rad2deg(screw_angle))
 
     if mdamath.norm(updown) == 0:
-        logger.warn("PROBLEM (vector is at 0 or 180)")
+        logger.warning("PROBLEM (vector is at 0 or 180)")
 
     helix_dot_rehelix = mdamath.angle(updown, helix_vector)
 

--- a/package/MDAnalysis/analysis/hole.py
+++ b/package/MDAnalysis/analysis/hole.py
@@ -858,8 +858,8 @@ class HOLE(BaseHOLE):
 
         # sanity checks
         if self.shorto > 2:
-            logger.warn("SHORTO (%d) needs to be < 3 in order to extract a HOLE profile!",
-                        self.shorto)
+            logger.warning("SHORTO (%d) needs to be < 3 in order to extract a HOLE profile!",
+                           self.shorto)
         for program, path in self.exe.items():
             if path is None or which(path) is None:
                 logger.error("Executable %(program)r not found, should have been %(path)r.",
@@ -1130,7 +1130,8 @@ class HOLE(BaseHOLE):
         if len(self.profiles) == length:
             logger.info("Collected HOLE radius profiles for %d frames", len(self.profiles))
         else:
-            logger.warn("Missing data: Found %d HOLE profiles from %d frames.", len(self.profiles), length)
+            logger.warning("Missing data: Found %d HOLE profiles from %d frames.",
+                           len(self.profiles), length)
 
     def __del__(self):
         for f in self.tempfiles:

--- a/package/MDAnalysis/analysis/legacy/x3dna.py
+++ b/package/MDAnalysis/analysis/legacy/x3dna.py
@@ -706,7 +706,7 @@ class X3DNA(BaseX3DNA):
         if len(self.profiles) == length:
             logger.info("Collected X3DNA profiles for %d frames", len(self.profiles))
         else:
-            logger.warn("Missing data: Found %d X3DNA profiles from %d frames.", len(self.profiles), length)
+            logger.warning("Missing data: Found %d X3DNA profiles from %d frames.", len(self.profiles), length)
 
     def __del__(self):
         for f in self.tempfiles:

--- a/package/MDAnalysis/coordinates/PDB.py
+++ b/package/MDAnalysis/coordinates/PDB.py
@@ -578,8 +578,8 @@ class PDBWriter(base.WriterBase):
             if not self.has_END:
                 self.END()
             else:
-                logger.warn("END record has already been written"
-                            " before the final closing of the file")
+                logger.warning("END record has already been written"
+                               " before the final closing of the file")
             self.pdbfile.close()
         self.pdbfile = None
 

--- a/package/MDAnalysis/topology/PSFParser.py
+++ b/package/MDAnalysis/topology/PSFParser.py
@@ -287,9 +287,9 @@ class PSFParser(TopologyReaderBase):
                 # space-separated "PSF" file from VMD version < 1.9.1
                 atom_parser = atom_parsers['NAMD']
                 vals = set_type(atom_parser(line))
-                logger.warn("Guessing that this is actually a"
-                            " NAMD-type PSF file..."
-                            " continuing with fingers crossed!")
+                logger.warning("Guessing that this is actually a"
+                               " NAMD-type PSF file..."
+                               " continuing with fingers crossed!")
                 logger.debug("First NAMD-type line: {0}: {1}"
                              "".format(i, line.rstrip()))
 


### PR DESCRIPTION
The `warn` method from the `logging` module is deprecated at least in
python 3. This results in deprecation warnings being displayed instead
of the legitimate warning we want to log.

This commit replaces all occurrences of `logger.warn` by
`logger.warning`.