### PR TITLE
fixes rms.RMSD: selections are now applied to atomgroup itself

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -52,6 +52,8 @@ Fixes
   * XDR files now avoid offset recalculation on a rewind (PR #1667)
   * Universe creation doesn't Matryoshka NamedStream anymore (PR #1669)
   * Fixed triclinic unit cell distances for box edges (Issue #1475)
+  * Fixed analysis.rms.RMSD: selections are now applied to atomgroup, not to
+    atomgroup.universe
 
 Changes
   * remove deprecated TimeSeriesCollection

--- a/package/MDAnalysis/analysis/rms.py
+++ b/package/MDAnalysis/analysis/rms.py
@@ -510,12 +510,15 @@ class RMSD(AnalysisBase):
         # Explicitly check for "mass" because this option CAN
         # be used with groupselection. (get_weights() returns the mass array
         # for "mass")
-        if self.weights != "mass":
+        if not iterable(self.weights) and self.weights == "mass":
+            pass
+        else:
             self.weights = get_weights(self.mobile_atoms, self.weights)
 
         # cannot use arbitrary weight array (for superposition) with
         # groupselections because arrays will not match
-        if len(self.groupselections) > 0 and self.weights not in ("mass", None):
+        if (len(self.groupselections) > 0 and (
+                iterable(self.weights) or self.weights not in ("mass", None))):
             raise ValueError("groupselections can only be combined with "
                              "weights=None or weights='mass', not a weight "
                              "array.")
@@ -527,7 +530,7 @@ class RMSD(AnalysisBase):
     def _prepare(self):
         self._n_atoms = self.mobile_atoms.n_atoms
 
-        if self.weights == 'mass':
+        if not iterable(self.weights) and self.weights == 'mass':
             self.weights = self.ref_atoms.masses
         if self.weights is not None:
             self.weights = np.asarray(self.weights, dtype=np.float64) / np.mean(self.weights)

--- a/package/MDAnalysis/analysis/rms.py
+++ b/package/MDAnalysis/analysis/rms.py
@@ -317,8 +317,7 @@ class RMSD(AnalysisBase):
     def __init__(self, atomgroup, reference=None, select='all',
                  groupselections=None, filename="rmsd.dat",
                  weights=None, tol_mass=0.1, ref_frame=0, **kwargs):
-        r"""
-        Parameters
+        r"""Parameters
         ----------
         atomgroup : AtomGroup or Universe
             Group of atoms for which the RMSD is calculated. If a trajectory is
@@ -350,11 +349,14 @@ class RMSD(AnalysisBase):
             described under :ref:`ordered-selections-label`).
 
         groupselections : list (optional)
-            A list of selections as described for `select`. Each selection
-            describes additional RMSDs to be computed *after the
-            structures have been superimposed* according to `select`. No
-            additional fitting is performed.The output contains one
-            additional column for each selection.
+            A list of selections as described for `select`, with the difference
+            that these selections are *always applied to the full universes*,
+            i.e., ``atomgroup.universe.select_atoms(sel1)`` and
+            ``reference.universe.select_atoms(sel2)``. Each selection describes
+            additional RMSDs to be computed *after the structures have been
+            superimposed* according to `select`. No additional fitting is
+            performed.The output contains one additional column for each
+            selection.
 
             .. Note:: Experimental feature. Only limited error checking
                       implemented.
@@ -433,11 +435,12 @@ class RMSD(AnalysisBase):
         .. versionchanged:: 0.17.0
            removed deprecated `mass_weighted` keyword; `groupselections`
            are *not* rotationally superimposed any more.
+
         """
         super(RMSD, self).__init__(atomgroup.universe.trajectory,
                                    **kwargs)
-        self.universe = atomgroup.universe
-        self.reference = reference if reference is not None else self.universe
+        self.atomgroup = atomgroup
+        self.reference = reference if reference is not None else self.atomgroup
 
         select = process_selection(select)
         self.groupselections = ([process_selection(s) for s in groupselections]
@@ -448,7 +451,7 @@ class RMSD(AnalysisBase):
         self.filename = filename
 
         self.ref_atoms = self.reference.select_atoms(*select['reference'])
-        self.mobile_atoms = self.universe.select_atoms(*select['mobile'])
+        self.mobile_atoms = self.atomgroup.select_atoms(*select['mobile'])
 
         if len(self.ref_atoms) != len(self.mobile_atoms):
             err = ("Reference and trajectory atom selections do "
@@ -488,8 +491,8 @@ class RMSD(AnalysisBase):
         #   *groupselections* groups each a dict with reference/mobile
         self._groupselections_atoms = [
             {
-                'reference': self.reference.select_atoms(*s['reference']),
-                'mobile': self.universe.select_atoms(*s['mobile']),
+                'reference': self.reference.universe.select_atoms(*s['reference']),
+                'mobile': self.atomgroup.universe.select_atoms(*s['mobile']),
             }
             for s in self.groupselections]
         # sanity check
@@ -529,13 +532,13 @@ class RMSD(AnalysisBase):
         if self.weights is not None:
             self.weights = np.asarray(self.weights, dtype=np.float64) / np.mean(self.weights)
 
-        current_frame = self.reference.trajectory.ts.frame
+        current_frame = self.reference.universe.trajectory.ts.frame
 
         try:
             # Move to the ref_frame
             # (coordinates MUST be stored in case the ref traj is advanced
             # elsewhere or if ref == mobile universe)
-            self.reference.trajectory[self.ref_frame]
+            self.reference.universe.trajectory[self.ref_frame]
             self._ref_com = self.ref_atoms.center(self.weights)
             # makes a copy
             self._ref_coordinates = self.ref_atoms.positions - self._ref_com
@@ -546,7 +549,7 @@ class RMSD(AnalysisBase):
                     self.groupselections]
         finally:
             # Move back to the original frame
-            self.reference.trajectory[current_frame]
+            self.reference.universe.trajectory[current_frame]
 
         self._ref_coordinates64 = self._ref_coordinates.astype(np.float64)
 

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -1306,7 +1306,7 @@ def get_weights(atoms, weights):
         also raised if ``atoms.masses`` is not defined.
 
     """
-    if weights == "mass":
+    if not iterable(weights) and weights == "mass":
         try:
             weights = atoms.masses
         except AttributeError:

--- a/testsuite/MDAnalysisTests/analysis/test_rms.py
+++ b/testsuite/MDAnalysisTests/analysis/test_rms.py
@@ -198,6 +198,14 @@ class TestRMSD(object):
                                   err_msg="error: rmsd profile should match" +
                                   "test values")
 
+    def test_rmsd_atomgroup_selections(self, universe):
+        # see Issue #1684
+        R1 = MDAnalysis.analysis.rms.RMSD(universe.atoms,
+                                          select="resid 1-30").run()
+        R2 = MDAnalysis.analysis.rms.RMSD(universe.atoms.select_atoms("name CA"),
+                                          select="resid 1-30").run()
+        assert not np.allclose(R1.rmsd[:, 2], R2.rmsd[:, 2])
+
     def test_rmsd_single_frame(self, universe):
         RMSD = MDAnalysis.analysis.rms.RMSD(universe, select='name CA',
                                             start=5, stop=6).run()


### PR DESCRIPTION
Fixes #1684

Changes made in this Pull Request:
 - Previously, using an atomgroup with select was broken (the select string was applied to atomgroup.universe). Now: selections are now applied to atomgroup itself

Note: for group_selections, the selection strings ARE still applied      to the whole atomgroup.universe for maximum flexibility

Tests are still missing.


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
