### PR TITLE
TST: show links to commits on GitHub in asv report

### DIFF
--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -15,6 +15,9 @@
     "dvcs": "git",
     "branches": ["develop"],
 
+    // The base URL to show information about a particular commit.
+    "show_commit_url": "https://github.com/MDAnalysis/mdanalysis/commit/",
+
     // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.
     "pythons": ["2.7"],


### PR DESCRIPTION
- fixes MDAnalysis/benchmarks#1
- must use show_commit_url http://asv.readthedocs.io/en/latest/asv.conf.json.html#show-commit-url which was not included in our asv.json

[ci skip]
