### PR TITLE
fix HydrogenBondAutoCorrel for scipy >= 1.0.1

### DIFF
--- a/package/MDAnalysis/analysis/hbonds/hbond_autocorrel.py
+++ b/package/MDAnalysis/analysis/hbonds/hbond_autocorrel.py
@@ -484,7 +484,7 @@ class HydrogenBondAutoCorrel(object):
             if within_bounds(p):
                 return y - self._my_solve(x, *p)
             else:
-                return 100000
+                return np.full_like(y, 100000)
 
         def double(x, A1, tau1, tau2):
             """ Sum of two exponential functions """


### PR DESCRIPTION
One hydrogen bond autocorrelation test fails when scipy 1.0.1 is installed.
Apparently, `scipy.optimize.leastsq()` nowadays feels kinda unhappy if the return value of the function it's supposed to minimize changes shape between function calls.

pytest log (shortened):
```
=================================== FAILURES ===================================
______________ TestHydrogenBondAutocorrel.test_solve_intermittent ______________

self = <testsuite.MDAnalysisTests.analysis.test_hydrogenbondautocorrel.TestHydrogenBondAutocorrel object at 0x2aacfe5e2290>
u = <Universe with 8184 atoms>, hydrogens = <AtomGroup with 960 atoms>
oxygens = <AtomGroup with 960 atoms>, nitrogens = <AtomGroup with 960 atoms>

    def test_solve_intermittent(self, u, hydrogens, oxygens, nitrogens):
        hbond = HBAC(u,
                     hydrogens=hydrogens,
                     acceptors=oxygens,
                     donors=nitrogens,
                     bond_type='intermittent',
                     sample_time=0.06,
        )
    
        def actual_function_int(t):
            A1 = 0.33
            A2 = 0.33
            A3 = 0.34
            tau1 = 5
            tau2 = 1
            tau3 = 0.1
            return A1 * np.exp(-t/tau1) + A2 * np.exp(-t/tau2) + A3 * np.exp(-t/tau3)
        hbond.solution['time'] = time = np.arange(0, 6.0, 0.01)
        hbond.solution['results'] = actual_function_int(time)
    
>       hbond.solve()

testsuite/MDAnalysisTests/analysis/test_hydrogenbondautocorrel.py:195: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
[...]/MDAnalysis-0.17.1.dev0-py2.7-linux-x86_64.egg/MDAnalysis/analysis/hbonds/hbond_autocorrel.py:519: in solve
    err, p_guess, args=(time, results), full_output=True)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

func = <function err at 0x2aad09b63b18>
x0 = array([0.33 , 0.33 , 0.6  , 0.06 , 0.006])
args = (array([0.  , 0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09, 0.1 ,
     ...5.88, 5.89, 5.9 , 5.91, 5.92, 5.93,
... 0.90015115, 0.87233986,
       0.84...0.10146257,
       0.10125294, 0.1010438 , 0.10083515, 0.10062698, 0.10041929]))
Dfun = None, full_output = True, col_deriv = 0, ftol = 1.49012e-08
xtol = 1.49012e-08, gtol = 0.0, maxfev = 1200, epsfcn = 2.220446049250313e-16
factor = 100, diag = None

    def leastsq(func, x0, args=(), Dfun=None, full_output=0,
                col_deriv=0, ftol=1.49012e-8, xtol=1.49012e-8,
                gtol=0.0, maxfev=0, epsfcn=None, factor=100, diag=None):

        [...]

        if Dfun is None:
            if maxfev == 0:
                maxfev = 200*(n + 1)
            retval = _minpack._lmdif(func, x0, args, full_output, ftol, xtol,
>                                    gtol, maxfev, epsfcn, factor, diag)
E           ValueError: The array returned by a function changed size between calls

[...]/scipy/optimize/minpack.py:387: ValueError
```

Letting the minimized `err()` function return a value with the same shape in the "out-of-bounds"  as in the "within-bounds" case seems to fix the issue.

Fixes #

Changes made in this Pull Request:
 - 


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
