### PR TITLE
BENCH: add rdf asv benchmarks

### DIFF
--- a/benchmarks/benchmarks/analysis/rdf.py
+++ b/benchmarks/benchmarks/analysis/rdf.py
@@ -1,0 +1,58 @@
+from __future__ import division, absolute_import, print_function
+
+import MDAnalysis
+
+try:
+    from MDAnalysisTests.datafiles import PSF, DCD
+except:
+    pass
+
+try:
+    from MDAnalysis.analysis.rdf import InterRDF
+except:
+    pass
+
+class SimpleRdfBench(object):
+    """Benchmarks for MDAnalysis.analysis.rdf
+    """
+
+    params = ([20,75,200],
+              [[0,5], [0,15], [0,20]])
+
+    param_names = ['nbins',
+                   'range_val']
+
+    def setup(self, nbins, range_val):
+        
+        # use explicit OR in selections
+        # for increased backward compatibility
+        self.g1_sel_str = ('(resname ALA) or '
+                           '(resname ARG) or '
+                           '(resname ASN)')
+
+        self.g2_sel_str = ('(resname THR) or '
+                           '(resname TYR) or '
+                           '(resname VAL)')
+
+        self.u = MDAnalysis.Universe(PSF, DCD)
+
+        try:
+            self.sel1 = self.u.select_atoms(self.g1_sel_str)
+            self.sel2 = self.u.select_atoms(self.g2_sel_str)
+        except AttributeError:
+            self.sel1 = self.u.selectAtoms(self.g1_sel_str)
+            self.sel2 = self.u.selectAtoms(self.g2_sel_str)
+
+        # do not include initialization of the
+        # InterRDF object in the benchmark itself
+
+        self.rdf = InterRDF(g1=self.sel1,
+                            g2=self.sel2,
+                            nbins=nbins,
+                            range=range_val)
+
+    def time_interrdf(self, nbins, range_val):
+        """Benchmark a full trajectory parse
+        by MDAnalysis.analysis.rdf.InterRDF
+        """
+        self.rdf.run()


### PR DESCRIPTION
* Added benchmarks for `MDAnalysis.analysis.rdf.InterRDF`

* the [log.txt](https://github.com/MDAnalysis/mdanalysis/files/1831720/log.txt) from running the command shown below suggests that there are warnings related to the density calculation -- you may wish to suggest a more suitable test file for RDF (with appropriate box size I guess) if one comes to mind, although the benchmarks still run

Here is a screencap summary of the results from running `asv run -e -s 20 --bench SimpleRdfBench -j 10 "ddb57592..bf147ef4 --merges" >& log.txt` with Cython pinned to `0.27.3` to avoid issues:

![image](https://user-images.githubusercontent.com/7903078/37690460-a7f5c750-2c70-11e8-8f4e-a54f72b8eab9.png)

The benchmarks start working from version `0.13`, which is where the [rdf docs](https://www.mdanalysis.org/docs/documentation_pages/analysis/rdf.html) indicate the feature was added.

Also, perhaps worth noting that benchmarking any analysis routine that iterates through a trajectory may inherently have confounding effects from the speed of trajectory iteration itself, but that could presumably be handled either by trying to benchmark some of the hidden internal functions and / or cross-checking with raw trajectory iteration performances for the given format.