### PR TITLE
Named stream issue

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -48,6 +48,7 @@ Fixes
   * Fixed analysis.rms.RMSD: group RMSD calculation does not
     superimpose groupselections anymore (issue #720)
   * XDR files now avoid offset recalculation on a rewind (PR #1667)
+  * Universe creation doesn't Matryoshka NamedStream anymore (PR #1669)
 
 Changes
   * remove deprecated TimeSeriesCollection

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -237,7 +237,9 @@ class Universe(object):
                 self._topology = args[0]
                 self.filename = None
             else:
-                if isstream(args[0]):
+                if isinstance(args[0], NamedStream):
+                    self.filename = args[0]
+                elif isstream(args[0]):
                     filename = None
                     if hasattr(args[0], 'name'):
                         filename = args[0].name

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -622,6 +622,13 @@ class NamedStream(io.IOBase, PathLike):
 
         .. versionadded:: 0.9.0
         """
+        # constructing the class from an instance of itself has weird behavior
+        # on __del__ and super on python 3. Let's warn the user and ensure the
+        # class works normally.
+        if isinstance(stream, NamedStream):
+            warnings.warn("Constructed NamedStream from a NamedStream",
+                          RuntimeWarning)
+            stream = stream.stream
         self.stream = stream
         self.name = filename
         self.close_stream = close

--- a/testsuite/MDAnalysisTests/utils/test_streamio.py
+++ b/testsuite/MDAnalysisTests/utils/test_streamio.py
@@ -161,6 +161,14 @@ class TestNamedStream(object):
                 ns.close()
                 obj.close()
 
+    def test_matryoshka(self):
+        obj = cStringIO()
+        ns = util.NamedStream(obj, 'r')
+        with pytest.warns(RuntimeWarning):
+            ns2 = util.NamedStream(ns, 'f')
+        assert not isinstance(ns2.stream, util.NamedStream)
+        assert ns2.name == 'f'
+
 
 class TestNamedStream_filename_behavior(object):
     textname = "~/stories/jabberwock.txt"  # with tilde ~ to test regular expanduser()


### PR DESCRIPTION
Fixes #1530

Changes made in this Pull Request:
 - NamedStream doesn't chock on the `__del__` method anymore. It should fix some of the warnings we see in the tests.


PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
