### PR TITLE
updated docs on how users should run the tests

### DIFF
--- a/package/MDAnalysis/tests/__init__.py
+++ b/package/MDAnalysis/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
-# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
 #
 # MDAnalysis --- https://www.mdanalysis.org
 # Copyright (c) 2006-2017 The MDAnalysis Development Team and contributors
@@ -36,8 +36,11 @@ installed for the tests to run at all.
 
 Run all the tests with
 
-   >>> import MDAnalysis.tests
-   >>> MDAnalysis.tests.test()
+.. code-block:: bash
+
+   pytest --pyargs MDAnalysisTests
+
+
 
 Data
 ====
@@ -79,11 +82,3 @@ The `SciPy testing guidelines`_ are also a good howto for writing test cases.
 .. _Gromacs: http://www.gromacs.org
 
 """
-from __future__ import absolute_import, print_function
-
-try:
-    from MDAnalysisTests import run as test
-except ImportError:
-    print("Install MDAnalysisTests first. The source package is available from")
-    print("http://pypi.python.org/pypi/MDAnalysisTests")
-    raise ImportError("Package MDAnalysisTests required!")

--- a/testsuite/MDAnalysisTests/__init__.py
+++ b/testsuite/MDAnalysisTests/__init__.py
@@ -20,8 +20,7 @@
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
 
-"""
-=========================
+"""=========================
 Test cases for MDAnalysis
 =========================
 
@@ -35,10 +34,20 @@ an :exc:`ImportError` is raised.
 We are using the NumPy_ testing frame work; thus, :mod:`numpy` *must* be
 installed for the tests to run at all.
 
-Run all the tests with
+Run all the tests with ::
 
-   >>> from MDAnalysisTests import run
-   >>> run()
+    pytest --pyargs MDAnalysisTests
+
+If you have the `pytest-xdist`_ plugin installed then you can run the
+tests in parallel
+
+.. code-block:: bash
+
+   pytest -n 4 --pyargs MDAnalysisTests
+
+
+.. _`pytest-xdist`:
+   https://github.com/pytest-dev/pytest-xdist
 
 
 Data


### PR DESCRIPTION
Changes made in this Pull Request:
 - updated docs that still wrongly stated the old nosetest way of running the tests; instead follow https://docs.pytest.org/en/latest/example/pythoncollection.html#interpreting-cmdline-arguments-as-python-packages `pytest --pyargs MDAnalysisTests`
 - updated https://github.com/MDAnalysis/mdanalysis/wiki/UnitTests

See https://groups.google.com/d/msg/mdnalysis-discussion/YZCNtWxOpvA/iDajySEgBwAJ for the discussion.

PR Checklist
------------
 - n/a Tests?
 - [x] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
