### PR TITLE
Add reindex option to write atom id to gro file

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,7 +13,8 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-mm/dd/18 richardjgowers, palnabarun, bieniekmateusz, kain88-de, orbeckst
+mm/dd/18 richardjgowers, palnabarun, bieniekmateusz, kain88-de, orbeckst,
+         Zhiyi Wu
 
   * 0.17.1
 
@@ -24,6 +25,8 @@ Enhancements
     (Issue #1029)
   * Added copy method to various core classes including Reader, TransTable,
     Topology, TopologyAttr (Issue #1029)
+  * Added `reindex` option to GROWriter to preserve original atom ids when set to
+    False (Issue #1777)
 
 Fixes
   * Fixed waterdynamics SurvivalProbability ignoring the t0 start time

--- a/package/MDAnalysis/coordinates/GRO.py
+++ b/package/MDAnalysis/coordinates/GRO.py
@@ -293,27 +293,28 @@ class GROWriter(base.WriterBase):
         convert_units : str (optional)
             units are converted to the MDAnalysis base format; ``None`` selects
             the value of :data:`MDAnalysis.core.flags` ['convert_lengths']
-        
+
         reindex : bool (optional)
             By default, all the atoms were reindexed to have a atom id starting
             from 1. [``True``] However, this behaviour can be turned off by
             specifying `reindex` ``=False``.
-            
+
         Note
         ----
-        To use the reindex keyword, user can follow the two examples given blow.::
-        
+        To use the reindex keyword, user can follow the two examples given
+        below.::
+
            u = mda.Universe()
-        
+
         Usage 1::
-        
+
            u.atoms.write('out.gro', reindex=False)
-        
+
         Usage 2::
-        
+
            with mda.Writer('out.gro', reindex=False) as w:
                w.write(u.atoms)
-               
+
         """
         self.filename = util.filename(filename, ext='gro')
         self.n_atoms = n_atoms

--- a/package/MDAnalysis/coordinates/GRO.py
+++ b/package/MDAnalysis/coordinates/GRO.py
@@ -293,6 +293,27 @@ class GROWriter(base.WriterBase):
         convert_units : str (optional)
             units are converted to the MDAnalysis base format; ``None`` selects
             the value of :data:`MDAnalysis.core.flags` ['convert_lengths']
+        
+        reindex : bool (optional)
+            By default, all the atoms were reindexed to have a atom id starting
+            from 1. [``True``] However, this behaviour can be turned off by
+            specifying `reindex` ``=False``.
+            
+        Note
+        ----
+        To use the reindex keyword, user can follow the two examples given blow.::
+        
+           u = mda.Universe()
+        
+        Usage 1::
+        
+           u.atoms.write('out.gro', reindex=False)
+        
+        Usage 2::
+        
+           with mda.Writer('out.gro', reindex=False) as w:
+               w.write(u.atoms)
+               
         """
         self.filename = util.filename(filename, ext='gro')
         self.n_atoms = n_atoms

--- a/package/MDAnalysis/coordinates/GRO.py
+++ b/package/MDAnalysis/coordinates/GRO.py
@@ -247,6 +247,20 @@ class GROWriter(base.WriterBase):
        Removed the `convert_dimensions_to_unitcell` method,
        use `Timestep.triclinic_dimensions` instead.
        Now now writes velocities where possible.
+    .. versionchanged:: 0.17.1
+       Now the user can choose to write gro file with specified atoms id.
+       The default option is to reindex all the atoms starting from 1.
+       However, this behaviour can be turned off by specifying `reindex=False`.
+       `u = mda.Universe()`
+
+       Usage 1:
+       `u.atoms.write('out.gro', reindex=False)`
+
+       Usage 2:
+       ```
+       with mda.Writer('out.gro', reindex=False) as w:
+           w.write(u.atoms)
+       ```
     """
 
     format = 'GRO'
@@ -348,12 +362,12 @@ class GROWriter(base.WriterBase):
 
         if not self.reindex:
             try:
-                atom_indexs = ag_or_ts.ids
+                atom_indices = ag_or_ts.ids
             except (AttributeError, NoDataError):
-                atom_indexs = range(1, ag_or_ts.n_atoms+1)
+                atom_indices = range(1, ag_or_ts.n_atoms+1)
                 missing_topology.append('ids')
         else:
-            atom_indexs = range(1, ag_or_ts.n_atoms + 1)
+            atom_indices = range(1, ag_or_ts.n_atoms + 1)
         if missing_topology:
             warnings.warn(
                 "Supplied AtomGroup was missing the following attributes: "
@@ -387,7 +401,7 @@ class GROWriter(base.WriterBase):
             # all attributes could be infinite cycles!
             for atom_index, resid, resname, name in zip(
                     range(ag_or_ts.n_atoms), resids, resnames, names):
-                truncated_atom_index = util.ltruncate_int(atom_indexs[atom_index], 5)
+                truncated_atom_index = util.ltruncate_int(atom_indices[atom_index], 5)
                 truncated_resid = util.ltruncate_int(resid, 5)
                 if has_velocities:
                     output_gro.write(self.fmt['xyz_v'].format(

--- a/package/MDAnalysis/coordinates/GRO.py
+++ b/package/MDAnalysis/coordinates/GRO.py
@@ -344,6 +344,15 @@ class GROWriter(base.WriterBase):
         except (AttributeError, NoDataError):
             resids = itertools.cycle((1,))
             missing_topology.append('resids')
+        reindex = True
+        if reindex:
+            try:
+                atom_indexs = ag_or_ts.ids
+            except (AttributeError, NoDataError):
+                atom_indexs = range(1, ag_or_ts.n_atoms+1)
+                missing_topology.append('ids')
+        else:
+            atom_indexs = range(1, ag_or_ts.n_atoms + 1)
         if missing_topology:
             warnings.warn(
                 "Supplied AtomGroup was missing the following attributes: "
@@ -377,7 +386,7 @@ class GROWriter(base.WriterBase):
             # all attributes could be infinite cycles!
             for atom_index, resid, resname, name in zip(
                     range(ag_or_ts.n_atoms), resids, resnames, names):
-                truncated_atom_index = util.ltruncate_int(atom_index + 1, 5)
+                truncated_atom_index = util.ltruncate_int(atom_indexs[atom_index], 5)
                 truncated_resid = util.ltruncate_int(resid, 5)
                 if has_velocities:
                     output_gro.write(self.fmt['xyz_v'].format(

--- a/package/MDAnalysis/coordinates/GRO.py
+++ b/package/MDAnalysis/coordinates/GRO.py
@@ -248,7 +248,7 @@ class GROWriter(base.WriterBase):
        use `Timestep.triclinic_dimensions` instead.
        Now now writes velocities where possible.
     .. versionchanged:: 0.17.1
-       Now the user can choose to write gro file with specified atoms id.
+       Now user can choose to write gro file with specified atom ids.
        The default option is to reindex all the atoms starting from 1.
        However, this behaviour can be turned off by specifying `reindex=False`.
        `u = mda.Universe()`

--- a/package/MDAnalysis/coordinates/GRO.py
+++ b/package/MDAnalysis/coordinates/GRO.py
@@ -282,6 +282,7 @@ class GROWriter(base.WriterBase):
         """
         self.filename = util.filename(filename, ext='gro')
         self.n_atoms = n_atoms
+        self.reindex = kwargs.pop('reindex', True)
 
         if convert_units is None:
             convert_units = flags['convert_lengths']
@@ -344,8 +345,8 @@ class GROWriter(base.WriterBase):
         except (AttributeError, NoDataError):
             resids = itertools.cycle((1,))
             missing_topology.append('resids')
-        reindex = True
-        if reindex:
+
+        if not self.reindex:
             try:
                 atom_indexs = ag_or_ts.ids
             except (AttributeError, NoDataError):

--- a/testsuite/CHANGELOG
+++ b/testsuite/CHANGELOG
@@ -13,10 +13,11 @@ Also see https://github.com/MDAnalysis/mdanalysis/wiki/MDAnalysisTests
 and https://github.com/MDAnalysis/mdanalysis/wiki/UnitTests
 
 ------------------------------------------------------------------------------
-01/24/18 sobuelow
+01/24/18 sobuelow, Zhiyi Wu
   * 0.17.0
     - Unit test for residue names in 'protein' atom selection (PR #1704)
     - Test for waterdynamics.SurvivalProbability starting time t0 (PR #1759)
+    - Add Tests for the reindex keyword of GROwriter (PR #1781)
 
 mm/dd/yy
 

--- a/testsuite/MDAnalysisTests/coordinates/test_gro.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_gro.py
@@ -419,56 +419,54 @@ def test_growriter_resid_truncation():
     # larger digits should get truncated
     assert line.startswith('56789UNK')
 
-class TestGrowriterReindex():
-    def __init__(self):
+class TestGrowriterReindex(Object):
+    @pytest.fixture
+    def u():
         gro = '''test
 1
     2CL      CL20850   0.000   0.000   0.000
 7.29748 7.66094 9.82962'''
-        self.u = mda.Universe(StringIO(gro), format='gro')
-        self.u.atoms[0].id = 3
+        u = mda.Universe(StringIO(gro), format='gro')
+        u.atoms[0].id = 3
+        return u
 
     @tempdir.run_in_tempdir()
     def test_growriter_resid_true(self):
-        self.u.atoms.write('temp.gro', reindex=True)
+        u().atoms.write('temp.gro', reindex=True)
 
         with open('temp.gro', 'r') as grofile:
             grofile.readline()
             grofile.readline()
             line = grofile.readline()
-        # larger digits should get truncated
         assert line.startswith('    2CL      CL    1')
 
     @tempdir.run_in_tempdir()
     def test_growriter_resid_false(self):
-        self.u.atoms.write('temp.gro', reindex=False)
+        u().atoms.write('temp.gro', reindex=False)
         with open('temp.gro', 'r') as grofile:
             grofile.readline()
             grofile.readline()
             line = grofile.readline()
-        # larger digits should get truncated
         assert line.startswith('    2CL      CL    3')
 
     @tempdir.run_in_tempdir()
     def test_writer_resid_false(self):
         with mda.Writer('temp.gro', reindex=False) as w:
-            w.write(self.u.atoms)
+            w.write(u().atoms)
         with open('temp.gro', 'r') as grofile:
             grofile.readline()
             grofile.readline()
             line = grofile.readline()
-        # larger digits should get truncated
         assert line.startswith('    2CL      CL    3')
 
     @tempdir.run_in_tempdir()
     def test_writer_resid_true(self):
         with mda.Writer('temp.gro', reindex=True) as w:
-            w.write(self.u.atoms)
+            w.write(u().atoms)
         with open('temp.gro', 'r') as grofile:
             grofile.readline()
             grofile.readline()
             line = grofile.readline()
-        # larger digits should get truncated
         assert line.startswith('    2CL      CL    1')
 
 class TestGROTimestep(BaseTimestepTest):

--- a/testsuite/MDAnalysisTests/coordinates/test_gro.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_gro.py
@@ -420,7 +420,7 @@ def test_growriter_resid_truncation():
     assert line.startswith('56789UNK')
 
 class TestGrowriterReindex(object):
-    @pytest.fixture
+    @pytest.fixture(scope='class')
     def u():
         gro = '''test
 1

--- a/testsuite/MDAnalysisTests/coordinates/test_gro.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_gro.py
@@ -419,7 +419,7 @@ def test_growriter_resid_truncation():
     # larger digits should get truncated
     assert line.startswith('56789UNK')
 
-class TestGrowriterReindex(Object):
+class TestGrowriterReindex(object):
     @pytest.fixture
     def u():
         gro = '''test

--- a/testsuite/MDAnalysisTests/coordinates/test_gro.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_gro.py
@@ -40,6 +40,7 @@ from numpy.testing import (
     assert_equal,
 )
 import pytest
+from six import StringIO
 
 
 class TestGROReaderOld(RefAdK):
@@ -418,6 +419,30 @@ def test_growriter_resid_truncation():
     # larger digits should get truncated
     assert line.startswith('56789UNK')
 
+@tempdir.run_in_tempdir()
+def test_growriter_resid_truncation():
+    gro = '''test
+1
+    2CL      CL20850   0.000   0.000   0.000
+7.29748 7.66094 9.82962'''
+    u = mda.Universe(StringIO(gro), format='gro')
+    u.atoms[0].id = 3
+    u.atoms.write('temp.gro', reindex=True)
+
+    with open('temp.gro', 'r') as grofile:
+        grofile.readline()
+        grofile.readline()
+        line = grofile.readline()
+    # larger digits should get truncated
+    assert line.startswith('    2CL      CL    1')
+
+    u.atoms.write('temp.gro', reindex=False)
+    with open('temp.gro', 'r') as grofile:
+        grofile.readline()
+        grofile.readline()
+        line = grofile.readline()
+    # larger digits should get truncated
+    assert line.startswith('    2CL      CL    3')
 
 class TestGROTimestep(BaseTimestepTest):
     Timestep = mda.coordinates.GRO.Timestep

--- a/testsuite/MDAnalysisTests/coordinates/test_gro.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_gro.py
@@ -419,9 +419,10 @@ def test_growriter_resid_truncation():
     # larger digits should get truncated
     assert line.startswith('56789UNK')
 
+@tempdir.run_in_tempdir()
 class TestGrowriterReindex(object):
-    @pytest.fixture(scope='class')
-    def u():
+    @pytest.fixture()
+    def u(self):
         gro = '''test
 1
     2CL      CL20850   0.000   0.000   0.000
@@ -430,9 +431,8 @@ class TestGrowriterReindex(object):
         u.atoms[0].id = 3
         return u
 
-    @tempdir.run_in_tempdir()
-    def test_growriter_resid_true(self):
-        u().atoms.write('temp.gro', reindex=True)
+    def test_growriter_resid_true(self, u):
+        u.atoms.write('temp.gro', reindex=True)
 
         with open('temp.gro', 'r') as grofile:
             grofile.readline()
@@ -440,29 +440,26 @@ class TestGrowriterReindex(object):
             line = grofile.readline()
         assert line.startswith('    2CL      CL    1')
 
-    @tempdir.run_in_tempdir()
-    def test_growriter_resid_false(self):
-        u().atoms.write('temp.gro', reindex=False)
+    def test_growriter_resid_false(self, u):
+        u.atoms.write('temp.gro', reindex=False)
         with open('temp.gro', 'r') as grofile:
             grofile.readline()
             grofile.readline()
             line = grofile.readline()
         assert line.startswith('    2CL      CL    3')
 
-    @tempdir.run_in_tempdir()
-    def test_writer_resid_false(self):
+    def test_writer_resid_false(self, u):
         with mda.Writer('temp.gro', reindex=False) as w:
-            w.write(u().atoms)
+            w.write(u.atoms)
         with open('temp.gro', 'r') as grofile:
             grofile.readline()
             grofile.readline()
             line = grofile.readline()
         assert line.startswith('    2CL      CL    3')
 
-    @tempdir.run_in_tempdir()
-    def test_writer_resid_true(self):
+    def test_writer_resid_true(self, u):
         with mda.Writer('temp.gro', reindex=True) as w:
-            w.write(u().atoms)
+            w.write(u.atoms)
         with open('temp.gro', 'r') as grofile:
             grofile.readline()
             grofile.readline()

--- a/testsuite/MDAnalysisTests/coordinates/test_gro.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_gro.py
@@ -419,30 +419,57 @@ def test_growriter_resid_truncation():
     # larger digits should get truncated
     assert line.startswith('56789UNK')
 
-@tempdir.run_in_tempdir()
-def test_growriter_resid_truncation():
-    gro = '''test
+class TestGrowriterReindex():
+    def __init__(self):
+        gro = '''test
 1
     2CL      CL20850   0.000   0.000   0.000
 7.29748 7.66094 9.82962'''
-    u = mda.Universe(StringIO(gro), format='gro')
-    u.atoms[0].id = 3
-    u.atoms.write('temp.gro', reindex=True)
+        self.u = mda.Universe(StringIO(gro), format='gro')
+        self.u.atoms[0].id = 3
 
-    with open('temp.gro', 'r') as grofile:
-        grofile.readline()
-        grofile.readline()
-        line = grofile.readline()
-    # larger digits should get truncated
-    assert line.startswith('    2CL      CL    1')
+    @tempdir.run_in_tempdir()
+    def test_growriter_resid_true(self):
+        self.u.atoms.write('temp.gro', reindex=True)
 
-    u.atoms.write('temp.gro', reindex=False)
-    with open('temp.gro', 'r') as grofile:
-        grofile.readline()
-        grofile.readline()
-        line = grofile.readline()
-    # larger digits should get truncated
-    assert line.startswith('    2CL      CL    3')
+        with open('temp.gro', 'r') as grofile:
+            grofile.readline()
+            grofile.readline()
+            line = grofile.readline()
+        # larger digits should get truncated
+        assert line.startswith('    2CL      CL    1')
+
+    @tempdir.run_in_tempdir()
+    def test_growriter_resid_false(self):
+        self.u.atoms.write('temp.gro', reindex=False)
+        with open('temp.gro', 'r') as grofile:
+            grofile.readline()
+            grofile.readline()
+            line = grofile.readline()
+        # larger digits should get truncated
+        assert line.startswith('    2CL      CL    3')
+
+    @tempdir.run_in_tempdir()
+    def test_writer_resid_false(self):
+        with mda.Writer('temp.gro', reindex=False) as w:
+            w.write(self.u.atoms)
+        with open('temp.gro', 'r') as grofile:
+            grofile.readline()
+            grofile.readline()
+            line = grofile.readline()
+        # larger digits should get truncated
+        assert line.startswith('    2CL      CL    3')
+
+    @tempdir.run_in_tempdir()
+    def test_writer_resid_true(self):
+        with mda.Writer('temp.gro', reindex=True) as w:
+            w.write(self.u.atoms)
+        with open('temp.gro', 'r') as grofile:
+            grofile.readline()
+            grofile.readline()
+            line = grofile.readline()
+        # larger digits should get truncated
+        assert line.startswith('    2CL      CL    1')
 
 class TestGROTimestep(BaseTimestepTest):
     Timestep = mda.coordinates.GRO.Timestep


### PR DESCRIPTION
Fixes #1777 
Can I have some advice on which doc should I change? 
Should I only change https://www.mdanalysis.org/docs/documentation_pages/coordinates/GRO.html
or should I mention it on other writer pages? 
Suggestions are welcomed.

Changes made in this Pull Request:
 - 
```python
from MDAnalysis import Universe
from six import StringIO
gro = '''test
1
    2CL      CL20850   0.000   0.000   0.000
7.29748 7.66094 9.82962'''
u = Universe(StringIO(gro), format='gro')
u.atoms[0].id = 3
u.atoms.write('temp.gro', reindex=False)
```
Gives
```
test
1
    2CL      CL    3   0.000   0.000   0.000
7.29748 7.66094 9.82962
```

While
```python
from MDAnalysis import Universe
from six import StringIO
gro = '''test
1
    2CL      CL20850   0.000   0.000   0.000
7.29748 7.66094 9.82962'''
u = Universe(StringIO(gro), format='gro')
u.atoms[0].id = 3
u.atoms.write('temp.gro', reindex=True)
```
Gives
```
test
1
    2CL      CL    1   0.000   0.000   0.000
7.29748 7.66094 9.82962
```

PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
