### PR TITLE
TST: Adding MDAnalysis.analysis.leaflet asv benchmarks

### DIFF
--- a/benchmarks/benchmarks/analysis/leaflet.py
+++ b/benchmarks/benchmarks/analysis/leaflet.py
@@ -1,0 +1,49 @@
+from __future__ import division, absolute_import, print_function
+
+import MDAnalysis
+
+# use a lipid bilayer system for leaflet testing
+# since this is a common use case
+try:
+    from MDAnalysisTests.datafiles import Martini_membrane_gro
+except:
+    pass
+
+try:
+    from MDAnalysis.analysis import leaflet
+except:
+    pass
+
+class LeafletBench(object):
+    """Benchmarks for MDAnalysis.analysis.leaflet
+    functions.
+    """
+
+    params = ([7.0, 15.0, 23.0],
+              [None, True, False],
+              [True, False])
+    param_names = ['cutoff', 'sparse', 'pbc']
+
+    def setup(self, cutoff, sparse, pbc):
+        self.u = MDAnalysis.Universe(Martini_membrane_gro)
+        self.headgroup_sel = 'name PO4'
+
+    def time_leafletfinder(self, cutoff, sparse, pbc):
+        """Benchmark LeafletFinder for test lipid
+        membrane system.
+        """
+        leaflet.LeafletFinder(self.u,
+                              self.headgroup_sel,
+                              cutoff,
+                              pbc,
+                              sparse)
+
+    def time_optimize_cutoff(self, cutoff, sparse, pbc):
+        """Benchmark optimize_cutoff for test lipid
+        membrane system using default network distance
+        range.
+        """
+        leaflet.optimize_cutoff(self.u,
+                                self.headgroup_sel,
+                                pbc=pbc,
+                                sparse=sparse)

--- a/benchmarks/benchmarks/analysis/leaflet.py
+++ b/benchmarks/benchmarks/analysis/leaflet.py
@@ -15,8 +15,8 @@ except:
     pass
 
 class LeafletBench(object):
-    """Benchmarks for MDAnalysis.analysis.leaflet
-    functions.
+    """Benchmarks for MDAnalysis.analysis.leaflet.
+    LeafletFinder
     """
 
     params = ([7.0, 15.0, 23.0],
@@ -32,18 +32,32 @@ class LeafletBench(object):
         """Benchmark LeafletFinder for test lipid
         membrane system.
         """
-        leaflet.LeafletFinder(self.u,
-                              self.headgroup_sel,
-                              cutoff,
-                              pbc,
-                              sparse)
+        leaflet.LeafletFinder(universe=self.u,
+                              selectionstring=self.headgroup_sel,
+                              cutoff=cutoff,
+                              pbc=pbc,
+                              sparse=sparse)
 
-    def time_optimize_cutoff(self, cutoff, sparse, pbc):
+
+class LeafletOptimizeBench(object):
+    """Benchmarks for MDAnalysis.analysis.leaflet.
+    optimize_cutoff
+    """
+
+    params = ([None, True, False],
+              [True, False])
+    param_names = ['sparse', 'pbc']
+
+    def setup(self, sparse, pbc):
+        self.u = MDAnalysis.Universe(Martini_membrane_gro)
+        self.headgroup_sel = 'name PO4'
+
+    def time_optimize_cutoff(self, sparse, pbc):
         """Benchmark optimize_cutoff for test lipid
         membrane system using default network distance
         range.
         """
-        leaflet.optimize_cutoff(self.u,
-                                self.headgroup_sel,
+        leaflet.optimize_cutoff(universe=self.u,
+                                selection=self.headgroup_sel,
                                 pbc=pbc,
                                 sparse=sparse)


### PR DESCRIPTION
A draft of working `MDAnalysis.analysis.leaflet` `asv` benchmarks. Results and things that could be improved summarized below.

Ran locally with command: `asv run -e -s 20 --bench LeafletBench -j 10 "ddb57592..9ba1ab964 --merges" >& log.txt`

and the [log file is available](https://github.com/MDAnalysis/mdanalysis/files/1537279/log.txt).

Issues I can think of:
- I think `time_optimize_cutoff` needs to be moved to its own class because we get redundant runs for the cutoff parameter (that parameter is not used since the function is, after all, trying to find the cutoff); it was only grouped in the same class because I like to group thematically in class objects, but hard to justify wasting cycles like that
- I suspect the failures in the log file / missing older history results are related to missing test files and / or missing analysis module / function, but haven't looked at this in detail

Sample results plots:
`time_optimize_cutoff`:
![image](https://user-images.githubusercontent.com/7903078/33691629-4f4a7590-daa6-11e7-88de-b7f450999a2d.png)
`time_leafletfinder`:
![image](https://user-images.githubusercontent.com/7903078/33691673-80ef836a-daa6-11e7-8b3e-6997f6a26950.png)





