### PR TITLE
TST: Added asv benchmarks for analysis.rms

### DIFF
--- a/benchmarks/benchmarks/analysis/rms.py
+++ b/benchmarks/benchmarks/analysis/rms.py
@@ -1,0 +1,54 @@
+from __future__ import division, absolute_import, print_function
+
+import MDAnalysis
+
+try:
+    from MDAnalysisTests.datafiles import PSF, DCD
+except:
+    pass
+
+try:
+    from MDAnalysis.analysis import rms
+except:
+    pass
+
+class SimpleRmsBench(object):
+    """Benchmarks for MDAnalysis.analysis.rms.rmsd
+    """
+
+    params = ([100, 500, 2000],
+              [None, [1.0, 0.5]],
+              [False, True],
+              [False, True])
+    param_names = ['num_atoms',
+                   'weights',
+                   'center',
+                   'superposition']
+
+    def setup(self, num_atoms, weights, center, superposition):
+        # mimic rmsd docstring example code
+        self.u = MDAnalysis.Universe(PSF, DCD)
+        # ag.positions is the new syntax
+        # but older commit hashes will need to use
+        # ag.coordinates()
+        try:
+            self.A = self.u.atoms.positions.copy()[:num_atoms]
+            self.u.trajectory[-1]
+            self.B = self.u.atoms.positions.copy()[:num_atoms]
+        except:
+            self.A = self.u.atoms.coordinates().copy()[:num_atoms]
+            self.u.trajectory[-1]
+            self.B = self.u.atoms.coordinates().copy()[:num_atoms]
+
+    def time_rmsd(self, num_atoms, weights, center, superposition):
+        """Benchmark rmsd function using a setup similar to
+        its docstring example code along with several possible
+        permutations of parameters.
+        """
+        rms.rmsd(a=self.A,
+                 b=self.B,
+                 weights=weights,
+                 center=center,
+                 superposition=superposition)
+
+

--- a/benchmarks/benchmarks/analysis/rms.py
+++ b/benchmarks/benchmarks/analysis/rms.py
@@ -51,4 +51,58 @@ class SimpleRmsBench(object):
                  center=center,
                  superposition=superposition)
 
+class RmsdTrajBench(object):
+    """Benchmarks for MDAnalysis.analysis.rms.RMSD
+    """
 
+    # TODO: RMSD has many parameters / options,
+    # some of which are apparently still considered
+    # experimental -- we'll eventually want to
+    # benchmark more of these
+
+    params = (['all', 'backbone'],
+              [None, 'mass'])
+
+    param_names = ['select',
+                   'weights']
+
+    def setup(self, select, weights):
+        self.u = MDAnalysis.Universe(PSF, DCD)
+        self.RMSD_inst = rms.RMSD(atomgroup=self.u,
+                                  reference=None,
+                                  select=select,
+                                  weights=weights)
+
+    def time_RMSD(self, select, weights):
+        """Benchmark RMSD.run() method, which parses
+        over the entire trajectory.
+        """
+        self.RMSD_inst.run()
+
+
+class RmsfTrajBench(object):
+    """Benchmarks for MDAnalysis.analysis.rms.RMSF
+    """
+
+    params = ([100,500,2000],
+              [None, 3],
+              [None,'mass'])
+
+    param_names = ['n_atoms',
+                   'step',
+                   'weights']
+
+    def setup(self, n_atoms, step, weights):
+        self.u = MDAnalysis.Universe(PSF, DCD)
+        self.ag = self.u.atoms[:n_atoms]
+        self.RMSF_inst = rms.RMSF(atomgroup=self.ag,
+                                  start=None,
+                                  stop=None,
+                                  step=step,
+                                  weights=weights)
+
+    def time_RMSF(self, n_atoms, step, weights):
+        """Benchmark RMSF.run() method, which parses
+        over the entire trajectory.
+        """
+        self.RMSF_inst.run()


### PR DESCRIPTION
This PR contains some draft `asv` benchmark code for the `analysis.rms` module. A few notes:

- I've not tested these benchmarks locally yet; may wait for feedback first (also a bit tighter for time at the moment)
- the corresponding sphinx docs for this module are a bit of a mess, and indeed the API for rms stuff seems to have changed quite a lot across versions --I think we already knew this, but it does contribute to the challenge of writing clean benchmarks, especially because we need to think about commit hash history API changes, etc.
- there are some parameters for rms code that are still considered experimental according to the docs! So there is probably a lot of potential to expand the benchmarks to test all these params. If you have clear suggestions for parameters you understand well that you'd like to see here, I'd suggest letting me know, but also providing a possible example for the values because the API is indeed tricky.