### PR TITLE
Remove yield test

### DIFF
--- a/testsuite/MDAnalysisTests/core/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/core/test_atomgroup.py
@@ -597,16 +597,16 @@ class TestAtomGroupProperties(object):
         idx = [0, 1, 4, 7, 11, 14]
         return master[idx]
 
-    stuff = (('name', 'names', 'string'),
-             ('type', 'types', 'string'),
-             ('altLoc', 'altLocs', 'string'),
-             ('charge', 'charges', 'float'),
-             ('mass', 'masses', 'float'),
-             ('radius', 'radii', 'float'),
-             ('bfactor', 'bfactors', 'float'),
-             ('occupancy', 'occupancies', 'float'))
+    attributes = (('name', 'names', 'string'),
+                  ('type', 'types', 'string'),
+                  ('altLoc', 'altLocs', 'string'),
+                  ('charge', 'charges', 'float'),
+                  ('mass', 'masses', 'float'),
+                  ('radius', 'radii', 'float'),
+                  ('bfactor', 'bfactors', 'float'),
+                  ('occupancy', 'occupancies', 'float'))
 
-    @pytest.mark.parametrize('att, atts, att_type', stuff)
+    @pytest.mark.parametrize('att, atts, att_type', attributes)
     def test_ag_matches_atom(self, att, atts, ag, att_type):
         """Checking Atomgroup property matches Atoms"""
         # Check that accessing via AtomGroup is identical to doing
@@ -615,7 +615,7 @@ class TestAtomGroupProperties(object):
         assert_equal(ref, getattr(ag, atts),
                      err_msg="AtomGroup doesn't match Atoms for property: {0}".format(att))
 
-    @pytest.mark.parametrize('att, atts, att_type', stuff)
+    @pytest.mark.parametrize('att, atts, att_type', attributes)
     def test_atom_check_ag(self, att, atts, ag, att_type):
         """Changing Atom, checking AtomGroup matches this"""
         vals = self.get_new(att_type)

--- a/testsuite/MDAnalysisTests/core/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/core/test_atomgroup.py
@@ -587,17 +587,38 @@ class TestAtomGroupProperties(object):
         elif att_type == 'int':
             return [4, 6, 8, 1, 5, 4]
 
-    def _check_ag_matches_atom(self, att, atts, ag):
+    @pytest.fixture
+    def ag(self):
+        u = make_Universe(('names', 'resids', 'segids', 'types', 'altLocs',
+                           'charges', 'masses', 'radii', 'bfactors',
+                           'occupancies'))
+        u.atoms.occupancies = 1.0
+        master = u.atoms
+        idx = [0, 1, 4, 7, 11, 14]
+        return master[idx]
+
+    stuff = (('name', 'names', 'string'),
+             ('type', 'types', 'string'),
+             ('altLoc', 'altLocs', 'string'),
+             ('charge', 'charges', 'float'),
+             ('mass', 'masses', 'float'),
+             ('radius', 'radii', 'float'),
+             ('bfactor', 'bfactors', 'float'),
+             ('occupancy', 'occupancies', 'float'))
+
+    @pytest.mark.parametrize('att, atts, att_type', stuff)
+    def test_ag_matches_atom(self, att, atts, ag, att_type):
         """Checking Atomgroup property matches Atoms"""
         # Check that accessing via AtomGroup is identical to doing
         # a list comprehension over AG
         ref = [getattr(atom, att) for atom in ag]
-
         assert_equal(ref, getattr(ag, atts),
                      err_msg="AtomGroup doesn't match Atoms for property: {0}".format(att))
 
-    def _change_atom_check_ag(self, att, atts, vals, ag):
+    @pytest.mark.parametrize('att, atts, att_type', stuff)
+    def test_atom_check_ag(self, att, atts, ag, att_type):
         """Changing Atom, checking AtomGroup matches this"""
+        vals = self.get_new(att_type)
         # Set attributes via Atoms
         for atom, val in zip(ag, vals):
             setattr(atom, att, val)
@@ -606,29 +627,6 @@ class TestAtomGroupProperties(object):
 
         assert_equal(vals, other,
                      err_msg="Change to Atoms not reflected in AtomGroup for property: {0}".format(att))
