### PR TITLE
added 'periodic' keyword to select_atoms

### DIFF
--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -2020,7 +2020,7 @@ class AtomGroup(GroupBase):
             warnings.warn(
                 'Periodic selection requested but no box information was '
                 'available.  Box information can be set via the dimensions '
-                'attribute.  Reverting to non periodic selection.'
+                'attribute.  Reverting to non periodic selection.',
                 UserWarning)
 
         if updating:

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -1992,34 +1992,36 @@ class AtomGroup(GroupBase):
         .. versionadded:: 0.17.0
            Added *moltype* and *molnum* selections.
         .. versionchanged:: 0.17.1
-           Added ``periodic`` and ``use_kdtree`` keyword arguments
+           Added ``periodic`` and ``kdtree`` keyword arguments
         """
         updating = selgroups.pop('updating', False)
         # TODO: When removing flags, change this to default
         periodic = selgroups.pop('periodic', flags['use_periodic_selections'])
         # check to see if system is actually periodic
+        forced_unperiodic = False
         if periodic:
             # Universe without traj has no dimensions
             if hasattr(self, 'dimensions') and any(self.dimensions == 0.0):
                 periodic = False
                 # remember that we forced periodic to False
                 # if we later do a distance selection, warn about this
-                missing_box = True
-            else:
-                missing_box = False
+                force_unperiodic = True
 
-        use_kdtree = selgroups.pop('use_kdtree', None)
+        kdtree = selgroups.pop('kdtree', None)
 
         sel_strs = (sel,) + othersel
         selections = tuple((selection.Parser.parse(s, selgroups,
                                                    periodic=periodic,
-                                                   use_kdtree=use_kdtree)
+                                                   kdtree=kdtree)
                             for s in sel_strs))
-
-        if missing_box and any(isinstance(s, selection.DistanceSelection)
+        # if we forced an unperoidic selection, check if we did distance
+        if forced_unperiodic and any(isinstance(s, selection.DistanceSelection)
                                for s in selections):
-            warnings.warn('Periodic selection on non periodic system',
-                          UserWarning)
+            warnings.warn(
+                'Periodic selection requested but no box information was '
+                'available.  Box information can be set via the dimensions '
+                'attribute.  Reverting to non periodic selection.'
+                UserWarning)
 
         if updating:
             atomgrp = UpdatingAtomGroup(self, selections, sel_strs)

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -1994,8 +1994,12 @@ class AtomGroup(GroupBase):
 
         """
         updating = selgroups.pop('updating', False)
+        periodic = selgroups.pop('periodic', flags['use_periodic_selections'])
+
         sel_strs = (sel,) + othersel
