### PR TITLE
Fixed MPI fork() warning when importing MDAnalysis after MPI_Init() call

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -99,6 +99,8 @@ Chronological list of authors
   - Nabarun Pal
   - Mateusz Bieniek
   - Navya Khare
+  - Johannes Zeman
+
 
 External code
 -------------

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -14,7 +14,7 @@ The rules for this file:
 
 ------------------------------------------------------------------------------
 mm/dd/18 richardjgowers, palnabarun, bieniekmateusz, kain88-de, orbeckst,
-         xiki-tempula, navyakhare
+         xiki-tempula, navyakhare, zemanj
 
   * 0.17.1
 
@@ -33,6 +33,8 @@ Enhancements
   * Added periodic boundary condition option to HydrogenBondAnalysis (Issue #1188)
 
 Fixes
+  * Fixed MPI fork() warning when importing MDAnalysis in an Infiniband-enabled
+    MPI environment (PR #1794)
   * Fixed waterdynamics SurvivalProbability ignoring the t0 start time
     (Issue #1759)
   * AtomGroup.dimensions now strictly returns a copy (Issue #1582)

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -92,18 +92,18 @@ import warnings
 import MDAnalysis
 import sys
 
-# When used in an MPI environment, importing MDAnalysis may trigger an MPI
-# warning because importing the uuid module triggers a call to os.fork().
-# This happens if MPI_Init() has been called prior to importing MDAnalysis.
-# The problem is actually caused by the uuid module and not by MDAnalysis
-# itself. Python 3.7 fixes the problem. However, for Python < 3.7, the uuid
-# module works perfectly fine with os.fork() disabled during import.
-# A clean solution is therefore simply to disable os.fork() prior to
-# importing the uuid module and to re-enable it afterwards.
-if sys.version_info[0] + 0.1 * sys.version_info[1] >= 3.7:
+# When used in an MPI environment with Infiniband, importing MDAnalysis may
+# trigger an MPI warning because importing the uuid module triggers a call to
+# os.fork(). This happens if MPI_Init() has been called prior to importing
+# MDAnalysis. The problem is actually caused by the uuid module and not by
+# MDAnalysis itself. Python 3.7 fixes the problem. However, for Python < 3.7,
+# the uuid module works perfectly fine with os.fork() disabled during import.
+# A clean solution is therefore simply to disable os.fork() prior to importing
+# the uuid module and to re-enable it afterwards.
+import os
+if sys.version_info >= (3, 7):
     import uuid
 else:
-    import os
     _os_dot_fork, os.fork = os.fork, None
     import uuid
     os.fork = _os_dot_fork

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -87,11 +87,27 @@ import errno
 import numpy as np
 import logging
 import copy
-import uuid
 import warnings
 
 import MDAnalysis
 import sys
+
+# When used in an MPI environment, importing MDAnalysis may trigger an MPI
+# warning because importing the uuid module triggers a call to os.fork().
+# This happens if MPI_Init() has been called prior to importing MDAnalysis.
+# The problem is actually caused by the uuid module and not by MDAnalysis
+# itself. Python 3.7 fixes the problem. However, for Python < 3.7, the uuid
+# module works perfectly fine with os.fork() disabled during import.
+# A clean solution is therefore simply to disable os.fork() prior to
+# importing the uuid module and to re-enable it afterwards.
+if sys.version_info[0] + 0.1 * sys.version_info[1] >= 3.7:
+    import uuid
+else:
+    import os
+    _os_dot_fork, os.fork = os.fork, None
+    import uuid
+    os.fork = _os_dot_fork
+    del _os_dot_fork
 
 from .. import _ANCHOR_UNIVERSES, _TOPOLOGY_ATTRS, _PARSERS
 from ..exceptions import NoDataError


### PR DESCRIPTION
Solved problem:
---------------
When used in an MPI environment **using Infiniband**, importing MDAnalysis
may trigger an MPI warning because importing the `uuid` module in
`MDAnalysis.core.universe` triggers a call to `os.fork()`.
This happens if `MPI_Init()` has been called prior to importing MDAnalysis.

Why this was fixed:
-------------------
For the user, it is completely unclear where and why the MPI warning was
triggered and whether that is of any concern.

How to reproduce:
-----------------
With OpenMPI (version should be irrelevant, tested on 1.10.2) and Python < 3.7, executing
the command
```bash
  echo "import mpi4py.MPI, MDAnalysis" | mpirun --mca btl openib --mca mpi_warn_on_fork 1 -n 1 python -
```
yields the following output:

```
An MPI process has executed an operation involving a call to the
"fork()" system call to create a child process.  Open MPI is currently
operating in a condition that could result in memory corruption or
other system errors; your MPI job may hang, crash, or produce silent
data corruption.  The use of fork() (or system() or other calls that
create child processes) is strongly discouraged.  

The process that invoked fork was:

  Local host:          <hostname> (PID <pid>)
  MPI_COMM_WORLD rank: 0

If you are *absolutely sure* that your application will successfully
and correctly survive a call to fork(), you may disable this warning
by setting the mpi_warn_on_fork MCA parameter to 0.
```

Note that that in order to reproduce the warning, the above command must
be executed on a machine with a working Infiniband connection and OpenMPI
must be configured in a way that it is able to use the OpenFabrics bit transport
layer (btl openib)!

Explanation:
------------
The problem is actually caused by the `uuid` module, which is imported in
`MDAnalysis.core.universe` and triggers a call to `os.fork()` by calling a couple
of methods from the `ctypes` module which in turn use the `subprocess` module
(that's where `os.fork()` actually gets called).
This means that the real problem is not due to MDAnalysis itself, but it also
means that it will probably never be fixed for older Python versions.
In Python 3.7, the problem with the `uuid` module is solved. (see
https://bugs.python.org/issue11063 for further information)
Luckily, for Python < 3.7, the `uuid` module works perfectly fine with
`os.fork()` disabled during its import.
A clean fix is therefore simply to disable `os.fork()` prior to importing the
`uuid` module in `MDAnalysis.core.universe` and to re-enable it afterwards (for
Python < 3.7 only).

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [ ] Issue raised/referenced?
