### PR TITLE
use minimally version 0.7.0 of seaborn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ env:
     - SETUP_CMD="${PYTEST_FLAGS}"
     - BUILD_CMD="pip install -v package/ && pip install testsuite/"
     - CONDA_MIN_DEPENDENCIES="mmtf-python mock six biopython networkx cython joblib matplotlib scipy griddataformats hypothesis"
-    - CONDA_DEPENDENCIES="${CONDA_MIN_DEPENDENCIES} seaborn clustalw=2.1 netcdf4 scikit-learn coveralls"
+    - CONDA_DEPENDENCIES="${CONDA_MIN_DEPENDENCIES} seaborn>=0.7.0 clustalw=2.1 netcdf4 scikit-learn coveralls"
     - CONDA_CHANNELS='biobuilds conda-forge'
     - CONDA_CHANNEL_PRIORITY=True
     - NUMPY_VERSION=stable


### PR DESCRIPTION
This version does not depend on a specific numpy version in either the default
or conda-forge channel and also have python 3.4 packages available.

Fixes #

Changes made in this Pull Request:
 - speed up py34 build on travis


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
