### PR TITLE
PEP8 fixes topology/test_topology_str_types.py

### DIFF
--- a/testsuite/MDAnalysisTests/topology/test_topology_str_types.py
+++ b/testsuite/MDAnalysisTests/topology/test_topology_str_types.py
@@ -21,56 +21,65 @@
 #
 from __future__ import division, absolute_import
 
+
+from six import string_types
 import MDAnalysis
 import pytest
-from six import string_types
 
 from MDAnalysis.tests.datafiles import (
-    CRD, LAMMPSdata,
+    CRD,
+    LAMMPSdata,
     DLP_CONFIG_minimal,
-    GRO, TPR,
-    DMS, GMS_SYMOPT,
-    MMTF,mol2_molecule,
-    PRM7, PDB_small,
+    GRO,
+    TPR,
+    DMS,
+    GMS_SYMOPT,
+    MMTF,
+    mol2_molecule,
+    PRM7,
+    PDB_small,
     PDBQT_input,
-    PQR, PRM,
-    PSF, PRM12,
-    HoomdXMLdata, XPDB_small,
-    XYZ_mini, DLP_HISTORY_minimal,
-)
+    PQR,
+    PRM,
+    PSF,
+    PRM12,
+    HoomdXMLdata,
+    XPDB_small,
+    XYZ_mini,
+    DLP_HISTORY_minimal, )
 
-@pytest.mark.parametrize('prop',
-['name',
- 'resname',
- 'type',
- 'segid',
- 'moltype',
-]
-)
+
+@pytest.mark.parametrize('prop', [
+    'name',
+    'resname',
+    'type',
+    'segid',
+    'moltype',
+])
 # topology formats curated from values available in
 # MDAnalysis._PARSERS
-@pytest.mark.parametrize('top_format, top',
-	 [('CONFIG', DLP_CONFIG_minimal),
-	 ('CRD', CRD),
-	 ('DATA', LAMMPSdata),
-	 ('DMS', DMS),
-	 ('GMS', GMS_SYMOPT),
-	 ('GRO', GRO),
-	 ('HISTORY', DLP_HISTORY_minimal),
-	 ('MMTF', MMTF),
-	 ('MOL2', mol2_molecule),
-	 ('PARM7',PRM7),
-	 ('PDB', PDB_small),
-	 ('PDBQT', PDBQT_input),
-	 ('PQR', PQR),
-	 ('PRMTOP', PRM),
-	 ('PSF', PSF),
-	 ('TOP', PRM12),
-	 ('TPR', TPR),
-	 ('XML', HoomdXMLdata),
-	 ('XPDB',XPDB_small),
-	 ('XYZ', XYZ_mini)]
-)
+@pytest.mark.parametrize( 'top_format, top', [
+    ('CONFIG', DLP_CONFIG_minimal),
+    ('CRD', CRD),
+    ('DATA', LAMMPSdata),
+    ('DMS', DMS),
+    ('GMS', GMS_SYMOPT),
+    ('GRO', GRO),
+    ('HISTORY', DLP_HISTORY_minimal),
+    ('MMTF', MMTF),
+    ('MOL2', mol2_molecule),
+    ('PARM7', PRM7),
+    ('PDB', PDB_small),
+    ('PDBQT', PDBQT_input),
+    ('PQR', PQR),
+    ('PRMTOP', PRM),
+    ('PSF', PSF),
+    ('TOP', PRM12),
+    ('TPR', TPR),
+    ('XML', HoomdXMLdata),
+    ('XPDB', XPDB_small),
+    ('XYZ', XYZ_mini)
+])
 def test_str_types(top_format, top, prop):
     # Python 2/3 topology string type checking
     # Related to Issue #1336


### PR DESCRIPTION
* Replace hard tabs with spaces for indentation
* Order imports

Fixes #

Changes made in this Pull Request:
 - 


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
