### PR TITLE
ENH: hole trajectory analysis: can use dynamic cpoint

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -31,6 +31,8 @@ Enhancements
   * Added boolean property *Group.isunique (PR #1922)
   * Added *Group.copy() methods returning an identical copy of the respective
     group (PR #1922)
+  * HOLEtraj kwarg cpoint can now be an AtomGroup in order to
+    dynamically set CPOINT for each frame (PR #1814)
 
 Fixes
   * rewind in the SingleFrameReader now reads the frame from the file (Issue #1929)

--- a/package/MDAnalysis/analysis/hole.py
+++ b/package/MDAnalysis/analysis/hole.py
@@ -1228,7 +1228,7 @@ class HOLEtraj(BaseHOLE):
              description).
 
 
-        .. versionchanged:: 0.17.1
+        .. versionchanged:: 0.18.1
            `cpoint` can also be an ``AtomGroup``
         """
 
@@ -1319,10 +1319,10 @@ class HOLEtraj(BaseHOLE):
         #       (although the file renaming might create problems...)
         protein = self.universe.select_atoms(self.selection)
         for q, ts in zip(self.orderparameters[start:stop:step], self.universe.trajectory[start:stop:step]):
-            logger.info("HOLE analysis frame %4d (orderparameter %g)", ts.frame, q)
+            logger.debug("HOLE analysis frame %4d (orderparameter %g)", ts.frame, q)
             if self._dynamic_cpoint:
                 hole_kw['cpoint'] = self.cpoint.center_of_geometry()
-                logger.info("New dynamic CPOINT %r for frame %r", hole_kw['cpoint'], ts.frame)
+                logger.debug("New dynamic CPOINT %r for frame %r", hole_kw['cpoint'], ts.frame)
 
             fd, pdbfile = tempfile.mkstemp(suffix=".pdb")
             os.close(fd)  # only need an empty file that can be overwritten, close right away (Issue 129)

--- a/package/MDAnalysis/analysis/hole.py
+++ b/package/MDAnalysis/analysis/hole.py
@@ -620,11 +620,6 @@ class HOLE(BaseHOLE):
     The class also provides some simple plotting functions of the collected
     data such as :meth:`HOLE.plot` or :meth:`HOLE.plot3D`.
 
-    .. versionadded:: 0.7.7
-
-    .. versionchanged:: 0.16.0
-           Added `raseed` keyword argument.
-
     .. _`HOLE control parameters`:
        http://www.holeprogram.org/doc/old/hole_d03.html
 
@@ -800,6 +795,12 @@ class HOLE(BaseHOLE):
         - HOLE is very picky and does not read all DCD-like
           formats [#HOLEDCD]_. If in doubt, look into the `logfile` for
           error diagnostics.
+
+
+        .. versionadded:: 0.7.7
+
+        .. versionchanged:: 0.16.0
+           Added `raseed` keyword argument.
 
         """
 
@@ -1136,7 +1137,7 @@ class HOLE(BaseHOLE):
                         # end of records (empty line)
                         read_data = False
                         frame_hole_output = np.rec.fromrecords(records, formats="i4,f8,f8",
-                                                                  names="frame,rxncoord,radius")
+                                                               names="frame,rxncoord,radius")
                         # store the profile
                         self.profiles[hole_profile_no] = frame_hole_output
                         logger.debug("Collected HOLE profile for frame %d (%d datapoints)",

--- a/testsuite/MDAnalysisTests/analysis/test_hole.py
+++ b/testsuite/MDAnalysisTests/analysis/test_hole.py
@@ -29,10 +29,9 @@ import MDAnalysis.analysis.hole
 from MDAnalysis.analysis.hole import HOLEtraj, HOLE
 
 from numpy.testing import (
-    assert_equal,
     assert_almost_equal,
-    assert_array_equal,
-    assert_array_almost_equal
+    assert_equal,
+    assert_almost_equal
 )
 import numpy as np
 import matplotlib
@@ -75,7 +74,7 @@ class TestHOLE(object):
 
         p = profiles_values[0]
 
-        assert_equal(len(p), 425, err_msg="wrong number of points in HOLE profile")
+        assert len(p) == 425, "wrong number of points in HOLE profile"
         assert_almost_equal(p.rxncoord.mean(), -1.41225, err_msg="wrong mean HOLE rxncoord")
         assert_almost_equal(p.radius.min(), 1.19707, err_msg="wrong min HOLE radius")
 
@@ -84,8 +83,7 @@ class TestHOLE(object):
             filename = H.create_vmd_surface(filename="hole.vmd")
             with open(filename) as f:
                 nlines = len(f.readlines())
-            assert_equal(nlines, 6504,
-                         err_msg="HOLE VMD surface file is incomplete")
+            assert nlines == 6504, "HOLE VMD surface file is incomplete"
 
 
 
@@ -121,24 +119,23 @@ class _TestHOLEtraj(object):
             "min_radius": np.array([[5., 1.19819], [6., 1.29628]]),
         }
 
-
     # This is VERY slow on 11 frames so we just take 2
     def test_HOLEtraj(self, H, frames, reference):
-        assert_array_equal(sorted(H.profiles.keys()), frames,
+        assert_equal(sorted(H.profiles.keys()), frames,
                            err_msg="H.profiles.keys() should contain the frame numbers")
 
         data = np.transpose([(len(p), p.rxncoord.mean(), p.radius.min())
                              for p in H.profiles.values()])
 
-        assert_array_equal(data[0], reference["profile length"],
+        assert_equal(data[0], reference["profile length"],
                            err_msg="incorrect profile lengths")
-        assert_array_almost_equal(data[1], reference["mean HOLE rxncoord"],
+        assert_almost_equal(data[1], reference["mean HOLE rxncoord"],
                                   err_msg="wrong mean HOLE rxncoord")
-        assert_array_almost_equal(data[2], reference["minimum radius"],
+        assert_almost_equal(data[2], reference["minimum radius"],
                                   err_msg="wrong minimum radius")
 
     def test_min_radius(self, H, reference):
-        assert_array_almost_equal(
+        assert_almost_equal(
             H.min_radius(), reference['min_radius'],
             err_msg="min_radius() array not correct"
         )


### PR DESCRIPTION
Changes made in this Pull Request:
 
The hole.HOLEtraj kwarg cpoint can now also a AtomGroup. In this case, the cpoint is recalculated for each frame as the COG of the ag, which helps with proteins that undergo conformational changes.

Basic tests were added.

PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [ ] Issue raised/referenced?
