### PR TITLE
Fix py3 compatibility regarding the HydrogenBondAnalysis.save_table()

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -35,6 +35,8 @@ Enhancements
   * introduce the water bridge analysis module (PR #1722)
   * Universe.add_TopologyAttr now accepts strings to add a given attribute
     to the Universe (Issue #1092, PR #1186)
+  * Fix py3 compatibility regarding the HydrogenBondAnalysis.save_table()
+    (Issue #1743, PR #1742)
 
 Deprecations
   * HydrogenBondAnalysis detect_hydrogens=heuristic is marked for deprecation in 1.0

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -36,7 +36,7 @@ Enhancements
   * Universe.add_TopologyAttr now accepts strings to add a given attribute
     to the Universe (Issue #1092, PR #1186)
   * Fix py3 compatibility regarding the HydrogenBondAnalysis.save_table()
-    (Issue #1743, PR #1742)
+    (Issue #1743, PR #1744)
 
 Deprecations
   * HydrogenBondAnalysis detect_hydrogens=heuristic is marked for deprecation in 1.0

--- a/package/MDAnalysis/analysis/hbonds/hbond_analysis.py
+++ b/package/MDAnalysis/analysis/hbonds/hbond_analysis.py
@@ -1194,7 +1194,7 @@ class HydrogenBondAnalysis(object):
         """
         if self.table is None:
             self.generate_table()
-        with open(filename, 'w') as f:
+        with open(filename, 'wb') as f:
             cPickle.dump(self.table, f, protocol=cPickle.HIGHEST_PROTOCOL)
 
     def _has_timeseries(self):


### PR DESCRIPTION
Fixes #1743  

Changes made in this Pull Request:


Change the `HydrogenBondAnalysis.save_table()` method so that it will work under py3.
I can add a test to prove that the current implementation works in both py2/3 but I'm not sure whether it is necessary as technically I only changed one character.


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