-        selections = tuple((selection.Parser.parse(s, selgroups)
+        selections = tuple((selection.Parser.parse(s,
+                                                   periodic=periodic,
+                                                   selgroups=selgroups)
                             for s in sel_strs))
         if updating:
             atomgrp = UpdatingAtomGroup(self, selections, sel_strs)

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -1994,12 +1994,13 @@ class AtomGroup(GroupBase):
 
         """
         updating = selgroups.pop('updating', False)
-        periodic = selgroups.pop('periodic', flags['use_periodic_selections'])
+        periodic = selgroups.pop('periodic', None)
+        use_kdtree = selgroups.pop('use_kdtree', None)
 
         sel_strs = (sel,) + othersel
-        selections = tuple((selection.Parser.parse(s,
+        selections = tuple((selection.Parser.parse(s, selgroups,
                                                    periodic=periodic,
-                                                   selgroups=selgroups)
+                                                   use_kdtree=use_kdtree)
                             for s in sel_strs))
         if updating:
             atomgrp = UpdatingAtomGroup(self, selections, sel_strs)

--- a/package/MDAnalysis/core/selection.py
+++ b/package/MDAnalysis/core/selection.py
@@ -284,8 +284,11 @@ class AroundSelection(DistanceSelection):
             for atom in sel.positions:
                 kdtree.search(atom, self.cutoff)
                 found_indices.append(kdtree.get_indices())
-            unique_idx = np.unique(np.concatenate(found_indices))
-
+            # avoid concatenating an empty list
+            if found_indices:
+                unique_idx = np.unique(np.concatenate(found_indices))
+            else:
+                unique_idx = np.array([])
         else:
             kdtree = PeriodicKDTree(box, bucket_size=10)
             kdtree.set_coords(sys.positions)

--- a/package/MDAnalysis/core/selection.py
+++ b/package/MDAnalysis/core/selection.py
@@ -393,7 +393,7 @@ class SphericalZoneSelection(DistanceSelection):
         return group[idx].unique
 
 
-class CylindricalSelection(Selection):
+class CylindricalSelection(DistanceSelection):
     def __init__(self, periodic):
         self.periodic = periodic
 

--- a/package/MDAnalysis/core/selection.py
+++ b/package/MDAnalysis/core/selection.py
@@ -239,9 +239,6 @@ class DistanceSelection(Selection):
             self.apply = self._apply_distmat
 
         self.periodic = periodic
-        # KDTree doesn't support periodic
-        if self.periodic:
-            self.apply = self._apply_distmat
 
     def validate_dimensions(self, dimensions):
         r"""Check if the system is periodic in all three-dimensions.

--- a/package/MDAnalysis/core/selection.py
+++ b/package/MDAnalysis/core/selection.py
@@ -1212,10 +1212,10 @@ class SelectionParser(object):
         selgroups : dict
           mapping of name to AtomGroup for atomgroups to be used in
           `group` selections
-        periodic : bool
+        periodic : bool, optional
           for distance based selections, whether to consider periodic
           boundaries in calculations.
-        use_kdtree : bool
+        use_kdtree : bool, optional
           for distance based selections, whether to use KDTree based
           methods
 

--- a/package/MDAnalysis/core/selection.py
+++ b/package/MDAnalysis/core/selection.py
@@ -264,7 +264,7 @@ class AroundSelection(DistanceSelection):
 
     def __init__(self, parser, tokens):
         super(AroundSelection, self).__init__(
-            periodic=parser.periodic, kdtree=parser.use_kdtree)
+            periodic=parser.periodic, kdtree=parser.kdtree)
         self.cutoff = float(tokens.popleft())
         self.sel = parser.parse_expression(self.precedence)
 
@@ -322,7 +322,7 @@ class SphericalLayerSelection(DistanceSelection):
 
     def __init__(self, parser, tokens):
         super(SphericalLayerSelection, self).__init__(
-            periodic=parser.periodic, kdtree=parser.use_kdtree)
+            periodic=parser.periodic, kdtree=parser.kdtree)
         self.inRadius = float(tokens.popleft())
         self.exRadius = float(tokens.popleft())
         self.sel = parser.parse_expression(self.precedence)
@@ -367,7 +367,7 @@ class SphericalZoneSelection(DistanceSelection):
 
     def __init__(self, parser, tokens):
         super(SphericalZoneSelection, self).__init__(
-            periodic=parser.periodic, kdtree=parser.use_kdtree)
+            periodic=parser.periodic, kdtree=parser.kdtree)
         self.cutoff = float(tokens.popleft())
         self.sel = parser.parse_expression(self.precedence)
 
@@ -493,7 +493,7 @@ class PointSelection(DistanceSelection):
 
     def __init__(self, parser, tokens):
         super(PointSelection, self).__init__(
-            periodic=parser.periodic, kdtree=parser.use_kdtree)
+            periodic=parser.periodic, kdtree=parser.kdtree)
         x = float(tokens.popleft())
         y = float(tokens.popleft())
         z = float(tokens.popleft())
