### PR TITLE
change Universe.load_new() to return universe itself

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -36,7 +36,7 @@ Fixes
   * correctly read little-endian TRZ files on big-endian architectures (issue
     #1424)
   * Fixed type matching and inclusion compilation warnings for the
-  ENCORE analysis package (issue #1390)
+    ENCORE analysis package (issue #1390)
   * Fix extra deprecation warnings for instant segment and residue selectors
     (Issue #1476)
   * Accessing segments from a universe with an instant selector now issues a
@@ -56,7 +56,10 @@ Changes
     writing (if available) or fall back to netcdf (see also Issue #506)
   * libmdaxdr classes now accept more argument types for a write (PR #1442)
   * libmdaxdr classes now raise EOFError when accessing another frame after
-  the end of the file. Used to raise IOError.
+    the end of the file. Used to raise IOError.
+  * Universe.load_new() now returns the universe itself instead of
+    tuple (filename_or_array, trajectory_type) (Issue #1613)
+  
 
 
 mm/dd/17 richardjgowers, rathann, jbarnoud, orbeckst, utkbansal

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -411,8 +411,7 @@ class Universe(object):
 
         Returns
         -------
-        filename : str or list
-        trajectory_format : str
+        universe : Universe
 
         Raises
         ------
@@ -429,17 +428,13 @@ class Universe(object):
            features than the
            :class:`~MDAnalysis.coordinates.chain.ChainReader`.
 
+        .. versionchanged:: 0.17.0
+           Now returns a :class:`Universe` instead of the tuple of file/array
+           and detected file type.
         """
-        # the following was in the doc string:
-        # TODO
-        # ----
-        # - check what happens if filename is ``None``
-        # - look up raises doc formating
-        #
-        #
-        # TODO: is this really sensible? Why not require a filename arg?
+        # filename==None happens when only a topology is provided
         if filename is None:
-            return
+            return self
 
         if len(util.asiterable(filename)) == 1:
             # make sure a single filename is not handed to the ChainReader
@@ -470,7 +465,7 @@ class Universe(object):
         if in_memory:
             self.transfer_to_memory(step=kwargs.get("in_memory_step", 1))
 
-        return filename, self.trajectory.format
+        return self
 
     def transfer_to_memory(self, start=None, stop=None, step=None,
                            verbose=None, quiet=None):

--- a/testsuite/MDAnalysisTests/core/test_universe.py
+++ b/testsuite/MDAnalysisTests/core/test_universe.py
@@ -112,7 +112,6 @@ class TestUniverseCreation(object):
         with pytest.raises(AttributeError):
             getattr(u, 'trajectory')
 
-
     def test_Universe_topology_unrecognizedformat_VE(self):
         with pytest.raises(ValueError):
             mda.Universe('some.weird.not.pdb.but.converted.xtc')
@@ -219,6 +218,16 @@ class TestUniverse(object):
         u = mda.Universe(PSF, DCD)
         u.load_new(PDB_small)
         assert_equal(len(u.trajectory), 1, "Failed to load_new(PDB)")
+
+    def test_load_new_returns_Universe(self):
+        u = mda.Universe(PSF)
+        result = u.load_new(PDB_small)
+        assert result is u
+
+    def test_load_new_None_returns_Universe(self):
+        u = mda.Universe(PSF)
+        result = u.load_new(None)
+        assert result is u
 
     def test_load_new_TypeError(self):
         u = mda.Universe(PSF, DCD)


### PR DESCRIPTION
- Universe.load_new() returns self (instead of tuple filename_or_array,
  file_type) so that one can more easily chain methods (see #1613)
- closes #1613
- added comments for why load_new() accepts None: to build Universes
  with empty coordinates; now make sure that this case ALSO returns
  the universe itself (and not just None as before, which was inconsistent)
- added tests for load_new(DCD) and load_new(None)


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
