### PR TITLE
AtomGroup.dimensions now always returns a copy

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -22,6 +22,7 @@ Enhancements
     (Issue #1753)
 
 Fixes
+  * AtomGroup.dimensions now strictly returns a copy (Issue #1582)
 
 
 01/24/18 richardjgowers, rathann, orbeckst, tylerjereddy, mtiberti, kain88-de,

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -590,7 +590,8 @@ class GroupBase(_MutableBase):
 
     @property
     def dimensions(self):
-        return self.universe.trajectory.ts.dimensions
+        """Obtain a copy of the dimensions of the currently loaded Timestep"""
+        return self.universe.trajectory.ts.dimensions.copy()
 
     @dimensions.setter
     def dimensions(self, dimensions):
@@ -1774,8 +1775,8 @@ class AtomGroup(GroupBase):
         implicitly combined with an or operator. For example
 
            >>> sel = universe.select_atoms('resname MET GLY')
-           
-        is equivalent to 
+
+        is equivalent to
 
            >>> sel = universe.select_atoms('resname MET or resname GLY')
 

--- a/testsuite/MDAnalysisTests/coordinates/test_timestep_api.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_timestep_api.py
@@ -27,6 +27,7 @@ _TestTimestepInterface tests the Readers are correctly using Timesteps
 """
 from __future__ import absolute_import
 
+import numpy as np
 from numpy.testing import assert_equal
 
 import MDAnalysis as mda
@@ -108,3 +109,28 @@ class TestBaseTimestepInterface(object):
 
     def test_dt(self, universe):
         assert_equal(universe.trajectory.dt, universe.trajectory.ts.dt)
+
+
+@pytest.mark.parametrize('uni', [
+    [(PSF, DCD), {}],  # base Timestep
+    [(DLP_CONFIG,), {'format': 'CONFIG'}],  # DLPoly
+    [(DMS,), {}],  # DMS
+    [(GRO,), {}],  # GRO
+    [(np.zeros((1, 30, 3)),), {}],  # memory
+    [(PRM, TRJ), {}],  # TRJ
+    [(TRZ_psf, TRZ), {}],  # TRZ
+])
+def test_atomgroup_dims_access(uni):
+    uni_args, uni_kwargs = uni
+    # check that AtomGroup.dimensions always returns a copy
+    u = mda.Universe(*uni_args, **uni_kwargs)
+
+    ag = u.atoms[:10]
+
+    dims = ag.dimensions
+    ts = u.trajectory.ts
+
+    # dimensions from AtomGroup should be equal
+    assert_equal(dims, ts.dimensions)
+    # but not identical
+    assert dims is not ts.dimensions


### PR DESCRIPTION
Fixes #1582

Changes made in this Pull Request:
 - AtomGroup.dimensions now always returns a copy


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
