### PR TITLE
Fixed _calc_dihedral and Dihedral.dihedrals

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -91,7 +91,7 @@ Chronological list of authors
   - Andrew William King
   - Kathleen Clark
   - Dominik 'Rathann' Mierzejewski
-  
+  - Nestor Wendt
 
 External code
 -------------

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -28,6 +28,7 @@ Enhancements
 Deprecations
 
 Fixes
+  * Fixed nuclinfo.tors() not converting delta (Issue #1572)
   * Changed _calc_dihedral and Dihedrals.dihedrals() vectors calculation to
     match IUPAC convention (Issue #1565)
   * Fixed _calc_dihedral returning negative angles as positive (Issue #1554)

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -14,7 +14,7 @@ The rules for this file:
 
 ------------------------------------------------------------------------------
 mm/dd/17 richardjgowers, rathann, orbeckst, tylerjereddy, mtiberti, kain88-de,
-         jbarnoud
+         jbarnoud, nestorwendt
 
   * 0.17.0
 
@@ -28,6 +28,9 @@ Enhancements
 Deprecations
 
 Fixes
+  * Changed _calc_dihedral and Dihedrals.dihedrals() vectors calculation to
+    match IUPAC convention (Issue #1565)
+  * Fixed _calc_dihedral returning negative angles as positive (Issue #1554)
   * correctly read little-endian TRZ files on big-endian architectures (issue
     #1424)
   * Fixed type matching and inclusion compilation warnings for the

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -29,8 +29,8 @@ Deprecations
 
 Fixes
   * Fixed nuclinfo.tors() not converting delta (Issue #1572)
-  * Changed _calc_dihedral and Dihedrals.dihedrals() vectors calculation to
-    match IUPAC convention (Issue #1565)
+  * Changed _calc_dihedral and Dihedral.value() to match IUPAC convention
+    (Issue #1565)
   * Fixed _calc_dihedral returning negative angles as positive (Issue #1554)
   * correctly read little-endian TRZ files on big-endian architectures (issue
     #1424)

--- a/package/MDAnalysis/analysis/nuclinfo.py
+++ b/package/MDAnalysis/analysis/nuclinfo.py
@@ -312,11 +312,7 @@ def phase_cp(universe, seg, i):
          + (r5_d * cos(4 * pi * 4.0 / 5.0))) * sqrt(2.0 / 5.0)
 
     phase_ang = (atan2(D, C) + (pi / 2.)) * 180. / pi
-    if phase_ang < 0:
-        phase_ang = phase_ang + 360
-    else:
-        phase_ang
-    return phase_ang
+    return phase_ang % 360
 
 
 def phase_as(universe, seg, i):
@@ -385,11 +381,7 @@ def phase_as(universe, seg, i):
          + (data5 * cos(2 * 2 * pi * (5 - 1.) / 5.))) * 2. / 5.
 
     phase_ang = atan2(B, A) * 180. / pi
-    if phase_ang < 0:
-        phase_ang = phase_ang + 360
-    else:
-        phase_ang
-    return phase_ang
+    return phase_ang % 360
 
 
 def tors(universe, seg, i):
@@ -460,26 +452,14 @@ def tors(universe, seg, i):
                                   " atom {0!s} {1!s} N9 ".format(seg, i),
                                   " atom {0!s} {1!s} C4  ".format(seg, i))
 
-    alpha = a.dihedral.value()
-    beta = b.dihedral.value()
-    gamma = g.dihedral.value()
-    delta = d.dihedral.value()
-    epsilon = e.dihedral.value()
-    zeta = z.dihedral.value()
-    chi = c.dihedral.value()
+    alpha = a.dihedral.value() % 360
+    beta = b.dihedral.value() % 360
+    gamma = g.dihedral.value() % 360
+    delta = d.dihedral.value() % 360
+    epsilon = e.dihedral.value() % 360
+    zeta = z.dihedral.value() % 360
+    chi = c.dihedral.value() % 360
 
-    if alpha < 0:
-        alpha = alpha + 360
-    if beta < 0:
-        beta = beta + 360
-    if gamma < 0:
-        gamma = gamma + 360
-    if epsilon < 0:
-        epsilon = epsilon + 360
-    if zeta < 0:
-        zeta = zeta + 360
-    if chi < 0:
-        chi = chi + 360
     return [alpha, beta, gamma, delta, epsilon, zeta, chi]
 
 
@@ -509,9 +489,7 @@ def tors_alpha(universe, seg, i):
                               " atom {0!s} {1!s} P  ".format(seg, i),
                               " atom {0!s} {1!s} O5\' ".format(seg, i),
                               " atom {0!s} {1!s} C5\' ".format(seg, i))
-    alpha = a.dihedral.value()
-    if alpha < 0:
-        alpha = alpha + 360
+    alpha = a.dihedral.value() % 360
     return alpha
 
 
@@ -541,9 +519,7 @@ def tors_beta(universe, seg, i):
                               " atom {0!s} {1!s} O5\' ".format(seg, i),
                               " atom {0!s} {1!s} C5\' ".format(seg, i),
                               " atom {0!s} {1!s} C4\' ".format(seg, i))
-    beta = b.dihedral.value()
-    if beta < 0:
-        beta = beta + 360
+    beta = b.dihedral.value() % 360
     return beta
 
 
@@ -573,9 +549,7 @@ def tors_gamma(universe, seg, i):
                               " atom {0!s} {1!s} C5\' ".format(seg, i),
                               " atom {0!s} {1!s} C4\' ".format(seg, i),
                               " atom {0!s} {1!s} C3\' ".format(seg, i))
-    gamma = g.dihedral.value()
-    if gamma < 0:
-        gamma = gamma + 360
+    gamma = g.dihedral.value() % 360
     return gamma
 
 
@@ -605,9 +579,7 @@ def tors_delta(universe, seg, i):
                               " atom {0!s} {1!s} C4\' ".format(seg, i),
                               " atom {0!s} {1!s} C3\' ".format(seg, i),
                               " atom {0!s} {1!s} O3\' ".format(seg, i))
-    delta = d.dihedral.value()
-    if delta < 0:
-        delta = delta + 360
+    delta = d.dihedral.value() % 360
     return delta
 
 
@@ -637,9 +609,7 @@ def tors_eps(universe, seg, i):
                               " atom {0!s} {1!s} C3\' ".format(seg, i),
                               " atom {0!s} {1!s} O3\' ".format(seg, i),
                               " atom {0!s} {1!s} P    ".format(seg, i + 1))
-    epsilon = e.dihedral.value()
-    if epsilon < 0:
-        epsilon = epsilon + 360
+    epsilon = e.dihedral.value() % 360
     return epsilon
 
 
@@ -669,9 +639,7 @@ def tors_zeta(universe, seg, i):
                               " atom {0!s} {1!s} O3\' ".format(seg, i),
                               " atom {0!s} {1!s} P    ".format(seg, i + 1),
                               " atom {0!s} {1!s} O5\' ".format(seg, i + 1))
-    zeta = z.dihedral.value()
-    if zeta < 0:
-        zeta = zeta + 360
+    zeta = z.dihedral.value() % 360
     return zeta
 
 
@@ -706,9 +674,7 @@ def tors_chi(universe, seg, i):
                                   " atom {0!s} {1!s} C1\' ".format(seg, i),
                                   " atom {0!s} {1!s} N9 ".format(seg, i),
                                   " atom {0!s} {1!s} C4  ".format(seg, i))
-    chi = c.dihedral.value()
-    if chi < 0:
-        chi = chi + 360
+    chi = c.dihedral.value() % 360
     return chi
 
 
@@ -742,12 +708,10 @@ def hydroxyl(universe, seg, i):
                               " atom {0!s} {1!s} O2\' ".format(seg, i),
                               " atom {0!s} {1!s} H2\'\' ".format(seg, i))
     try:
