### PR TITLE
Enable pytest warnings

### DIFF
--- a/testsuite/setup.cfg
+++ b/testsuite/setup.cfg
@@ -1,5 +1,9 @@
 [wheel]
 universal = 1
 
+# "encountered in " Runtimewarnings come from numpy for unit cell conversions.
+# They should be activated again once we fixed the occurrence in the code.
 [tool:pytest]
 filterwarnings= always
+                 ignore::UserWarning
+                 ignore:invalid value encountered in.*:RuntimeWarning

--- a/testsuite/setup.cfg
+++ b/testsuite/setup.cfg
@@ -5,5 +5,9 @@ universal = 1
 # They should be activated again once we fixed the occurrence in the code.
 [tool:pytest]
 filterwarnings= always
-                 ignore::UserWarning
-                 ignore:invalid value encountered in.*:RuntimeWarning
+
+# Settings to test for warnings we throw
+# [tool:pytest]
+# Filterwarnings= always
+#                  ignore::UserWarning
+#                  ignore:invalid value encountered in.*:RuntimeWarning


### PR DESCRIPTION
Changes made in this Pull Request:
 - clean up xdr tests a bit
 - use [pytest filterwarnings](https://docs.pytest.org/en/latest/warnings.html#pytest-mark-filterwarnings)

This reduces the number of warnings a pytest run prints to below 700 for me now. Now the warnings log at the end of a test run is starting to be useful. For one I see that we are using a lot of our own deprecated functions in the tests and also some deprecated functions from Biopython.

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
