### PR TITLE
Added custom atom_style to Lammps data parser

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -27,6 +27,9 @@ Enhancements
     Topology, TopologyAttr (Issue #1029)
   * Added `reindex` option to GROWriter to preserve original atom ids when set to
     False (Issue #1777)
+  * Can now pass 'atom_style' keyword argument when parsing Lammps Data files
+    to specify what is on each line.  Eg atom_style = 'id type charge x y z'
+    (Issue #1791)
 
 Fixes
   * Fixed waterdynamics SurvivalProbability ignoring the t0 start time

--- a/package/MDAnalysis/coordinates/GRO.py
+++ b/package/MDAnalysis/coordinates/GRO.py
@@ -28,6 +28,26 @@ Classes to read and write Gromacs_ GRO_ coordinate files; see the notes on the
 `GRO format`_ which includes a conversion routine for the box.
 
 
+Writing GRO files
+-----------------
+
+By default any written GRO files will renumber the atom ids to move sequentially
+from 1.  This can be disabled, and instead the original atom ids kept, by
+using the `reindex=False` keyword argument.  This is useful when writing a
+subsection of a larger Universe while wanting to preserve the original
+identities of atoms.
+
+For example::
+
+   >>> u = mda.Universe()`
+
+   >>> u.atoms.write('out.gro', reindex=False)
+
+   # OR
+   >>> with mda.Writer('out.gro', reindex=False) as w:
+   ...     w.write(u.atoms)
+
+
 Classes
 -------
 
@@ -248,19 +268,8 @@ class GROWriter(base.WriterBase):
        use `Timestep.triclinic_dimensions` instead.
        Now now writes velocities where possible.
     .. versionchanged:: 0.17.1
-       Now user can choose to write gro file with specified atom ids.
-       The default option is to reindex all the atoms starting from 1.
-       However, this behaviour can be turned off by specifying `reindex=False`.
-       `u = mda.Universe()`
-
-       Usage 1:
-       `u.atoms.write('out.gro', reindex=False)`
-
-       Usage 2:
-       ```
-       with mda.Writer('out.gro', reindex=False) as w:
-           w.write(u.atoms)
-       ```
+       Added `reindex` keyword argument to allow original atom
+       ids to be kept.
     """
 
     format = 'GRO'

--- a/package/MDAnalysis/coordinates/LAMMPS.py
+++ b/package/MDAnalysis/coordinates/LAMMPS.py
@@ -45,6 +45,13 @@ keywords *timeunit* and/or *lengthunit* to :class:`DCDWriter` and
 :class:`~MDAnalysis.core.universe.Universe` (which then calls
 :class:`DCDReader`).
 
+Data file formats
+-----------------
+
+By default either the `atomic` or `full` atom styles are expected,
+however this can be customised, see :ref:`atom_style`.
+
+
 Example: Loading a LAMMPS simulation
 ------------------------------------
 

--- a/package/MDAnalysis/coordinates/LAMMPS.py
+++ b/package/MDAnalysis/coordinates/LAMMPS.py
@@ -49,7 +49,7 @@ Data file formats
 -----------------
 
 By default either the `atomic` or `full` atom styles are expected,
-however this can be customised, see :ref:`atom_style`.
+however this can be customised, see :ref:`atom_style_kwarg`.
 
 
 Example: Loading a LAMMPS simulation

--- a/package/MDAnalysis/coordinates/LAMMPS.py
+++ b/package/MDAnalysis/coordinates/LAMMPS.py
@@ -188,12 +188,13 @@ class DATAReader(base.SingleFrameReaderBase):
         self.n_atoms = kwargs.pop('n_atoms', None)
         if self.n_atoms is None:  # this should be done by parsing DATA first
             raise ValueError("DATAReader requires n_atoms keyword")
+        self.atom_style = kwargs.pop('atom_style', None)
         super(DATAReader, self).__init__(filename, **kwargs)
 
     def _read_first_frame(self):
         with DATAParser(self.filename) as p:
             self.ts = p.read_DATA_timestep(self.n_atoms, self._Timestep,
-                                           self._ts_kwargs)
+                                           self._ts_kwargs, self.atom_style)
 
         self.ts.frame = 0
         if self.convert_units:

--- a/package/MDAnalysis/topology/LAMMPSParser.py
+++ b/package/MDAnalysis/topology/LAMMPSParser.py
@@ -329,8 +329,8 @@ class DATAParser(TopologyReaderBase):
 
         try:
             positions, ordering = self._parse_pos(sects['Atoms'])
-        except KeyError as k:
-            raise IOError("Position information not found: {}".format(k))
+        except KeyError as err:
+            raise IOError("Position information not found: {}".format(err))
 
         if 'Velocities' in sects:
             velocities = self._parse_vel(sects['Velocities'], ordering)

--- a/package/MDAnalysis/topology/LAMMPSParser.py
+++ b/package/MDAnalysis/topology/LAMMPSParser.py
@@ -24,13 +24,13 @@
 LAMMPSParser
 ============
 
-Parses data files_ produced by LAMMPS_.
+Parses data_ files produced by LAMMPS_.
 
 .. _LAMMPS: http://lammps.sandia.gov/
-.. _files DATA file format: :http://lammps.sandia.gov/doc/2001/data_format.html
+.. _data: DATA file format: :http://lammps.sandia.gov/doc/2001/data_format.html
 
 
-.. _atom_style:
+.. _atom_style_kwarg:
 
 Atom styles
 -----------
@@ -178,7 +178,7 @@ class DATAParser(TopologyReaderBase):
 
     By default the parser expects either *atomic* or *full* `atom_style`
     however this can be by passing an `atom_style` keyword argument,
-    see :ref:`atom_style`.
+    see :ref:`atom_style_kwarg`.
 
     .. versionadded:: 0.9.0
     """

--- a/package/MDAnalysis/topology/LAMMPSParser.py
+++ b/package/MDAnalysis/topology/LAMMPSParser.py
@@ -24,9 +24,39 @@
 LAMMPSParser
 ============
 
-Parses data files for LAMMPS_.
+Parses data files_ produced by LAMMPS_.
 
 .. _LAMMPS: http://lammps.sandia.gov/
+.. _files DATA file format: :http://lammps.sandia.gov/doc/2001/data_format.html
+
+
+.. _atom_style:
+
+Atom styles
+-----------
+
+By default parsers and readers for Lammps data files expect either an
+*atomic* or *full* `atom_style`_.  This can be customised by passing
+the `atom_style` keyword argument.  This should be a space separated
+string indicating the position of the `id`, `type`, `resid`, `charge`,
+`x`, `y` and `z` fields.  The `resid` and `charge` fields are optional
+and any other specified field will be ignored.
+
+For example to read a file with the following format, where there is no resid::
+
+  Atoms # atomic
+
+  1 1 3.7151744275286681e+01 1.8684434743140471e+01 1.9285127961842125e+01 0 0 0
+
+
+The following code could be used::
+
+  >>> import MDAnalysis as mda
+  >>>
+  >>> u = mda.Universe('myfile.data', atom_style='id type x y z')
+
+
+.. _`atom_style`: http://lammps.sandia.gov/doc/atom_style.html
 
 Classes
 -------
@@ -140,18 +170,15 @@ HEADERS = set([
 class DATAParser(TopologyReaderBase):
     """Parse a LAMMPS DATA file for topology and coordinates.
 
-    Note that LAMMPS_ DATA files can be used standalone.
+    Note that LAMMPS DATA files can be used standalone.
 
     Both topology and coordinate parsing functionality is kept in this
     class as the topology and coordinate reader share many common
     functions
 
-    The parser implements the `LAMMPS DATA file format`_ but only for
-    the LAMMPS `atom_style`_ *full* (numeric ids 7, 10) and
-    *molecular* (6, 9).
-
-    .. _LAMMPS DATA file format: :http://lammps.sandia.gov/doc/2001/data_format.html
-    .. _`atom_style`: http://lammps.sandia.gov/doc/atom_style.html
+    By default the parser expects either *atomic* or *full* `atom_style`
+    however this can be by passing an `atom_style` keyword argument,
+    see :ref:`atom_style`.
 
     .. versionadded:: 0.9.0
     """

--- a/package/MDAnalysis/topology/LAMMPSParser.py
+++ b/package/MDAnalysis/topology/LAMMPSParser.py
@@ -304,7 +304,8 @@ class DATAParser(TopologyReaderBase):
 
         return top
 
-    def read_DATA_timestep(self, n_atoms, TS_class, TS_kwargs, atom_style):
+    def read_DATA_timestep(self, n_atoms, TS_class, TS_kwargs,
+                           atom_style=None):
         """Read a DATA file and try and extract x, v, box.
 
         - positions
@@ -314,6 +315,8 @@ class DATAParser(TopologyReaderBase):
         Fills this into the Timestep object and returns it
 
         .. versionadded:: 0.9.0
+        .. versionchanged:: 0.17.1
+           Added atom_style kwarg
         """
         if atom_style is None:
             self.style_dict = None


### PR DESCRIPTION
Fixes #1791

Changes made in this Pull Request:
 - Can now pass 'atom_style' keyword argument when parsing Lammps Data files  to specify what is on each line.  Eg atom_style = 'id type charge x y z'


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