-        hydr = h.dihedral.value()
+        hydr = h.dihedral.value() % 360
     except ValueError:
         raise ValueError("Resid {0} does not contain atoms C1', C2', O2', H2' but atoms {1}"
                          .format(i, str(list(h.atoms))))
-    if hydr < 0:
-        hydr = hydr + 360
     return hydr
 
 
@@ -796,7 +760,5 @@ def pseudo_dihe_baseflip(universe, bp1, bp2, i,
     x = [bf1.center_of_mass(), bf2.center_of_mass(),
          bf3.center_of_mass(), bf4.center_of_mass()]
     pseudo = mdamath.dihedral(x[0] - x[1], x[1] - x[2], x[2] - x[3])
-    pseudo = np.rad2deg(pseudo)
-    if pseudo < 0:
-        pseudo = pseudo + 360
+    pseudo = np.rad2deg(pseudo) % 360
     return pseudo

--- a/package/MDAnalysis/core/topologyobjects.py
+++ b/package/MDAnalysis/core/topologyobjects.py
@@ -945,12 +945,12 @@ class TopologyGroup(object):
             raise TypeError("TopologyGroup is not of type 'dihedral' or "
                             "'improper'")
 
-        vec1 = self._ags[1].positions - self._ags[0].positions
-        vec2 = self._ags[2].positions - self._ags[1].positions
-        vec3 = self._ags[3].positions - self._ags[2].positions
+        ab = self._ags[0].positions - self._ags[1].positions
+        bc = self._ags[1].positions - self._ags[2].positions
+        cd = self._ags[2].positions - self._ags[3].positions
 
         return np.array([mdamath.dihedral(a, b, c)
-                         for a, b, c in zip(vec1, vec2, vec3)])
+                         for a, b, c in zip(ab, bc, cd)])
 
     def dihedrals(self, result=None, pbc=False):
         """Calculate the dihedralal angle in radians for this topology

--- a/package/MDAnalysis/lib/include/calc_distances.h
+++ b/package/MDAnalysis/lib/include/calc_distances.h
@@ -531,12 +531,12 @@ static void _calc_angle_triclinic(coordinate* atom1, coordinate* atom2,
   }
 }
 
-static double _calc_dihedral_angle(double* va, double* vb, double* vc)
+static void _calc_dihedral_angle(double* va, double* vb, double* vc, double* result)
 {
   // Returns atan2 from vectors va, vb, vc
   double n1[3], n2[3];
   double xp[3], vb_norm;
-  double x, y, angle;
+  double x, y;
 
   //n1 is normal vector to -va, vb
   //n2 is normal vector to -vb, vc
@@ -558,13 +558,15 @@ static double _calc_dihedral_angle(double* va, double* vb, double* vc)
 
   vb_norm = sqrt(vb[0]*vb[0] + vb[1]*vb[1] + vb[2]*vb[2]);
 
-  if ( abs(x) == 0.0 && abs(y) == 0.0 ) // numpy consistency
-    return NAN;
-
   y = (xp[0]*vb[0] + xp[1]*vb[1] + xp[2]*vb[2]) / vb_norm;
 
-  angle = -atan2(y, x); //atan2 is better conditioned than acos
-  return angle;
+  if ( (fabs(x) == 0.0) && (fabs(y) == 0.0) ) // numpy consistency
+  {
+    *result = NAN;
+    return;
+  }
+
+  *result = atan2(y, x); //atan2 is better conditioned than acos
 }
 
 static void _calc_dihedral(coordinate* atom1, coordinate* atom2,
@@ -579,19 +581,19 @@ static void _calc_dihedral(coordinate* atom1, coordinate* atom2,
 #endif
   for (i=0; i<numatom; i++) {
     // connecting vectors between all 4 atoms: 1 -va-> 2 -vb-> 3 -vc-> 4
-    va[0] = atom1[i][0] - atom2[i][0];
-    va[1] = atom1[i][1] - atom2[i][1];
-    va[2] = atom1[i][2] - atom2[i][2];
+    va[0] = atom2[i][0] - atom1[i][0];
+    va[1] = atom2[i][1] - atom1[i][1];
+    va[2] = atom2[i][2] - atom1[i][2];
 
-    vb[0] = atom2[i][0] - atom3[i][0];
-    vb[1] = atom2[i][1] - atom3[i][1];
-    vb[2] = atom2[i][2] - atom3[i][2];
+    vb[0] = atom3[i][0] - atom2[i][0];
+    vb[1] = atom3[i][1] - atom2[i][1];
+    vb[2] = atom3[i][2] - atom2[i][2];
 
-    vc[0] = atom3[i][0] - atom4[i][0];
-    vc[1] = atom3[i][1] - atom4[i][1];
-    vc[2] = atom3[i][2] - atom4[i][2];
+    vc[0] = atom4[i][0] - atom3[i][0];
+    vc[1] = atom4[i][1] - atom3[i][1];
+    vc[2] = atom4[i][2] - atom3[i][2];
 
-    *(angles + i) = _calc_dihedral_angle(va, vb, vc);
+    _calc_dihedral_angle(va, vb, vc, angles + i);
   }
 }
 
@@ -612,22 +614,22 @@ static void _calc_dihedral_ortho(coordinate* atom1, coordinate* atom2,
 #endif
   for (i=0; i<numatom; i++) {
     // connecting vectors between all 4 atoms: 1 -va-> 2 -vb-> 3 -vc-> 4
-    va[0] = atom1[i][0] - atom2[i][0];
-    va[1] = atom1[i][1] - atom2[i][1];
-    va[2] = atom1[i][2] - atom2[i][2];
+    va[0] = atom2[i][0] - atom1[i][0];
+    va[1] = atom2[i][1] - atom1[i][1];
+    va[2] = atom2[i][2] - atom1[i][2];
     minimum_image(va, box, inverse_box);
 
-    vb[0] = atom2[i][0] - atom3[i][0];
-    vb[1] = atom2[i][1] - atom3[i][1];
-    vb[2] = atom2[i][2] - atom3[i][2];
+    vb[0] = atom3[i][0] - atom2[i][0];
+    vb[1] = atom3[i][1] - atom2[i][1];
+    vb[2] = atom3[i][2] - atom2[i][2];
     minimum_image(vb, box, inverse_box);
 
-    vc[0] = atom3[i][0] - atom4[i][0];
-    vc[1] = atom3[i][1] - atom4[i][1];
-    vc[2] = atom3[i][2] - atom4[i][2];
+    vc[0] = atom4[i][0] - atom3[i][0];
+    vc[1] = atom4[i][1] - atom3[i][1];
+    vc[2] = atom4[i][2] - atom3[i][2];
     minimum_image(vc, box, inverse_box);
 
-    *(angles + i) = _calc_dihedral_angle(va, vb, vc);
+    _calc_dihedral_angle(va, vb, vc, angles + i);
   }
 }
 
@@ -657,22 +659,22 @@ static void _calc_dihedral_triclinic(coordinate* atom1, coordinate* atom2,
 #endif
   for (i=0; i<numatom; i++) {
     // connecting vectors between all 4 atoms: 1 -va-> 2 -vb-> 3 -vc-> 4
-    va[0] = atom1[i][0] - atom2[i][0];
-    va[1] = atom1[i][1] - atom2[i][1];
-    va[2] = atom1[i][2] - atom2[i][2];
+    va[0] = atom2[i][0] - atom1[i][0];
+    va[1] = atom2[i][1] - atom1[i][1];
+    va[2] = atom2[i][2] - atom1[i][2];
     minimum_image_triclinic(va, box, box_half);
 
-    vb[0] = atom2[i][0] - atom3[i][0];
-    vb[1] = atom2[i][1] - atom3[i][1];
-    vb[2] = atom2[i][2] - atom3[i][2];
+    vb[0] = atom3[i][0] - atom2[i][0];
+    vb[1] = atom3[i][1] - atom2[i][1];
+    vb[2] = atom3[i][2] - atom2[i][2];
     minimum_image_triclinic(vb, box, box_half);
 
-    vc[0] = atom3[i][0] - atom4[i][0];
-    vc[1] = atom3[i][1] - atom4[i][1];
-    vc[2] = atom3[i][2] - atom4[i][2];
+    vc[0] = atom4[i][0] - atom3[i][0];
+    vc[1] = atom4[i][1] - atom3[i][1];
+    vc[2] = atom4[i][2] - atom3[i][2];
     minimum_image_triclinic(vc, box, box_half);
 
-    *(angles + i) = _calc_dihedral_angle(va, vb, vc);
+    _calc_dihedral_angle(va, vb, vc, angles + i);
   }
 }
 #endif

--- a/package/MDAnalysis/lib/include/calc_distances.h
+++ b/package/MDAnalysis/lib/include/calc_distances.h
@@ -535,7 +535,7 @@ static double _calc_dihedral_angle(double* va, double* vb, double* vc)
 {
   // Returns atan2 from vectors va, vb, vc
   double n1[3], n2[3];
-  double xp[3];
+  double xp[3], vb_norm;
   double x, y, angle;
 
   //n1 is normal vector to -va, vb
@@ -551,14 +551,16 @@ static double _calc_dihedral_angle(double* va, double* vb, double* vc)
   // x = dot(n1,n2) = cos theta
   x = (n1[0]*n2[0] + n1[1]*n2[1] + n1[2]*n2[2]);
 
+  // xp = cross(n1,n2)
   xp[0] = n1[1]*n2[2] - n1[2]*n2[1];
   xp[1] =-n1[0]*n2[2] + n1[2]*n2[0];
   xp[2] = n1[0]*n2[1] - n1[1]*n2[0];
 
-  y = (xp[0]*vb[0] + xp[1]*vb[1] + xp[2]*vb[2]) / \
-      sqrt(vb[0]*vb[0] + vb[1]*vb[1] + vb[2]*vb[2]);
+  vb_norm = sqrt(vb[0]*vb[0] + vb[1]*vb[1] + vb[2]*vb[2]);
 
-  angle = -atan2(y, x);
+  y = (xp[0]*vb[0] + xp[1]*vb[1] + xp[2]*vb[2]) / vb_norm;
+
+  angle = -atan2(y, x); //atan2 is better conditioned than acos
   return angle;
 }
 
@@ -586,7 +588,7 @@ static void _calc_dihedral(coordinate* atom1, coordinate* atom2,
     vc[1] = atom3[i][1] - atom4[i][1];
     vc[2] = atom3[i][2] - atom4[i][2];
 
-    *(angles + i) = _calc_dihedral_angle(va, vb, vc); //atan2 is better conditioned than acos
+    *(angles + i) = _calc_dihedral_angle(va, vb, vc);
   }
 }
 
@@ -622,7 +624,7 @@ static void _calc_dihedral_ortho(coordinate* atom1, coordinate* atom2,
     vc[2] = atom3[i][2] - atom4[i][2];
     minimum_image(vc, box, inverse_box);
 
-    *(angles + i) = _calc_dihedral_angle(va, vb, vc); //atan2 is better conditioned than acos
+    *(angles + i) = _calc_dihedral_angle(va, vb, vc);
   }
 }
 
@@ -667,7 +669,7 @@ static void _calc_dihedral_triclinic(coordinate* atom1, coordinate* atom2,
     vc[2] = atom3[i][2] - atom4[i][2];
     minimum_image_triclinic(vc, box, box_half);
 
-    *(angles + i) = _calc_dihedral_angle(va, vb, vc); //atan2 is better conditioned than acos
+    *(angles + i) = _calc_dihedral_angle(va, vb, vc);
   }
 }
 #endif

--- a/package/MDAnalysis/lib/include/calc_distances.h
+++ b/package/MDAnalysis/lib/include/calc_distances.h
@@ -558,6 +558,9 @@ static double _calc_dihedral_angle(double* va, double* vb, double* vc)
 
   vb_norm = sqrt(vb[0]*vb[0] + vb[1]*vb[1] + vb[2]*vb[2]);
 
+  if ( abs(x) == 0.0 && abs(y) == 0.0 ) // numpy consistency
+    return NAN;
+
   y = (xp[0]*vb[0] + xp[1]*vb[1] + xp[2]*vb[2]) / vb_norm;
 
   angle = -atan2(y, x); //atan2 is better conditioned than acos

--- a/package/MDAnalysis/lib/include/calc_distances.h
+++ b/package/MDAnalysis/lib/include/calc_distances.h
@@ -47,7 +47,7 @@ static void minimum_image_triclinic(double *dx, coordinate* box, float* box_half
   // Minimum image convention for triclinic systems, modelled after domain.cpp in LAMMPS
   // Assumes that there is a maximum separation of 1 box length (enforced in dist functions
   // by moving all particles to inside the box before calculating separations)
-  // Requires a box 
+  // Requires a box
   // Assumes box having zero values for box[0][1], box[0][2] and box [1][2]
 
   // z
@@ -179,7 +179,7 @@ static void _calc_distance_array_triclinic(coordinate* ref, int numref,
   double dx[3];
   float box_half[3], box_inverse[3];
   double rsq;
-  
+
   box_half[0] = 0.5 * box[0][0];
   box_half[1] = 0.5 * box[1][1];
   box_half[2] = 0.5 * box[2][2];
@@ -217,11 +217,11 @@ static void _calc_self_distance_array(coordinate* ref, int numref, double* dista
 
 #ifdef PARALLEL
 #pragma omp parallel for private(i, distpos, j, dx, rsq) shared(distances)
-#endif    
+#endif
   for (i=0; i<numref; i++) {
 #ifdef PARALLEL
     distpos = i * (2 * numref - i - 1) / 2;  // calculates the offset into distances
-#endif    
+#endif
     for (j=i+1; j<numref; j++) {
       dx[0] = ref[j][0] - ref[i][0];
       dx[1] = ref[j][1] - ref[i][1];
@@ -251,7 +251,7 @@ static void _calc_self_distance_array_ortho(coordinate* ref, int numref, float* 
 #endif
   for (i=0; i<numref; i++) {
 #ifdef PARALLEL
-    distpos = i * (2 * numref - i - 1) / 2;  // calculates the offset into distances    
+    distpos = i * (2 * numref - i - 1) / 2;  // calculates the offset into distances
 #endif
     for (j=i+1; j<numref; j++) {
       dx[0] = ref[j][0] - ref[i][0];
@@ -292,7 +292,7 @@ static void _calc_self_distance_array_triclinic(coordinate* ref, int numref,
 #endif
   for (i=0; i<numref; i++){
 #ifdef PARALLEL
-    distpos = i * (2 * numref - i - 1) / 2;  // calculates the offset into distances    
+    distpos = i * (2 * numref - i - 1) / 2;  // calculates the offset into distances
 #endif
     for (j=i+1; j<numref; j++){
       dx[0] = ref[j][0] - ref[i][0];
@@ -310,7 +310,7 @@ static void _coord_transform(coordinate* coords, int numCoords, coordinate* box)
 {
   int i, j, k;
   float new[3];
-  // Matrix multiplication inCoords * box = outCoords  
+  // Matrix multiplication inCoords * box = outCoords
   // Multiplication done in place using temp array 'new'
   // Used to transform coordinates to/from S/R space in trilinic boxes
 #ifdef PARALLEL
@@ -319,7 +319,7 @@ static void _coord_transform(coordinate* coords, int numCoords, coordinate* box)
   for (i=0; i < numCoords; i++){
     new[0] = 0.0;
     new[1] = 0.0;
-    new[2] = 0.0;    
+    new[2] = 0.0;
     for (j=0; j<3; j++){
       for (k=0; k<3; k++){
         new[j] += coords[i][k] * box[k][j];
@@ -361,7 +361,7 @@ static void _calc_bond_distance_ortho(coordinate* atom1, coordinate* atom2,
   inverse_box[0] = 1.0/box[0];
   inverse_box[1] = 1.0/box[1];
   inverse_box[2] = 1.0/box[2];
- 
+
 #ifdef PARALLEL
 #pragma omp parallel for private(i, dx, rsq) shared(distances)
 #endif
@@ -391,7 +391,7 @@ static void _calc_bond_distance_triclinic(coordinate* atom1, coordinate* atom2,
   box_inverse[0] = 1.0/box[0][0];
   box_inverse[1] = 1.0/box[1][1];
   box_inverse[2] = 1.0/box[2][2];
- 
+
   _triclinic_pbc(atom1, numatom, box, box_inverse);
   _triclinic_pbc(atom2, numatom, box, box_inverse);
 
@@ -531,54 +531,62 @@ static void _calc_angle_triclinic(coordinate* atom1, coordinate* atom2,
   }
 }
 
+static double _calc_dihedral_angle(double* va, double* vb, double* vc)
+{
+  // Returns atan2 from vectors va, vb, vc
+  double n1[3], n2[3];
+  double xp[3];
+  double x, y, angle;
+
+  //n1 is normal vector to -va, vb
+  //n2 is normal vector to -vb, vc
+  n1[0] =-va[1]*vb[2] + va[2]*vb[1];
+  n1[1] = va[0]*vb[2] - va[2]*vb[0];
+  n1[2] =-va[0]*vb[1] + va[1]*vb[0];
+
+  n2[0] =-vb[1]*vc[2] + vb[2]*vc[1];
+  n2[1] = vb[0]*vc[2] - vb[2]*vc[0];
+  n2[2] =-vb[0]*vc[1] + vb[1]*vc[0];
+
+  // x = dot(n1,n2) = cos theta
+  x = (n1[0]*n2[0] + n1[1]*n2[1] + n1[2]*n2[2]);
+
+  xp[0] = n1[1]*n2[2] - n1[2]*n2[1];
+  xp[1] =-n1[0]*n2[2] + n1[2]*n2[0];
+  xp[2] = n1[0]*n2[1] - n1[1]*n2[0];
+
+  y = (xp[0]*vb[0] + xp[1]*vb[1] + xp[2]*vb[2]) / \
+      sqrt(vb[0]*vb[0] + vb[1]*vb[1] + vb[2]*vb[2]);
+
+  angle = -atan2(y, x);
+  return angle;
+}
+
 static void _calc_dihedral(coordinate* atom1, coordinate* atom2,
                            coordinate* atom3, coordinate* atom4,
                            int numatom, double* angles)
 {
   int i;
   double va[3], vb[3], vc[3];
-  double n1[3], n2[3];
-  double xp[3];
-  double x, y;
 
 #ifdef PARALLEL
-#pragma omp parallel for private(i, va, vb, vc, n1, n2, x, xp, y) shared(angles)
+#pragma omp parallel for private(i, va, vb, vc) shared(angles)
 #endif
   for (i=0; i<numatom; i++) {
     // connecting vectors between all 4 atoms: 1 -va-> 2 -vb-> 3 -vc-> 4
-    va[0] = atom2[i][0] - atom1[i][0];
-    va[1] = atom2[i][1] - atom1[i][1];
-    va[2] = atom2[i][2] - atom1[i][2];
+    va[0] = atom1[i][0] - atom2[i][0];
+    va[1] = atom1[i][1] - atom2[i][1];
+    va[2] = atom1[i][2] - atom2[i][2];
 
-    vb[0] = atom3[i][0] - atom2[i][0];
-    vb[1] = atom3[i][1] - atom2[i][1];
-    vb[2] = atom3[i][2] - atom2[i][2];
+    vb[0] = atom2[i][0] - atom3[i][0];
+    vb[1] = atom2[i][1] - atom3[i][1];
+    vb[2] = atom2[i][2] - atom3[i][2];
 
-    vc[0] = atom4[i][0] - atom3[i][0];
-    vc[1] = atom4[i][1] - atom3[i][1];
-    vc[2] = atom4[i][2] - atom3[i][2];
+    vc[0] = atom3[i][0] - atom4[i][0];
+    vc[1] = atom3[i][1] - atom4[i][1];
+    vc[2] = atom3[i][2] - atom4[i][2];
 
-    //n1 is normal vector to -va, vb
-    //n2 is normal vector to -vb, vc
-    n1[0] =-va[1]*vb[2] + va[2]*vb[1];
-    n1[1] = va[0]*vb[2] - va[2]*vb[0];
-    n1[2] =-va[0]*vb[1] + va[1]*vb[0];
-
-    n2[0] =-vb[1]*vc[2] + vb[2]*vc[1];
-    n2[1] = vb[0]*vc[2] - vb[2]*vc[0];
-    n2[2] =-vb[0]*vc[1] + vb[1]*vc[0];
-
-    // x = dot(n1,n2) = cos theta
-    // y = norm(cross(n1,n2)) = sin theta
-    // tan theta = y/x
-    x = (n1[0]*n2[0] + n1[1]*n2[1] + n1[2]*n2[2]);
-
-    xp[0] = n1[1]*n2[2] - n1[2]*n2[1];
-    xp[1] =-n1[0]*n2[2] + n1[2]*n2[0];
-    xp[2] = n1[0]*n2[1] - n1[1]*n2[0];
-    y = sqrt(xp[0]*xp[0] + xp[1]*xp[1] + xp[2]*xp[2]);
-
-    *(angles + i) = atan2(y,x); //atan2 is better conditioned than acos
+    *(angles + i) = _calc_dihedral_angle(va, vb, vc); //atan2 is better conditioned than acos
   }
 }
 
@@ -588,9 +596,6 @@ static void _calc_dihedral_ortho(coordinate* atom1, coordinate* atom2,
 {
   int i;
   double va[3], vb[3], vc[3];
-  double n1[3], n2[3];
-  double xp[3];
-  double x, y;
   float inverse_box[3];
 
   inverse_box[0] = 1.0/box[0];
@@ -598,46 +603,26 @@ static void _calc_dihedral_ortho(coordinate* atom1, coordinate* atom2,
   inverse_box[2] = 1.0/box[2];
 
 #ifdef PARALLEL
-#pragma omp parallel for private(i, va, vb, vc, n1, n2, x, xp, y) shared(angles)
+#pragma omp parallel for private(i, va, vb, vc) shared(angles)
 #endif
   for (i=0; i<numatom; i++) {
     // connecting vectors between all 4 atoms: 1 -va-> 2 -vb-> 3 -vc-> 4
-    va[0] = atom2[i][0] - atom1[i][0];
-    va[1] = atom2[i][1] - atom1[i][1];
-    va[2] = atom2[i][2] - atom1[i][2];
+    va[0] = atom1[i][0] - atom2[i][0];
+    va[1] = atom1[i][1] - atom2[i][1];
+    va[2] = atom1[i][2] - atom2[i][2];
     minimum_image(va, box, inverse_box);
 
-    vb[0] = atom3[i][0] - atom2[i][0];
-    vb[1] = atom3[i][1] - atom2[i][1];
-    vb[2] = atom3[i][2] - atom2[i][2];
+    vb[0] = atom2[i][0] - atom3[i][0];
+    vb[1] = atom2[i][1] - atom3[i][1];
+    vb[2] = atom2[i][2] - atom3[i][2];
     minimum_image(vb, box, inverse_box);
 
-    vc[0] = atom4[i][0] - atom3[i][0];
-    vc[1] = atom4[i][1] - atom3[i][1];
-    vc[2] = atom4[i][2] - atom3[i][2];
+    vc[0] = atom3[i][0] - atom4[i][0];
+    vc[1] = atom3[i][1] - atom4[i][1];
+    vc[2] = atom3[i][2] - atom4[i][2];
     minimum_image(vc, box, inverse_box);
 
-    //n1 is normal vector to -va, vb
-    //n2 is normal vector to -vb, vc
-    n1[0] =-va[1]*vb[2] + va[2]*vb[1];
-    n1[1] = va[0]*vb[2] - va[2]*vb[0];
-    n1[2] =-va[0]*vb[1] + va[1]*vb[0];
-
-    n2[0] =-vb[1]*vc[2] + vb[2]*vc[1];
-    n2[1] = vb[0]*vc[2] - vb[2]*vc[0];
-    n2[2] =-vb[0]*vc[1] + vb[1]*vc[0];
-
-    // x = dot(n1,n2) = cos theta
-    // y = norm(cross(n1,n2)) = sin theta
-    // tan theta = y/x
-    x = (n1[0]*n2[0] + n1[1]*n2[1] + n1[2]*n2[2]);
-
-    xp[0] = n1[1]*n2[2] - n1[2]*n2[1];
-    xp[1] =-n1[0]*n2[2] + n1[2]*n2[0];
-    xp[2] = n1[0]*n2[1] - n1[1]*n2[0];
-    y = sqrt(xp[0]*xp[0] + xp[1]*xp[1] + xp[2]*xp[2]);
-
-    *(angles + i) = atan2(y,x); //atan2 is better conditioned than acos
+    *(angles + i) = _calc_dihedral_angle(va, vb, vc); //atan2 is better conditioned than acos
   }
 }
 
@@ -647,9 +632,6 @@ static void _calc_dihedral_triclinic(coordinate* atom1, coordinate* atom2,
 {
   int i;
   double va[3], vb[3], vc[3];
-  double n1[3], n2[3];
-  double xp[3];
-  double x, y;
   float box_half[3], box_inverse[3];
 
   box_half[0] = 0.5 * box[0][0];
@@ -666,46 +648,26 @@ static void _calc_dihedral_triclinic(coordinate* atom1, coordinate* atom2,
   _triclinic_pbc(atom4, numatom, box, box_inverse);
 
 #ifdef PARALLEL
-#pragma omp parallel for private(i, va, vb, vc, n1, n2, x, xp, y) shared(angles)
+#pragma omp parallel for private(i, va, vb, vc) shared(angles)
 #endif
   for (i=0; i<numatom; i++) {
     // connecting vectors between all 4 atoms: 1 -va-> 2 -vb-> 3 -vc-> 4
-    va[0] = atom2[i][0] - atom1[i][0];
-    va[1] = atom2[i][1] - atom1[i][1];
-    va[2] = atom2[i][2] - atom1[i][2];
+    va[0] = atom1[i][0] - atom2[i][0];
+    va[1] = atom1[i][1] - atom2[i][1];
+    va[2] = atom1[i][2] - atom2[i][2];
     minimum_image_triclinic(va, box, box_half);
 
-    vb[0] = atom3[i][0] - atom2[i][0];
-    vb[1] = atom3[i][1] - atom2[i][1];
-    vb[2] = atom3[i][2] - atom2[i][2];
+    vb[0] = atom2[i][0] - atom3[i][0];
+    vb[1] = atom2[i][1] - atom3[i][1];
+    vb[2] = atom2[i][2] - atom3[i][2];
     minimum_image_triclinic(vb, box, box_half);
 
-    vc[0] = atom4[i][0] - atom3[i][0];
-    vc[1] = atom4[i][1] - atom3[i][1];
-    vc[2] = atom4[i][2] - atom3[i][2];
+    vc[0] = atom3[i][0] - atom4[i][0];
+    vc[1] = atom3[i][1] - atom4[i][1];
+    vc[2] = atom3[i][2] - atom4[i][2];
     minimum_image_triclinic(vc, box, box_half);
 
-    //n1 is normal vector to -va, vb
-    //n2 is normal vector to -vb, vc
-    n1[0] =-va[1]*vb[2] + va[2]*vb[1];
-    n1[1] = va[0]*vb[2] - va[2]*vb[0];
-    n1[2] =-va[0]*vb[1] + va[1]*vb[0];
-
-    n2[0] =-vb[1]*vc[2] + vb[2]*vc[1];
-    n2[1] = vb[0]*vc[2] - vb[2]*vc[0];
-    n2[2] =-vb[0]*vc[1] + vb[1]*vc[0];
-
-    // x = dot(n1,n2) = cos theta
-    // y = norm(cross(n1,n2)) = sin theta
-    // tan theta = y/x
-    x = (n1[0]*n2[0] + n1[1]*n2[1] + n1[2]*n2[2]);
-
-    xp[0] = n1[1]*n2[2] - n1[2]*n2[1];
-    xp[1] =-n1[0]*n2[2] + n1[2]*n2[0];
-    xp[2] = n1[0]*n2[1] - n1[1]*n2[0];
-    y = sqrt(xp[0]*xp[0] + xp[1]*xp[1] + xp[2]*xp[2]);
-
-    *(angles + i) = atan2(y,x); //atan2 is better conditioned than acos
+    *(angles + i) = _calc_dihedral_angle(va, vb, vc); //atan2 is better conditioned than acos
   }
 }
 #endif

--- a/testsuite/MDAnalysisTests/utils/test_distances.py
+++ b/testsuite/MDAnalysisTests/utils/test_distances.py
@@ -553,9 +553,9 @@ class TestCythonFunctions(object):
         vec1 = a - b
         vec2 = c - b
         angles_numpy = np.array([mdamath.angle(x, y) for x, y in zip(vec1, vec2)])
-        ab = b - a
-        bc = c - b
-        cd = d - c
+        ab = a - b
+        bc = b - c
+        cd = c - d
         dihedrals_numpy = np.array([mdamath.dihedral(x, y, z) for x, y, z in zip(ab, bc, cd)])
 
         assert_almost_equal(bonds, bonds_numpy, self.prec,

--- a/testsuite/MDAnalysisTests/utils/test_distances.py
+++ b/testsuite/MDAnalysisTests/utils/test_distances.py
@@ -44,7 +44,7 @@ def ref_system():
     conf = points[1:]
 
     return box, points, ref, conf
-    
+
 
 @pytest.mark.parametrize('backend', ['serial', 'openmp'])
 class TestDistanceArray(object):
@@ -493,10 +493,10 @@ class TestCythonFunctions(object):
                                                             backend=backend)
         # Check calculated values
         assert_equal(len(dihedrals), 4, err_msg="calc_dihedrals results have wrong length")
-        #        assert_almost_equal(dihedrals[0], 0.0, self.prec, err_msg="Zero length dihedral failed")
-        #        assert_almost_equal(dihedrals[1], 0.0, self.prec, err_msg="Straight line dihedral failed")
+        assert np.isnan(dihedrals[0]), "Zero length dihedral failed"
+        assert np.isnan(dihedrals[1]), "Straight line dihedral failed"
         assert_almost_equal(dihedrals[2], np.pi, self.prec, err_msg="180 degree dihedral failed")
-        assert_almost_equal(dihedrals[3], 0.50714064, self.prec,
+        assert_almost_equal(dihedrals[3], -0.50714064, self.prec,
                             err_msg="arbitrary dihedral angle failed")
 
     # Check data type checks
@@ -563,8 +563,7 @@ class TestCythonFunctions(object):
         # numpy 0 angle returns NaN rather than 0
         assert_almost_equal(angles[1:], angles_numpy[1:], self.prec,
                             err_msg="Cython angles didn't match numpy calcuations")
-        # same issue with first two dihedrals
-        assert_almost_equal(dihedrals[2:], dihedrals_numpy[2:], self.prec,
+        assert_almost_equal(dihedrals, dihedrals_numpy, self.prec,
                             err_msg="Cython dihedrals didn't match numpy calculations")
 
 


### PR DESCRIPTION
 Closes #1554 and #1565
-
Changes made in this Pull Request:
 -
### #1554:
Fixed *y* calculation in calc_distances.h _calc_dihedral* following this equation:

![Dihedral formula](https://wikimedia.org/api/rest_v1/media/math/render/svg/a561bd1500d44bf102e7426692bd572cd40b531e)

To reduce redundancy in the C code I created a new function that receives three vectors as input and returns the angle.

### #1565:
While discussing #1554 with @mnmelo, we discovered that _calc_dihedral* and Dihedrals.dihedrals() calculate the inverse vectors (ba, cb, dc) instead of (ab, bc, cd). This results in this methods returning the inverse angle. Dihedral.value() is fine (follows the [IUPAC convention](https://goldbook.iupac.org/html/T/T06406.html)), so I changed the formers to follow the IUPAC convention as well.

### Tests:
Tests were modified to fit the changes. There are 4 tests failing. This is intentional and happens because when the dihedral angle is 180° the C code returns *0.0* and the numpy/.value() methods return *nan*. The tests expect the dihedral angle to be *nan*. Should we strive for consistency between methods?

PR Checklist
------------
 - [X] Tests?
 - [ ] Docs?
 - [X] CHANGELOG updated?
 - [X] Issue raised/referenced?
