### PR TITLE
TST: asv benchmark tests for simple select_atoms selections

### DIFF
--- a/benchmarks/benchmarks/selections.py
+++ b/benchmarks/benchmarks/selections.py
@@ -30,4 +30,7 @@ class SimpleSelectionBench(object):
         """Benchmark simple selections on the protein-based
         standard test GRO file.
         """
-        self.u.select_atoms(selection_string)
+        if hasattr(MDAnalysis.Universe, 'select_atoms'):
+            self.u.select_atoms(selection_string)
+        else:
+            self.u.selectAtoms(selection_string)

--- a/benchmarks/benchmarks/selections.py
+++ b/benchmarks/benchmarks/selections.py
@@ -18,7 +18,7 @@ class SimpleSelectionBench(object):
               'resid 1:10',
               'resnum 1:10',
               'resname LYS',
-              'name CA'
+              'name CA',
               'bynum 0:10')
 
     param_names = ['selection_string']

--- a/benchmarks/benchmarks/selections.py
+++ b/benchmarks/benchmarks/selections.py
@@ -1,0 +1,33 @@
+from __future__ import division, absolute_import, print_function
+
+import MDAnalysis
+
+try:
+    from MDAnalysisTests.datafiles import GRO
+except:
+    pass
+
+class SimpleSelectionBench(object):
+    """Benchmarks for the various MDAnalysis
+    simple selection strings.
+    """
+    params = ('protein',
+              'backbone',
+              'nucleic',
+              'nucleicbackbone',
+              'resid 1:10',
+              'resnum 1:10',
+              'resname LYS',
+              'name CA'
+              'bynum 0:10')
+
+    param_names = ['selection_string']
+
+    def setup(self, selection_string):
+        self.u = MDAnalysis.Universe(GRO)
+
+    def time_simple_selections(self, selection_string):
+        """Benchmark simple selections on the protein-based
+        standard test GRO file.
+        """
+        self.u.select_atoms(selection_string)


### PR DESCRIPTION
This feature branch contains `asv` benchmarks for `select_atoms` selection string performance. My intention was to cover a large number of the **simple** selection strings, but not be comprehensive yet in this particular PR.

Nonetheless, it looks like there's lots of interesting stuff going on in the results below. Before I get to those results, a few thoughts off the top of my head:

- for the nucleic acid type selections we may want to use a test file that actually produces a non-zero selection for this (pretty sure we do have one)
- in `time_simple_selections()` we should avoid any non-benchmark code as much as possible -- the unfortunate migration from `selectAtoms` to `select_atoms` was circumvented as shown in this PR, but perhaps even better would be an approach that compiles in the correct version with the commit hash (i.e., similar to the function of the alternative compilation enabled by C preprocessor `#define` literal substitution constants); still, I suspect this simple `if` statement is probably not polluting things that much

Overall results image:
![image](https://user-images.githubusercontent.com/7903078/31690991-ad87e6fa-b351-11e7-8f1c-56c36794a208.png)

Regressions report image:
![image](https://user-images.githubusercontent.com/7903078/31691020-c913f206-b351-11e7-88f1-db421e63db54.png)

