### PR TITLE
Fix the forgotten StopIteration in generator

### DIFF
--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -1940,7 +1940,7 @@ class SingleFrameReaderBase(ProtoReader):
 
     def __iter__(self):
         yield self.ts
-        raise StopIteration
+        return
 
     def _read_frame(self, frame):
         if frame != 0:


### PR DESCRIPTION
Remove a `raise SopIteration` I forgot in #1679. See #1662.