### PR TITLE
Add a molnums topology attribute to TPR parser

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -26,8 +26,6 @@ Enhancements
   * Python versions 3.4 and upwards are now supported (Issue #260)
   * add low level lib.formats.libdcd module for reading/writing DCD (PR #1372)
   * replace old DCD reader with a Python 3 ready DCD reader (Issue #659)
-  * The TPR parser populate the `moltypes` topology attribute and
-    the `moltype` selection keyword is added (Issue #1555)
   * about 20% speed improvements for GNM analysis. (PR #1579)
   * added support for Tinker TXYZ and ARC files
   * libmdaxdr and libdcd classes can now be pickled (PR #1680)
@@ -35,6 +33,9 @@ Enhancements
   * introduce the water bridge analysis module (PR #1722)
   * Universe.add_TopologyAttr now accepts strings to add a given attribute
     to the Universe (Issue #1092, PR #1186)
+  * The TPR parser populate the `moltypes` and `molnums` topology attributes;
+    the `moltype` and `molnum` selection keyword are added
+    (Issue #1555, PR #1578)
 
 Deprecations
   * HydrogenBondAnalysis detect_hydrogens=heuristic is marked for deprecation in 1.0

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -2027,7 +2027,7 @@ class AtomGroup(GroupBase):
         try:
             levelindices = getattr(self, accessors[level])
         except AttributeError:
-            raise ValueError('This universe does not have {} '
+            raise AttributeError('This universe does not have {} '
                              'information. Maybe it is not provided in the '
                              'topology format in use.'.format(level))
         except KeyError:

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -1989,7 +1989,7 @@ class AtomGroup(GroupBase):
         .. versionadded:: 0.16.0
            Updating selections now possible by setting the ``updating`` argument.
         .. versionadded:: 0.17.0
-           Added *moltype* selection.
+           Added *moltype* and *molnum* selections.
 
         """
         updating = selgroups.pop('updating', False)
@@ -2009,13 +2009,16 @@ class AtomGroup(GroupBase):
 
         Parameters
         ----------
-        level : {'atom', 'residue', 'segment'}
+        level : {'atom', 'residue', 'molecule', 'segment'}
 
 
         .. versionadded:: 0.9.0
+        .. versionchanged:: 0.17.0
+           Added the 'molecule' level.
         """
         accessors = {'segment': 'segindices',
-                     'residue': 'resindices'}
+                     'residue': 'resindices',
+                     'molecule': 'molnums'}
 
         if level == "atom":
             return [self.universe.atoms[[a.ix]] for a in self]
@@ -2023,6 +2026,10 @@ class AtomGroup(GroupBase):
         # higher level groupings
         try:
             levelindices = getattr(self, accessors[level])
+        except AttributeError:
+            raise ValueError('This universe does not have {} '
+                             'information. Maybe it is not provided in the '
+                             'topology format in use.'.format(level))
         except KeyError:
             raise ValueError("level = '{0}' not supported, "
                              "must be one of {1}".format(level,

--- a/package/MDAnalysis/core/selection.py
+++ b/package/MDAnalysis/core/selection.py
@@ -766,6 +766,8 @@ class ResidSelection(Selection):
 
 
 class RangeSelection(Selection):
+    value_offset=0
+
     def __init__(self, parser, tokens):
         values = grab_not_keywords(tokens)
         if not values:
@@ -792,13 +794,9 @@ class RangeSelection(Selection):
         self.lowers = lowers
         self.uppers = uppers
 
-
-class ResnumSelection(RangeSelection):
-    token = 'resnum'
-
     def apply(self, group):
         mask = np.zeros(len(group), dtype=np.bool)
-        vals = group.resnums
+        vals = getattr(group, self.field) + self.value_offset
 
         for upper, lower in zip(self.uppers, self.lowers):
             if upper is not None:
@@ -809,25 +807,22 @@ class ResnumSelection(RangeSelection):
 
             mask |= thismask
         return group[mask].unique
+
+
+class ResnumSelection(RangeSelection):
+    token = 'resnum'
+    field = 'resnums'
 
 
 class ByNumSelection(RangeSelection):
     token = 'bynum'
+    field = 'indices'
+    value_offset = 1  # queries are in 1 based indices
 
-    def apply(self, group):
-        mask = np.zeros(len(group), dtype=np.bool)
-        vals = group.indices + 1  # queries are in 1 based indices
 
-        for upper, lower in zip(self.uppers, self.lowers):
-            if upper is not None:
-                thismask = vals >= lower
-                thismask &= vals <= upper
-            else:
-                thismask = vals == lower
-
-            mask |= thismask
-        return group[mask].unique
-
+class MolidSelection(RangeSelection):
+    token = 'molnum'
+    field = 'molnums'
 
 
 class ProteinSelection(Selection):

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -1342,6 +1342,16 @@ class Moltypes(ResidueAttr):
     target_classes = [AtomGroup, ResidueGroup, SegmentGroup, Atom, Residue]
 
 
+class Molnums(ResidueAttr):
+    """Name of the molecule type
+
+    Two molecules that share a molecule type share a common template topology.
+    """
+    attrname = 'molnums'
+    singular = 'molnum'
+    target_classes = [Atom, Residue]
+
+
 # segment attributes
 
 class SegmentAttr(TopologyAttr):

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -1349,7 +1349,7 @@ class Molnums(ResidueAttr):
     """
     attrname = 'molnums'
     singular = 'molnum'
-    target_classes = [Atom, Residue]
+    target_classes = [AtomGroup, ResidueGroup, Atom, Residue]
 
 
 # segment attributes

--- a/package/MDAnalysis/topology/__init__.py
+++ b/package/MDAnalysis/topology/__init__.py
@@ -105,7 +105,8 @@ the attributes they provide.
    TPR [#b]_         tpr       names, types,     Gromacs portable run input reader (limited
                                resids, resnames, experimental support for some of the more recent
                                charges, bonds,   versions of the file format);
-                               masses, moltypes  :mod:`MDAnalysis.topology.TPRParser`
+                               masses, moltypes, :mod:`MDAnalysis.topology.TPRParser`
+                               molnums
 
    MOL2 [#a]_        mol2      ids, names,       Tripos MOL2 molecular structure format;
                                types, resids,    :mod:`MDAnalysis.topology.MOL2Parser`

--- a/testsuite/MDAnalysisTests/core/test_atomselections.py
+++ b/testsuite/MDAnalysisTests/core/test_atomselections.py
@@ -409,7 +409,7 @@ class TestSelectionsGRO(object):
 
 class TestSelectionsTPR(object):
     @staticmethod
-    @pytest.fixture
+    @pytest.fixture(scope='class')
     def universe():
         return MDAnalysis.Universe(TPR,XTC)
 

--- a/testsuite/MDAnalysisTests/core/test_atomselections.py
+++ b/testsuite/MDAnalysisTests/core/test_atomselections.py
@@ -408,9 +408,10 @@ class TestSelectionsGRO(object):
 
 
 class TestSelectionsTPR(object):
-    @pytest.fixture()
-    def universe(self):
-        return MDAnalysis.Universe(TPR, XTC)
+    @staticmethod
+    @pytest.fixture
+    def universe():
+        return MDAnalysis.Universe(TPR,XTC)
 
     def test_same_fragment(self, universe):
         """Test the 'same ... as' construct (Issue 217)"""
@@ -428,6 +429,17 @@ class TestSelectionsTPR(object):
         sel = universe.select_atoms("moltype NA+")
         ref = np.array([47677, 47678, 47679, 47680], dtype=np.int32)
         assert_equal(sel.ids, ref)
+
+    @pytest.mark.parametrize(
+        'selection_string,reference',
+        (('molnum 1', [3341, 3342, 3343, 3344]),
+         ('molnum 2:4', [3345, 3346, 3347, 3348, 3349, 3350,
+                         3351, 3352, 3353, 3354, 3355, 3356]),
+         )
+    )
+    def test_molnum(self, universe, selection_string, reference):
+        sel = universe.select_atoms(selection_string)
+        assert_equal(sel.ids, np.array(reference, dtype=np.int32))
 
 
 class TestSelectionsNucleicAcids(object):

--- a/testsuite/MDAnalysisTests/topology/test_tprparser.py
+++ b/testsuite/MDAnalysisTests/topology/test_tprparser.py
@@ -40,12 +40,18 @@ import MDAnalysis.topology.TPRParser
 
 class TPRAttrs(ParserBase):
     parser = MDAnalysis.topology.TPRParser.TPRParser
-    expected_attrs = ['ids', 'names', 'resids', 'resnames', 'moltypes']
+    expected_attrs = ['ids', 'names',
+                      'resids', 'resnames',
+                      'moltypes', 'molnums']
     guessed_attrs = ['elements']
 
     def test_moltypes(self, top):
         moltypes = top.moltypes.values
         assert_equal(moltypes, self.ref_moltypes)
+
+    def test_molnums(self, top):
+        molnums = top.molnums.values
+        assert_equal(molnums, self.ref_molnums)
 
 
 class TestTPR(TPRAttrs):
@@ -57,6 +63,7 @@ class TestTPR(TPRAttrs):
     expected_n_segments = 3
     ref_moltypes = np.array(['AKeco'] * 214 + ['SOL'] * 11084 + ['NA+'] * 4,
                             dtype=object)
+    ref_molnums = np.array([0] * 214 + list(range(1, 1 + 11084 + 4)))
 
     @pytest.fixture()
     def filename(self):
@@ -71,6 +78,7 @@ class TestTPRGromacsVersions(TPRAttrs):
     expected_n_residues = 230
     expected_n_segments = 2
     ref_moltypes = np.array(['Protein_A'] * 129 + ['SOL'] * 101, dtype=object)
+    ref_molnums = np.array([0] * 129 + list(range(1, 1 + 101)))
 
     @pytest.fixture(params=[TPR400, TPR402, TPR403, TPR404, TPR405, TPR406,
                             TPR407, TPR450, TPR451, TPR452, TPR453, TPR454,
@@ -87,6 +95,7 @@ class TestTPRDouble(TPRAttrs):
                             + ['DOPC'] * 21 + ['DPPC'] * 10 + ['CHOL'] * 3
                             + ['SOL'] * 4284,
                             dtype=object)
+    ref_molnums = np.arange(4352)
 
     @pytest.fixture()
     def filename(self):
@@ -102,6 +111,8 @@ class TestTPR46x(TPRAttrs):
                             + ['Protein_E'] * 27
                             + ['SOL'] * 10530 + ['NA+'] * 26 + ['CL-'] * 21,
                             dtype=object)
+    ref_molnums = np.array([0] * 27 + [1] * 27 + [2] * 27 + [3] * 27 + [4] * 27
+                           + list(range(5, 5 + 10530 + 26 + 21)))
 
     @pytest.fixture(params=[TPR460, TPR461])
     def filename(self, request):


### PR DESCRIPTION
PR #1557 introduced the moltype attribute that gives a name to each kind
of molecule in a topology. This commit adds the related molnums
attribute that gives an index to each individual molecules.

The molnums attributes allows to split a system by molecule without
ambiguity when the attribute is defines. Without this commit, the only
way of splitting a system per molecule is `atom_group.fragments`. While
it works most of the time, it can fail in some topology that use other
topology tricks than bonds to connect atoms; this is the case in gromacs
with virtual sites for instance. Fragments can also be time consuming on
large systems. This commits allows to slit a system per molecule without
ambiguity with `atom_group.groupby('molnums')` or
`atom_group.split('molecule')`.

Using `AtomGroup.split` rather than `AtomGroup.fragments` is about 10 times faster according to [a very crude benchmark](https://gist.github.com/jbarnoud/de00e574591e7b8de74e5a95c3a774a4).

This commit also adds the `molnum` selection keyword. To do so, this
commit refactored `mda.core.selection.SelectionRange` to avoid code
duplication.

Note that, like `moltypes`, `molnums` is only implemented to the TPR parser; but it could be implemented for any topology format that includes the information. Latter on, a guesser for `molnums` could be implemented based on fragments.

For some context, I need to count cholesterol molecules in my simulations. Yet, martini cholesterol defines 2 beads as virtual sites. As a result each molecule appears 3 fragments. Also, systems tend to become larger and larger, so that computing the fragments started to be an annoyance. Cholesterol is a single residue per molecule, so I fell back to counting residues, but at the same time a colleague of mine wants to count molecules in a system that contains proteins. Earlier this year, an other colleague wanted to count polymer chains and had to find a workaround. All of this was frustrating since we all use gromacs that has the molecule information.

PR Checklist
------------
 - [X] Tests?
 - [X] Docs?
 - [x] CHANGELOG updated?
 - [ ] Issue raised/referenced?
