### PR TITLE
TST: Adding atomgroup method & attribute asv benchmarks

### DIFF
--- a/benchmarks/benchmarks/ag_methods.py
+++ b/benchmarks/benchmarks/ag_methods.py
@@ -79,7 +79,7 @@ class AtomGroupMethodsBench(object):
         """
         self.ag.centroid(pbc=False)
 
-    def time_concat(self, num_atoms):
+    def time_concatenate(self, num_atoms):
         """Benchmark atomgroup concatenation.
         """
         self.ag.concatenate(self.ag)
@@ -96,7 +96,7 @@ class AtomGroupMethodsBench(object):
         """
         self.ag.groupby('resnames')
 
-    def time_guessbonds(self, num_atoms):
+    def time_guess_bonds(self, num_atoms):
         """Benchmark atomgroup bond guessing
         with artificially-seeded vdw values.
         """
@@ -107,42 +107,42 @@ class AtomGroupMethodsBench(object):
         """
         self.ag.intersection(self.ag)
 
-    def time_strict_subset(self, num_atoms):
+    def time_is_strict_subset(self, num_atoms):
         """Benchmark ag strict subset operation.
         """
         self.ag.is_strict_subset(self.ag)
 
-    def time_strict_superset(self, num_atoms):
+    def time_is_strict_superset(self, num_atoms):
         """Benchmark ag strict superset operation.
         """
         self.ag.is_strict_superset(self.ag)
 
-    def time_disjoint(self, num_atoms):
+    def time_isdisjoint(self, num_atoms):
         """Benchmark disjoint operation between
         atomgroups.
         """
         self.ag.isdisjoint(self.ag)
 
-    def time_subset(self, num_atoms):
+    def time_issubset(self, num_atoms):
         """Benchmark subset operation between
         atomgroups.
         """
         self.ag.issubset(self.ag)
 
-    def time_superset(self, num_atoms):
+    def time_issuperset(self, num_atoms):
         """Benchmark superset operation between
         atomgroups.
         """
         self.ag.issuperset(self.ag)
 
-    def time_packing(self, num_atoms):
+    def time_pack_into_box(self, num_atoms):
         """Benchmark shifting atoms of ag
         into primary unit cell, using
         default parameters.
         """
         self.ag.pack_into_box()
 
-    def time_rotation(self, num_atoms):
+    def time_rotate(self, num_atoms):
         """Benchmark simple rotation operation
         on atomgroup.
         """
@@ -167,7 +167,7 @@ class AtomGroupMethodsBench(object):
         """
         self.ag.subtract(self.ag)
 
-    def time_symm_diff(self, num_atoms):
+    def time_symmetric_difference(self, num_atoms):
         """Benchmark ag symmetric difference
         operation.
         """
@@ -220,7 +220,7 @@ class AtomGroupAttrsBench(object):
         self.ag[:3].angle
 
     def time_atoms(self, num_atoms):
-        """Benchmark creation of identical
+        """Benchmark returning of identical
         atomgroup.
         """
         self.ag.atoms

--- a/benchmarks/benchmarks/ag_methods.py
+++ b/benchmarks/benchmarks/ag_methods.py
@@ -5,6 +5,7 @@ import numpy as np
 
 try:
     from MDAnalysisTests.datafiles import GRO
+    from MDAnalysis.exceptions import NoDataError
 except:
     pass
 
@@ -39,12 +40,6 @@ class AtomGroupMethodsBench(object):
         with pbc inactive.
         """
         self.ag.bbox(pbc=False)
-
-    def time_bond(self, num_atoms):
-        """Benchmark Bond object creation.
-        Requires ag of size 2.
-        """
-        self.ag[:2].bond()
 
     def time_bsphere_pbc(self, num_atoms):
         """Benchmark bounding sphere calculation
@@ -318,3 +313,9 @@ class AtomGroupAttrsBench(object):
         elements in atomgroup.
         """
         self.ag.unique
+
+    def time_bond(self, num_atoms):
+        """Benchmark Bond object creation.
+        Requires ag of size 2.
+        """
+        self.ag[:2].bond

