### PR TITLE
silence duecredit import failure

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,7 +13,7 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-??/??/18 richardjgowers, palnabarun
+??/??/18 richardjgowers, palnabarun, orbeckst
 
   * 0.18.1
 
@@ -22,7 +22,8 @@ Enhancements
 Fixes
   * Fixed order of indices in Angle/Dihedral/Improper repr
   * coordinates.memory.MemoryReader now takes np.ndarray only (Issue #1685)
-
+  * Silenced warning when duecredit is not installed (Issue #1872)
+        
 Changes
 
 

--- a/package/MDAnalysis/due.py
+++ b/package/MDAnalysis/due.py
@@ -82,10 +82,10 @@ except Exception as err:
         warnings.warn(errmsg)
         logging.getLogger("duecredit").error(
             "Failed to import duecredit due to {}".format(str(err)))
-    else:
-        # for debugging
-        import warnings
-        warnings.warn(str(err))
+    # else:
+    #   Do not issue any warnings if duecredit is not installed;
+    #   this is the user's choice (Issue #1872)
+
     # Initiate due stub
     due = InactiveDueCreditCollector()
     BibTeX = Doi = Url = _donothing_func


### PR DESCRIPTION
Fixes #1872 

Changes made in this Pull Request:
- Do not show a warning if duecredit is not installed;
  if users want the functionality they can install duecredit
  but we should not bother all others.
- NOTE: This was manually tested in a local installation without
        duecredit but doing a real unit test is difficult and
        has not been attempted.


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
