### PR TITLE
allow pickling xdr/dcd trajectory readers

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -27,6 +27,7 @@ Enhancements
     the `moltype` selection keyword is added (Issue #1555)
   * about 20% speed improvements for GNM analysis. (PR #1579)
   * added support for Tinker TXYZ and ARC files
+  * libmdaxdr classes can now be pickled (PR #1680)
 
 Deprecations
 

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -27,7 +27,7 @@ Enhancements
     the `moltype` selection keyword is added (Issue #1555)
   * about 20% speed improvements for GNM analysis. (PR #1579)
   * added support for Tinker TXYZ and ARC files
-  * libmdaxdr classes can now be pickled (PR #1680)
+  * libmdaxdr and libdcd classes can now be pickled (PR #1680)
 
 Deprecations
 

--- a/package/MDAnalysis/lib/formats/libdcd.pyx
+++ b/package/MDAnalysis/lib/formats/libdcd.pyx
@@ -178,12 +178,13 @@ cdef class DCDFile:
     -----
     DCD is not a well defined format. One consequence of this is that different
     programs like CHARMM and NAMD are using different convention to store the
-    unitcell information. The :class:`DCDFile` will read the unitcell information
-    as is when available. Post processing depending on the program this DCD file
-    was written with is necessary. Have a look at the MDAnalysis DCD reader for
-    possible post processing into a common unitcell data structure. You can also
-    find more information how different programs store unitcell information in DCD
-    on the `mdawiki`_ .
+    unitcell information. The :class:`DCDFile` will read the unitcell
+    information as is when available. Post processing depending on the program
+    this DCD file was written with is necessary. Have a look at the MDAnalysis
+    DCD reader for possible post processing into a common unitcell data
+    structure. You can also find more information how different programs store
+    unitcell information in DCD on the `mdawiki`_ . This class can be pickled.
+    The pickle will store filename, mode, current frame
 
     .. _mdawiki: https://github.com/MDAnalysis/mdanalysis/wiki/FileFormats#dcd
     """
@@ -248,6 +249,23 @@ cdef class DCDFile:
         if not self.is_open:
             raise IOError('No file currently opened')
         return self.n_frames
+
+    def __reduce__(self):
+        return (self.__class__, (self.fname.decode(), self.mode),
+                self.__getstate__())
+
+    def __getstate__(self):
+        return self.is_open, self.current_frame
+
+    def __setstate__(self, state):
+        is_open = state[0]
+        if not is_open:
+            self.close()
+            return
+
+        current_frame = state[1]
+        self.seek(current_frame)
+
 
     def tell(self):
         """

--- a/package/MDAnalysis/lib/formats/libmdaxdr.pyx
+++ b/package/MDAnalysis/lib/formats/libmdaxdr.pyx
@@ -274,6 +274,39 @@ cdef class _XDRFile:
             raise IOError('No file currently opened')
         return self.offsets.size
 
+    def __reduce__(self):
+        """low level pickle function. It gives instructions for unpickling which class
+        should be created with arguments to `__cinit__` and the current state
+
+        """
+        return (self.__class__, (self.fname.decode(), self.mode),
+                self.__getstate__())
+
+    def __getstate__(self):
+        """
+        current state
+        """
+        return (self.is_open, self.current_frame, self._offsets,
+                self._has_offsets)
+
+    def __setstate__(self, state):
+        """
+        reset state offsets and current frame
+        """
+        is_open = state[0]
+        # by default the file is open
+        if not is_open:
+            self.close()
+            return
+
+        # set them now to avoid recalculation
+        self._offsets = state[2]
+        self._has_offsets = state[3]
+
+        # where was I
+        current_frame = state[1]
+        self.seek(current_frame)
+
     def seek(self, frame):
         """Seek to Frame.
 
@@ -402,6 +435,11 @@ cdef class TRRFile(_XDRFile):
     >>> with TRRFile('foo.trr') as f:
     >>>     for frame in f:
     >>>         print(frame.x)
+
+    Notes
+    -----
+    This class can be pickled. The pickle will store filename, mode, current
+    frame and offsets
     """
 
     def _calc_natoms(self, fname):
@@ -614,6 +652,11 @@ cdef class XTCFile(_XDRFile):
     >>> with XTCFile('foo.trr') as f:
     >>>     for frame in f:
     >>>         print(frame.x)
+
+    Notes
+    -----
+    This class can be pickled. The pickle will store filename, mode, current
+    frame and offsets
     """
     cdef float precision
 

--- a/testsuite/MDAnalysisTests/formats/test_libmdaxdr.py
+++ b/testsuite/MDAnalysisTests/formats/test_libmdaxdr.py
@@ -20,6 +20,7 @@
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
 from __future__ import print_function, absolute_import
+from six.moves import cPickle as pickle
 
 import numpy as np
 
@@ -114,6 +115,25 @@ class TestCommonAPI(object):
         with xdr(fname, 'w') as f:
             with pytest.raises(IOError):
                 f.read()
+
+    def test_pickle(self, reader):
+        reader.seek(len(reader) - 1)
+        dump = pickle.dumps(reader)
+        new_reader = pickle.loads(dump)
+
+        assert reader.fname == new_reader.fname
+        assert reader.tell() == new_reader.tell()
+        assert_almost_equal(reader.offsets, new_reader.offsets)
+
+    def test_pickle_closed(self, reader):
+        reader.seek(len(reader) - 1)
+        reader.close()
+        dump = pickle.dumps(reader)
+        new_reader = pickle.loads(dump)
+
+        assert reader.fname == new_reader.fname
+        assert reader.tell() != new_reader.tell()
+
 
 
 @pytest.mark.parametrize("xdrfile, fname, offsets",


### PR DESCRIPTION
Changes made in this Pull Request:
 Add methods to pickle the low level xdr readers. This allows us to write a version of pmda that is independent of the dask scheduler.


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [ ]~ Issue raised/referenced?~
