### PR TITLE
document (and test) setting DX array type (#1725)

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -36,6 +36,9 @@ Enhancements
   * The TPR parser populate the `moltypes` and `molnums` topology attributes;
     the `moltype` and `molnum` selection keyword are added
     (Issue #1555, PR #1578)
+  * use gridDataFormats >= 0.4.0 for new 'type' kwarg in
+    analysis.density.Density.export() to enable writing DX files
+    compatible with (buggy) PyMOL (#1725)
 
 Deprecations
   * HydrogenBondAnalysis detect_hydrogens=heuristic is marked for deprecation in 1.0

--- a/package/MDAnalysis/analysis/density.py
+++ b/package/MDAnalysis/analysis/density.py
@@ -24,8 +24,7 @@
 # Copyright (c) 2007-2011 Oliver Beckstein <orbeckst@gmail.com>
 # (based on code from Hop --- a framework to analyze solvation dynamics from MD simulations)
 
-r"""
-Generating densities from trajectories --- :mod:`MDAnalysis.analysis.density`
+r"""Generating densities from trajectories --- :mod:`MDAnalysis.analysis.density`
 =============================================================================
 
 :Author: Oliver Beckstein
@@ -53,15 +52,15 @@ To generate the density of water molecules around a protein::
   u = Universe(TPR, XTC)
   D = density_from_Universe(u, delta=1.0, atomselection="name OW")
   D.convert_density('TIP4P')
-  D.export("water.dx")
+  D.export("water.dx", type="double")
 
 The positions of all water oxygens are histogrammed on a grid with spacing
-*delta* = 1 Å. Initially the density is measured in :math:`\text{Å}^{-3}`. With the
-:meth:`Density.convert_density` method, the units of measurement are
+*delta* = 1 Å. Initially the density is measured in :math:`\text{Å}^{-3}`. With
+the :meth:`Density.convert_density` method, the units of measurement are
 changed. In the example we are now measuring the density relative to the
 literature value of the TIP4P water model at ambient conditions (see the values
-in :data:`MDAnalysis.units.water` for details). Finally, the density is
-writte as an OpenDX_ compatible file that can be read in VMD_ or PyMOL_.
+in :data:`MDAnalysis.units.water` for details). Finally, the density is written
+as an OpenDX_ compatible file that can be read in VMD_, Chimera_, or PyMOL_.
 
 See :class:`Density` for details. In particular, the density is stored
 as a NumPy array in :attr:`Density.grid`, which can be processed in
@@ -104,8 +103,8 @@ can be used in downstream processing).
 
 .. _OpenDX: http://www.opendx.org/
 .. _VMD:   http://www.ks.uiuc.edu/Research/vmd/
+.. _Chimera: https://www.cgl.ucsf.edu/chimera/
 .. _PyMOL: http://www.pymol.org/
-.. _GridDataFormats: https://github.com/MDAnalysis/GridDataFormats
 
 """
 
@@ -120,30 +119,7 @@ import os.path
 import errno
 import warnings
 
-try:
-    from gridData import Grid
-except ImportError:
-    raise ImportError(
-        """ImportError: The GridDataFormats package can not be found!
-
-        The 'gridData' module from GridDataFormats could not be
-        imported. Please install it first.  You can try installing
-        directly from the internet:
-
-          pip install GridDataFormats
-
-        or
-
-          conda config --add channels conda-forge
-          conda install griddataformats
-
-        Alternatively, download the package from
-
-          http://pypi.python.org/pypi/GridDataFormats/
-
-        and install in the usual manner.
-        """
-    )
+from gridData import Grid
 
 import MDAnalysis
 from MDAnalysis.core import groups
@@ -222,9 +198,14 @@ class Density(Grid):
     The attribute :attr:`Density.metadata` holds a user-defined dictionary that
     can be used to annotate the data. It is also saved with :meth:`Density.save`.
 
-    The :meth:`Density.export` method always exports a 3D object
-    (written in such a way to be readable in VMD_ and PyMOL_), the
-    rest should work for an array of any dimension.
+    The :meth:`Density.export` method always exports a 3D object (written in
+    such a way to be readable in VMD_, Chimera_, and PyMOL_), the rest should
+    work for an array of any dimension. Note that PyMOL_ only understands DX
+    files with the DX data type "double" in the "array" object (see `known
+    issues when writing OpenDX files`_ and issue
+    `MDAnalysis/GridDataFormats#35`_ for details). Using the keyword
+    ``type="double"`` for the method :meth:`Density.export`, the user can
+    ensure that the DX file is written in a format suitable for PyMOL_.
 
     If the input histogram consists of counts per cell then the
     :meth:`Density.make_density` method converts the grid to a physical density. For
@@ -237,6 +218,11 @@ class Density(Grid):
     data represent counts or a density. As a special convenience, if data are
     read from a file and the user has not set ``isDensity`` then it is assumed
     that the data are in fact a density.
+
+    .. _`MDAnalysis/GridDataFormats#35`:
+       https://github.com/MDAnalysis/GridDataFormats/issues/35
+    .. _`known issues when writing OpenDX files`:
+       https://www.mdanalysis.org/GridDataFormats/gridData/formats/OpenDX.html#known-issues-for-writing-opendx-files
 
     See Also
     --------

--- a/package/doc/sphinx/source/conf.py
+++ b/package/doc/sphinx/source/conf.py
@@ -333,5 +333,5 @@ intersphinx_mapping = {'https://docs.python.org/': None,
                        'https://docs.scipy.org/doc/scipy/reference/': None,
                        'http://matplotlib.org': None,
                        'https://networkx.github.io/documentation/stable/': None,
-                       'https://gridDataFormats.readthedocs.io/en/stable/': None,
+                       'https://www.mdanalysis.org/GridDataFormats/': None,
                        }

--- a/package/setup.py
+++ b/package/setup.py
@@ -513,7 +513,7 @@ if __name__ == '__main__':
               'numpy>=1.10.4',
               'biopython>=1.59',
               'networkx>=1.0',
-              'GridDataFormats>=0.3.2',
+              'GridDataFormats>=0.4.0',
               'six>=1.4.0',
               'mmtf-python>=1.0.0',
               'joblib',


### PR DESCRIPTION
Fixes #1725 

Changes made in this Pull Request:
- requires gridDataFormats >= 0.4.0 (to be released)
- documented that PyMOL requires type="double" (see  MDAnalysis/GridDataFormats#35 for details)
- added tests for Density.export(..., type=<type>) -- note  that they really only test gridData.Grid.export()


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
