### PR TITLE
reST formatting fixes

### DIFF
--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -776,10 +776,11 @@ class Masses(AtomAttr):
         center : ndarray
             center of group given masses as weights
 
-        Notes
-        -----
-            The :class:`MDAnalysis.core.flags` flag *use_pbc* when set to
-            ``True`` allows the *pbc* flag to be used by default.
+        Note
+        ----
+        The :class:`MDAnalysis.core.flags` flag *use_pbc* when set to
+        ``True`` allows the *pbc* flag to be used by default.
+
 
         .. versionchanged:: 0.8 Added `pbc` parameter
         """
@@ -808,11 +809,14 @@ class Masses(AtomAttr):
             If ``True``, move all atoms within the primary unit cell before
             calculation. [``False``]
 
-        .. note::
-            The :class:`MDAnalysis.core.flags` flag *use_pbc* when set to
-            ``True`` allows the *pbc* flag to be used by default.
+        Note
+        ----
+        The :class:`MDAnalysis.core.flags` flag *use_pbc* when set to
+        ``True`` allows the *pbc* flag to be used by default.
+
 
         .. versionchanged:: 0.8 Added *pbc* keyword
+
         """
         atomgroup = group.atoms
         pbc = kwargs.pop('pbc', flags['use_pbc'])
@@ -862,11 +866,14 @@ class Masses(AtomAttr):
             If ``True``, move all atoms within the primary unit cell before
             calculation. [``False``]
 
-        .. note::
-            The :class:`MDAnalysis.core.flags` flag *use_pbc* when set to
-            ``True`` allows the *pbc* flag to be used by default.
+        Note
+        ----
+        The :class:`MDAnalysis.core.flags` flag *use_pbc* when set to
+        ``True`` allows the *pbc* flag to be used by default.
+
 
         .. versionchanged:: 0.8 Added *pbc* keyword
+
         """
         atomgroup = group.atoms
         pbc = kwargs.pop('pbc', flags['use_pbc'])
@@ -889,7 +896,7 @@ class Masses(AtomAttr):
     def shape_parameter(group, **kwargs):
         """Shape parameter.
 
-        See [Dima2004]_ for background information.
+        See [Dima2004a]_ for background information.
 
         Parameters
         ----------
@@ -897,17 +904,24 @@ class Masses(AtomAttr):
             If ``True``, move all atoms within the primary unit cell before
             calculation. [``False``]
 
-        .. note::
-            The :class:`MDAnalysis.core.flags` flag *use_pbc* when set to
-            ``True`` allows the *pbc* flag to be used by default.
+        Note
+        ----
+        The :class:`MDAnalysis.core.flags` flag *use_pbc* when set to
+        ``True`` allows the *pbc* flag to be used by default.
 
-        .. [Dima2004] Dima, R. I., & Thirumalai, D. (2004). Asymmetry in the
-                  shapes of folded and denatured states of proteins. *J
-                  Phys Chem B*, 108(21),
-                  6564-6570. doi:`10.1021/jp037128y`_
+
+        References
+        ----------
+        .. [Dima2004a] Dima, R. I., & Thirumalai, D. (2004). Asymmetry
+           in the shapes of folded and denatured states of
+           proteins. *J Phys Chem B*, 108(21),
+           6564-6570. doi:`10.1021/jp037128y
+           <https://doi.org/10.1021/jp037128y>`_
+
 
         .. versionadded:: 0.7.7
         .. versionchanged:: 0.8 Added *pbc* keyword
+
         """
         atomgroup = group.atoms
         pbc = kwargs.pop('pbc', flags['use_pbc'])
@@ -935,7 +949,7 @@ class Masses(AtomAttr):
     def asphericity(group, pbc=None):
         """Asphericity.
 
-        See [Dima2004]_ for background information.
+        See [Dima2004b]_ for background information.
 
         Parameters
         ----------
@@ -944,17 +958,26 @@ class Masses(AtomAttr):
             calculation. If ``None`` use value defined in
             MDAnalysis.core.flags['use_pbc']
 
-        .. note::
-            The :class:`MDAnalysis.core.flags` flag *use_pbc* when set to
-            ``True`` allows the *pbc* flag to be used by default.
+        Note
+        ----
+        The :class:`MDAnalysis.core.flags` flag *use_pbc* when set to
+        ``True`` allows the *pbc* flag to be used by default.
 
-        .. [Dima2004] Dima, R. I., & Thirumalai, D. (2004). Asymmetry in the
-                  shapes of folded and denatured states of proteins. *J
-                  Phys Chem B*, 108(21),
-                  6564-6570. doi:`10.1021/jp037128y`_
+
+        References
+        ----------
+
+        .. [Dima2004b] Dima, R. I., & Thirumalai, D. (2004). Asymmetry
+           in the shapes of folded and denatured states of
+           proteins. *J Phys Chem B*, 108(21),
+           6564-6570. doi:`10.1021/jp037128y
+           <https://doi.org/10.1021/jp037128y>`_
+
+
 
         .. versionadded:: 0.7.7
         .. versionchanged:: 0.8 Added *pbc* keyword
+
         """
         atomgroup = group.atoms
         if pbc is None:
@@ -998,15 +1021,17 @@ class Masses(AtomAttr):
             If ``True``, move all atoms within the primary unit cell before
             calculation. If ``None`` use value defined in setup flags.
 
-        .. note::
-            The :class:`MDAnalysis.core.flags` flag *use_pbc* when set to
-            ``True`` allows the *pbc* flag to be used by default.
-
         Returns
         -------
         axis_vectors : array
             3 x 3 array with ``v[0]`` as first, ``v[1]`` as second, and
             ``v[2]`` as third eigenvector.
+
+        Note
+        ----
+        The :class:`MDAnalysis.core.flags` flag *use_pbc* when set to
+        ``True`` allows the *pbc* flag to be used by default.
+
 
         .. versionchanged:: 0.8 Added *pbc* keyword
 

--- a/package/MDAnalysis/units.py
+++ b/package/MDAnalysis/units.py
@@ -177,6 +177,11 @@ from __future__ import unicode_literals, division
 #:    6.02214179e+23 mol**-1 by -5.00000000e+16 mol**-1.
 N_Avogadro = 6.02214129e+23  # mol**-1
 
+#
+# NOTE: Whenever a constant is added to the constants dict, you also
+#       MUST add an appropriate entry to
+#       test_units:TestConstants.constants_reference !
+
 #: Values of physical constants are taken from `CODATA 2010 at NIST`_. The
 #: thermochemical calorie is defined in the `ISO 80000-5:2007`_ standard
 #: and is also listed in the `NIST Guide to SI: Appendix B.8: Factors for Units`_.
@@ -189,10 +194,6 @@ N_Avogadro = 6.02214129e+23  # mol**-1
 #:    http://physics.nist.gov/Pubs/SP811/appenB8.html#C
 #:
 #: .. versionadded:: 0.9.0
-#
-# NOTE: Whenever a constant is added to the constants dict, you also
-#       MUST add an appropriate entry to
-#       test_units:TestConstants.constants_reference !
 constants = {
     'N_Avogadro': 6.02214129e+23,          # mol**-1
     'elementary_charge': 1.602176565e-19,  # As


### PR DESCRIPTION
Fixes doc build failure after PR #1776 

Changes made in this Pull Request:
 - Fixes to the reST docs (numpy style) were necessary because the new Sphinx 1.7 is more stringent and flagged warnings (which we treat as errors).



PR Checklist
------------
 - n/a Tests?
 - [x] Docs?
 - n/a CHANGELOG updated?
 - [x] Issue raised/referenced?
