### PR TITLE
Remove StopIteration in generators

### DIFF
--- a/package/MDAnalysis/analysis/hole.py
+++ b/package/MDAnalysis/analysis/hole.py
@@ -564,7 +564,7 @@ class BaseHOLE(object):
         The iterator produces tuples ``(q, profile)``.
         """
         if self.profiles is None:
-            raise StopIteration
+            return
         for q in sorted(self.profiles):
             yield (q, self.profiles[q])
 

--- a/package/MDAnalysis/analysis/legacy/x3dna.py
+++ b/package/MDAnalysis/analysis/legacy/x3dna.py
@@ -438,7 +438,7 @@ class BaseX3DNA(object):
         frame number.
         """
         if self.profiles is None:
-            raise StopIteration
+            return
         for q in sorted(self.profiles):
             yield (q, self.profiles[q])
 


### PR DESCRIPTION
Fixes #1662

Changes made in this Pull Request:
 - Remove the two occurrences of generators raising `StopIteration`. Use `return` instead.
