### PR TITLE
deprecating save() methods in analysis classes

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -71,6 +71,11 @@ Changes
     updated or modified. (PR #1922)
   * The TPR parser reads SETTLE constraints as bonds. (Issue #1949)
 
+Deprecations
+  * almost all "save()", "save_results()", "save_table()" methods in
+    analysis classes were deprecated and will be removed in 1.0 (Issue
+    #1972 and #1745)
+
 
 04/15/18 tylerjereddy, richardjgowers, palnabarun, bieniekmateusz, kain88-de,
          orbeckst, xiki-tempula, navyakhare, zemanj, ayushsuhane, davidercruz,

--- a/package/MDAnalysis/analysis/align.py
+++ b/package/MDAnalysis/analysis/align.py
@@ -204,7 +204,7 @@ import MDAnalysis.lib.qcprot as qcp
 from MDAnalysis.exceptions import SelectionError, SelectionWarning
 import MDAnalysis.analysis.rms as rms
 from MDAnalysis.coordinates.memory import MemoryReader
-from MDAnalysis.lib.util import get_weights
+from MDAnalysis.lib.util import get_weights, deprecate
 
 from .base import AnalysisBase
 
@@ -679,7 +679,10 @@ class AlignTraj(AnalysisBase):
         if not self._verbose:
             logging.disable(logging.NOTSET)
 
+    @deprecate(release="0.19.0", remove="1.0")
     def save(self, rmsdfile):
+        """save rmsd as a numpy array
+        """
         # these are the values of the new rmsd between the aligned trajectory
         # and reference structure
         np.savetxt(rmsdfile, self.rmsd)

--- a/package/MDAnalysis/analysis/contacts.py
+++ b/package/MDAnalysis/analysis/contacts.py
@@ -208,13 +208,12 @@ import warnings
 import bz2
 
 import numpy as np
-from numpy.lib.utils import deprecate
 
 import logging
 
 import MDAnalysis
 import MDAnalysis.lib.distances
-from MDAnalysis.lib.util import openany
+from MDAnalysis.lib.util import openany, deprecate
 from MDAnalysis.analysis.distances import distance_array
 from MDAnalysis.core.groups import AtomGroup
 from .base import AnalysisBase
@@ -454,6 +453,7 @@ class Contacts(AnalysisBase):
     def _conclude(self):
         self.timeseries = np.array(self.timeseries, dtype=float)
 
+    @deprecate(release="0.19.0", remove="1.0.0")
     def save(self, outfile):
         """save contacts timeseries
 

--- a/package/MDAnalysis/analysis/diffusionmap.py
+++ b/package/MDAnalysis/analysis/diffusionmap.py
@@ -170,11 +170,12 @@ from six.moves import range
 import logging
 import warnings
 
-from MDAnalysis.core.universe import Universe
 import numpy as np
 
+from MDAnalysis.core.universe import Universe
 from .rms import rmsd
 from .base import AnalysisBase
+from MDAnalysis.lib.util import deprecate
 
 logger = logging.getLogger("MDAnalysis.analysis.diffusionmap")
 
@@ -195,10 +196,6 @@ class DistanceMatrix(AnalysisBase):
         Array of all possible ij metric distances between frames in trajectory.
         This matrix is symmetric with zeros on the diagonal.
 
-    Methods
-    -------
-    save(filename)
-        Save the `dist_matrix` to a given filename
     """
     def __init__(self, u, select='all', metric=rmsd, cutoff=1E0-5,
                  weights=None, start=None, stop=None, step=None,
@@ -276,7 +273,17 @@ class DistanceMatrix(AnalysisBase):
     def _conclude(self):
         self._calculated = True
 
+    @deprecate(release="0.19.0", remove="1.0.0",
+               message="Use ``np.save(filename, DistanceMatrix.dist_matrix)`` instead.")
     def save(self, filename):
+        """save squared distance matrix
+
+        Parameters
+        ----------
+        outfile : str
+            file to save distance matrix
+
+        """
         np.save(filename, self.dist_matrix)
         logger.info("Wrote the distance-squared matrix to file %r", filename)
 

--- a/package/MDAnalysis/analysis/hbonds/hbond_analysis.py
+++ b/package/MDAnalysis/analysis/hbonds/hbond_analysis.py
@@ -83,9 +83,8 @@ indicates comments that are not part of the output.)::
 
 Using the :meth:`HydrogenBondAnalysis.generate_table` method one can reformat
 the results as a flat "normalised" table that is easier to import into a
-database or dataframe for further processing.
-:meth:`HydrogenBondAnalysis.save_table` saves the table to a pickled file. The
-table itself is a :class:`numpy.recarray`.
+database or dataframe for further processing. The table itself is a
+:class:`numpy.recarray`.
 
 .. _Detection-of-hydrogen-bonds:
 
@@ -320,15 +319,17 @@ from __future__ import division, absolute_import
 import six
 from six.moves import range, zip, map, cPickle
 
-from collections import defaultdict
-import numpy as np
 import warnings
 import logging
+from collections import defaultdict
+
+import numpy as np
 
 from MDAnalysis import MissingDataWarning, NoDataError, SelectionError, SelectionWarning
 from MDAnalysis.lib.log import ProgressMeter, _set_verbose
 from MDAnalysis.lib.NeighborSearch import AtomNeighborSearch
 from MDAnalysis.lib import distances
+from MDAnalysis.lib.util import deprecate
 
 
 logger = logging.getLogger('MDAnalysis.analysis.hbonds')
@@ -1168,6 +1169,9 @@ class HydrogenBondAnalysis(object):
         self.table = out.view(np.recarray)
         logger.debug("HBond: Stored results as table with %(num_records)d entries.", vars())
 
+    @deprecate(release="0.19.0", remove="1.0.0",
+               message="You can instead use ``np.save(filename, "
+               "HydrogendBondAnalysis.table)``.")
     def save_table(self, filename="hbond_table.pickle"):
         """Saves :attr:`~HydrogenBondAnalysis.table` to a pickled file.
 

--- a/package/MDAnalysis/analysis/hbonds/hbond_autocorrel.py
+++ b/package/MDAnalysis/analysis/hbonds/hbond_autocorrel.py
@@ -30,7 +30,7 @@ Hydrogen bond autocorrelation --- :mod:`MDAnalysis.analysis.hbonds.hbond_autocor
 .. versionadded:: 0.9.0
 
 Description
----------------
+-----------
 
 Calculates the time autocorrelation function, :math:`C_x(t)`, for the hydrogen
 bonds in the selections passed to it.  The population of hydrogen bonds at a
@@ -142,18 +142,17 @@ Examples
   plt.show()
 
 
+Classes
+-------
+
 .. autoclass:: HydrogenBondAutoCorrel
-
-   .. automethod:: run
-
-   .. automethod:: solve
-
-   .. automethod:: save_results
+   :members:
 
 
 """
 from __future__ import division, absolute_import
 from six.moves import zip
+
 import numpy as np
 import scipy.optimize
 
@@ -161,6 +160,7 @@ import warnings
 
 from MDAnalysis.lib.log import ProgressMeter
 from MDAnalysis.lib.distances import distance_array, calc_angles, calc_bonds
+from MDAnalysis.lib.util import deprecate
 
 from MDAnalysis.due import due, Doi
 due.cite(Doi("10.1063/1.4922445"),
@@ -403,6 +403,10 @@ class HydrogenBondAutoCorrel(object):
 
         return results
 
+    @deprecate(release="0.19.0", remove="1.0.0",
+               message="You can instead use "
+               "``np.savez(filename, time=HydrogenBondAutoCorrel.solution['time'], "
+               "results=HydrogenBondAutoCorrel.solution['results'])``.")
     def save_results(self, filename='hbond_autocorrel'):
         """Saves the results to a numpy zipped array (.npz, see np.savez)
 
@@ -412,6 +416,7 @@ class HydrogenBondAutoCorrel(object):
         ----------
         filename : str, optional
             The desired filename [hbond_autocorrel]
+
         """
         if self.solution['results'] is not None:
             np.savez(filename, time=self.solution['time'],

--- a/package/MDAnalysis/analysis/hbonds/wbridge_analysis.py
+++ b/package/MDAnalysis/analysis/hbonds/wbridge_analysis.py
@@ -285,9 +285,10 @@ from __future__ import absolute_import, division
 import six
 
 from collections import defaultdict
-import numpy as np
 import logging
 import warnings
+
+import numpy as np
 
 from .hbond_analysis import HydrogenBondAnalysis
 from MDAnalysis.lib.NeighborSearch import AtomNeighborSearch
@@ -843,26 +844,6 @@ class WaterBridgeAnalysis(HydrogenBondAnalysis):
         WaterBridgeAnalysis.table
         """
         super(WaterBridgeAnalysis, self).generate_table()
-
-    def save_table(self, filename="wbridge_table.pickle"):
-        """Saves :attr:`~WaterBridgeAnalysis.table` to a pickled file.
-
-        If :attr:`~WaterBridgeAnalysis.table` does not exist yet,
-        :meth:`generate_table` is called first.
-
-        Parameters
-        ----------
-        filename : str (optional)
-             path to the filename
-
-        Example
-        -------
-        Load with ::
-
-           import cPickle
-           table = cPickle.load(open(filename))
-        """
-        super(WaterBridgeAnalysis, self).save_table(filename)
 
     def count_by_type(self):
         """Counts the frequency of water bridge of a specific type.

--- a/package/MDAnalysis/analysis/hole.py
+++ b/package/MDAnalysis/analysis/hole.py
@@ -275,8 +275,8 @@ import matplotlib.pyplot as plt
 
 from MDAnalysis import Universe
 from MDAnalysis.exceptions import ApplicationError
-from MDAnalysis.lib.util import which, realpath, asiterable
-from MDAnalysis.lib.util import FORTRANReader
+from MDAnalysis.lib.util import (which, realpath, asiterable,
+                                 FORTRANReader, deprecate)
 
 from ..due import due, Doi
 
@@ -388,6 +388,9 @@ def seq2str(v):
 class BaseHOLE(object):
     """Baseclass for HOLE analysis, providing plotting and utility functions"""
 
+    @deprecate(release="0.19.0", remove="1.0.0",
+               message="You can instead use "
+               "``cPickle.dump(HOLE.profiles, open(filename, 'wb'))``.")
     def save(self, filename="hole.pickle"):
         """Save :attr:`profiles` as a Python pickle file *filename*.
 
@@ -395,6 +398,7 @@ class BaseHOLE(object):
 
            import cPickle
            profiles = cPickle.load(open(filename))
+
 
         """
 

--- a/package/MDAnalysis/analysis/lineardensity.py
+++ b/package/MDAnalysis/analysis/lineardensity.py
@@ -30,19 +30,19 @@ fixed volume cells (thus for simulations in canonical NVT ensemble).
 from __future__ import division, absolute_import
 
 import os.path as path
+
 import numpy as np
 
 from MDAnalysis.analysis.base import AnalysisBase
-
+from MDAnalysis.lib.util import deprecate
 
 class LinearDensity(AnalysisBase):
     """Linear density profile
-    LinearDensity(selection, grouping='atoms', binsize=0.25)
 
     Parameters
     ----------
     selection : AtomGroup
-      Any atomgroup
+          any atomgroup
     grouping : str {'atoms', 'residues', 'segments', 'fragments'}
           Density profiles will be computed on the center of geometry
           of a selected group of atoms ['atoms']
@@ -60,6 +60,13 @@ class LinearDensity(AnalysisBase):
           Show detailed progress of the calculation if set to ``True``; the
           default is ``False``.
 
+    Attributes
+    ----------
+    results : dict
+          Keys 'x', 'y', and 'z' for the three directions. Under these
+          keys, find 'pos', 'pos_std' (mass-weighted density and
+          standard deviation), 'char', 'char_std' (charge density and
+          its standard deviation), 'slice_volume' (volume of bin).
 
     Example
     -------
@@ -69,15 +76,9 @@ class LinearDensity(AnalysisBase):
       ldens = LinearDensity(selection)
       ldens.run()
 
-    Density profiles can be written to file through the `save` method::
-
-      ldens.save(description='mydensprof', form='txt')
-
-    which will output the density profiles in a file named
-    `<trajectory_filename>.mydensprof_<grouping>.ldens`.
-    Results can be saved in npz format by specifying `form='npz'`
 
     .. versionadded:: 0.14.0
+
     """
 
     def __init__(self, selection, grouping='atoms', binsize=0.25, **kwargs):
@@ -190,8 +191,12 @@ class LinearDensity(AnalysisBase):
             self.results[dim]['pos_std'] /= self.results[dim]['slice volume'] * k
             self.results[dim]['char_std'] /= self.results[dim]['slice volume'] * k
 
+    @deprecate(release="0.19.0", remove="1.0.0",
+               message="Instead save the :attr:`results` dictionary directly in "
+               "your favorite format (pickle, json, hdf5, ...).")
     def save(self, description='', form='txt'):
         """Save density profile to file
+
         Allows to save the density profile to either a ASCII txt file or a
         binary numpy npz file. Output file has extension 'ldens' and begins
         with the name of the trajectory file.
@@ -214,6 +219,7 @@ class LinearDensity(AnalysisBase):
         which will output the linear density profiles in a file named
         `<trajectory_filename>.mydensprof_<grouping>.ldens`.
 
+
         """
         # Take root of trajectory filename for output file naming
         trajname = path.splitext(path.basename(
@@ -230,6 +236,7 @@ class LinearDensity(AnalysisBase):
             raise ValueError('form argument must be either txt or npz')
 
     def _savetxt(self, filename):
+        # DEPRECATED: remove in 1.0.0
         bins = np.linspace(0.0, max(self.dimensions), num=self.nbins)
 
         # Create list of results which will be output
@@ -253,6 +260,7 @@ class LinearDensity(AnalysisBase):
                    header=header)
 
     def _savez(self, filename):
+        # DEPRECATED: remove in 1.0.0
         bins = np.linspace(0.0, max(self.dimensions), num=self.nbins)
         dictionary = {'bins': bins}
 

--- a/package/MDAnalysis/analysis/psa.py
+++ b/package/MDAnalysis/analysis/psa.py
@@ -216,19 +216,19 @@ import six
 from six.moves import range, cPickle
 from six import string_types
 
+import os
+import warnings
+import numbers
+
 import numpy as np
 from scipy import spatial, cluster
 from scipy.spatial.distance import directed_hausdorff
 import matplotlib
 
-import warnings
-import numbers
-
 import MDAnalysis
 import MDAnalysis.analysis.align
 from MDAnalysis import NoDataError
-
-import os
+from MDAnalysis.lib.util import deprecate
 
 import logging
 logger = logging.getLogger('MDAnalysis.analysis.psa')
@@ -1506,14 +1506,27 @@ class PSAnalysis(object):
         store : bool
              if ``True`` then writes :attr:`PSAnalysis.D` to text and
              compressed npz (numpy) files [``True``]
+
+             .. deprecated:: 0.19.0
+                `store` will be removed together with :meth:`save_results` in 1.0.0.
+
         filename : str
              string, filename to save :attr:`PSAnalysis.D`
+
+             .. deprecated:: 0.19.0
+                `filename` will be removed together with :meth:`save_results` in 1.0.0.
+
 
         """
         metric = kwargs.pop('metric', 'hausdorff')
         start = kwargs.pop('start', None)
         stop = kwargs.pop('stop', None)
         step = kwargs.pop('step', None)
+        # DEPRECATED 0.19.0: remove in 1.0
+        if 'store' in kwargs:
+            warnings.warn("PSAnalysis.run(): 'store' was deprecated in 0.19.0 "
+                          "and will be removed in 1.0",
+                          category=DeprecationWarning)
         store = kwargs.pop('store', True)
 
         if isinstance(metric, string_types):
@@ -1531,6 +1544,11 @@ class PSAnalysis(object):
                 D[j,i] = D[i,j]
         self.D = D
         if store:
+            # DEPRECATED 0.19.0: remove in 1.0
+            if 'filename' in kwargs:
+                warnings.warn("PSAnalysis.run(): 'filename' was deprecated in "
+                              "0.19.0 and will be removed in 1.0",
+                              category=DeprecationWarning)
             filename = kwargs.pop('filename', metric)
             if not isinstance(metric, string_types):
                 filename = 'custom_metric'
@@ -1594,7 +1612,9 @@ class PSAnalysis(object):
                     self._HP.append(pp.get_hausdorff_pair())
         self.D = D
 
-
+    @deprecate(release="0.19.0", remove="1.0.0",
+               message="You can save the distance matrix :attr:`D` to a numpy "
+               "file with ``np.save(filename, PSAnalysis.D)``.")
     def save_result(self, filename=None):
         """Save distance matrix :attr:`PSAnalysis.D` to a numpy compressed npz
         file and text file.

--- a/package/MDAnalysis/core/selection.py
+++ b/package/MDAnalysis/core/selection.py
@@ -585,7 +585,7 @@ class SelgroupSelection(Selection):
         mask = np.in1d(group.indices, self.grp.indices)
         return group[mask]
 
-
+# TODO: remove in 1.0 (should have been removed in 0.15.0)
 class FullSelgroupSelection(Selection):
     token = 'fullgroup'
 

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -138,6 +138,14 @@ Class decorators
 
 .. autofunction:: cached
 
+
+Code management
+---------------
+
+.. autofunction:: deprecate
+.. autoclass:: _Deprecate
+.. autofunction:: dedent_docstring
+
 .. Rubric:: Footnotes
 
 .. [#NamedStreamClose] The reason why :meth:`NamedStream.close` does
@@ -171,10 +179,13 @@ import re
 import io
 import warnings
 import collections
+import functools
 from functools import wraps
+import textwrap
+
 import mmtf
 import numpy as np
-import functools
+
 from numpy.testing import assert_equal
 import inspect
 
@@ -1804,3 +1815,237 @@ def warn_if_not_unique(groupmethod):
             warn_if_not_unique.warned = False
         return result
     return wrapper
+
+
+#------------------------------------------------------------------
+#
+# our own deprecate function, derived from numpy (see
+# https://github.com/MDAnalysis/mdanalysis/pull/1763#issuecomment-403231136)
+#
+# From numpy/lib/utils.py 1.14.5 (used under the BSD 3-clause licence,
+# https://www.numpy.org/license.html#license) and modified
+
+def _set_function_name(func, name):
+    func.__name__ = name
+    return func
+
+class _Deprecate(object):
+    """
+    Decorator class to deprecate old functions.
+
+    Refer to `deprecate` for details.
+
+    See Also
+    --------
+    deprecate
+
+
+    .. versionadded:: 0.19.0
+    """
+
+    def __init__(self, old_name=None, new_name=None,
+                 release=None, remove=None, message=None):
+        self.old_name = old_name
+        self.new_name = new_name
+        if release is None:
+            raise ValueError("deprecate: provide release in which "
+                             "feature was deprecated.")
+        self.release = str(release)
+        self.remove = str(remove) if remove is not None else remove
+        self.message = message
+
+    def __call__(self, func, *args, **kwargs):
+        """
+        Decorator call.  Refer to ``decorate``.
+
+        """
+        old_name = self.old_name
+        new_name = self.new_name
+        message = self.message
+        release = self.release
+        remove = self.remove
+
+        if old_name is None:
+            try:
+                old_name = func.__name__
+            except AttributeError:
+                old_name = func.__name__
+        if new_name is None:
+            depdoc = "`{0}` is deprecated!".format(old_name)
+        else:
+            depdoc = "`{0}` is deprecated, use `{1}` instead!".format(
+                old_name, new_name)
+
+        warn_message = depdoc
+
+        remove_text = ""
+        if remove is not None:
+            remove_text = "`{0}` will be removed in release {1}.".format(
+                old_name, remove)
+            warn_message += "\n" + remove_text
+        if message is not None:
+            warn_message += "\n" + message
+
+        def newfunc(*args, **kwds):
+            """This function is deprecated."""
+            warnings.warn(warn_message, DeprecationWarning, stacklevel=2)
+            return func(*args, **kwds)
+
+        newfunc = _set_function_name(newfunc, old_name)
+
+        # Build the doc string
+        # First line: func is deprecated, use newfunc instead!
+        # Normal docs follows.
+        # Last: .. deprecated::
+
+        # make sure that we do not mess up indentation, otherwise sphinx
+        # docs do not build properly
+        try:
+            doc = dedent_docstring(func.__doc__)
+        except TypeError:
+            doc = ""
+
+        deprecation_text = dedent_docstring("""\n\n
+        .. deprecated:: {0}
+           {1}
+           {2}
+        """.format(release,
+                   message if message else depdoc,
+                   remove_text))
+
+        doc = "{0}\n\n{1}\n{2}\n".format(depdoc, doc, deprecation_text)
+
+        newfunc.__doc__ = doc
+        try:
+            d = func.__dict__
+        except AttributeError:
+            pass
+        else:
+            newfunc.__dict__.update(d)
+        return newfunc
+
+def deprecate(*args, **kwargs):
+    """Issues a DeprecationWarning, adds warning to `old_name`'s
+    docstring, rebinds ``old_name.__name__`` and returns the new
+    function object.
+
+    This function may also be used as a decorator.
+
+    It adds a restructured text ``.. deprecated:: release`` block with
+    the sphinx deprecated role to the end of the docs. The `message`
+    is added under the deprecation block and contains the `release` in
+    which the function was deprecated.
+
+    Parameters
+    ----------
+    func : function
+        The function to be deprecated.
+    old_name : str, optional
+        The name of the function to be deprecated. Default is None, in
+        which case the name of `func` is used.
+    new_name : str, optional
+        The new name for the function. Default is None, in which case the
+        deprecation message is that `old_name` is deprecated. If given, the
+        deprecation message is that `old_name` is deprecated and `new_name`
+        should be used instead.
+    release : str
+        Release in which the function was deprecated. This is given as
+        a keyword argument for technical reasons but is required; a
+        :exc:`ValueError` is raised if it is missing.
+    remove : str, optional
+        Release for which removal of the feature is planned.
+    message : str, optional
+        Additional explanation of the deprecation.  Displayed in the
+        docstring after the warning.
+
+    Returns
+    -------
+    old_func : function
+        The deprecated function.
+
+    Examples
+    --------
+    When :func:`deprecate` is used as a function as in the following
+    example,
+
+    .. code-block:: python
+
+       oldfunc = deprecate(func, release="0.19.0", remove="1.0",
+                           message="Do it yourself instead.")
+
+    then ``oldfunc`` will return a value after printing
+    :exc:`DeprecationWarning`; ``func`` is still available as it was
+    before.
+
+    When used as a decorator, ``func`` will be changed and issue the
+    warning and contain the deprecation note in the do string.
+
+    .. code-block:: python
+
+       @deprecate(release="0.19.0", remove="1.0",
+                  message="Do it yourself instead.")
+       def func():
+           \"\"\"Just pass\"\"\"
+           pass
+
+    The resulting doc string (``help(func)``) will look like:
+
+    .. code-block:: reST
+
+       `func` is deprecated!
+
+       Just pass.
+
+       .. deprecated:: 0.19.0
+          Do it yourself instead.
+          `func` will be removed in 1.0.
+
+    (It is possible but confusing to change the name of ``func`` with
+    the decorator so it is not recommended to use the `new_func`
+    keyword argument with the decorator.)
+
+    .. versionadded:: 0.19.0
+
+    """
+    # Deprecate may be run as a function or as a decorator
+    # If run as a function, we initialise the decorator class
+    # and execute its __call__ method.
+
+    if args:
+        fn = args[0]
+        args = args[1:]
+        return _Deprecate(*args, **kwargs)(fn)
+    else:
+        return _Deprecate(*args, **kwargs)
+#
+#------------------------------------------------------------------
+
+def dedent_docstring(text):
+    """Dedent typical python doc string.
+
+    Parameters
+    ----------
+    text : str
+        string, typically something like ``func.__doc__``.
+
+    Returns
+    -------
+    str
+        string with the leading common whitespace removed from each
+        line
+
+    See Also
+    --------
+    textwrap.dedent
+
+
+    .. versionadded:: 0.19.0
+    """
+    lines = text.splitlines()
+    if len(lines) < 2:
+        return text.lstrip()
+
+    # treat first line as special (typically no leading whitespace!) which messes up dedent
+    return lines[0].lstrip() + "\n" + textwrap.dedent("\n".join(lines[1:]))
+
+

--- a/testsuite/MDAnalysisTests/lib/test_util.py
+++ b/testsuite/MDAnalysisTests/lib/test_util.py
@@ -26,6 +26,8 @@ from six.moves import range, StringIO
 import pytest
 import os
 import warnings
+import re
+import textwrap
 
 import numpy as np
 from numpy.testing import (assert_equal, assert_almost_equal,
@@ -1270,7 +1272,7 @@ class TestWarnIfNotUnique(object):
         @warn_if_not_unique
         def func(group):
             pass
-            
+
         class dummy(object):
             pass
 
@@ -1290,3 +1292,80 @@ class TestWarnIfNotUnique(object):
                 func(atoms)
                 assert not w.list
             assert len(record) == 0
+
+@pytest.mark.parametrize("old_name", (None, "MDAnalysis.Universe"))
+@pytest.mark.parametrize("new_name", (None, "Multiverse"))
+@pytest.mark.parametrize("remove", (None, "99.0.0", 2099))
+@pytest.mark.parametrize("message", (None, "use the new stuff"))
+def test_deprecate(old_name, new_name, remove, message, release="2.7.1"):
+    def AlternateUniverse(anything):
+        # important: first line needs to be """\ so that textwrap.dedent()
+        # works
+        """\
+        AlternateUniverse provides a true view of the Universe.
+
+        Parameters
+        ----------
+        anything : object
+
+        Returns
+        -------
+        truth
+
+        """
+        return True
+
+    oldfunc = util.deprecate(AlternateUniverse, old_name=old_name,
+                             new_name=new_name,
+                             release=release, remove=remove,
+                             message=message)
+    with pytest.warns(DeprecationWarning, match_expr="`.+` is deprecated"):
+        oldfunc(42)
+
+    doc = oldfunc.__doc__
+    name = old_name if old_name else AlternateUniverse.__name__
+
+    deprecation_line_1 = ".. deprecated:: {0}".format(release)
+    assert re.search(deprecation_line_1, doc)
+
+    if message:
+        deprecation_line_2 = message
+    else:
+        if new_name is None:
+            default_message = "`{0}` is deprecated!".format(name)
+        else:
+            default_message = "`{0}` is deprecated, use `{1}` instead!".format(
+                name, new_name)
+        deprecation_line_2 = default_message
+    assert re.search(deprecation_line_2, doc)
+
+    if remove:
+        deprecation_line_3 = "`{0}` will be removed in release {1}".format(
+            name,  remove)
+        assert re.search(deprecation_line_3, doc)
+
+    # check that the old docs are still present
+    assert re.search(textwrap.dedent(AlternateUniverse.__doc__), doc)
+
+
+def test_deprecate_missing_release_ValueError():
+    with pytest.raises(ValueError):
+        util.deprecate(mda.Universe)
+
+def test_set_function_name(name="bar"):
+    def foo():
+        pass
+    util._set_function_name(foo, name)
+    assert foo.__name__ == name
+
+@pytest.mark.parametrize("text",
+                         ("",
+                          "one line text",
+                          "  one line with leading space",
+                          "multiline\n\n   with some\n   leading space",
+                          "   multiline\n\n   with all\n   leading space"))
+def test_dedent_docstring(text):
+    doc = util.dedent_docstring(text)
+    for line in doc.splitlines():
+        assert line == line.lstrip()
+


### PR DESCRIPTION
Fix #1972 (preparation for #1745)

Changes made in this Pull Request:
 - deprecate `save()` methods in analysis classes (see #1972 )
 - add `lib.util.deprecate()`, which corrects some issues with the `numpy.lib.utils.deprecate()` function and produces nicer doc strings

PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
