### PR TITLE
BUG: Fixes #1795 sphzone selection regression

### DIFF
--- a/package/MDAnalysis/core/selection.py
+++ b/package/MDAnalysis/core/selection.py
@@ -388,7 +388,7 @@ class SphericalZoneSelection(DistanceSelection):
         sel = self.sel.apply(group)
         box = self.validate_dimensions(group.dimensions)
         periodic = box is not None
-        ref = sel.center_of_geometry(pbc=periodic).reshape(1, 3).\
+        ref = sel.center_of_geometry().reshape(1, 3).\
             astype(np.float32)
         d = distances.distance_array(ref,
                                      group.positions,

--- a/testsuite/MDAnalysisTests/core/test_atomselections.py
+++ b/testsuite/MDAnalysisTests/core/test_atomselections.py
@@ -21,7 +21,7 @@
 #
 from __future__ import division, absolute_import
 
-from six.moves import range
+from six.moves import range, zip
 
 import itertools
 import numpy as np
@@ -542,20 +542,6 @@ class BaseDistanceSelection(object):
 
         assert ref == set(result.indices)
 
-    @pytest.mark.parametrize('input_val, expected',
-                             zip(methods,
-                                 [25, 31, 33, 25,
-                                  55, 55, 55, 55]))
-    def test_spherical_zone(self, u, input_val, expected):
-        # NOTE: this has been modified to regression test
-        # only for resolution of Issue #1795
-        # pending proper pbc & wrapping implementations
-        # in the future
-        sel = Parser.parse('sphzone 5.0 resid 1', u.atoms)
-        sel = self.choosemeth(sel, input_val[0], input_val[1])
-        result = len(sel.apply(u.atoms))
-        assert result == expected
-
     @pytest.mark.parametrize('meth, periodic', methods)
     def test_point(self, u, meth, periodic):
         sel = Parser.parse('point 5.0 5.0 5.0  3.0', u.atoms)
@@ -602,11 +588,37 @@ class TestOrthogonalDistanceSelections(BaseDistanceSelection):
 
         assert ref == set(result.indices)
 
+    @pytest.mark.parametrize('input_val, expected',
+                             zip(BaseDistanceSelection.methods,
+                                 [25, 31, 33, 25]))
+    def test_spherical_zone(self, u, input_val, expected):
+        # NOTE: this has been modified to regression test
+        # only for resolution of Issue #1795
+        # pending proper pbc & wrapping implementations
+        # in the future
+        sel = Parser.parse('sphzone 5.0 resid 1', u.atoms)
+        sel = self.choosemeth(sel, input_val[0], input_val[1])
+        result = len(sel.apply(u.atoms))
+        assert result == expected
+
 
 class TestTriclinicDistanceSelections(BaseDistanceSelection):
     @pytest.fixture()
     def u(self):
         return mda.Universe(GRO)
+
+    @pytest.mark.parametrize('input_val, expected',
+                             zip(BaseDistanceSelection.methods,
+                                 [55, 55, 55, 55]))
+    def test_spherical_zone(self, u, input_val, expected):
+        # NOTE: this has been modified to regression test
+        # only for resolution of Issue #1795
+        # pending proper pbc & wrapping implementations
+        # in the future
+        sel = Parser.parse('sphzone 5.0 resid 1', u.atoms)
+        sel = self.choosemeth(sel, input_val[0], input_val[1])
+        result = len(sel.apply(u.atoms))
+        assert result == expected
 
 
 class TestTriclinicSelections(object):

--- a/testsuite/MDAnalysisTests/core/test_atomselections.py
+++ b/testsuite/MDAnalysisTests/core/test_atomselections.py
@@ -542,19 +542,19 @@ class BaseDistanceSelection(object):
 
         assert ref == set(result.indices)
 
-    @pytest.mark.parametrize('meth, periodic', methods)
-    def test_spherical_zone(self, u, meth, periodic):
+    @pytest.mark.parametrize('input_val, expected',
+                             zip(methods,
+                                 [25, 31, 33, 25,
+                                  55, 55, 55, 55]))
+    def test_spherical_zone(self, u, input_val, expected):
+        # NOTE: this has been modified to regression test
+        # only for resolution of Issue #1795
+        # pending proper pbc & wrapping implementations
+        # in the future
         sel = Parser.parse('sphzone 5.0 resid 1', u.atoms)
-        sel = self.choosemeth(sel, meth, periodic)
-        result = sel.apply(u.atoms)
-
-        r1 = u.select_atoms('resid 1')
-        box = u.dimensions if periodic else None
-        cog = r1.center_of_geometry(pbc=periodic).reshape(1, 3)
-        d = distance_array(u.atoms.positions, cog, box=box)
-        ref = set(np.where(d < 5.0)[0])
-
-        assert ref == set(result.indices)
+        sel = self.choosemeth(sel, input_val[0], input_val[1])
+        result = len(sel.apply(u.atoms))
+        assert result == expected
 
     @pytest.mark.parametrize('meth, periodic', methods)
     def test_point(self, u, meth, periodic):


### PR DESCRIPTION
Fixes #1795 

Supersedes attempted fix in #1806 based on feedback from @richardjgowers. The corresponding unit test now only crudely checks for regression of `sphzone` behavior as it relates to the reported issue, rather than making any claims about the geometric correctness of the selection.

I verified that the script I used for git bisecting the regression is happy with this fix & that the regression test (modified from the original unit test) does fail alongside the bisection script without the application of the fix used in this PR.

We'll see what the CI says. More detailed & correct handling of pbc & wrapping issues are delayed to future efforts, as discussed in the linked issue / PR above.