### PR TITLE
BLD: Adding MDA appveyor CI test for Python 3.6

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,78 @@
+# config based on examples from SciPy & NumPy repositories, which
+# themselves credit an original example by Olivier Grisel at
+# https://github.com/ogrisel/python-appveyor-demo/blob/master/appveyor.yml
+clone_depth: 50
+max_jobs: 100
+
+cache:
+    - '%LOCALAPPDATA%\pip\Cache'
+
+matrix:
+    # FIXME: allow all Windows builds
+    # to fail for now; remove this
+    # when we have full Windows compatibility
+    allow_failures:
+      - PYTHON_ARCH: 64
+
+image:
+    - Visual Studio 2015
+
+environment:
+    global:
+        MINGW_64: C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin
+        OPENBLAS_64: https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-5f998ef_gcc7_1_0_win64.zip
+        APPVEYOR_SAVE_CACHE_ON_ERROR: true
+        APPVEYOR_SKIP_FINALIZE_ON_EXIT: true
+        TEST_TIMEOUT: 1000
+        PYTHON: "C:\\conda"
+        MINICONDA_VERSION: "latest"
+        CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"
+
+    matrix:
+
+        - PYTHON_VERSION: 3.6
+          PYTHON_ARCH: 64
+          MSVC_VERSION: "Visual Studio 10 Win64"
+
+init:
+    - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
+    - "ECHO \"%APPVEYOR_SCHEDULED_BUILD%\""
+    # cancel build if newer one is submitted; complicated
+    # details for getting this to work are credited to JuliaLang
+    # developers
+    - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
+        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
+        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
+          raise "There are newer queued builds for this pull request, skipping build."
+        }
+
+install:
+    # set up a conda env
+    - "git clone --depth 1 git://github.com/astropy/ci-helpers.git"
+    - "powershell ci-helpers/appveyor/install-miniconda.ps1"
+    - SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%
+    # deal with missing stdint.h as previously described
+    # see: https://github.com/swistakm/pyimgui/blob/master/.appveyor.yml
+    - cp "c:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\include\stdint.h" "C:\Users\appveyor\AppData\Local\Programs\Common\Microsoft\Visual C++ for Python\9.0\VC\include\stdint.h"
+    - ps: conda config --append channels conda-forge
+    - ps: conda create -n testing python=$env:PYTHON_VERSION pip setuptools wheel cython mock six biopython networkx joblib matplotlib scipy vs2015_runtime pytest mmtf-python GridDataFormats hypothesis
+    - cmd: C:\conda\envs\testing\Scripts\pip.exe install gsd==1.5.2 duecredit
+    - cmd: C:\conda\envs\testing\Scripts\activate testing
+
+build_script:
+    - cmd: cd package
+    - cmd: C:\conda\envs\testing\python.exe setup.py develop --no-deps --user 3>&1
+
+test_script:
+    - cmd: cd ..\testsuite
+    - cmd: C:\conda\envs\testing\python.exe setup.py develop --no-deps --user 3>&1
+    - cmd: cd MDAnalysisTests
+    - cmd: C:\conda\envs\testing\Scripts\pytest.exe --disable-pytest-warnings 3>&1
+
+after_build:
+    # cache cleanup
+    - C:\cygwin\bin\find "%LOCALAPPDATA%\pip" -type f -mtime +360 -delete
+    - C:\cygwin\bin\find "%LOCALAPPDATA%\pip" -type f -size +10M -delete
+    - C:\cygwin\bin\find "%LOCALAPPDATA%\pip" -empty -delete
+    # Show size of cache
+    - C:\cygwin\bin\du -hs "%LOCALAPPDATA%\pip\Cache"


### PR DESCRIPTION
Early stage draft of appveyor config file, borrowing heavily from the NumPy / SciPy versions; I haven't actually set up with the service integration yet, but as we may decide to merge the Windows-related compatibility improvements in smaller PRs I'm starting the effort on this in a separate PR.

I think I still have to pull in more dependencies for the build to work. I've had some success with conda using powershell locally, but it was a bit of an effort and if pip is working for the other projects we may want to stick with that.
