### PR TITLE
AMBER NCDF reader mmap=None as default

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -43,7 +43,11 @@ Fixes
   * DCDReader now reports the correct time based on istart information (PR #1767)
   * added requirement scipy >= 1.0.0 (absolutely needed: >= 0.19) (Issue #1775)
   * Universe.empty now warns about empty Residues and Segmnets (Issue #1771)
-
+  * AMBER netcdf reader now defaults to mmap=None as described in the docs
+    (meaning mmap=True for files and NOT in memory), thus avoiding
+    memory problems on big trajectories (Issue #1807)
+  
+        
 Changes
   * scipy >= 1.0.0 is now required (issue #1775 because of PR #1758)
 

--- a/package/MDAnalysis/coordinates/TRJ.py
+++ b/package/MDAnalysis/coordinates/TRJ.py
@@ -459,7 +459,7 @@ class NCDFReader(base.ReaderBase):
     _Timestep = Timestep
 
     def __init__(self, filename, n_atoms=None, **kwargs):
-        self._mmap = kwargs.pop('mmap', False)
+        self._mmap = kwargs.pop('mmap', None)
 
         super(NCDFReader, self).__init__(filename, **kwargs)
 

--- a/testsuite/MDAnalysisTests/coordinates/test_netcdf.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_netcdf.py
@@ -84,9 +84,48 @@ class _NCDFReaderTest(_TRJReaderTest):
         with pytest.raises(IOError):
             universe.trajectory.__getitem__(2)
 
+    def test_mmap_kwarg(self, universe):
+        # default is None
+        assert universe.trajectory._mmap == None
+
+
+# Ugly way to create the tests for mmap
+
+class _NCDFReaderTest_mmap_None(_NCDFReaderTest):
+    @pytest.fixture()
+    def universe(self):
+        return mda.Universe(self.topology, self.filename, mmap=None)
+
+class _NCDFReaderTest_mmap_True(_NCDFReaderTest):
+    @pytest.fixture()
+    def universe(self):
+        return mda.Universe(self.topology, self.filename, mmap=True)
+
+    def test_mmap_kwarg(self, universe):
+        # default is None
+        assert universe.trajectory._mmap == True
+
+class _NCDFReaderTest_mmap_False(_NCDFReaderTest):
+    @pytest.fixture()
+    def universe(self):
+        return mda.Universe(self.topology, self.filename, mmap=False)
+
+    def test_mmap_kwarg(self, universe):
+        assert universe.trajectory._mmap == False
+
 
 class TestNCDFReader(_NCDFReaderTest, RefVGV):
     pass
+
+class TestNCDFReader_mmap_None(_NCDFReaderTest_mmap_None, RefVGV):
+    pass
+
+class TestNCDFReader_mmap_True(_NCDFReaderTest_mmap_True, RefVGV):
+    pass
+
+class TestNCDFReader_mmap_False(_NCDFReaderTest_mmap_False, RefVGV):
+    pass
+
 
 
 class TestNCDFReaderTZ2(_NCDFReaderTest, RefTZ2):


### PR DESCRIPTION
Fixes #1807 

Changes made in this Pull Request:
- The default was wrongly set to False, which means to load the trajectory
  into memory, which can lead to memory problems with big trajectories
  (see Issue #1807)
- added tests for value of mmap and for the reader with
  (1) no arguments (default), (2) None, (3) True, (4) False



PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
