### PR TITLE
TST: Added MDAnalysisTests to the asv dependency matrix

### DIFF
--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -22,6 +22,7 @@
     // package (in PyPI) and the values are version numbers.  An empty
     // list indicates to just test against the default (latest)
     // version.
+    "conda_channels": ["conda-forge"],
     "matrix": {
         "Cython": [],
         "numpy": [],
@@ -31,6 +32,7 @@
 	    "nose": [],
 	    "psutil": [],
 	    "mock": [],
+        "MDAnalysisTests": [],
     },
     // The directory (relative to the current directory) that benchmarks are
     // stored in.  If not provided, defaults to "benchmarks"


### PR DESCRIPTION
Fixes #1577 

I've added `MDAnalysisTests` to the `asv` JSON depedency matrix . Because our test suite is not in the default conda channel I've also modified our branch of `asv` to allow for a new configuration key in the JSON file that contains a list of custom conda channels (you don't have access to this just yet--see below).

I will open a pull request to our fork of asv with the appropriate adjustments and it will fall upon someone to confirm on their own machine that the simultaneous changes I've made to our fork of asv and our JSON file here combine to allow benchmarks to run for them. @kain88-de in particular raised the issue so it would be helpful if he could test it.

I also note that we are now polluting our JSON file with a key that may never actually get incorporated into asv itself upstream, which causes various philosophical / maintenance issues. Because I think the asv  adjustment I've made to allow custom channel specification is actually pretty clean, I suspect that has a better chance of making it in upstream sooner (but we'll have to see). So, you may want to hold off on merging this in case i.e., my adjustments to asv get merged upstream, but there are some adjustments to the name of the key used to specify conda channels, etc. Or just accept that our commit history is going to have to contain some reverting corrections to the JSON file as my work on asv features evolves.

I'll try to link the PR I open to asv shortly and the PR I open to our fork of asv. The PR to asv itself for the conda specification feature will be separate from the PR for the custom build feature so I'd likely plan to rebase our fork / branch for custom install on that if it gets merged.

So yeah, this is getting complicated & adds core development of a third library to my duties, so I may indeed be rather slow dealing with some of this.
