### PR TITLE
Fix tests about moltypes

### DIFF
--- a/testsuite/MDAnalysisTests/topology/test_tprparser.py
+++ b/testsuite/MDAnalysisTests/topology/test_tprparser.py
@@ -41,8 +41,8 @@ class TPRAttrs(ParserBase):
     expected_attrs = ['ids', 'names', 'resids', 'resnames', 'moltypes']
     guessed_attrs = ['elements']
 
-    def test_moltypes(self):
-        moltypes = self.top.moltypes.values
+    def test_moltypes(self, top):
+        moltypes = top.moltypes.values
         assert_array_equal(moltypes, self.ref_moltypes)
 
 


### PR DESCRIPTION
Changes merged in MDAnalysisTests.topology.base broke the tests about
the moltype topology attribute. Indeed, the topology object being tested
is now a pytest fixture while it used to be a object attribute.

This commit fixes the tests.