### PR TITLE
keep offsets on xdr reopen

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -47,6 +47,7 @@ Fixes
   * Fixed analysis.rms.RMSD failure with select != "all" (Issue #1487)
   * Fixed analysis.rms.RMSD: group RMSD calculation does not
     superimpose groupselections anymore (issue #720)
+  * XDR files now avoid offset recalculation on a rewind (PR #1667)
 
 Changes
   * remove deprecated TimeSeriesCollection

--- a/package/MDAnalysis/coordinates/XDR.py
+++ b/package/MDAnalysis/coordinates/XDR.py
@@ -214,8 +214,12 @@ class XDRBaseReader(base.ReaderBase):
         """reopen trajectory"""
         self.ts.frame = 0
         self._frame = -1
+        offsets = self._xdr.offsets.copy()
         self._xdr.close()
         self._xdr.open(self.filename.encode('utf-8'), 'r')
+        # only restore in case we actually had offsets
+        if len(offsets) != 0:
+            self._xdr.set_offsets(offsets)
 
     def _read_frame(self, i):
         """read frame i"""

--- a/package/MDAnalysis/lib/formats/libmdaxdr.pyx
+++ b/package/MDAnalysis/lib/formats/libmdaxdr.pyx
@@ -170,7 +170,7 @@ cdef class _XDRFile:
     cdef str mode
     cdef np.ndarray box
     cdef np.ndarray _offsets
-    cdef int _has_offsets
+    cdef readonly int _has_offsets
 
     def __cinit__(self, fname, mode='r'):
         self.fname = fname.encode('utf-8')

--- a/testsuite/MDAnalysisTests/coordinates/test_xdr.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_xdr.py
@@ -102,6 +102,7 @@ class _GromacsReader(object):
     def test_rewind_xdrtrj(self, universe):
         universe.trajectory.rewind()
         assert_equal(universe.coord.frame, 0, "rewinding to frame 1")
+        assert universe.trajectory._xdr._has_offsets == 1
 
     def test_next_xdrtrj(self, universe):
         universe.trajectory.rewind()


### PR DESCRIPTION
Changes made in this Pull Request:
 - If we close a xdr file then libmdaxdr discards the old offsets. This is OK
   because it can't know if the new file will have different offsets. Here we now
   store the offsets before we reopen the xdrfile.

The old behavior can lead to recalculating the offsets. This is especially noticeable for the chain reader

PR Checklist
------------
 - [x] Tests?
 - ~[ ] Docs?~
 - [x] CHANGELOG updated?
 - ~~[ ] Issue raised/referenced?~~
