### PR TITLE
TST: Added traj reader striding asv test

### DIFF
--- a/benchmarks/benchmarks/traj_reader.py
+++ b/benchmarks/benchmarks/traj_reader.py
@@ -8,7 +8,8 @@ try:
 except ImportError:
     pass
 
-class TrajReaderBench(object):
+
+class TrajReaderCreation(object):
     """Benchmarks for trajectory file format reading."""
     params = (['XTC', 'TRR', 'DCD'])
     param_names = ['traj_format']
@@ -25,7 +26,8 @@ class TrajReaderBench(object):
         """
         self.traj_reader(self.traj_file)
 
-class TrajReaderStriding(object):
+
+class TrajReaderIteration(object):
     """Benchmarks for trajectory file format striding."""
     params = (['XTC', 'TRR', 'DCD'])
     param_names = ['traj_format']

--- a/benchmarks/benchmarks/traj_reader.py
+++ b/benchmarks/benchmarks/traj_reader.py
@@ -24,3 +24,22 @@ class TrajReaderBench(object):
         from our standard test files.
         """
         self.traj_reader(self.traj_file)
+
+class TrajReaderStriding(object):
+    """Benchmarks for trajectory file format striding."""
+    params = (['XTC', 'TRR', 'DCD'])
+    param_names = ['traj_format']
+
+    def setup(self, traj_format):
+        self.traj_dict = {'XTC': [XTC, XTCReader],
+                          'TRR': [TRR, TRRReader],
+                          'DCD': [DCD, DCDReader]}
+        self.traj_file, self.traj_reader = self.traj_dict[traj_format]
+        self.reader_object = self.traj_reader(self.traj_file)
+
+    def time_strides(self, traj_format):
+        """Benchmark striding over full trajectory
+        test files for each format.
+        """
+        for ts in self.reader_object:
+            pass

--- a/benchmarks/benchmarks/traj_reader.py
+++ b/benchmarks/benchmarks/traj_reader.py
@@ -4,20 +4,22 @@ try:
     from MDAnalysis.coordinates.DCD import DCDReader
     from MDAnalysis.coordinates.XTC import XTCReader
     from MDAnalysis.coordinates.TRR import TRRReader
-    from MDAnalysisTests.datafiles import XTC, TRR, DCD
+    from MDAnalysis.coordinates.TRJ import NCDFReader
+    from MDAnalysisTests.datafiles import XTC, TRR, DCD, NCDF
 except ImportError:
     pass
 
 
 class TrajReaderCreation(object):
     """Benchmarks for trajectory file format reading."""
-    params = (['XTC', 'TRR', 'DCD'])
+    params = (['XTC', 'TRR', 'DCD', 'NCDF'])
     param_names = ['traj_format']
 
     def setup(self, traj_format):
         self.traj_dict = {'XTC': [XTC, XTCReader],
                           'TRR': [TRR, TRRReader],
-                          'DCD': [DCD, DCDReader]}
+                          'DCD': [DCD, DCDReader],
+                          'NCDF': [NCDF, NCDFReader]}
         self.traj_file, self.traj_reader = self.traj_dict[traj_format]
 
     def time_reads(self, traj_format):
@@ -29,13 +31,14 @@ class TrajReaderCreation(object):
 
 class TrajReaderIteration(object):
     """Benchmarks for trajectory file format striding."""
-    params = (['XTC', 'TRR', 'DCD'])
+    params = (['XTC', 'TRR', 'DCD', 'NCDF'])
     param_names = ['traj_format']
 
     def setup(self, traj_format):
         self.traj_dict = {'XTC': [XTC, XTCReader],
                           'TRR': [TRR, TRRReader],
-                          'DCD': [DCD, DCDReader]}
+                          'DCD': [DCD, DCDReader],
+                          'NCDF': [NCDF, NCDFReader]}
         self.traj_file, self.traj_reader = self.traj_dict[traj_format]
         self.reader_object = self.traj_reader(self.traj_file)
 

