### PR TITLE
SurvivalProbability did not respect the starting time t0 - and formatting changes

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -97,6 +97,7 @@ Chronological list of authors
   - Sören von Bülow
 2018
   - Nabarun Pal
+  - Mateusz Bieniek
 
 External code
 -------------

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -67,6 +67,8 @@ Deprecations
   * timeseries keyword format is replaced by order. The format keyword is marked for deprecation in 1.0
 
 Fixes
+  * Fixed waterdynamics SurvivalProbability ignoring the t0 start time
+    (Issue #1759)
   * Fixed analysis.psa.dist_mat_to_vec not returning int values (Issue #1507)
   * Fixed triclinic PBC transform for a- and b- axes (Issue #1697)
   * Fixed nuclinfo.tors() not converting delta (Issue #1572)

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,7 +13,7 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-mm/dd/18 richardjgowers, palnabarun
+mm/dd/18 richardjgowers, palnabarun, bieniekmateusz
 
   * 0.17.1
 
@@ -22,6 +22,8 @@ Enhancements
     (Issue #1753)
 
 Fixes
+  * Fixed waterdynamics SurvivalProbability ignoring the t0 start time
+    (Issue #1759)
   * AtomGroup.dimensions now strictly returns a copy (Issue #1582)
   * lib.distances.transform_StoR now checks input type (Issue #1699)
 
@@ -67,8 +69,6 @@ Deprecations
   * timeseries keyword format is replaced by order. The format keyword is marked for deprecation in 1.0
 
 Fixes
-  * Fixed waterdynamics SurvivalProbability ignoring the t0 start time
-    (Issue #1759)
   * Fixed analysis.psa.dist_mat_to_vec not returning int values (Issue #1507)
   * Fixed triclinic PBC transform for a- and b- axes (Issue #1697)
   * Fixed nuclinfo.tors() not converting delta (Issue #1572)

--- a/package/MDAnalysis/analysis/waterdynamics.py
+++ b/package/MDAnalysis/analysis/waterdynamics.py
@@ -1217,7 +1217,7 @@ class SurvivalProbability(object):
         self.timeseries = []
 
 
-    def run(self, **kwargs):
+    def run(self):
         """Analyze trajectory and produce timeseries"""
 
         # select all frames to an array
@@ -1261,16 +1261,17 @@ class SurvivalProbability(object):
         """
         Gives one point to calculate the mean and
         gets one point of the plot C_vect vs t.
-        - Ex: t0=1 and tau=1 so calculate
-        how many selected beads survive from the frame 1 to 2
-        - Ex: t0=5 and tau=3 so calculate
-        how many selected beads survive from the frame 5 to 8
+        - Ex: t=1 and tau=1 calculates
+        how many selected water molecules survive from the frame 1 to 2
+        - Ex: t=5 and tau=3 calculates
+        how many selected water molecules survive from the frame 5 to 8
         """
 
         Nt = len(selected[t])
         if Nt == 0:
             return 0
 
+        # fraction of water molecules that survived
         Ntau = self._NumPart_tau(selected, t, tau)
         return Ntau/Nt
 

--- a/package/MDAnalysis/analysis/waterdynamics.py
+++ b/package/MDAnalysis/analysis/waterdynamics.py
@@ -1221,20 +1221,21 @@ class SurvivalProbability(object):
         """Analyze trajectory and produce timeseries"""
 
         # select all frames to an array
-        preloaded_selection = self._selection_serial(self.universe, self.selection)
+        selected = self._selection_serial(self.universe, self.selection)
 
-        if len(preloaded_selection) < self.dtmax:
+        if len(selected) < self.dtmax:
             print ("ERROR: Cannot select fewer frames than dtmax")
             return
 
         for window_size in list(range(1, self.dtmax + 1)):
-            output = self._getMeanOnePoint(preloaded_selection, window_size)
+            output = self._getMeanOnePoint(selected, window_size)
             self.timeseries.append(output)
 
 
     def _selection_serial(self, universe, selection_str):
         selected = []
-        pm = ProgressMeter(universe.trajectory.n_frames, interval=10, verbose=True)
+        pm = ProgressMeter(self.tf-self.t0, interval=10,
+                           verbose=True, offset=-self.t0)
         for ts in universe.trajectory[self.t0:self.tf]:
             selected.append(universe.select_atoms(selection_str))
             pm.echo(ts.frame)
@@ -1258,9 +1259,12 @@ class SurvivalProbability(object):
 
     def _getOneDeltaPoint(self, selected, t, tau):
         """
-        Gives one point to calculate the mean and gets one point of the plot C_vect vs t.
-        - Ex: t0=1 and tau=1 so calculate how many selected beads survive from the frame 1 to 2
-        - Ex: t0=5 and tau=3 so calculate how many selected beads survive from the frame 5 to 8
+        Gives one point to calculate the mean and
+        gets one point of the plot C_vect vs t.
+        - Ex: t0=1 and tau=1 so calculate
+        how many selected beads survive from the frame 1 to 2
+        - Ex: t0=5 and tau=3 so calculate
+        how many selected beads survive from the frame 5 to 8
         """
 
         Nt = len(selected[t])
@@ -1274,7 +1278,8 @@ class SurvivalProbability(object):
     def _NumPart_tau(self, selected, t, tau):
         """
         Compares the molecules in t selection and t+tau selection and
-        select only the particles that remain from t to t+tau and at each point in between.
+        select only the particles that remain from t to t+tau and
+        at each point in between.
         It returns the number of remaining particles.
         """
         survivors = set(selected[t])

--- a/testsuite/AUTHORS
+++ b/testsuite/AUTHORS
@@ -80,6 +80,7 @@ Chronological list of authors
   - Jose Borreguero
   - Ruggero Cortini
   - Sören von Bülow
+  - Mateusz Bieniek
 
 
 External code

--- a/testsuite/CHANGELOG
+++ b/testsuite/CHANGELOG
@@ -16,6 +16,7 @@ and https://github.com/MDAnalysis/mdanalysis/wiki/UnitTests
 01/24/18 sobuelow
   * 0.17.0
     - Unit test for residue names in 'protein' atom selection (PR #1704)
+    - Test for waterdynamics.SurvivalProbability starting time t0 (PR #1759)
 
 mm/dd/yy
 

--- a/testsuite/MDAnalysisTests/analysis/test_waterdynamics.py
+++ b/testsuite/MDAnalysisTests/analysis/test_waterdynamics.py
@@ -21,7 +21,7 @@
 #
 from __future__ import print_function, absolute_import
 import MDAnalysis
-import MDAnalysis.analysis.waterdynamics
+from MDAnalysis.analysis import waterdynamics
 import pytest
 
 from MDAnalysisTests.datafiles import waterPSF, waterDCD
@@ -41,40 +41,34 @@ def universe():
 
 
 @pytest.fixture(scope='module')
-def universe_protein():
+def universe_prot():
     return MDAnalysis.Universe(PDB, XTC)
 
 
 def test_HydrogenBondLifetimes(universe):
-    hbl = MDAnalysis.analysis.waterdynamics.HydrogenBondLifetimes(universe,
-                                                                  SELECTION1,
-                                                                  SELECTION1,
-                                                                  0, 5, 3)
+    hbl = waterdynamics.HydrogenBondLifetimes(
+        universe, SELECTION1, SELECTION1, 0, 5, 3)
     hbl.run()
     assert_almost_equal(hbl.timeseries[2][1], 0.75, 5)
 
 
 def test_WaterOrientationalRelaxation(universe):
-    wor = MDAnalysis.analysis.waterdynamics.WaterOrientationalRelaxation(
-        universe,
-        SELECTION1, 0, 5, 2)
+    wor = waterdynamics.WaterOrientationalRelaxation(
+        universe, SELECTION1, 0, 5, 2)
     wor.run()
     assert_almost_equal(wor.timeseries[1][2], 0.35887,
                         decimal=5)
 
 
 def test_WaterOrientationalRelaxation_zeroMolecules(universe):
-    wor_zero = MDAnalysis.analysis.waterdynamics.WaterOrientationalRelaxation(
-        universe,
-        SELECTION2, 0, 5, 2)
+    wor_zero = waterdynamics.WaterOrientationalRelaxation(
+        universe, SELECTION2, 0, 5, 2)
     wor_zero.run()
     assert_almost_equal(wor_zero.timeseries[1], (0.0, 0.0, 0.0))
 
 
 def test_AngularDistribution(universe):
-    ad = MDAnalysis.analysis.waterdynamics.AngularDistribution(universe,
-                                                               SELECTION1,
-                                                               40)
+    ad = waterdynamics.AngularDistribution(universe, SELECTION1, 40)
     ad.run()
     # convert a string with two "floats" into a float array
     result = np.array(ad.graph[0][39].split(), dtype=np.float64)
@@ -82,41 +76,33 @@ def test_AngularDistribution(universe):
 
 
 def test_MeanSquareDisplacement(universe):
-    msd = MDAnalysis.analysis.waterdynamics.MeanSquareDisplacement(universe,
-                                                                   SELECTION1,
-                                                                   0, 10, 2)
+    msd = waterdynamics.MeanSquareDisplacement(universe, SELECTION1, 0, 10, 2)
     msd.run()
     assert_almost_equal(msd.timeseries[1], 0.03984,
                         decimal=5)
 
 
 def test_MeanSquareDisplacement_zeroMolecules(universe):
-    msd_zero = MDAnalysis.analysis.waterdynamics.MeanSquareDisplacement(
-        universe,
-        SELECTION2, 0, 10, 2)
+    msd_zero = waterdynamics.MeanSquareDisplacement(
+        universe, SELECTION2, 0, 10, 2)
     msd_zero.run()
     assert_almost_equal(msd_zero.timeseries[1], 0.0)
 
 
-def test_SurvivalProbability(universe_protein):
-    # The first timepoint has to be '1' since it is an autocorrelation function
-    sp = MDAnalysis.analysis.waterdynamics.SurvivalProbability(
-        universe_protein, SELECTION3, 0, 10, 4)
+def test_SurvivalProbability(universe_prot):
+    sp = waterdynamics.SurvivalProbability(universe_prot, SELECTION3, 0, 10, 4)
     sp.run()
-    assert_almost_equal(sp.timeseries, [1.0, 0.3543, 0.2677, 0.2426], decimal=4)
+    assert_almost_equal(sp.timeseries, [1.0, 0.354, 0.267, 0.242], decimal=3)
 
 
-def test_SurvivalProbability_t0Ignored(universe_protein):
-    sp = MDAnalysis.analysis.waterdynamics.SurvivalProbability(
-        universe_protein, SELECTION3, 3, 10, 4)
+def test_SurvivalProbability_t0Ignored(universe_prot):
+    sp = waterdynamics.SurvivalProbability(universe_prot, SELECTION3, 3, 10, 4)
     sp.run()
-    assert_almost_equal(sp.timeseries, [1.0, 0.3917, 0.2929, 0.2610], decimal=4)
+    assert_almost_equal(sp.timeseries, [1.0, 0.391, 0.292, 0.261], decimal=3)
 
 
 
 def test_SurvivalProbability_zeroMolecules(universe):
-    sp_zero = MDAnalysis.analysis.waterdynamics.SurvivalProbability(universe,
-                                                                    SELECTION2,
-                                                                    0, 6, 3)
+    sp_zero = waterdynamics.SurvivalProbability(universe, SELECTION2, 0, 6, 3)
     sp_zero.run()
     assert_almost_equal(sp_zero.timeseries[1], 0.0)

--- a/testsuite/MDAnalysisTests/analysis/test_waterdynamics.py
+++ b/testsuite/MDAnalysisTests/analysis/test_waterdynamics.py
@@ -28,11 +28,11 @@ from MDAnalysisTests.datafiles import waterPSF, waterDCD
 from MDAnalysisTests.datafiles import PDB, XTC
 
 import numpy as np
-from numpy.testing import assert_almost_equal, assert_equal
+from numpy.testing import assert_almost_equal
 
 SELECTION1 = "byres name OH2"
 SELECTION2 = "byres name P1"
-SELECTION3 = "around 10 protein"
+SELECTION3 = "around 4 (resid 151 and name OE1)"
 
 
 @pytest.fixture(scope='module')
@@ -103,20 +103,14 @@ def test_SurvivalProbability(universe_protein):
     sp = MDAnalysis.analysis.waterdynamics.SurvivalProbability(
         universe_protein, SELECTION3, 0, 10, 4)
     sp.run()
-    assert_equal(sp.timeseries[0], 1.0)
+    assert_almost_equal(sp.timeseries, [1.0, 0.3543, 0.2677, 0.2426], decimal=4)
 
 
 def test_SurvivalProbability_t0Ignored(universe_protein):
-    # two different intervals
-    sp1 = MDAnalysis.analysis.waterdynamics.SurvivalProbability(
-        universe_protein, SELECTION3, 0, 10, 5)
-    sp2 = MDAnalysis.analysis.waterdynamics.SurvivalProbability(
-        universe_protein, SELECTION3, 3, 10, 5)
-    sp1.run()
-    sp2.run()
-    assert_equal(np.any(np.not_equal(sp1.timeseries[1], sp2.timeseries[1])),
-                 True, err_msg="Water should not behave the same way"
-                               "in two different time intervals")
+    sp = MDAnalysis.analysis.waterdynamics.SurvivalProbability(
+        universe_protein, SELECTION3, 3, 10, 4)
+    sp.run()
+    assert_almost_equal(sp.timeseries, [1.0, 0.3917, 0.2929, 0.2610], decimal=4)
 
 
 


### PR DESCRIPTION
Fixes #
- Removed the bug where t0 was completely ignored

Changes made in this Pull Request:
- Simplified internal functions to avoid unnecessarily large number of arguments
- Removed the mention of parallel selection which was not implemented 
- Used consistent variable names
- Organised functions in order they are called.
- Inlined the function which only did "return len(selected[t])" 
- Adjusted ProgressMeter to display the right loading bar

PR Checklist
------------
 - [ ] Tests: 
*I manually checked against the original implementation (with starting point t0=0) and the results are consistent. 
*I manually tested whether the ProgressMeter behaves correctly 
 - [ ] Docs: Slight corrections to simplify documentation. But the skeleton stayed the same. 
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced? I did not raise the issue in the original problem (starting time t0 ignored) 
