### PR TITLE
workaround for Travis CI OSX build failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,15 @@ matrix:
   allow_failures:
     - env: NUMPY_VERSION=dev EVENT_TYPE="cron"
 
+before_install:
+  # Workaround for Travis CI macOS bug (https://github.com/travis-ci/travis-ci/issues/6307)
+  # See https://github.com/searchivarius/nmslib/pull/259
+  - |
+     if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
+        command curl -sSL https://rvm.io/mpapis.asc | gpg --import -;
+        rvm get head || true
+     fi
+
 install:
   # download hole first to use system curl
   # additional external tools (Issue #898) -- HOLE


### PR DESCRIPTION
- workaround for travis-ci/travis-ci#6307 (`rvm` upgrade) where Travis fails with `/Users/travis/.rvm/scripts/functions/support: line 57: shell_session_update: command not found`
- based on solution in PR searchivarius/nmslib#259
- partially fixes #1712 

Changes made in this Pull Request:
 - install most recent version of rpm to avoid travis-ci/travis-ci#6307
 - based on searchivarius/nmslib#259

Will not fix any issues related to tests failing due to too many open files or other things mentioned in #1712.

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?
