### PR TITLE
MAINT: Config / DOC updates for latest asv version

### DIFF
--- a/benchmarks/README.rst
+++ b/benchmarks/README.rst
@@ -12,20 +12,9 @@ benchmark the performance of MDAnalysis at different
 time points in its history (for different git commit
 hashes).
 
-At the time of writing, Airspeed Velocity expects the
-project ``setup.py`` to be in the root directory of
-the git repository. MDAnalysis has had ``setup.py``
-for the main package in a subdirectory for quite some
-time now, so for the time being we are using a modified
-branch (``flexible_build``) of Airspeed Velocity in our `fork of their
-package`_, which enables Airspeed Velocity to build
-MDAnalysis despite the location of ``setup.py``. A WIP
-PR is open to enable more flexible Airspeed Velocity
-build mechanics, but for now we will use our fork.
-
-To build / install our fork of Airspeed Velocity it should
-suffice to clone the git repo, checkout the ``flexible_build``
-branch, and run::
+To build / install Airspeed Velocity it should
+suffice to clone the `git repo`_, building the master
+branch with::
 
     python setup.py install --user
 
@@ -51,7 +40,9 @@ It is also possible to specify ``ALL`` to space the performance
 tests over the entire lifetime of the project, but exercise
 caution as very early commits may represent a state of the
 project where many features are not available and / or
-files are not in the expected locations.
+files are not in the expected locations. Using ``--merges`` is also
+frequently advisable as merge commits are more likely to build
+and run successfully.
 
 The ``asv run`` command will store detailed benchmark data locally
 as ``JSON`` files, which can be converted into interactive website
@@ -60,7 +51,7 @@ data and hosted locally with::
     asv publish
     asv preview
 
-.. _fork of their package: https://github.com/MDAnalysis/asv
+.. _git repo: https://github.com/airspeed-velocity/asv
 .. _Airspeed Velocity commands: http://asv.readthedocs.io/en/latest/commands.html
 
 Writing benchmarks

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -13,6 +13,7 @@
     // benchmarked
     "repo": "..",
     "dvcs": "git",
+    "repo_subdir":"package",
     "branches": ["develop"],
 
     // The base URL to show information about a particular commit.


### PR DESCRIPTION
Fixes #1772

Changes made in this Pull Request:
 - I updated the asv configuration file to use the new JSON entry for specifying the project `setup.py` path--a [feature recently added to the asv master branch](https://github.com/airspeed-velocity/asv/pull/611)
- This mean we don't need to use our custom forks / branches of asv anymore, so I've adjusted the benchmarks `README` accordingly, along with a brief note for the value of testing performance with merge commits only

More broadly, I'd also move that we aim to delete our custom fork of `asv`, as this is now basically extraneous & not a maintenance burden that we want.

For completeness, I purged my local copy of asv and reinstalled the master branch from a clean git clone, then ran: `asv continuous --bench "\btime_hausdorff\b" ad3d811729 36e12e98c`

And seemed to work ok, with following summarized output:
```
       before           after         ratio
     [ad3d8117]       [36e12e98]
-         816±0μs         293±20μs     0.36  analysis.psa.PSA_metricBench.time_hausdorff(100, 5)
-        2.18±0ms          710±0μs     0.33  analysis.psa.PSA_metricBench.time_hausdorff(100, 50)
-      1.45±0.1ms          467±0μs     0.32  analysis.psa.PSA_metricBench.time_hausdorff(100, 25)
-      2.18±0.1ms         605±40μs     0.28  analysis.psa.PSA_metricBench.time_hausdorff(200, 5)
-        8.41±0ms         2.19±0ms     0.26  analysis.psa.PSA_metricBench.time_hausdorff(200, 50)
-        4.97±0ms      1.02±0.06ms     0.20  analysis.psa.PSA_metricBench.time_hausdorff(200, 25)

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
```

Please do feel free to test locally with asv master branch or suggest any other things I need to update if you agree that we can now just switch to asv master instead of a custom fork.