### PR TITLE
Adds a check to MDAnalysis.coordinates.memory.MemoryReader to check f…

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,7 +13,7 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-??/??/18 richardjgowers
+??/??/18 richardjgowers, palnabarun
 
   * 0.18.1
 
@@ -21,6 +21,7 @@ Enhancements
 
 Fixes
   * Fixed order of indices in Angle/Dihedral/Improper repr
+  * coordinates.memory.MemoryReader now takes np.ndarray only (Issue #1685)
 
 Changes
 

--- a/package/MDAnalysis/coordinates/memory.py
+++ b/package/MDAnalysis/coordinates/memory.py
@@ -264,7 +264,7 @@ class MemoryReader(base.ProtoReader):
 
         .. _`#1041`: https://github.com/MDAnalysis/mdanalysis/issues/1041
 
-        .. versionchanged:: 0.17.1
+        .. versionchanged:: 0.18.1
             The input to the MemoryReader now must be a np.ndarray
 
         """
@@ -340,7 +340,7 @@ class MemoryReader(base.ProtoReader):
         for auxname, auxread in self._auxs.items():
             new.add_auxiliary(auxname, auxread.copy())
 
-        return new        
+        return new
 
     def set_array(self, coordinate_array, order='fac'):
         """

--- a/package/MDAnalysis/coordinates/memory.py
+++ b/package/MDAnalysis/coordinates/memory.py
@@ -264,6 +264,14 @@ class MemoryReader(base.ProtoReader):
         super(MemoryReader, self).__init__()
         self.filename = filename
         self.stored_order = order
+
+        try:
+            if len(coordinate_array.shape) == 2 and coordinate_array.shape[1] == 3:
+                    coordinate_array = coordinate_array[np.newaxis, :, :]
+        except AttributeError as e:
+            raise ValueError("Input to the MemoryReader is of improper format."
+                )
+
         self.set_array(np.asarray(coordinate_array), order)
         self.n_frames = \
             self.coordinate_array.shape[self.stored_order.find('f')]

--- a/testsuite/MDAnalysisTests/core/test_universe.py
+++ b/testsuite/MDAnalysisTests/core/test_universe.py
@@ -183,6 +183,22 @@ class TestUniverseCreation(object):
         with pytest.raises(TypeError):
             u.load_new('thisfile', format = 'soup')
 
+    def test_load_new_memory_reader_success(self):
+        u = mda.Universe(GRO)
+        prot = u.select_atoms('protein')
+        u2 = mda.Merge(prot)
+        assert u2.load_new( [ prot.positions ], format=mda.coordinates.memory.MemoryReader) is u2
+
+    def test_load_new_memory_reader_fails(self):
+        def load():
+            u = mda.Universe(GRO)
+            prot = u.select_atoms('protein')
+            u2 = mda.Merge(prot)
+            u2.load_new( [[ prot.positions ]], format=mda.coordinates.memory.MemoryReader)
+
+        with pytest.raises(TypeError):
+            load()
+
     def test_universe_kwargs(self):
         u = mda.Universe(PSF, PDB_small, fake_kwarg=True)
         assert_equal(len(u.atoms), 3341, "Loading universe failed somehow")


### PR DESCRIPTION
…or special cases

Fixes #1685 

Changes made in this Pull Request:
 - Adds a check to `MDAnalysis.coordinates.memory.MemoryReader` which checks whether the input is a (N, 3) array and in such cases reshapes the array.


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