-
-    def test_attributes(self):
-        u = make_Universe(('names', 'resids', 'segids', 'types', 'altLocs',
-                           'charges', 'masses', 'radii', 'bfactors',
-                           'occupancies'))
-        u.atoms.occupancies = 1.0
-        master = u.atoms
-        idx = [0, 1, 4, 7, 11, 14]
-        ag = master[idx]
-
-        for att, atts, att_type in (
-                ('name', 'names', 'string'),
-                ('type', 'types', 'string'),
-                ('altLoc', 'altLocs', 'string'),
-                ('charge', 'charges', 'float'),
-                ('mass', 'masses', 'float'),
-                ('radius', 'radii', 'float'),
-                ('bfactor', 'bfactors', 'float'),
-                ('occupancy', 'occupancies', 'float')
-        ):
-            vals = self.get_new(att_type)
-            yield self._check_ag_matches_atom, att, atts, ag
-            yield self._change_atom_check_ag, att, atts, vals, ag
 
 
 class TestOrphans(object):

--- a/testsuite/MDAnalysisTests/core/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/core/test_atomgroup.py
@@ -665,28 +665,27 @@ class TestOrphans(object):
 
 class TestCrossUniverse(object):
     """Test behaviour when we mix Universes"""
-    def _check_badadd(self, a, b):
-        def add(x, y):
-            return x + y
-        with pytest.raises(ValueError):
-            add(a, b)
-
-    def test_add_mixed_universes(self):
-        # Issue #532
-        # Checks that adding objects from different universes
-        # doesn't proceed quietly.
+    @pytest.mark.parametrize(
+        # Checks Atom to Atom, Atom to AG, AG to Atom and AG to AG
+        'index_u1, index_u2',
+        itertools.product([0, 1], repeat=2)
+    )
+    def test_add_mixed_universes(self, index_u1, index_u2):
+        """ Issue #532
+        Checks that adding objects from different universes
+        doesn't proceed quietly.
+        """
         u1 = mda.Universe(two_water_gro)
         u2 = mda.Universe(two_water_gro)
 
         A = [u1.atoms[:2], u1.atoms[3]]
         B = [u2.atoms[:3], u2.atoms[0]]
 
-        # Checks Atom to Atom, Atom to AG, AG to Atom and AG to AG
-        for x, y in itertools.product(A, B):
-            yield self._check_badadd, x, y
+        with pytest.raises(ValueError):
+            A[index_u1] + B[index_u2]
 
     def test_adding_empty_ags(self):
-        # Check that empty AtomGroups don't trip up on the Universe check
+        """ Check that empty AtomGroups don't trip up on the Universe check """
         u = mda.Universe(two_water_gro)
 
         assert len(u.atoms[[]] + u.atoms[:3]) == 3

--- a/testsuite/MDAnalysisTests/core/test_groups.py
+++ b/testsuite/MDAnalysisTests/core/test_groups.py
@@ -776,13 +776,23 @@ class TestGroupBaseOperators(object):
         assert_(a.intersection(b) == b.intersection(a))
         assert_equal(len(a.intersection(d)), 0)
 
-    @pytest.mark.xfail
+    #@pytest.mark.xfail
     def test_subtract(self, groups):
         a, b, c, d, e = groups
         subtract_ab = a.subtract(b)
-        assert_array_equal(subtract_ab.ix, np.array([1, 2, 1, 2]))
+        reference = np.array([1, 2, 1, 2])
+        # The groups can be "simple" or "scrambled", if they are simple they
+        # do not contain repetitions and they are ordered. The reference for
+        # the simple groups should follow the same patern and should be ordered
+        # and without repetitions.
+        if len(a) == len(np.unique(a)):
+            reference = np.unique(reference)
+        assert_array_equal(subtract_ab.ix, reference)
         subtract_ba = b.subtract(a)
-        assert_array_equal(subtract_ba, np.array([7, 6, 5, 7]))
+        reference = np.array([7, 6, 5, 7, 6])
+        if len(a) == len(np.unique(a)):
+            reference = np.unique(reference)
+        assert_array_equal(subtract_ba.ix, reference)
         subtract_ad = a.subtract(d)
         assert_equal(subtract_ad, a)
         subtract_ae = a.subtract(e)

--- a/testsuite/MDAnalysisTests/core/test_groups.py
+++ b/testsuite/MDAnalysisTests/core/test_groups.py
@@ -776,7 +776,6 @@ class TestGroupBaseOperators(object):
         assert_(a.intersection(b) == b.intersection(a))
         assert_equal(len(a.intersection(d)), 0)
 
-    #@pytest.mark.xfail
     def test_subtract(self, groups):
         a, b, c, d, e = groups
         subtract_ab = a.subtract(b)


### PR DESCRIPTION
Fixes #

Changes made in this Pull Request:

This leaves 34 yield statements in `test_groups`. Removing the last yield tests requires to split up the tests functions. Having them as one big function like now that does different loops is not practical in pytest.


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