--- a/benchmarks/benchmarks/ag_methods.py
+++ b/benchmarks/benchmarks/ag_methods.py
@@ -1,0 +1,320 @@
+from __future__ import division, absolute_import, print_function
+
+import MDAnalysis
+import numpy as np
+
+try:
+    from MDAnalysisTests.datafiles import GRO
+except:
+    pass
+
+class AtomGroupMethodsBench(object):
+    """Benchmarks for the various MDAnalysis
+    atomgroup methods.
+    """
+    # NOTE: the write() method has been
+    # excluded as file writing is considered
+    # a separate benchmarking category
+
+    params = (10, 100, 1000, 10000)
+    param_names = ['num_atoms']
+
+    def setup(self, num_atoms):
+        self.u = MDAnalysis.Universe(GRO)
+        self.ag = self.u.atoms[:num_atoms]
+        self.weights = np.ones(num_atoms)
+        self.vdwradii = {'NA':1.0,
+                         'M':1.0}
+        self.rot_matrix = np.ones((3,3))
+        self.trans = np.ones((4,4))
+
+    def time_bbox_pbc(self, num_atoms):
+        """Benchmark bounding box calculation
+        with pbc active.
+        """
+        self.ag.bbox(pbc=True)
+
+    def time_bbox_no_pbc(self, num_atoms):
+        """Benchmark bounding box calculation
+        with pbc inactive.
+        """
+        self.ag.bbox(pbc=False)
+
+    def time_bond(self, num_atoms):
+        """Benchmark Bond object creation.
+        Requires ag of size 2.
+        """
+        self.ag[:2].bond()
+
+    def time_bsphere_pbc(self, num_atoms):
+        """Benchmark bounding sphere calculation
+        with pbc active.
+        """
+        self.ag.bsphere(pbc=True)
+
+    def time_bsphere_no_pbc(self, num_atoms):
+        """Benchmark bounding sphere calculation
+        with pbc inactive.
+        """
+        self.ag.bsphere(pbc=False)
+
+    def time_center_pbc(self, num_atoms):
+        """Benchmark center calculation with
+        pbc active.
+        """
+        self.ag.center(weights=self.weights,
+                       pbc=True)
+
+    def time_center_no_pbc(self, num_atoms):
+        """Benchmark center calculation with
+        pbc inactive.
+        """
+        self.ag.center(weights=self.weights,
+                       pbc=False)
+
+    def time_centroid_pbc(self, num_atoms):
+        """Benchmark centroid calculation with
+        pbc active.
+        """
+        self.ag.centroid(pbc=True)
+
+    def time_centroid_no_pbc(self, num_atoms):
+        """Benchmark centroid calculation with
+        pbc inactive.
+        """
+        self.ag.centroid(pbc=False)
+
+    def time_concat(self, num_atoms):
+        """Benchmark atomgroup concatenation.
+        """
+        self.ag.concatenate(self.ag)
+
+    def time_difference(self, num_atoms):
+        """Benchmark atomgroup difference
+        operation.
+        """
+        self.ag.difference(self.ag)
+
+    def time_groupby(self, num_atoms):
+        """Benchmark atomgroup groupby
+        operation.
+        """
+        self.ag.groupby('resnames')
+
+    def time_guessbonds(self, num_atoms):
+        """Benchmark atomgroup bond guessing
+        with artificially-seeded vdw values.
+        """
+        self.ag.guess_bonds(self.vdwradii)
+
+    def time_intersection(self, num_atoms):
+        """Benchmark ag intersection.
+        """
+        self.ag.intersection(self.ag)
+
+    def time_strict_subset(self, num_atoms):
+        """Benchmark ag strict subset operation.
+        """
+        self.ag.is_strict_subset(self.ag)
+
+    def time_strict_superset(self, num_atoms):
+        """Benchmark ag strict superset operation.
+        """
+        self.ag.is_strict_superset(self.ag)
+
+    def time_disjoint(self, num_atoms):
+        """Benchmark disjoint operation between
+        atomgroups.
+        """
+        self.ag.isdisjoint(self.ag)
+
+    def time_subset(self, num_atoms):
+        """Benchmark subset operation between
+        atomgroups.
+        """
+        self.ag.issubset(self.ag)
+
+    def time_superset(self, num_atoms):
+        """Benchmark superset operation between
+        atomgroups.
+        """
+        self.ag.issuperset(self.ag)
+
+    def time_packing(self, num_atoms):
+        """Benchmark shifting atoms of ag
+        into primary unit cell, using
+        default parameters.
+        """
+        self.ag.pack_into_box()
+
+    def time_rotation(self, num_atoms):
+        """Benchmark simple rotation operation
+        on atomgroup.
+        """
+        self.ag.rotate(self.rot_matrix)
+
+    def time_rotateby(self, num_atoms):
+        """Benchmark rotation by an angle
+        of the ag coordinates.
+        """
+        self.ag.rotateby(angle=45,
+                         axis=[1,0,0])
+
+    def time_split(self, num_atoms):
+        """Benchmark ag splitting into
+        multiple ags based on a simple
+        criterion.
+        """
+        self.ag.split('residue')
+
+    def time_subtract(self, num_atoms):
+        """Benchmark ag subtraction.
+        """
+        self.ag.subtract(self.ag)
+
+    def time_symm_diff(self, num_atoms):
+        """Benchmark ag symmetric difference
+        operation.
+        """
+        self.ag.symmetric_difference(self.ag)
+
+    def time_transform(self, num_atoms):
+        """Benchmark application of transformation
+        matrix to atomgroup.
+        """
+        self.ag.transform(self.trans)
+
+    def time_translate(self, num_atoms):
+        """Benchmark the application of a
+        translation vector to the ag
+        coordinates.
+        """
+        self.ag.translate([0,0.5,1])
+        
+    def time_union(self, num_atoms):
+        """Benchmark union operation
+        on atomgroups.
+        """
+        self.ag.union(self.ag)
+
+    def time_wrap(self, num_atoms):
+        """Benchmark wrap() operation on
+        atomgroup with default params.
+        """
+        self.ag.wrap()
+        
+
+
+class AtomGroupAttrsBench(object):
+    """Benchmarks for the various MDAnalysis
+    atomgroup attributes.
+    """
+
+    params = (10, 100, 1000, 10000)
+    param_names = ['num_atoms']
+
+    def setup(self, num_atoms):
+        self.u = MDAnalysis.Universe(GRO)
+        self.ag = self.u.atoms[:num_atoms]
+
+    def time_angle(self, num_atoms):
+        """Benchmark simple angle
+        calculation. Requires ag
+        with three atoms.
+        """
+        self.ag[:3].angle
+
+    def time_atoms(self, num_atoms):
+        """Benchmark creation of identical
+        atomgroup.
+        """
+        self.ag.atoms
+
+    def time_dihedral(self, num_atoms):
+        """Benchmark Dihedral object
+        creation time. Requires ag of 
+        size 4.
+        """
+        self.ag[:4].dihedral
+
+    #TODO: use universe / ag that
+    # is suitable for force calc
+    def time_forces(self, num_atoms):
+        """Benchmark atomgroup force
+        calculation.
+        """
+        try:
+            self.ag.forces
+        except NoDataError:
+            pass
+
+    #TODO: use universe / ag that
+    # is suitable for velocity extraction
+    def time_velocity(self, num_atoms):
+        """Benchmark atomgroup velocity
+        values return.
+        """
+        try:
+            self.ag.velocities
+        except NoDataError:
+            pass
+
+    def time_improper(self, num_atoms):
+        """Benchmark improper dihedral
+        calculation. Requires ag of size
+        4.
+        """
+        self.ag[:4].improper
+
+    def time_indices(self, num_atoms):
+        """Benchmark atom index calculation.
+        """
+        self.ag.ix
+
+    def time_atomcount(self, num_atoms):
+        """Benchmark counting of atoms in
+        atomgroup.
+        """
+        self.ag.n_atoms
+
+    def time_residuecount(self, num_atoms):
+        """Benchmark counting of residues in
+        atomgroup.
+        """
+        self.ag.n_residues
+
+    def time_segmentcount(self, num_atoms):
+        """Benchmark counting of segments in
+        atomgroup.
+        """
+        self.ag.n_segments
+
+    def time_positions(self, num_atoms):
+        """Benchmark returning the positions
+        of the atoms in the group.
+        """
+        self.ag.positions
+
+    def time_residues(self, num_atoms):
+        """Benchmark creation of the ResidueGroup
+        from the AtomGroup.
+        """
+        self.ag.residues
+
+    def time_segments(self, num_atoms):
+        """Benchmark determination of sorted
+        SegmentGroup from AtomGroup.
+        """
+        self.ag.segments
+
+    def time_ts(self, num_atoms):
+        """Benchmark returning of a timestep
+        instance from atomgroup.
+        """
+        self.ag.ts
+
+    def time_unique(self, num_atoms):
+        """Benchmark determination of unique
+        elements in atomgroup.
+        """
+        self.ag.unique


