### PR TITLE
Checking input array dtype for lib.distances.transform_StoR

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -95,6 +95,8 @@ Chronological list of authors
   - Micaela Matta
   - Jose Borreguero
   - Sören von Bülow
+2018
+  - Nabarun Pal
 
 External code
 -------------

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,7 +13,7 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-mm/dd/18 richardjgowers
+mm/dd/18 richardjgowers, palnabarun
 
   * 0.17.1
 
@@ -23,6 +23,7 @@ Enhancements
 
 Fixes
   * AtomGroup.dimensions now strictly returns a copy (Issue #1582)
+  * lib.distances.transform_StoR now checks input type (Issue #1699)
 
 
 01/24/18 richardjgowers, rathann, orbeckst, tylerjereddy, mtiberti, kain88-de,

--- a/package/MDAnalysis/lib/distances.py
+++ b/package/MDAnalysis/lib/distances.py
@@ -182,6 +182,11 @@ def _check_array(coords, desc):
     if (coords.ndim != 2 or coords.shape[1] != 3):
         raise ValueError("{0} must be a sequence of 3 dimensional coordinates"
                          "".format(desc))
+    _check_array_dtype(coords, desc)
+
+
+def _check_array_dtype(coords, desc):
+    """Check whether an array contains values of dtype: np.float32 or not"""
     if coords.dtype != np.float32:
         raise TypeError("{0} must be of type float32".format(desc))
 
@@ -473,7 +478,7 @@ def transform_StoR(inputcoords, box, backend="serial"):
     .. versionchanged:: 0.13.0
        Added *backend* keyword.
     """
-    _check_array(inputcoords, 'S')
+    _check_array_dtype(inputcoords, 'S')
     coords = inputcoords.copy('C')
 
     is_1d = False  # True if only one vector coordinate

--- a/package/MDAnalysis/lib/distances.py
+++ b/package/MDAnalysis/lib/distances.py
@@ -473,6 +473,7 @@ def transform_StoR(inputcoords, box, backend="serial"):
     .. versionchanged:: 0.13.0
        Added *backend* keyword.
     """
+    _check_array(inputcoords, 'S')
     coords = inputcoords.copy('C')
 
     is_1d = False  # True if only one vector coordinate

--- a/testsuite/MDAnalysisTests/lib/test_distances.py
+++ b/testsuite/MDAnalysisTests/lib/test_distances.py
@@ -1,0 +1,44 @@
+# -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 fileencoding=utf-8
+#
+# MDAnalysis --- https://www.mdanalysis.org
+# Copyright (c) 2006-2017 The MDAnalysis Development Team and contributors
+# (see the file AUTHORS for the full list of names)
+#
+# Released under the GNU Public Licence, v2 or any higher version
+#
+# Please cite your use of MDAnalysis in published work:
+#
+# R. J. Gowers, M. Linke, J. Barnoud, T. J. E. Reddy, M. N. Melo, S. L. Seyler,
+# D. L. Dotson, J. Domanski, S. Buchoux, I. M. Kenney, and O. Beckstein.
+# MDAnalysis: A Python package for the rapid analysis of molecular dynamics
+# simulations. In S. Benthall and S. Rostrup editors, Proceedings of the 15th
+# Python in Science Conference, pages 102-109, Austin, TX, 2016. SciPy.
+#
+# N. Michaud-Agrawal, E. J. Denning, T. B. Woolf, and O. Beckstein.
+# MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
+# J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
+#
+
+import pytest
+import numpy as np
+from numpy.testing import assert_equal
+
+import MDAnalysis as mda
+
+def test_transform_StoR_pass():
+    box = np.array([10, 7, 3, 45, 60, 90], dtype=np.float32)
+    s = np.array([[0.5, -0.1, 0.5]], dtype=np.float32)
+
+    original_r = np.array([[ 5.75,  0.36066014, 0.75000012]], dtype=np.float32)
+
+    test_r = mda.lib.distances.transform_StoR(s, box)
+
+    assert_equal(original_r, test_r)
+
+def test_transform_StoR_fail():
+    box = np.array([10, 7, 3, 45, 60, 90], dtype=np.float32)
+    s = np.array([[0.5, -0.1, 0.5]])
+
+    with pytest.raises(TypeError, match='S must be of type float32'):
+        r = mda.lib.distances.transform_StoR(s, box)


### PR DESCRIPTION
Fixes #1699 

Changes made in this Pull Request:
 - The input coordinate array is now checked for whether it is of type np.float32 or not
 - `lib.distances._check_array` is refactored
 - A new function `lib.distances._check_array_dtype` is introduced. This was done because `lib.distances._check_array` also checked for the dimensionality of input arrays which was failing test cases of `lib.test_pkdtree` as they pass on some 1D arrays.
 - Tests are written for `lib.distances` in `lin.test_distances` for testing the new changes.

PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