@@ -1211,7 +1211,7 @@ class SelectionParser(object):
                 "".format(self.tokens[0], token))
 
     def parse(self, selectstr, selgroups,
-              periodic=None, use_kdtree=None):
+              periodic=None, kdtree=None):
         """Create a Selection object from a string.
 
         Parameters
@@ -1224,7 +1224,7 @@ class SelectionParser(object):
         periodic : bool, optional
           for distance based selections, whether to consider periodic
           boundaries in calculations.
-        use_kdtree : bool, optional
+        kdtree : bool, optional
           for distance based selections, whether to use KDTree based
           methods
 
@@ -1246,10 +1246,10 @@ class SelectionParser(object):
             periodic = flags['use_periodic_selections']
         self.periodic = periodic
 
-        if use_kdtree is None:
+        if kdtree is None:
             # TODO: Once flags are removed, change the default to live here
-            use_kdtree = flags['use_KDTree_routines'] in (True, 'fast', 'always')
-        self.use_kdtree = use_kdtree
+            kdtree = flags['use_KDTree_routines'] in (True, 'fast', 'always')
+        self.kdtree = kdtree
 
         tokens = selectstr.replace('(', ' ( ').replace(')', ' ) ')
         self.tokens = collections.deque(tokens.split() + [None])

--- a/package/MDAnalysis/core/selection.py
+++ b/package/MDAnalysis/core/selection.py
@@ -276,6 +276,10 @@ class AroundSelection(DistanceSelection):
         # All atoms in group that aren't in sel
         sys = group[~np.in1d(group.indices, sel.indices)]
 
+        # if sys is empty, return empty AtomGroup
+        if not sys:
+            return sys[[]]
+
         box = self.validate_dimensions(group.dimensions)
         if box is None:
             kdtree = KDTree(dim=3, bucket_size=10)

--- a/package/MDAnalysis/core/selection.py
+++ b/package/MDAnalysis/core/selection.py
@@ -401,10 +401,12 @@ class SphericalZoneSelection(DistanceSelection):
 
 
 class CylindricalSelection(DistanceSelection):
+    # If _apply_KDTree method added, pass this in super.__init__
     def __init__(self, periodic):
-        self.periodic = periodic
+        super(CylindricalSelection, self).__init__(
+            periodic=periodic, kdtree=False)
 
-    def apply(self, group):
+    def _apply_distmat(self, group):
         sel = self.sel.apply(group)
 
         # Calculate vectors between point of interest and our group

--- a/testsuite/MDAnalysisTests/core/test_atomselections.py
+++ b/testsuite/MDAnalysisTests/core/test_atomselections.py
@@ -1037,3 +1037,24 @@ def test_kdtree_around_empty():
                        use_kdtree=True, periodic=True)
     assert mp.called
 
+
+def test_kdtree_around_single_atom():
+    # around selection where SYS is empty
+    u = make_Universe(('names',), trajectory=True)
+
+    ag = u.atoms[[0]]
+    ag.names = 'X'
+
+    ag2 = ag.select_atoms('around 2.0 name X',
+                          use_kdtree=True, periodic=True)
+
+    assert isinstance(ag2, mda.core.groups.AtomGroup)
+    assert len(ag2) == 0
+
+    # check that _apply_KDTree (target of test) was used
+    with mock.patch.object(
+            mda.core.selection.AroundSelection, '_apply_KDTree') as mp:
+        u.select_atoms('around 2.0 name X',
+                       use_kdtree=True, periodic=True)
+    assert mp.called
+

--- a/testsuite/MDAnalysisTests/core/test_atomselections.py
+++ b/testsuite/MDAnalysisTests/core/test_atomselections.py
@@ -28,6 +28,7 @@ import numpy as np
 from numpy.testing import(
     assert_equal,
 )
+import mock
 
 import MDAnalysis
 import MDAnalysis as mda
@@ -1019,3 +1020,20 @@ class TestICodeSelection(object):
         u = make_Universe(('resids',))
         with pytest.raises(ValueError):
             u.select_atoms('resid 10A-12')
+
+
+def test_kdtree_around_empty():
+    u = make_Universe(('names',), trajectory=True)
+
+    ag = u.select_atoms('name X and around 2.0 name Y',
+                        use_kdtree=True, periodic=True)
+    assert isinstance(ag, mda.core.groups.AtomGroup)
+    assert len(ag) == 0
+
+    # check that _apply_KDTree (target of test) was used
+    with mock.patch.object(
+            mda.core.selection.AroundSelection, '_apply_KDTree') as mp:
+        u.select_atoms('name X and around 2.0 name Y',
+                       use_kdtree=True, periodic=True)
+    assert mp.called
+


### PR DESCRIPTION
Fixes #759

Changes made in this Pull Request:
 - adds `periodic` and `use_kdtree` kwargs to `select_atoms`

For now, defaults are still defined by `flags`, so setting flag behaviour and not using these kwargs will give the "old" behaviour.  Once we rip out flags, the kwargs are now in place though

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
