### PR TITLE
raise minimum scipy version to 1.0.0

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,7 +13,7 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-mm/dd/18 richardjgowers, palnabarun, bieniekmateusz, kain88-de
+mm/dd/18 richardjgowers, palnabarun, bieniekmateusz, kain88-de, orbeckst
 
   * 0.17.1
 
@@ -28,8 +28,12 @@ Fixes
   * lib.distances.transform_StoR now checks input type (Issue #1699)
   * libdcd now writes correct length of remark section (Issue #1701)
   * DCDReader now reports the correct time based on istart information (PR #1767)
+  * added requirement scipy >= 1.0.0 (absolutely needed: >= 0.19) (Issue #1775)
 
+Changes
+  * scipy >= 1.0.0 is now required (issue #1775 because of PR #1758)
 
+        
 01/24/18 richardjgowers, rathann, orbeckst, tylerjereddy, mtiberti, kain88-de,
          jbarnoud, nestorwendt, mmattaNU, jmborr, sobuelow, sseyler, rcortini,
          xiki-tempula, manuel.nuno.melo

--- a/package/setup.py
+++ b/package/setup.py
@@ -502,7 +502,7 @@ if __name__ == '__main__':
           cmdclass=cmdclass,
           requires=['numpy (>=1.10.4)', 'biopython', 'mmtf (>=1.0.0)',
                     'networkx (>=1.0)', 'GridDataFormats (>=0.3.2)', 'joblib',
-                    'scipy', 'matplotlib (>=1.5.1)'],
+                    'scipy (>=1.0.0)', 'matplotlib (>=1.5.1)'],
           # all standard requirements are available through PyPi and
           # typically can be installed without difficulties through setuptools
           setup_requires=[
@@ -517,7 +517,7 @@ if __name__ == '__main__':
               'six>=1.4.0',
               'mmtf-python>=1.0.0',
               'joblib',
-              'scipy',
+              'scipy>=1.0.0',
               'matplotlib>=1.5.1',
           ],
           # extras can be difficult to install through setuptools and/or


### PR DESCRIPTION
- fixes #1775
- We need scipy >= 0.19.0 for the directed Hausdorff distance that was
  added in PR #1758 but give the recent 1.0 release of scipy, we will
  simply depend on scipy >= 1.0.0
- only added scipy version information to package/setup.py; possibly todo:
  - [ ] conda recipe
  - [ ] pypi ??



PR Checklist
------------
 - n/a Tests?
 - n/a Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
