### PR TITLE
Adds checks for arbitrary inputs in groups.select_atoms

### DIFF
--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -2063,6 +2063,11 @@ class AtomGroup(GroupBase):
         """
         updating = selgroups.pop('updating', False)
         sel_strs = (sel,) + othersel
+
+        for group, thing in selgroups.items():
+            if not isinstance(thing, MDAnalysis.core.groups.AtomGroup):
+                raise TypeError("Only AtomGroup type is allowed for the passed arbitrary atomgroups, you provided type {} for {}".format(str(type(thing)), group))
+
         selections = tuple((selection.Parser.parse(s, selgroups)
                             for s in sel_strs))
         if updating:

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -1821,6 +1821,10 @@ class AtomGroup(GroupBase):
         are not any duplicates, which can happen with complicated
         selections).
 
+        Raises
+        ------
+        `TypeError` if the arbitrary atomgroups passed are of type MDAnalysis.core.groups.AtomGroup
+
         Examples
         --------
         All simple selection listed below support multiple arguments which are

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -1823,7 +1823,7 @@ class AtomGroup(GroupBase):
 
         Raises
         ------
-        `TypeError` if the arbitrary atomgroups passed are of type MDAnalysis.core.groups.AtomGroup
+        `TypeError` if the arbitrary atomgroups passed are not of type `MDAnalysis.core.groups.AtomGroup`
 
         Examples
         --------

--- a/testsuite/MDAnalysisTests/core/test_atomselections.py
+++ b/testsuite/MDAnalysisTests/core/test_atomselections.py
@@ -1019,3 +1019,13 @@ class TestICodeSelection(object):
         u = make_Universe(('resids',))
         with pytest.raises(ValueError):
             u.select_atoms('resid 10A-12')
+
+class TestArbitraryAtomGroupSelection:
+    def test_arbitrary_atom_group_raises_error(self):
+        u = mda.Universe(GRO)
+        with pytest.raises(TypeError):
+            u.select_atoms('around 2.0 group this', this=u.atoms[0])
+
+    def test_arbitrary_atom_group_raises_no_error(self):
+        u = mda.Universe(GRO)
+        u.select_atoms('around 2.0 group this', this=u.atoms)


### PR DESCRIPTION
Fixes #1852 

Changes made in this Pull Request:
 - Adds a check for arbitrary atomgroups passed to MDAnalysis.core.groups.select_atoms


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?