--- a/benchmarks/benchmarks/traj_reader.py
+++ b/benchmarks/benchmarks/traj_reader.py
@@ -24,16 +24,18 @@ try:
 except ImportError:
     pass
 
+traj_dict = {'XTC': [XTC, XTCReader],
+             'TRR': [TRR, TRRReader],
+             'DCD': [DCD, DCDReader],
+             'NCDF': [NCDF, NCDFReader]}
+
 class TrajReaderCreation(object):
     """Benchmarks for trajectory file format reading."""
     params = (['XTC', 'TRR', 'DCD', 'NCDF'])
     param_names = ['traj_format']
 
     def setup(self, traj_format):
-        self.traj_dict = {'XTC': [XTC, XTCReader],
-                          'TRR': [TRR, TRRReader],
-                          'DCD': [DCD, DCDReader],
-                          'NCDF': [NCDF, NCDFReader]}
+        self.traj_dict = traj_dict
         self.traj_file, self.traj_reader = self.traj_dict[traj_format]
 
     def time_reads(self, traj_format):
@@ -49,10 +51,7 @@ class TrajReaderIteration(object):
     param_names = ['traj_format']
 
     def setup(self, traj_format):
-        self.traj_dict = {'XTC': [XTC, XTCReader],
-                          'TRR': [TRR, TRRReader],
-                          'DCD': [DCD, DCDReader],
-                          'NCDF': [NCDF, NCDFReader]}
+        self.traj_dict = traj_dict
         self.traj_file, self.traj_reader = self.traj_dict[traj_format]
         self.reader_object = self.traj_reader(self.traj_file)
 

--- a/benchmarks/benchmarks/traj_reader.py
+++ b/benchmarks/benchmarks/traj_reader.py
@@ -2,13 +2,27 @@ from __future__ import division, absolute_import, print_function
 
 try:
     from MDAnalysis.coordinates.DCD import DCDReader
-    from MDAnalysis.coordinates.XTC import XTCReader
-    from MDAnalysis.coordinates.TRR import TRRReader
-    from MDAnalysis.coordinates.TRJ import NCDFReader
-    from MDAnalysisTests.datafiles import XTC, TRR, DCD, NCDF
+    from MDAnalysisTests.datafiles import DCD
 except ImportError:
     pass
 
+try:
+    from MDAnalysis.coordinates.XTC import XTCReader
+    from MDAnalysisTests.datafiles import XTC
+except ImportError:
+    pass
+
+try:
+    from MDAnalysis.coordinates.TRR import TRRReader
+    from MDAnalysisTests.datafiles import TRR
+except ImportError:
+    pass
+
+try:
+    from MDAnalysis.coordinates.TRJ import NCDFReader
+    from MDAnalysisTests.datafiles import NCDF
+except ImportError:
+    pass
 
 class TrajReaderCreation(object):
     """Benchmarks for trajectory file format reading."""


### PR DESCRIPTION
This PR adds a first draft of `asv` testing code for trajectory reader *striding* (over frames). Using the following command:

`asv run -e -s 20 ddb57592..e0bc3034 --bench TrajReaderStriding -j`

Produces the following results for trajectory reader *striding* (note that the test files for the formats may very well have differing numbers of frames & atoms / frame, etc.):

![traj_reader_bench_asv_striding](https://user-images.githubusercontent.com/7903078/28857945-3967d114-770a-11e7-9428-4707e031c0a8.PNG)

I'm guessing the spike for DCD and recent adjustment may not be coincidental.

Some considerations:
- in addition to probing single-frame stride performance we may also want tests that probe frame 'skipping' by N frames, and possibly even trajectory striding in the reverse direction???
- even with just two kinds of performance tests for trajectory readers we already have a fair bit of code duplication -- I suspect some of the setup code should likely be abstracted to a separate function and / or class inheritance should be used
   - as we add more tests of this nature, the way we organize the classes / functions will probably evolve a bit based on what we need to recycle / reuse, etc.
- other trajectory reader formats that should be added?