### PR TITLE
Adding asv geometric selection benchmarks

### DIFF
--- a/benchmarks/benchmarks/selections.py
+++ b/benchmarks/benchmarks/selections.py
@@ -52,7 +52,7 @@ class GeoSelectionBench(object):
                'prop z >= 5.0',
                'prop abs z <= 5.0'],
               [True, False], # updating flags
-              [[False, True], [True, False]) # periodic flags
+              [[False, True], [True, False]]) # periodic flags
 
 
     # benchmarks should include static &

--- a/benchmarks/benchmarks/selections.py
+++ b/benchmarks/benchmarks/selections.py
@@ -34,3 +34,51 @@ class SimpleSelectionBench(object):
             self.u.select_atoms(selection_string)
         else:
             self.u.selectAtoms(selection_string)
+
+class GeoSelectionBench(object):
+    """Benchmarks for the various MDAnalysis
+    geometric selection strings.
+    """
+
+    # all selection strings verified
+    # to produce non-zero atom groups
+    # with GRO test file
+    params = (['around 5.0 resid 1',
+               'sphlayer 2.4 6.0 (protein)',
+               'sphzone 6.0 (protein)',
+               'cylayer 5 10 10 -8 protein',
+               'cyzone 15 4 -8 protein',
+               'point 5.0 5.0 5.0 3.5',
+               'prop z >= 5.0',
+               'prop abs z <= 5.0'],
+              [True, False], # updating flags
+              [[False, True], [True, False]) # periodic flags
+
+
+    # benchmarks should include static &
+    # dynamic selections & periodic
+    # vs non-periodic
+    param_names = ['selection_string',
+                   'dynamic_selection',
+                   'periodic_selection']
+
+
+    def setup(self,
+              selection_string,
+              dynamic_selection,
+              periodic_selection):
+        self.u = MDAnalysis.Universe(GRO)
+
+    def time_geometric_selections(self,
+                                  selection_string,
+                                  dynamic_selection,
+                                  periodic_selection):
+
+        # set core flags for PBC accounting
+        MDAnalysis.core.flags['use_periodic_selections'] = periodic_selection[0]
+        MDAnalysis.core.flags['use_KDTree_routines'] = periodic_selection[1]
+
+        if hasattr(MDAnalysis.Universe, 'select_atoms'):
+            self.u.select_atoms(selection_string, updating=dynamic_selection)
+        else:
+            self.u.selectAtoms(selection_string, updating=dynamic_selection)


### PR DESCRIPTION
This PR attempts to add benchmarks for the geometric selection strings available in MDAnalysis. These types of selections are a bit more complicated to thoroughly benchmark because of the possibility of dynamic (updating) selections and the decision to consider or ignore periodicity, where that feature is available.

The large number of permutations of possible strings and parameters is sufficiently large that I'm just going tho show the results for a single type of selection string, but with all of the parameter permutations considered, as an example of looking at static vs. dynamic (and periodic vs. non-periodic) performance, without being too overwhelming:

![image](https://user-images.githubusercontent.com/7903078/32287839-a80309c4-bef7-11e7-8315-3ebcb9331f07.png)

The command used to generate the benchmark data was: `asv run -e -s 20 --bench GeoSelectionBench -j 10 "ddb57592..ec528ad35 --merges"`

The table of "regressions:"

![image](https://user-images.githubusercontent.com/7903078/32287912-de25d6d0-bef7-11e7-8c6e-bd32999d7c27.png)

The areas where feedback might be helpful:

- do we actually want the full spectrum of parameter permutations (periodic & dynamic selections) all mixed together like this, or should these be further broken down / isolated (i.e., is pbc only supported by a subset of the geometric sel strings / situations and so on)
- can we gracefully mitigate the gap in benchmarks observed in the first plot above? perhaps related to certain older combinations of `selectAtoms` and the `updating` keyword, or something of that nature?