### PR TITLE
Periodic kDTree

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -93,6 +93,7 @@ Chronological list of authors
   - Dominik 'Rathann' Mierzejewski
   - Nestor Wendt
   - Micaela Matta
+  - Jose Borreguero
 
 
 External code

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -19,6 +19,7 @@ mm/dd/17 richardjgowers, rathann, orbeckst, tylerjereddy, mtiberti, kain88-de,
   * 0.17.0
 
 Enhancements
+  * KDTree for neighbor search on periodic systems (PR #1660)
   * Python versions 3.4 and upwards are now supported (Issue #260)
   * add low level lib.formats.libdcd module for reading/writing DCD (PR #1372)
   * replace old DCD reader with a Python 3 ready DCD reader (Issue #659)

--- a/package/MDAnalysis/lib/NeighborSearch.py
+++ b/package/MDAnalysis/lib/NeighborSearch.py
@@ -31,6 +31,7 @@ from __future__ import absolute_import
 
 import numpy as np
 from Bio.KDTree import KDTree
+from MDAnalysis.lib.pkdtree import PeriodicKDTree
 
 from MDAnalysis.core.groups import AtomGroup, Atom
 
@@ -43,13 +44,18 @@ class AtomNeighborSearch(object):
     yourself that the trajectory has been corrected for PBC artifacts.
     """
 
-    def __init__(self, atom_group, bucket_size=10):
+    def __init__(self, atom_group, box=None, bucket_size=10):
         """
 
         Parameters
         ----------
         atom_list : AtomGroup
           list of atoms
+        box : array-like or ``None``, optional, default ``None``
+          Simulation cell dimensions in the form of
+          :attr:`MDAnalysis.trajectory.base.Timestep.dimensions` when
+          periodic boundary conditions should be taken into account for
+          the calculation of contacts.
         bucket_size : int
           Number of entries in leafs of the KDTree. If you suffer poor
           performance you can play around with this number. Increasing the
@@ -58,7 +64,10 @@ class AtomNeighborSearch(object):
         """
         self.atom_group = atom_group
         self._u = atom_group.universe
-        self.kdtree = KDTree(dim=3, bucket_size=bucket_size)
+        if box is None:
+            self.kdtree = KDTree(dim=3, bucket_size=bucket_size)
+        else:
+            self.kdtree = PeriodicKDTree(box, bucket_size=bucket_size)
         self.kdtree.set_coords(atom_group.positions)
 
     def search(self, atoms, radius, level='A'):

--- a/package/MDAnalysis/lib/NeighborSearch.py
+++ b/package/MDAnalysis/lib/NeighborSearch.py
@@ -36,12 +36,11 @@ from MDAnalysis.lib.pkdtree import PeriodicKDTree
 from MDAnalysis.core.groups import AtomGroup, Atom
 
 class AtomNeighborSearch(object):
-    """This class can be used to find all atoms/residues/segements within the
+    """This class can be used to find all atoms/residues/segments within the
     radius of a given query position.
 
-    This class is using the BioPython KDTree for the neighborsearch. This class
-    also does not apply PBC to the distance calculattions. So you have to ensure
-    yourself that the trajectory has been corrected for PBC artifacts.
+    For the neighbor search, this class uses the BioPython KDTree and its
+    wrapper PeriodicKDTree for non-periodic and periodic systems, respectively.
     """
 
     def __init__(self, atom_group, box=None, bucket_size=10):

--- a/package/MDAnalysis/lib/__init__.py
+++ b/package/MDAnalysis/lib/__init__.py
@@ -29,7 +29,7 @@
 from __future__ import absolute_import
 
 __all__ = ['log', 'transformations', 'util', 'mdamath', 'distances',
-           'NeighborSearch', 'formats']
+           'NeighborSearch', 'formats', 'pkdtree']
 
 from . import log
 from . import transformations
@@ -38,3 +38,4 @@ from . import mdamath
 from . import distances  # distances relies on mdamath
 from . import NeighborSearch
 from . import formats
+from . import pkdtree

--- a/package/MDAnalysis/lib/distances.py
+++ b/package/MDAnalysis/lib/distances.py
@@ -810,9 +810,9 @@ def apply_PBC(incoords, box, backend="serial"):
     # determine boxtype
     boxtype = _box_check(box)
     # Convert [A,B,C,alpha,beta,gamma] to [[A],[B],[C]]
-    if (boxtype == 'tri_box'):
+    if boxtype == 'tri_box':
         box = triclinic_vectors(box)
-    if (boxtype == 'tri_vecs_bad'):
+    if boxtype == 'tri_vecs_bad':
         box = triclinic_vectors(triclinic_box(box[0], box[1], box[2]))
 
     box_inv = np.zeros((3), dtype=np.float32)

--- a/package/MDAnalysis/lib/distances.py
+++ b/package/MDAnalysis/lib/distances.py
@@ -395,7 +395,7 @@ def transform_RtoS(inputcoords, box, backend="serial"):
     Parameters
     ----------
     inputcoords : array
-        A n x 3 array of coordinate data, of type ``np.float32``.
+        A (3,) coordinate or (n x 3) array of coordinates, type ``np.float32``.
     box : array
         The unitcell dimesions for this system.
         The dimensions must be provided in the same format as returned
@@ -414,7 +414,11 @@ def transform_RtoS(inputcoords, box, backend="serial"):
        Added *backend* keyword.
     """
     coords = inputcoords.copy('C')
-    numcoords = coords.shape[0]
+
+    is_1d = False  # True if only one vector coordinate
+    if len(coords.shape) == 1:
+        coords = coords.reshape(1, len(coords))
+        is_1d = True
 
     boxtype = _box_check(box)
     # Convert [A,B,C,alpha,beta,gamma] to [[A],[B],[C]]
@@ -435,6 +439,8 @@ def transform_RtoS(inputcoords, box, backend="serial"):
            args=(coords, inv),
            backend=backend)
 
+    if is_1d:
+        coords = coords.reshape(len(coords[0]), )
     return coords
 
 
@@ -448,7 +454,7 @@ def transform_StoR(inputcoords, box, backend="serial"):
     Parameters
     ----------
     inputcoords : array
-        A n x 3 array of coordinate data, of type np.float32
+        A (3,) coordinate or (n x 3) array of coordinates, type ``np.float32``.
     box : array
         The unitcell dimesions for this system.
         The dimensions must be provided in the same format as returned
@@ -468,7 +474,11 @@ def transform_StoR(inputcoords, box, backend="serial"):
        Added *backend* keyword.
     """
     coords = inputcoords.copy('C')
-    numcoords = coords.shape[0]
+
+    is_1d = False  # True if only one vector coordinate
+    if len(coords.shape) == 1:
+        coords = coords.reshape(1, len(coords))
+        is_1d = True
 
     boxtype = _box_check(box)
     # Convert [A,B,C,alpha,beta,gamma] to [[A],[B],[C]]
@@ -483,6 +493,8 @@ def transform_StoR(inputcoords, box, backend="serial"):
            args=(coords, box),
            backend=backend)
 
+    if is_1d:
+        coords = coords.reshape(len(coords[0]),)
     return coords
 
 

--- a/package/MDAnalysis/lib/pkdtree.py
+++ b/package/MDAnalysis/lib/pkdtree.py
@@ -29,6 +29,7 @@ boundary conditions.
 """
 
 from __future__ import absolute_import
+from six.moves import range
 
 import numpy as np
 from Bio.KDTree import _CKDTree

--- a/package/MDAnalysis/lib/pkdtree.py
+++ b/package/MDAnalysis/lib/pkdtree.py
@@ -155,7 +155,7 @@ class PeriodicKDTree(object):
           radius is half the smallest periodicity if radius exceeds this value
         """
         if not self.built:
-            raise Exception('Unbuilt tree. Run tree.set_coords first')
+            raise RuntimeError('Unbuilt tree. Run tree.set_coords first')
         if center.shape != (self.dim,):
             raise Exception('Expected a ({},) NumPy array'.format(self.dim))
         self._indices = None  # clear previous search

--- a/package/MDAnalysis/lib/pkdtree.py
+++ b/package/MDAnalysis/lib/pkdtree.py
@@ -211,11 +211,7 @@ class PeriodicKDTree(object):
             new_indices = self.kdt.get_indices()  # returns None or np.array
             if new_indices is not None:
                 self._indices.update(new_indices)
-        if self._indices:
-            self._indices = sorted(list(self._indices))
-        else:
-            # Bio.KDTree.KDTree.getIndices returns None if no neighbors are found
-            self._indices = None
+        self._indices = sorted(list(self._indices))
 
     def get_indices(self):
         return self._indices

--- a/package/MDAnalysis/lib/pkdtree.py
+++ b/package/MDAnalysis/lib/pkdtree.py
@@ -34,7 +34,7 @@ from six.moves import range
 import numpy as np
 from Bio.KDTree import _CKDTree
 
-from MDAnalysis.lib.distances import _check_array, apply_PBC
+from MDAnalysis.lib.distances import _box_check, _check_array, apply_PBC
 
 __all__ = ['PeriodicKDTree', ]
 
@@ -71,6 +71,7 @@ class PeriodicKDTree(object):
           `bucket_size` will speed up the construction of the KDTree but
           slow down the search.
         """
+        self.box_type = _box_check(box)  # ortho,tri_vecs,tri_vecs_bad,tri_box
         self.dim = 3  # 3D systems
         self.kdt = _CKDTree.KDTree(self.dim, bucket_size)
         self.box = box

--- a/package/MDAnalysis/lib/pkdtree.py
+++ b/package/MDAnalysis/lib/pkdtree.py
@@ -160,10 +160,10 @@ class PeriodicKDTree(object):
         self._indices = None  # clear previous search
         for c in self.find_centers(center, radius):
             self.kdt.search_center_radius(c, radius)
-            if self._indices is None:
-                self._indices = self.kdt.get_indices()
-            else:
-                np.append(self._indices, np.arange(2))
+            new_indices = self.kdt.get_indices()
+            if new_indices is not None:
+                self._indices = new_indices.copy('C') if self._indices is None\
+                    else np.append(self._indices, new_indices)
         if self._indices is not None:  # sort and remove duplicates
             self._indices = np.sort(np.unique(self._indices))
 

--- a/package/MDAnalysis/lib/pkdtree.py
+++ b/package/MDAnalysis/lib/pkdtree.py
@@ -111,9 +111,9 @@ class PeriodicKDTree(object):
                            [0, 0, 1]], dtype=np.float32)
         elif box_type in 'tri_box tri_vecs tri_vecs_bad':
             if box_type == 'tri_box':
-                dm = box.copy('C')
-            elif box_type == 'tri_box':
                 dm = triclinic_vectors(box)
+            elif box_type == 'tri_vecs':
+                dm = box.copy('C')
             else:  # case 'tri_vecs_bad'
                 dm = triclinic_vectors(triclinic_box(box[0], box[1], box[2]))
             rm = np.zeros(9, dtype=np.float32).reshape(3, 3)
@@ -168,8 +168,10 @@ class PeriodicKDTree(object):
         # the axis that we happen to be looking.
         displacements = list()
         for i in range(self.dim):
+            # distance to the plane containing the origin
             if np.dot(wrapped_c, self._rm[i]) < extents[i]:
                 displacements.append(self._dm[i])  # "upper" image
+            # distance to the plane containing point self._dm[i]
             elif np.dot(self._dm[i] - wrapped_c, self._rm[i]) < extents[i]:
                 displacements.append(-self._dm[i])  # "lower" image
         # If we have displacements along more than one axis, we have

--- a/package/MDAnalysis/lib/pkdtree.py
+++ b/package/MDAnalysis/lib/pkdtree.py
@@ -71,10 +71,10 @@ class PeriodicKDTree(object):
         self.built = 0
         if len(box) != self.dim:
             raise Exception('Expected array of length {}'.format(self.dim))
-        self.box = np.asarray(box)
-        # zero indicates no periodic boundary conditions along the corresponding axis
-        self.box = np.where(box == np.inf, 0.0, box)  # zero in place of infinite values
-        self.box = np.where(box > 0.0, box, 0.0)  # zero in place of negative values
+        self.box = np.copy(np.asarray(box))
+        # zero is the flag for no periodic boundary conditions
+        self.box = np.where(self.box == np.inf, 0.0, self.box)
+        self.box = np.where(self.box > 0.0, self.box, 0.0)
         if not self.box.any():
             raise Exception('No periodic axis found')
         self._indices = list()
@@ -90,6 +90,7 @@ class PeriodicKDTree(object):
           Positions of points, shape=(N, 3) for N atoms.
         """
         if coords.min() <= -1e6 or coords.max() >= 1e6:
+            # Same exception class as in Bio.KDTree.KDTree.set_coords
             raise Exception('Points should lie between -1e6 and 1e6')
         if len(coords.shape) != 2 or coords.shape[1] != self.dim:
             raise Exception('Expected a (N, {}) NumPy array'.format(self.dim))
@@ -187,14 +188,6 @@ if __name__ == "__main__" :
                       dtype=np.float32)
     tree = PeriodicKDTree(box)
     tree.set_coords(coords)
-    centers = tree.find_centers(np.array([5, 5, 5], dtype=np.float32), 1.5)  # box center
-    centers = tree.find_centers(np.array([1, 5, 5], dtype=np.float32), 1.5)  # box face
-    centers = tree.find_centers(np.array([1, 1, 5], dtype=np.float32), 1.5)  # box edge
-    centers = tree.find_centers(np.array([1, 1, 1], dtype=np.float32), 1.5)  # box vertex
-    centers = tree.find_centers(np.array([5, -1, 5], dtype=np.float32), 1.5)  # box face
-    centers = tree.find_centers(np.array([5, -1, 11], dtype=np.float32), 1.5)  # box edge
-    centers = tree.find_centers(np.array([1, -1, 11], dtype=np.float32), 1.5)  # box vertex
-    centers = tree.find_centers(np.array([21, -31, 1], dtype=np.float32), 1.5)  # box vertex
 
     center = np.array([11, 2, 2], dtype=np.float32)
     wrapped_center = center - np.where(tree.box > 0.0, np.floor(center / tree.box) * tree.box, 0.0)

--- a/package/MDAnalysis/lib/pkdtree.py
+++ b/package/MDAnalysis/lib/pkdtree.py
@@ -1,0 +1,215 @@
+# -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
+#
+# MDAnalysis --- http://www.mdanalysis.org
+# Copyright (c) 2006-2017 The MDAnalysis Development Team and contributors
+# (see the file AUTHORS for the full list of names)
+#
+# Released under the GNU Public Licence, v2 or any higher version
+#
+# Please cite your use of MDAnalysis in published work:
+#
+# R. J. Gowers, M. Linke, J. Barnoud, T. J. E. Reddy, M. N. Melo, S. L. Seyler,
+# D. L. Dotson, J. Domanski, S. Buchoux, I. M. Kenney, and O. Beckstein.
+# MDAnalysis: A Python package for the rapid analysis of molecular dynamics
+# simulations. In S. Benthall and S. Rostrup editors, Proceedings of the 15th
+# Python in Science Conference, pages 102-109, Austin, TX, 2016. SciPy.
+#
+# N. Michaud-Agrawal, E. J. Denning, T. B. Woolf, and O. Beckstein.
+# MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
+# J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
+#
+
+"""
+Periodic KDTree --- :mod:`MDAnalysis.lib.pkdtree`
+===============================================================================
+
+This module contains class to allow searches on a KDTree involving periodic
+boundary conditions.
+"""
+
+from __future__ import absolute_import
+
+import numpy as np
+from Bio.KDTree import _CKDTree
+
+__all__ = ['PeriodicKDTree', ]
+
+
+class PeriodicKDTree(object):
+    """
+    Wrapper around Bio.KDTree._CKDTree to enable search with periodic boundary conditions.
+    
+    A tree is first constructed with the coordinates wrapped onto the central cell.
+    
+    A query for neighbors around a center point is performed first by wrapping the center
+    point coordinates to the central cell, then generating images of this wrapped
+    center point and also searching for neighbors around the images.
+    
+    Only the necessary number of center point images is generated for each case. For
+    instance, if the wrapped center point lies well within the cell and far away
+    from the cell boundaries, there may be no need to generate any center point image.
+    """
+
+    def __init__(self, box, bucket_size=10):
+        """
+        Parameters
+        ----------
+        box : array-like or ``None``, optional, default ``None``
+          Simulation cell dimensions in the form of
+          :attr:`MDAnalysis.trajectory.base.Timestep.dimensions` when
+          periodic boundary conditions should be taken into account for
+          the calculation of contacts.
+        bucket_size : int
+          Number of entries in leafs of the KDTree. If you suffer poor
+          performance you can play around with this number. Increasing the
+          `bucket_size` will speed up the construction of the KDTree but
+          slow down the search.
+        """
+        self.dim = 3  # Strict implementation for 3D
+        self.kdt = _CKDTree.KDTree(self.dim, bucket_size)
+        self.built = 0
+        if len(box) != self.dim:
+            raise Exception('Expected array of length {}'.format(self.dim))
+        self.box = np.asarray(box)
+        # zero indicates no periodic boundary conditions along the corresponding axis
+        self.box = np.where(box == np.inf, 0.0, box)  # zero in place of infinite values
+        self.box = np.where(box > 0.0, box, 0.0)  # zero in place of negative values
+        if not self.box.any():
+            raise Exception('No periodic axis found')
+        self._indices = list()
+
+    def set_coords(self, coords):
+        """
+        Add coordinates of the points. Wrapping of coordinates to the central
+        cell is enforced along the periodic axes.
+
+        Parameters
+        ----------
+        coords: NumPy.array
+          Positions of points, shape=(N, 3) for N atoms.
+        """
+        if coords.min() <= -1e6 or coords.max() >= 1e6:
+            raise Exception('Points should lie between -1e6 and 1e6')
+        if len(coords.shape) != 2 or coords.shape[1] != self.dim:
+            raise Exception('Expected a (N, {}) NumPy array'.format(self.dim))
+        wrapped_data = (coords - np.where(self.box > 0.0,
+                                          np.floor(coords / self.box) * self.box, 0.0))
+        self.kdt.set_data(wrapped_data)
+        self.built = 1
+
+    def find_centers(self, center, radius):
+        """
+        Find relevant images of a center point.
+        
+        Parameters
+        ----------
+        center: NumPy.array
+          Coordinates of the query center point
+        radius: float 
+          Maximum distance from center in search for neighbors
+
+        Returns
+        ------
+        :class:`List`
+          center point and its relevant images
+        """
+        wrapped_center = (center - np.where(self.box > 0.0,
+                                            np.floor(center / self.box) * self.box, 0.0))
+        centers = [wrapped_center, ]
+        extents = self.box/2.0
+        extents = np.where(extents > radius, radius, extents)
+        # displacements are vectors that we add to wrapped_center to generate images
+        # "up" or "down" the central cell along the axis that we happen to be looking.
+        displacements = list()
+        for i in range(self.dim):
+            displacement = np.zeros(self.dim)
+            extent = extents[i]
+            if extent > 0.0:
+                if self.box[i] - wrapped_center[i] < extent:
+                    displacement[i] = -self.box[i]  # displacement generates "lower" image
+                    displacements.append(displacement)
+                elif wrapped_center[i] < extent:
+                    displacement[i] = self.box[i]  # displacement generates "upper" image
+                    displacements.append(displacement)
+        # If we have displacements along more than one axis, we have
+        # to combine them. This happens when wrapped_center is close
+        # to any edge or vertex of the central cell.
+        # face, n_displacements==1; no combination
+        # edge, n_displacements==2; combinations produce one extra displacement
+        # vertex, n_displacements==3; combinations produce five extra displacements
+        n_displacements = len(displacements)
+        if n_displacements > 1:
+            for start in range(n_displacements - 1, -1, -1):
+                for i in range(start+1, len(displacements)):
+                    displacements.append(displacements[start]+displacements[i])
+        centers.extend([wrapped_center + d for d in displacements])
+        return centers
+
+    def search(self, center, radius):
+        """Search all points within radius of center and its periodic images.
+        Wrapping of center coordinates is enforced to enable comparison to
+        wrapped coordinates of points in the tree.
+
+        Parameter
+        ---------
+        center: NumPy.array
+          origin around which to search for neighbors
+        radius: float
+          maximum distance around which to search for neighbors. The search radius
+          is set to half the smallest periodicity if radius exceeds this value.
+        """
+        if not self.built:
+            raise Exception('No point set specified')
+        if center.shape != (self.dim,):
+            raise Exception('Expected a ({},) NumPy array'.format(self.dim))
+        self._indices = None  # clear previous search
+        # Search neighbors for all relevant images of center point
+        for c in self.find_centers(center, radius):
+            self.kdt.search_center_radius(c, radius)
+            if self._indices is None:
+                self._indices = self.kdt.get_indices()
+            else:
+                np.append(self._indices, np.arange(2))
+        self._indices = np.sort(np.unique(self._indices)) # sort and remove duplicates
+
+    def get_indices(self):
+        return self._indices
+
+
+if __name__ == "__main__" :
+    box = np.array([10, 10, 10], dtype=np.float32)
+    coords = np.array([[2, 2, 2],
+                       [5, 5, 5],
+                       [1.1, 1.1, 1.1],
+                       [11, -11, 11],  # wrapped to [1, 9, 1]
+                       [21, 21, 3]],  # wrapped to [1, 1, 3]
+                      dtype=np.float32)
+    tree = PeriodicKDTree(box)
+    tree.set_coords(coords)
+    centers = tree.find_centers(np.array([5, 5, 5], dtype=np.float32), 1.5)  # box center
+    centers = tree.find_centers(np.array([1, 5, 5], dtype=np.float32), 1.5)  # box face
+    centers = tree.find_centers(np.array([1, 1, 5], dtype=np.float32), 1.5)  # box edge
+    centers = tree.find_centers(np.array([1, 1, 1], dtype=np.float32), 1.5)  # box vertex
+    centers = tree.find_centers(np.array([5, -1, 5], dtype=np.float32), 1.5)  # box face
+    centers = tree.find_centers(np.array([5, -1, 11], dtype=np.float32), 1.5)  # box edge
+    centers = tree.find_centers(np.array([1, -1, 11], dtype=np.float32), 1.5)  # box vertex
+    centers = tree.find_centers(np.array([21, -31, 1], dtype=np.float32), 1.5)  # box vertex
+
+    center = np.array([11, 2, 2], dtype=np.float32)
+    wrapped_center = center - np.where(tree.box > 0.0, np.floor(center / tree.box) * tree.box, 0.0)
+    tree.search(center, 1.5)
+    for i in tree.get_indices():
+        neighbor = coords[i]
+        wrapped_neighbor = (neighbor - np.where(tree.box > 0.0, np.floor(neighbor / tree.box) * tree.box, 0.0))
+        distance = np.sqrt(np.sum((wrapped_center-wrapped_neighbor)**2))
+
+    center = np.array([21, -31, 1], dtype=np.float32)
+    wrapped_center = center - np.where(tree.box > 0.0, np.floor(center / tree.box) * tree.box, 0.0)
+    tree.search(center, 1.5)
+    for i in tree.get_indices():
+        neighbor = coords[i]
+        wrapped_neighbor = (neighbor - np.where(tree.box > 0.0, np.floor(neighbor / tree.box) * tree.box, 0.0))
+        distance = np.sqrt(np.sum((wrapped_center-wrapped_neighbor)**2))
+
+    print('hello')

--- a/package/MDAnalysis/lib/pkdtree.py
+++ b/package/MDAnalysis/lib/pkdtree.py
@@ -172,7 +172,8 @@ class PeriodicKDTree(object):
                 self._indices = self.kdt.get_indices()
             else:
                 np.append(self._indices, np.arange(2))
-        self._indices = np.sort(np.unique(self._indices)) # sort and remove duplicates
+        if self._indices is not None:  # sort and remove duplicates
+            self._indices = np.sort(np.unique(self._indices))
 
     def get_indices(self):
         return self._indices

--- a/package/MDAnalysis/lib/pkdtree.py
+++ b/package/MDAnalysis/lib/pkdtree.py
@@ -85,8 +85,9 @@ class PeriodicKDTree(object):
         Store box information and define direct and reciprocal box matrices.
         Rows of the direct matrix are the components of the central cell
         vectors. Rows of the reciprocal matrix are the components of the
-        normalized reciprocal lattice vectors. Each represents the vector
-        normal to the unit cell face associated to each axis.
+        normalized reciprocal lattice vectors. Each row of the reciprocal
+        matrix represents the vector normal to the unit cell face
+        associated to each axis.
         For instance, in an orthorhombic cell the YZ-plane is associated to
         the X-axis and its normal vector is (1, 0, 0). In a triclinic cell,
         the plane associated to vector ``\vec{a}`` is perpendicular to the
@@ -210,7 +211,11 @@ class PeriodicKDTree(object):
             new_indices = self.kdt.get_indices()  # returns None or np.array
             if new_indices is not None:
                 self._indices.update(new_indices)
-        self._indices = sorted(list(self._indices))
+        if self._indices:
+            self._indices = sorted(list(self._indices))
+        else:
+            # Bio.KDTree.KDTree.getIndices returns None if no neighbors are found
+            self._indices = None
 
     def get_indices(self):
         return self._indices

--- a/package/MDAnalysis/lib/pkdtree.py
+++ b/package/MDAnalysis/lib/pkdtree.py
@@ -164,7 +164,7 @@ class PeriodicKDTree(object):
             new_indices = self.kdt.get_indices()  # returns None or np.array
             if new_indices is not None:
                 self._indices.update(new_indices)
-        self._indices = list(self._indices)
+        self._indices = sorted(list(self._indices))
 
     def get_indices(self):
         return self._indices

--- a/package/MDAnalysis/lib/pkdtree.py
+++ b/package/MDAnalysis/lib/pkdtree.py
@@ -158,15 +158,13 @@ class PeriodicKDTree(object):
             raise RuntimeError('Unbuilt tree. Run tree.set_coords first')
         if center.shape != (self.dim,):
             raise ValueError('Expected a ({},) NumPy array'.format(self.dim))
-        self._indices = None  # clear previous search
+        self._indices = set()  # clear previous search
         for c in self.find_centers(center, radius):
             self.kdt.search_center_radius(c, radius)
-            new_indices = self.kdt.get_indices()
+            new_indices = self.kdt.get_indices()  # returns None or np.array
             if new_indices is not None:
-                self._indices = new_indices.copy('C') if self._indices is None\
-                    else np.append(self._indices, new_indices)
-        if self._indices is not None:  # sort and remove duplicates
-            self._indices = np.sort(np.unique(self._indices))
+                self._indices.update(new_indices)
+        self._indices = list(self._indices)
 
     def get_indices(self):
         return self._indices

--- a/package/MDAnalysis/lib/pkdtree.py
+++ b/package/MDAnalysis/lib/pkdtree.py
@@ -157,7 +157,7 @@ class PeriodicKDTree(object):
         if not self.built:
             raise RuntimeError('Unbuilt tree. Run tree.set_coords first')
         if center.shape != (self.dim,):
-            raise Exception('Expected a ({},) NumPy array'.format(self.dim))
+            raise ValueError('Expected a ({},) NumPy array'.format(self.dim))
         self._indices = None  # clear previous search
         for c in self.find_centers(center, radius):
             self.kdt.search_center_radius(c, radius)

--- a/testsuite/AUTHORS
+++ b/testsuite/AUTHORS
@@ -77,6 +77,7 @@ Chronological list of authors
   - Vedant Rathore
   - Kashish Punjani
   - Xiki Tempula
+  - Jose Borreguero
 
 External code
 -------------

--- a/testsuite/CHANGELOG
+++ b/testsuite/CHANGELOG
@@ -16,6 +16,7 @@ and https://github.com/MDAnalysis/mdanalysis/wiki/UnitTests
 mm/dd/yy
 
   * 0.16.2 utkbansal
+    - Unit tests for pdktree (PR #1660)
     - Port to pytest - removed nose as a dependency (Issue #884)
 
 06/03/17 xiki_tempula

--- a/testsuite/MDAnalysisTests/lib/test_pkdtree.py
+++ b/testsuite/MDAnalysisTests/lib/test_pkdtree.py
@@ -29,6 +29,7 @@ from numpy.testing import assert_equal
 
 from MDAnalysis.lib.pkdtree import PeriodicKDTree
 
+
 @pytest.fixture
 def ptree():
     b = np.array([10, 10, 10, 90, 90, 90], dtype=np.float32)
@@ -42,6 +43,7 @@ def ptree():
     t.set_coords(coords)
     return {'coords': coords, 'tree': t, 'box': b, 'radius': 1.5}
 
+
 def test_set_coords(ptree):
     with pytest.raises(ValueError) as excinfo:
         xy = np.array([[2, 2], [5, 5], [1.1, 1.1]], dtype=np.float32)
@@ -50,54 +52,60 @@ def test_set_coords(ptree):
     assert_equal(str(excinfo.value),
                  'coords must be a sequence of 3 dimensional coordinates')
 
-def test_find_centers(ptree):
-    queries = ([5, 5, 5],  # case box center
-               [1, 5, 5],  # box face
-               [5, -1, 5],  # box face
-               [1, 1, 5],  # box edge
-               [5, -1, 11],  # box edge
-               [1, 1, 1],  # box vertex
-               [1, -1, 11],  # box vertex
-               [21, -31, 1]  # box vertex
-               )
-    centers = (([5, 5, 5], ),
-               ([1, 5, 5], [11, 5, 5]),  # centers for first case box face
-               ([5, 9, 5], [5, -1, 5]),
-               ([1, 1, 5], [11, 1, 5], [1, 11, 5], [11, 11, 5]),
-               ([5, 9, 1], [5, -1, 1], [5, 9, 11], [5, -1, 11]),
-               ([1, 1, 1], [11, 1, 1], [1, 11, 1], [1, 1, 11],
-                [1, 11, 11], [11, 11, 1], [11, 1, 11], [11, 11, 11]),
-               ([1, 9, 1], [11, 9, 1], [1, -1, 1], [1, 9, 11],
-                [1, -1, 11], [11, -1, 1], [11, 9, 11], [11, -1, 11]),
-               ([1, 9, 1], [11, 9, 1], [1, -1, 1], [1, 9, 11],
-                [1, -1, 11], [11, -1, 1], [11, 9, 11], [11, -1, 11])
-               )
-    for q, cs in zip(queries, centers):
-        q = np.array(q, dtype=np.float32)
-        cs = [np.array(c, dtype=np.float32) for c in cs]
-        assert_equal(ptree['tree'].find_centers(q, ptree['radius']), cs)
 
-def test_search(ptree):
-    queries = ([5, 5, 5],  # case box center
-               [-8.5, 11.5, 2.2],  # wrapped to [1.5, 1.5, 2.2]
-               [0, 100, 0.7],  # box face
-               [1, 1, 5],  # box edge
-               [1, 1, 1],  # box vertex
-               [-19, 42, 2],  # box vertex
-               [21, -31, 1]  # box vertex
-               )
-    neighbors = (([5, 5, 5], ),
-                 ([2, 2, 2], [1.1, 1.1, 1.1], [21, 21, 3]),
-                 ([11, -11, 11], ),
-                 (),
-                 ([1.1, 1.1, 1.1], ),
-                 ([2, 2, 2], [1.1, 1.1, 1.1], [21, 21, 3]),
-                 ([11, -11, 11], )
-                 )
-    for (q, ns) in zip(queries, neighbors):
-        ptree['tree'].search(np.array(q, dtype=np.float32), ptree['radius'])
-        indices = ptree['tree'].get_indices()
-        found_neighbors = list() if indices is None \
-            else [ptree['coords'][i] for i in indices]
-        ns = [np.array(n, dtype=np.float32) for n in ns]
-        assert_equal(found_neighbors, ns)
+queries = ([5, 5, 5],  # case box center
+           [1, 5, 5],  # box face
+           [5, -1, 5],  # box face
+           [1, 1, 5],  # box edge
+           [5, -1, 11],  # box edge
+           [1, 1, 1],  # box vertex
+           [1, -1, 11],  # box vertex
+           [21, -31, 1]  # box vertex
+           )
+centers = (([5, 5, 5], ),
+           ([1, 5, 5], [11, 5, 5]),  # centers for first case box face
+           ([5, 9, 5], [5, -1, 5]),
+           ([1, 1, 5], [11, 1, 5], [1, 11, 5], [11, 11, 5]),
+           ([5, 9, 1], [5, -1, 1], [5, 9, 11], [5, -1, 11]),
+           ([1, 1, 1], [11, 1, 1], [1, 11, 1], [1, 1, 11],
+            [1, 11, 11], [11, 11, 1], [11, 1, 11], [11, 11, 11]),
+           ([1, 9, 1], [11, 9, 1], [1, -1, 1], [1, 9, 11],
+            [1, -1, 11], [11, -1, 1], [11, 9, 11], [11, -1, 11]),
+           ([1, 9, 1], [11, 9, 1], [1, -1, 1], [1, 9, 11],
+            [1, -1, 11], [11, -1, 1], [11, 9, 11], [11, -1, 11])
+           )
+
+
+@pytest.mark.parametrize('q, cs', zip(queries, centers))
+def test_find_centers(ptree, q, cs):
+    q = np.array(q, dtype=np.float32)
+    cs = [np.array(c, dtype=np.float32) for c in cs]
+    assert_equal(ptree['tree'].find_centers(q, ptree['radius']), cs)
+
+
+queries = ([5, 5, 5],  # case box center
+           [-8.5, 11.5, 2.2],  # wrapped to [1.5, 1.5, 2.2]
+           [0, 100, 0.7],  # box face
+           [1, 1, 5],  # box edge
+           [1, 1, 1],  # box vertex
+           [-19, 42, 2],  # box vertex
+           [21, -31, 1]  # box vertex
+           )
+neighbors = (([5, 5, 5], ),
+             ([2, 2, 2], [1.1, 1.1, 1.1], [21, 21, 3]),
+             ([11, -11, 11], ),
+             (),
+             ([1.1, 1.1, 1.1], ),
+             ([2, 2, 2], [1.1, 1.1, 1.1], [21, 21, 3]),
+             ([11, -11, 11], )
+             )
+
+
+@pytest.mark.parametrize('q, ns', zip(queries, neighbors))
+def test_search(ptree, q, ns):
+    ptree['tree'].search(np.array(q, dtype=np.float32), ptree['radius'])
+    indices = ptree['tree'].get_indices()
+    found_neighbors = list() if indices is None \
+        else [ptree['coords'][i] for i in indices]
+    ns = [np.array(n, dtype=np.float32) for n in ns]
+    assert_equal(found_neighbors, ns)

--- a/testsuite/MDAnalysisTests/lib/test_pkdtree.py
+++ b/testsuite/MDAnalysisTests/lib/test_pkdtree.py
@@ -1,0 +1,63 @@
+# -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 fileencoding=utf-8
+#
+# MDAnalysis --- http://www.mdanalysis.org
+# Copyright (c) 2006-2017 The MDAnalysis Development Team and contributors
+# (see the file AUTHORS for the full list of names)
+#
+# Released under the GNU Public Licence, v2 or any higher version
+#
+# Please cite your use of MDAnalysis in published work:
+#
+# R. J. Gowers, M. Linke, J. Barnoud, T. J. E. Reddy, M. N. Melo, S. L. Seyler,
+# D. L. Dotson, J. Domanski, S. Buchoux, I. M. Kenney, and O. Beckstein.
+# MDAnalysis: A Python package for the rapid analysis of molecular dynamics
+# simulations. In S. Benthall and S. Rostrup editors, Proceedings of the 15th
+# Python in Science Conference, pages 102-109, Austin, TX, 2016. SciPy.
+#
+# N. Michaud-Agrawal, E. J. Denning, T. B. Woolf, and O. Beckstein.
+# MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
+# J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
+#
+
+from __future__ import print_function, absolute_import
+
+import numpy as np
+from numpy.testing import TestCase, assert_array_equal
+
+from MDAnalysis.lib.pkdtree import PeriodicKDTree
+
+
+class TestPeriodicKDTree(TestCase):
+    def setUp(self):
+        self.box = np.array([10, 10, 10], dtype=np.float32)
+        self.coords = np.array([[2, 2, 2],
+                                [5, 5, 5],
+                                [1.1, 1.1, 1.1],
+                                [11, 11, 11],  # wrapped to [1, 1, 1]
+                                [21, 21, 3]],  # wrapped to [1, 1, 3]
+                                dtype=np.float32)
+
+    def tearDown(self):
+        pass
+
+    def test_init(self):
+        box = np.array([10, np.inf, -3], dtype=np.float32)
+        tree = PeriodicKDTree(box)
+        assert_array_equal(tree.box,
+                           np.array([10, 0, 0], dtype=np.float32))
+
+    def test_set_coords(self):
+        tree = PeriodicKDTree(self.box)
+        tree.set_coords(self.coords)
+        print('hello')
+
+    def test_find_centers(self):
+        pass
+
+    def test_search(self):
+        pass
+
+if __name__ == "__main__" :
+    import sys
+    np.testing.run_module_suite(argv=sys.argv)

--- a/testsuite/MDAnalysisTests/lib/test_pkdtree.py
+++ b/testsuite/MDAnalysisTests/lib/test_pkdtree.py
@@ -43,7 +43,6 @@ def ptree():
     t.set_coords(coords)
     return {'coords': coords, 'tree': t, 'box': b, 'radius': 1.5}
 
-
 def test_set_coords(ptree):
     with pytest.raises(ValueError) as excinfo:
         xy = np.array([[2, 2], [5, 5], [1.1, 1.1]], dtype=np.float32)

--- a/testsuite/MDAnalysisTests/lib/test_pkdtree.py
+++ b/testsuite/MDAnalysisTests/lib/test_pkdtree.py
@@ -25,83 +25,79 @@ from six.moves import zip
 
 import pytest
 import numpy as np
-from numpy.testing import TestCase, assert_array_equal, assert_equal
+from numpy.testing import assert_equal
 
 from MDAnalysis.lib.pkdtree import PeriodicKDTree
 
+@pytest.fixture
+def ptree():
+    b = np.array([10, 10, 10, 90, 90, 90], dtype=np.float32)
+    coords = np.array([[2, 2, 2],
+                       [5, 5, 5],
+                       [1.1, 1.1, 1.1],
+                       [11, -11, 11],  # wrapped to [1, 9, 1]
+                       [21, 21, 3]],  # wrapped to [1, 1, 3]
+                      dtype=np.float32)
+    t = PeriodicKDTree(b)
+    t.set_coords(coords)
+    return {'coords': coords, 'tree': t, 'box': b, 'radius': 1.5}
 
-class TestPeriodicKDTree(TestCase):
+def test_set_coords(ptree):
+    with pytest.raises(ValueError) as excinfo:
+        xy = np.array([[2, 2], [5, 5], [1.1, 1.1]], dtype=np.float32)
+        tree = PeriodicKDTree(ptree['box'])
+        tree.set_coords(xy)
+    assert_equal(str(excinfo.value),
+                 'coords must be a sequence of 3 dimensional coordinates')
 
-    def setUp(self):
-        self.radius = 1.5
-        self.box = np.array([10, 10, 10], dtype=np.float32)
-        self.coords = np.array([[2, 2, 2],
-                                [5, 5, 5],
-                                [1.1, 1.1, 1.1],
-                                [11, -11, 11],  # wrapped to [1, 9, 1]
-                                [21, 21, 3]],  # wrapped to [1, 1, 3]
-                               dtype=np.float32)
+def test_find_centers(ptree):
+    queries = ([5, 5, 5],  # case box center
+               [1, 5, 5],  # box face
+               [5, -1, 5],  # box face
+               [1, 1, 5],  # box edge
+               [5, -1, 11],  # box edge
+               [1, 1, 1],  # box vertex
+               [1, -1, 11],  # box vertex
+               [21, -31, 1]  # box vertex
+               )
+    centers = (([5, 5, 5], ),
+               ([1, 5, 5], [11, 5, 5]),  # centers for first case box face
+               ([5, 9, 5], [5, -1, 5]),
+               ([1, 1, 5], [11, 1, 5], [1, 11, 5], [11, 11, 5]),
+               ([5, 9, 1], [5, -1, 1], [5, 9, 11], [5, -1, 11]),
+               ([1, 1, 1], [11, 1, 1], [1, 11, 1], [1, 1, 11],
+                [1, 11, 11], [11, 11, 1], [11, 1, 11], [11, 11, 11]),
+               ([1, 9, 1], [11, 9, 1], [1, -1, 1], [1, 9, 11],
+                [1, -1, 11], [11, -1, 1], [11, 9, 11], [11, -1, 11]),
+               ([1, 9, 1], [11, 9, 1], [1, -1, 1], [1, 9, 11],
+                [1, -1, 11], [11, -1, 1], [11, 9, 11], [11, -1, 11])
+               )
+    for q, cs in zip(queries, centers):
+        q = np.array(q, dtype=np.float32)
+        cs = [np.array(c, dtype=np.float32) for c in cs]
+        assert_equal(ptree['tree'].find_centers(q, ptree['radius']), cs)
 
-    def test_set_coords(self):
-        tree = PeriodicKDTree(self.box)
-        with pytest.raises(ValueError) as excinfo:
-            xy = np.array([[2, 2], [5, 5], [1.1, 1.1]], dtype=np.float32)
-            tree.set_coords(xy)
-        assert_equal(str(excinfo.value),
-                     'coords must be a sequence of 3 dimensional coordinates')
-
-    def test_find_centers(self):
-        tree = PeriodicKDTree(self.box)
-        tree.set_coords(self.coords)
-        queries = ([5, 5, 5],  # case box center
-                   [1, 5, 5],  # box face
-                   [5, -1, 5],  # box face
-                   [1, 1, 5],  # box edge
-                   [5, -1, 11],  # box edge
-                   [1, 1, 1],  # box vertex
-                   [1, -1, 11],  # box vertex
-                   [21, -31, 1]  # box vertex
-                   )
-        centers = (([5, 5, 5], ),
-                   ([1, 5, 5], [11, 5, 5]),  # centers for first case box face
-                   ([5, 9, 5], [5, -1, 5]),
-                   ([1, 1, 5], [11, 1, 5], [1, 11, 5], [11, 11, 5]),
-                   ([5, 9, 1], [5, -1, 1], [5, 9, 11], [5, -1, 11]),
-                   ([1, 1, 1], [11, 1, 1], [1, 11, 1], [1, 1, 11],
-                    [1, 11, 11], [11, 11, 1], [11, 1, 11], [11, 11, 11]),
-                   ([1, 9, 1], [11, 9, 1], [1, -1, 1], [1, 9, 11],
-                    [1, -1, 11], [11, -1, 1], [11, 9, 11], [11, -1, 11]),
-                   ([1, 9, 1], [11, 9, 1], [1, -1, 1], [1, 9, 11],
-                    [1, -1, 11], [11, -1, 1], [11, 9, 11], [11, -1, 11])
-                   )
-        for q, cs in zip(queries, centers):
-            q = np.array(q, dtype=np.float32)
-            cs = [np.array(c, dtype=np.float32) for c in cs]
-            assert_equal(tree.find_centers(q, self.radius), cs)
-
-    def test_search(self):
-        tree = PeriodicKDTree(self.box)
-        tree.set_coords(self.coords)
-        queries = ([5, 5, 5],  # case box center
-                   [-8.5, 11.5, 2.2],  # wrapped to [1.5, 1.5, 2.2]
-                   [0, 100, 0.7],  # box face
-                   [1, 1, 5],  # box edge
-                   [1, 1, 1],  # box vertex
-                   [-19, 42, 2],  # box vertex
-                   [21, -31, 1]  # box vertex
-                   )
-        neighbors = (([5, 5, 5], ),
-                     ([2, 2, 2], [1.1, 1.1, 1.1], [21, 21, 3]),
-                     ([11, -11, 11], ),
-                     (),
-                     ([1.1, 1.1, 1.1], ),
-                     ([2, 2, 2], [1.1, 1.1, 1.1], [21, 21, 3]),
-                     ([11, -11, 11], )
-                     )
-        for (q, ns) in zip(queries, neighbors):
-            tree.search(np.array(q, dtype=np.float32), self.radius)
-            indices = tree.get_indices()
-            found_neighbors = list() if indices is None \
-                else [self.coords[i] for i in indices]
-            ns = [np.array(n, dtype=np.float32) for n in ns]
-            assert_equal(found_neighbors, ns)
+def test_search(ptree):
+    queries = ([5, 5, 5],  # case box center
+               [-8.5, 11.5, 2.2],  # wrapped to [1.5, 1.5, 2.2]
+               [0, 100, 0.7],  # box face
+               [1, 1, 5],  # box edge
+               [1, 1, 1],  # box vertex
+               [-19, 42, 2],  # box vertex
+               [21, -31, 1]  # box vertex
+               )
+    neighbors = (([5, 5, 5], ),
+                 ([2, 2, 2], [1.1, 1.1, 1.1], [21, 21, 3]),
+                 ([11, -11, 11], ),
+                 (),
+                 ([1.1, 1.1, 1.1], ),
+                 ([2, 2, 2], [1.1, 1.1, 1.1], [21, 21, 3]),
+                 ([11, -11, 11], )
+                 )
+    for (q, ns) in zip(queries, neighbors):
+        ptree['tree'].search(np.array(q, dtype=np.float32), ptree['radius'])
+        indices = ptree['tree'].get_indices()
+        found_neighbors = list() if indices is None \
+            else [ptree['coords'][i] for i in indices]
+        ns = [np.array(n, dtype=np.float32) for n in ns]
+        assert_equal(found_neighbors, ns)

--- a/testsuite/MDAnalysisTests/lib/test_pkdtree.py
+++ b/testsuite/MDAnalysisTests/lib/test_pkdtree.py
@@ -23,6 +23,7 @@
 from __future__ import print_function, absolute_import
 from six.moves import zip
 
+import pytest
 import numpy as np
 from numpy.testing import TestCase, assert_array_equal, assert_equal
 
@@ -30,6 +31,7 @@ from MDAnalysis.lib.pkdtree import PeriodicKDTree
 
 
 class TestPeriodicKDTree(TestCase):
+
     def setUp(self):
         self.radius = 1.5
         self.box = np.array([10, 10, 10], dtype=np.float32)
@@ -40,19 +42,13 @@ class TestPeriodicKDTree(TestCase):
                                 [21, 21, 3]],  # wrapped to [1, 1, 3]
                                dtype=np.float32)
 
-    def test_init(self):
-        box = np.array([10, np.inf, -3], dtype=np.float32)
-        tree = PeriodicKDTree(box)
-        assert_array_equal(tree.box,
-                           np.array([10, 0, 0], dtype=np.float32))
-
     def test_set_coords(self):
-        xy = np.array([[2, 2], [5, 5], [1.1, 1.1]], dtype=np.float32)
         tree = PeriodicKDTree(self.box)
-        try:
+        with pytest.raises(ValueError) as excinfo:
+            xy = np.array([[2, 2], [5, 5], [1.1, 1.1]], dtype=np.float32)
             tree.set_coords(xy)
-        except Exception as e:
-            assert_equal(e.message, 'Expected a (N, 3) NumPy array')
+        assert_equal(str(excinfo.value),
+                     'coords must be a sequence of 3 dimensional coordinates')
 
     def test_find_centers(self):
         tree = PeriodicKDTree(self.box)


### PR DESCRIPTION
Fixes #137 

Changes made in this Pull Request:
Addition of `PeriodKDTree` class, a wrapper around `Bio.KDTree._CKDTree` to perform neighbor search in periodic systems. The wrapping style of `PeriodKDTree` follows that of `Bio.KDTree.KDTree`, which is the wrapper of `Bio.KDTree._CKDTree` for non-periodic systems.

PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
