### PR TITLE
Updated core/selection.py to include amber N- and C-termini resnames

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -94,7 +94,7 @@ Chronological list of authors
   - Nestor Wendt
   - Micaela Matta
   - Jose Borreguero
-
+  - Sören von Bülow
 
 External code
 -------------

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -14,11 +14,12 @@ The rules for this file:
 
 ------------------------------------------------------------------------------
 mm/dd/17 richardjgowers, rathann, orbeckst, tylerjereddy, mtiberti, kain88-de,
-         jbarnoud, nestorwendt, mmattaNU, jmborr
+         jbarnoud, nestorwendt, mmattaNU, jmborr, sobuelow
 
   * 0.17.0
 
 Enhancements
+  * added Amber residue names to 'protein' atom selection (PR #1704)
   * KDTree for neighbor search on periodic systems (PR #1660)
   * Python versions 3.4 and upwards are now supported (Issue #260)
   * add low level lib.formats.libdcd module for reading/writing DCD (PR #1372)

--- a/package/MDAnalysis/core/selection.py
+++ b/package/MDAnalysis/core/selection.py
@@ -826,8 +826,6 @@ class ProteinSelection(Selection):
 
       * manually added special CHARMM, OPLS/AA and Amber residue names.
 
-      * still missing: Amber N- and C-terminal residue names
-
     See Also
     --------
     :func:`MDAnalysis.lib.util.convert_aa_code`
@@ -848,11 +846,15 @@ class ProteinSelection(Selection):
         # from Gromacs 4.5.3 gromos53a6.ff/aminoacids.rtp
         'ASN1', 'CYS1', 'HISA', 'HISB', 'HIS2',
         # from Gromacs 4.5.3 amber03.ff/aminoacids.rtp
-        # Amber: there are also the C-term aas: 'CALA', 'CGLY', 'CSER', ...
-        # Amber: there are also the N-term aas: 'NALA', 'NGLY', 'NSER', ...
         'HID', 'HIE', 'HIP', 'ORN', 'DAB', 'LYN', 'HYP', 'CYM', 'CYX', 'ASH',
-        'GLH',
-        'ACE', 'NME',
+        'GLH', 'ACE', 'NME',
+        # from Gromacs 2016.3 amber99sb-star-ildn.ff/aminoacids.rtp
+        'NALA', 'NGLY', 'NSER', 'NTHR', 'NLEU', 'NILE', 'NVAL', 'NASN', 'NGLN',
+        'NARG', 'NHID', 'NHIE', 'NHIP', 'NTRP', 'NPHE', 'NTYR', 'NGLU', 'NASP',
+        'NLYS', 'NPRO', 'NCYS', 'NCYX', 'NMET', 'CALA', 'CGLY', 'CSER', 'CTHR',
+        'CLEU', 'CILE', 'CVAL', 'CASF', 'CASN', 'CGLN', 'CARG', 'CHID', 'CHIE',
+        'CHIP', 'CTRP', 'CPHE', 'CTYR', 'CGLU', 'CASP', 'CLYS', 'CPRO', 'CCYS',
+        'CCYX', 'CMET', 'CME', 'ASF',
     ])
 
     def __init__(self, parser, tokens):

--- a/testsuite/AUTHORS
+++ b/testsuite/AUTHORS
@@ -78,6 +78,7 @@ Chronological list of authors
   - Kashish Punjani
   - Xiki Tempula
   - Jose Borreguero
+  - Sören von Bülow
 
 External code
 -------------

--- a/testsuite/CHANGELOG
+++ b/testsuite/CHANGELOG
@@ -13,6 +13,10 @@ Also see https://github.com/MDAnalysis/mdanalysis/wiki/MDAnalysisTests
 and https://github.com/MDAnalysis/mdanalysis/wiki/UnitTests
 
 ------------------------------------------------------------------------------
+mm/dd/yy sobuelow
+  * 0.17.0
+    - Unit test for residue names in 'protein' atom selection (PR #1704)
+
 mm/dd/yy
 
   * 0.16.2 utkbansal

--- a/testsuite/MDAnalysisTests/core/test_atomselections.py
+++ b/testsuite/MDAnalysisTests/core/test_atomselections.py
@@ -75,6 +75,17 @@ class TestSelectionsCHARMM(object):
                      sorted(universe.s4AKE.atoms.indices),
                      "selected protein is not the same as auto-generated protein segment s4AKE")
 
+    @pytest.mark.parametrize('resname', MDAnalysis.core.selection.ProteinSelection.prot_res)
+    def test_protein_resnames(self, resname):
+        u = make_Universe(('resnames',))
+        # set half the residues' names to the resname we're testing
+        myprot = u.residues[::2]
+        myprot.resnames = resname
+        # select protein
+        sel = u.select_atoms('protein')
+        # check that contents (atom indices) are identical afterwards
+        assert_equal(myprot.atoms.ix, sel.ix)
+
     def test_backbone(self, universe):
         sel = universe.select_atoms('backbone')
         assert_equal(sel.n_atoms, 855)


### PR DESCRIPTION
Added the missing Amber resnames in core/selection.py. I tested the new code with the test system in  #1702. Now, the 'protein' atom selection recognizes CGLY. Is there other testing to be done? 

Fixes #1702.

Changes made in this Pull Request:
 - Changed prot_res list in core/selection.py

Test:
```
In [2]: import MDAnalysis as mda

In [3]: u = mda.Universe('test.pdb')

In [4]: mda.core.selection.ProteinSelection.prot_res
Out[4]: 
array(['ALA', 'ARG', 'ASN', 'ASP', 'CYS', 'GLN', 'GLU', 'GLY', 'HSD',
       'HSE', 'HSP', 'ILE', 'LEU', 'LYS', 'MET', 'PHE', 'PRO', 'SER',
       'THR', 'TRP', 'TYR', 'VAL', 'ALAD', 'HIS', 'MSE', 'ARGN', 'ASPH',
       'CYS2', 'CYSH', 'QLN', 'PGLU', 'GLUH', 'HIS1', 'HISD', 'HISE',
       'HISH', 'LYSH', 'ASN1', 'CYS1', 'HISA', 'HISB', 'HIS2', 'HID',
       'HIE', 'HIP', 'ORN', 'DAB', 'LYN', 'HYP', 'CYM', 'CYX', 'ASH',
       'GLH', 'ACE', 'NME', 'NALA', 'NGLY', 'NSER', 'NTHR', 'NLEU', 'NILE',
       'NVAL', 'NASN', 'NGLN', 'NARG', 'NHID', 'NHIE', 'NHIP', 'NTRP',
       'NPHE', 'NTYR', 'NGLU', 'NASP', 'NLYS', 'NPRO', 'NCYS', 'NCYX',
       'NMET', 'CALA', 'CGLY', 'CSER', 'CTHR', 'CLEU', 'CILE', 'CVAL',
       'CASF', 'CASN', 'CGLN', 'CARG', 'CHID', 'CHIE', 'CHIP', 'CTRP',
       'CPHE', 'CTYR', 'CGLU', 'CASP', 'CLYS', 'CPRO', 'CCYS', 'CCYX',
       'CMET', 'CME', 'ASF'],
      dtype='<U4')

In [5]: u.residues.resnames
Out[5]: 
array(['MET', 'GLN', 'ILE', 'PHE', 'VAL', 'LYS', 'THR', 'LEU', 'THR',
       'GLY', 'LYS', 'THR', 'ILE', 'THR', 'LEU', 'GLU', 'VAL', 'GLU',
       'PRO', 'SER', 'ASP', 'THR', 'ILE', 'GLU', 'ASN', 'VAL', 'LYS',
       'ALA', 'LYS', 'ILE', py'GLN', 'ASP', 'LYS', 'GLU', 'GLY', 'ILE',
       'PRO', 'PRO', 'ASP', 'GLN', 'GLN', 'ARG', 'LEU', 'ILE', 'PHE',
       'ALA', 'GLY', 'LYS', 'GLN', 'LEU', 'GLU', 'ASP', 'GLY', 'ARG',
       'THR', 'LEU', 'SER', 'ASP', 'TYR', 'ASN', 'ILE', 'GLN', 'LYS',
       'GLU', 'SER', 'THR', 'LEU', 'HID', 'LEU', 'VAL', 'LEU', 'ARG',
       'LEU', 'ARG', 'GLY', 'CGLY'], dtype=object)

In [6]: u_prot = u.select_atoms('protein')

In [7]: u_prot.residues.resnames
Out[7]: 
array(['MET', 'GLN', 'ILE', 'PHE', 'VAL', 'LYS', 'THR', 'LEU', 'THR',
       'GLY', 'LYS', 'THR', 'ILE', 'THR', 'LEU', 'GLU', 'VAL', 'GLU',
       'PRO', 'SER', 'ASP', 'THR', 'ILE', 'GLU', 'ASN', 'VAL', 'LYS',
       'ALA', 'LYS', 'ILE', 'GLN', 'ASP', 'LYS', 'GLU', 'GLY', 'ILE',
       'PRO', 'PRO', 'ASP', 'GLN', 'GLN', 'ARG', 'LEU', 'ILE', 'PHE',
       'ALA', 'GLY', 'LYS', 'GLN', 'LEU', 'GLU', 'ASP', 'GLY', 'ARG',
       'THR', 'LEU', 'SER', 'ASP', 'TYR', 'ASN', 'ILE', 'GLN', 'LYS',
       'GLU', 'SER', 'THR', 'LEU', 'HID', 'LEU', 'VAL', 'LEU', 'ARG',
       'LEU', 'ARG', 'GLY', 'CGLY'], dtype=object)
```

PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
