### PR TITLE
Update the adress of networkx doc in the doc

### DIFF
--- a/package/doc/sphinx/source/conf.py
+++ b/package/doc/sphinx/source/conf.py
@@ -332,6 +332,6 @@ intersphinx_mapping = {'https://docs.python.org/': None,
                        'https://docs.scipy.org/doc/numpy/': None,
                        'https://docs.scipy.org/doc/scipy/reference/': None,
                        'http://matplotlib.org': None,
-                       'https://networkx.readthedocs.io/en/stable/': None,
+                       'https://networkx.github.io/documentation/stable/': None,
                        'https://gridDataFormats.readthedocs.io/en/stable/': None,
                        }


### PR DESCRIPTION
The documentation of networkx changed its URL. This means that the
objects.inv files was unreachable at the previous URL which made the
build fail. This commit updates the URL of networkx's documentation.