### PR DESCRIPTION
This feature branch aims to add comprehensive `asv` benchmarking coverage of `atomgroup` methods and attributes. There are quite a few benchmarks in this PR so I will select just a few discussion points below for clarity.

Overall, I can (and did) run these benchmarks as-is using the following command:
`asv run -e -s 20 --bench AtomGroup* -j 10 "ddb57592..9ba1ab964 --merges" >& log.txt`

Of course, some of the features are fairly recent additions, etc., and might be handled more gracefully with attribute checks and / or try / except blocks at the top level; if you'd like to parse the complete output yourself (for failures, errors, exceptions) [see the complete log file](https://github.com/MDAnalysis/mdanalysis/files/1493006/log.txt), but `asv` was still able to produce the benchmark grid normally by skipping over the failures.

There are so many benchmarks that we might reasonably expect some interesting things to show up in the performance regression analysis:
![image](https://user-images.githubusercontent.com/7903078/33097639-0ebcb64e-cec8-11e7-816a-9f80e8b307c9.png)

Looks like `time_residues` slowed down by a factor of 287! Ok, let's take a look at its commit hash performance tracking:
![image](https://user-images.githubusercontent.com/7903078/33097732-53e9daa8-cec8-11e7-8d57-690ef8e6c07b.png)

Looks like that regression is consistent across all atom counts -- interesting.

Ok, given recent discussion of `rotate` performance, let's take a look at its commit hash performance history:
![image](https://user-images.githubusercontent.com/7903078/33097832-a16c0562-cec8-11e7-9e6b-78544955d508.png)

Looks like a similar timing on the regression there -- maybe coinciding with the tradeoffs related to the new topology system?

Alright, what about a method that is quite recent in the project history? What happens there? As you can see, the commit hash history is just much smaller because of the failures at older commits:
![image](https://user-images.githubusercontent.com/7903078/33097929-e0a88fa2-cec8-11e7-8a44-cff7b6940bb3.png)

For completeness, it may be sensible to move benchmarks requiring atomgroups of specific size (i.e., angle / dihedral stuff, etc.) outside of the main classes so that the indexing of the ag is not confounded with the calculation proper.