### PR TITLE
TopologyAttributes are now statically typed

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -26,8 +26,11 @@ Fixes
   * coordinates.memory.MemoryReader now takes np.ndarray only (Issue #1685)
   * Silenced warning when duecredit is not installed (Issue #1872)
   * Fixed HBondAnalysis not considering PBC for distances (Issue #1878)
+  * Adding new TopologyAttrs with values defined always coerces this into
+    a numpy array (Issue #1876)
 
 Changes
+  * TopologyAttrs are now statically typed (Issue #1876)
 
 
 04/15/18 tylerjereddy, richardjgowers, palnabarun, bieniekmateusz, kain88-de,

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -198,6 +198,8 @@ class TopologyAttr(six.with_metaclass(_TopologyAttrMeta, object)):
         name for the attribute on a singular object (Atom/Residue/Segment)
     per_object : str
         If there is a strict mapping between Component and Attribute
+    dtype : int/float/object
+        Type to coerce this attribute to be.  For string use 'object'
     top : Topology
         handle for the Topology object TopologyAttr is associated with
 
@@ -211,9 +213,13 @@ class TopologyAttr(six.with_metaclass(_TopologyAttrMeta, object)):
 
     groupdoc = None
     singledoc = None
+    dtype = None
 
     def __init__(self, values, guessed=False):
-        self.values = values
+        if self.dtype is None:
+            self.values = values
+        else:
+            self.values = np.asarray(values, dtype=self.dtype)
         self._guessed = guessed
 
     @staticmethod
@@ -244,6 +250,9 @@ class TopologyAttr(six.with_metaclass(_TopologyAttrMeta, object)):
         """
         if values is None:
             values = cls._gen_initial_values(n_atoms, n_residues, n_segments)
+        elif cls.dtype is not None:
+            # if supplied starting values and statically typed
+            values = np.asarray(values, dtype=cls.dtype)
         return cls(values)
 
     def copy(self):
@@ -450,6 +459,7 @@ class Atomids(AtomAttr):
     attrname = 'ids'
     singular = 'id'
     per_object = 'atom'
+    dtype = int
 
     @staticmethod
     def _gen_initial_values(na, nr, ns):
@@ -463,6 +473,7 @@ class Atomnames(AtomAttr):
     attrname = 'names'
     singular = 'name'
     per_object = 'atom'
+    dtype = object
     transplants = defaultdict(list)
 
     @staticmethod
@@ -627,6 +638,7 @@ class Atomtypes(AtomAttr):
     attrname = 'types'
     singular = 'type'
     per_object = 'atom'
+    dtype = object
 
     @staticmethod
     def _gen_initial_values(na, nr, ns):
@@ -638,6 +650,7 @@ class Elements(AtomAttr):
     """Element for each atom"""
     attrname = 'elements'
     singular = 'element'
+    dtype = object
 
     @staticmethod
     def _gen_initial_values(na, nr, ns):
@@ -650,6 +663,7 @@ class Radii(AtomAttr):
     attrname = 'radii'
     singular = 'radius'
     per_object = 'atom'
+    dtype = float
 
     @staticmethod
     def _gen_initial_values(na, nr, ns):
@@ -698,6 +712,7 @@ class ChainIDs(AtomAttr):
     attrname = 'chainIDs'
     singular = 'chainID'
     per_object = 'atom'
+    dtype = object
 
     @staticmethod
     def _gen_initial_values(na, nr, ns):
@@ -709,6 +724,7 @@ class Tempfactors(AtomAttr):
     attrname = 'tempfactors'
     singular = 'tempfactor'
     per_object = 'atom'
+    dtype = float
 
     @staticmethod
     def _gen_initial_values(na, nr, ns):
@@ -722,6 +738,7 @@ class Masses(AtomAttr):
     target_classes = [AtomGroup, ResidueGroup, SegmentGroup,
                       Atom, Residue, Segment]
     transplants = defaultdict(list)
+    dtype = np.float64
 
     groupdoc = """Mass of each component in the Group.
 
@@ -732,10 +749,6 @@ class Masses(AtomAttr):
     """
 
     singledoc = """Mass of the component."""
-
-    def __init__(self, values, guessed=False):
-        self.values = np.asarray(values, dtype=np.float64)
-        self._guessed = guessed
 
     @staticmethod
     def _gen_initial_values(na, nr, ns):
@@ -1092,6 +1105,7 @@ class Charges(AtomAttr):
     target_classes = [AtomGroup, ResidueGroup, SegmentGroup,
                       Atom, Residue, Segment]
     transplants = defaultdict(list)
+    dtype = float
 
     @staticmethod
     def _gen_initial_values(na, nr, ns):
@@ -1137,6 +1151,7 @@ class Bfactors(AtomAttr):
     attrname = 'bfactors'
     singular = 'bfactor'
     per_object = 'atom'
+    dtype = float
 
     @staticmethod
     def _gen_initial_values(na, nr, ns):
@@ -1148,6 +1163,7 @@ class Occupancies(AtomAttr):
     attrname = 'occupancies'
     singular = 'occupancy'
     per_object = 'atom'
+    dtype = float
 
     @staticmethod
     def _gen_initial_values(na, nr, ns):
@@ -1160,6 +1176,7 @@ class AltLocs(AtomAttr):
     attrname = 'altLocs'
     singular = 'altLoc'
     per_object = 'atom'
+    dtype = object
 
     @staticmethod
     def _gen_initial_values(na, nr, ns):
@@ -1205,6 +1222,7 @@ class Resids(ResidueAttr):
     attrname = 'resids'
     singular = 'resid'
     target_classes = [AtomGroup, ResidueGroup, SegmentGroup, Atom, Residue]
+    dtype = int
 
     @staticmethod
     def _gen_initial_values(na, nr, ns):
@@ -1217,6 +1235,7 @@ class Resnames(ResidueAttr):
     singular = 'resname'
     target_classes = [AtomGroup, ResidueGroup, SegmentGroup, Atom, Residue]
     transplants = defaultdict(list)
+    dtype = object
 
     @staticmethod
     def _gen_initial_values(na, nr, ns):
@@ -1378,6 +1397,7 @@ class Resnums(ResidueAttr):
     attrname = 'resnums'
     singular = 'resnum'
     target_classes = [AtomGroup, ResidueGroup, SegmentGroup, Atom, Residue]
+    dtype = int
 
     @staticmethod
     def _gen_initial_values(na, nr, ns):
@@ -1388,6 +1408,7 @@ class ICodes(ResidueAttr):
     """Insertion code for Atoms"""
     attrname = 'icodes'
     singular = 'icode'
+    dtype = object
 
     @staticmethod
     def _gen_initial_values(na, nr, ns):
@@ -1402,6 +1423,7 @@ class Moltypes(ResidueAttr):
     attrname = 'moltypes'
     singular = 'moltype'
     target_classes = [AtomGroup, ResidueGroup, SegmentGroup, Atom, Residue]
+    dtype = object
 
 
 class Molnums(ResidueAttr):
@@ -1412,7 +1434,7 @@ class Molnums(ResidueAttr):
     attrname = 'molnums'
     singular = 'molnum'
     target_classes = [AtomGroup, ResidueGroup, Atom, Residue]
-
+    dtype = int
 
 # segment attributes
 
@@ -1454,6 +1476,7 @@ class Segids(SegmentAttr):
     target_classes = [AtomGroup, ResidueGroup, SegmentGroup,
                       Atom, Residue, Segment]
     transplants = defaultdict(list)
+    dtype = object
 
     @staticmethod
     def _gen_initial_values(na, nr, ns):

--- a/testsuite/MDAnalysisTests/coordinates/test_pdb.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_pdb.py
@@ -730,32 +730,18 @@ class TestPSF_PDBReader(TestPDBReader):
         assert isinstance(self.universe.trajectory, PDBReader), "failed to choose PDBReader"
 
 
-class TestPDBWriterOccupancies(TestCase):
-    """Tests for Issue #620"""
+def test_write_occupancies(tmpdir):
+    """Tests for Issue #620 Modify occupancies, write out the file and check"""
+    u = mda.Universe(PDB_small)
+    u.atoms.occupancies = 0.12
 
-    def setUp(self):
-        self.tempdir = tempdir.TempDir()
-        self.outfile = self.tempdir.name + '/occ.pdb'
+    outfile = str(tmpdir.join('occ.pdb'))
 
-    def tearDown(self):
-        try:
-            os.unlink(self.outfile)
-        except OSError:
-            pass
-        del self.tempdir
-        del self.outfile
+    u.atoms.write(outfile)
 
-    def test_write_occupancies(self):
-        """Modify occupancies, write out the file and check"""
-        u = mda.Universe(PDB_small)
+    u2 = mda.Universe(outfile)
 
-        u.atoms.occupancies = 0.12
-
-        u.atoms.write(self.outfile)
-
-        u2 = mda.Universe(self.outfile)
-
-        assert all(u2.atoms.occupancies == 0.12)
+    assert_array_almost_equal(u2.atoms.occupancies, 0.12)
 
 
 class TestWriterAlignments(object):

--- a/testsuite/MDAnalysisTests/core/test_topologyattrs.py
+++ b/testsuite/MDAnalysisTests/core/test_topologyattrs.py
@@ -543,3 +543,19 @@ class TestRecordTypes(object):
         assert not rt[0].dtype == bool
         assert (rt[0] == 'ATOM').all()
         assert (rt[1] == 'HETATM').all()
+
+
+def test_static_typing():
+    ta = tpattrs.Charges(['1.0', '2.0', '3.0'])
+
+    assert isinstance(ta.values, np.ndarray)
+    assert ta.values.dtype == float
+
+
+def test_static_typing_from_empty():
+    u = mda.Universe.empty(3)
+
+    u.add_TopologyAttr('masses', values=['1.0', '2.0', '3.0'])
+
+    assert isinstance(u._topology.masses.values, np.ndarray)
+    assert isinstance(u.atoms[0].mass, float)


### PR DESCRIPTION
Fixes #1876

Changes made in this Pull Request:
 - all topologyattrs can now have a `dtype` specified, which forces an `np.asarray` call on creation


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
