### PR TITLE
use correct loop counter

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -59,6 +59,7 @@ Fixes
     atomgroup.universe
   * Default filename argument for AlignTraj works again (Issue #1713)
   * Fixed analysis.rms.RMSD failed when selection is unicode (PR #1710)
+  * Fixed analysis.align.AlignTraj failed when step > 1 (Issue #1714)
 
 Changes
   * remove deprecated TimeSeriesCollection

--- a/package/MDAnalysis/analysis/align.py
+++ b/package/MDAnalysis/analysis/align.py
@@ -661,7 +661,7 @@ class AlignTraj(AnalysisBase):
         self.rmsd = np.zeros((self.n_frames,))
 
     def _single_frame(self):
-        index = self._ts.frame
+        index = self._frame_index
         mobile_com = self.mobile_atoms.center(self._weights)
         mobile_coordinates = self.mobile_atoms.positions - mobile_com
         mobile_atoms, self.rmsd[index] = _fit_to(mobile_coordinates,

--- a/testsuite/MDAnalysisTests/analysis/test_align.py
+++ b/testsuite/MDAnalysisTests/analysis/test_align.py
@@ -147,6 +147,12 @@ class TestAlign(object):
         with pytest.raises(IOError):
             align.AlignTraj(fitted, reference, force=False)
 
+    def test_AlignTraj_step_works(self, universe, reference, tmpdir):
+        reference.trajectory[-1]
+        outfile = str(tmpdir.join('align_test.dcd'))
+        # this shouldn't throw an exception
+        align.AlignTraj(universe, reference, filename=outfile, step=10).run()
+
     def test_AlignTraj(self, universe, reference, tmpdir):
         reference.trajectory[-1]
         outfile = str(tmpdir.join('align_test.dcd'))


### PR DESCRIPTION
The frame argument contains the current frame which might be larger then our
allocated RMSD array if we use step > 1.

Fixes #1714

Changes made in this Pull Request:
 - 


PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
