### PR TITLE
BUG: Set default pbc sel flag to False

### DIFF
--- a/package/MDAnalysis/core/__init__.py
+++ b/package/MDAnalysis/core/__init__.py
@@ -268,7 +268,7 @@ class _Flag(Flag):
 _flags = [
     _Flag(
         'use_periodic_selections',
-        True,
+        False,
         {True: True, False: False},
         """
         Determines if distance selections (AROUND, POINT) respect periodicity.

--- a/testsuite/MDAnalysisTests/core/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/core/test_atomgroup.py
@@ -815,6 +815,9 @@ class TestPBCFlag(object):
         # Test default setting of flag
         assert mda.core.flags['use_pbc'] is False
 
+    def test_periodic_sel(self):
+        assert mda.core.flags['use_periodic_selections'] is False
+
     def test_default(self, ag, ref_noPBC):
         # Test regular behaviour
         assert_almost_equal(ag.center_of_geometry(), ref_noPBC['COG'], self.prec)


### PR DESCRIPTION
Fixes #1795 and adds corresponding unit test. See the associated issue for more detailed analysis & discussion.

In short, we now set (and test that we set) `use_periodic_selections` flag to `False` by default (it was `True` by default).

Longer term, flags are to be removed and the unit test (etc.) will need to be mutated accordingly. There's also (confusingly) a `use_pbc` flag that is set (and tested to be set) to `False` by default, but that is not used for the affected code in the original issue. That should perhaps be cleaned up, but we're planning to remove flags eventually anyway so perhaps better to hold over to that effort.
