### PR TITLE
Adds cylayer and cyzone to docstring of AtomGroup.select_atoms

### DIFF
--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -1924,10 +1924,6 @@ class AtomGroup(GroupBase):
                 cylinder of external radius 15 centered on the COG. In z, the
                 cylinder extends from 4 above the COG to 8 below. Positive
                 values for *zMin*, or negative ones for *zMax*, are allowed.
-                .. versionchanged:: 0.10.0
-                   keywords *cyzone* and *cylayer* now take *zMax* and *zMin*
-                   to be relative to the COG of *selection*, instead of
-                   absolute z-values in the box.
 
         **Connectivity**
 

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -1908,6 +1908,26 @@ class AtomGroup(GroupBase):
             sphlayer *inner radius* *outer radius* *selection*
                 Similar to sphzone, but also excludes atoms that are within
                 *inner radius* of the selection COG
+            cylayer *innerRadius* *externalRadius* *zMax* *zMin* *selection*
+                selects all atoms within a cylindric layer centered in the
+                center of geometry (COG) of a given selection,
+                e.g. ``cylayer 5 10 10 -8 protein`` selects the center of
+                geometry of protein, and creates a cylindrical layer of inner
+                radius 5, external radius 10 centered on the COG. In z, the
+                cylinder extends from 10 above the COG to 8 below. Positive
+                values for *zMin*, or negative ones for *zMax*, are allowed.
+            cyzone *externalRadius* *zMax* *zMin* *selection*
+                selects all atoms within a cylindric zone centered in the
+                center of geometry (COG) of a given selection,
+                e.g. ``cyzone 15 4 -8 protein and resid 42`` selects the
+                center of geometry of protein and resid 42, and creates a
+                cylinder of external radius 15 centered on the COG. In z, the
+                cylinder extends from 4 above the COG to 8 below. Positive
+                values for *zMin*, or negative ones for *zMax*, are allowed.
+                .. versionchanged:: 0.10.0
+                   keywords *cyzone* and *cylayer* now take *zMax* and *zMin*
+                   to be relative to the COG of *selection*, instead of
+                   absolute z-values in the box.
 
         **Connectivity**
 

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -2007,6 +2007,8 @@ class AtomGroup(GroupBase):
            Updating selections now possible by setting the ``updating`` argument.
         .. versionadded:: 0.17.0
            Added *moltype* and *molnum* selections.
+        .. versionchanged:: 0.17.1
+           Added *cylayer* and *cyzone* selections.
 
         """
         updating = selgroups.pop('updating', False)

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -1908,14 +1908,6 @@ class AtomGroup(GroupBase):
             sphlayer *inner radius* *outer radius* *selection*
                 Similar to sphzone, but also excludes atoms that are within
                 *inner radius* of the selection COG
-            cylayer *innerRadius* *externalRadius* *zMax* *zMin* *selection*
-                selects all atoms within a cylindric layer centered in the
-                center of geometry (COG) of a given selection,
-                e.g. ``cylayer 5 10 10 -8 protein`` selects the center of
-                geometry of protein, and creates a cylindrical layer of inner
-                radius 5, external radius 10 centered on the COG. In z, the
-                cylinder extends from 10 above the COG to 8 below. Positive
-                values for *zMin*, or negative ones for *zMax*, are allowed.
             cyzone *externalRadius* *zMax* *zMin* *selection*
                 selects all atoms within a cylindric zone centered in the
                 center of geometry (COG) of a given selection,
@@ -1923,6 +1915,14 @@ class AtomGroup(GroupBase):
                 center of geometry of protein and resid 42, and creates a
                 cylinder of external radius 15 centered on the COG. In z, the
                 cylinder extends from 4 above the COG to 8 below. Positive
+                values for *zMin*, or negative ones for *zMax*, are allowed.
+            cylayer *innerRadius* *externalRadius* *zMax* *zMin* *selection*
+                selects all atoms within a cylindric layer centered in the
+                center of geometry (COG) of a given selection,
+                e.g. ``cylayer 5 10 10 -8 protein`` selects the center of
+                geometry of protein, and creates a cylindrical layer of inner
+                radius 5, external radius 10 centered on the COG. In z, the
+                cylinder extends from 10 above the COG to 8 below. Positive
                 values for *zMin*, or negative ones for *zMax*, are allowed.
 
         **Connectivity**

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -2007,8 +2007,6 @@ class AtomGroup(GroupBase):
            Updating selections now possible by setting the ``updating`` argument.
         .. versionadded:: 0.17.0
            Added *moltype* and *molnum* selections.
-        .. versionchanged:: 0.17.1
-           Added *cylayer* and *cyzone* selections.
 
         """
         updating = selgroups.pop('updating', False)


### PR DESCRIPTION
Fixes #1788 

Changes made in this Pull Request:
 - Adds to docstring of `AtomGroup.select_atoms`


PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?
