### PR TITLE
remove toplevel import of MDAnalysis in groups.py

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,12 +13,13 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-??/??/18 richardjgowers, palnabarun, orbeckst
+??/??/18 richardjgowers, palnabarun, orbeckst, kain88-de
 
   * 0.18.1
 
 Enhancements
   * Added various duecredit stubs
+  * Import time reduced by a factor two (PR #1881)
 
 Fixes
   * Fixed order of indices in Angle/Dihedral/Improper repr

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -103,7 +103,6 @@ import warnings
 
 from numpy.lib.utils import deprecate
 
-import MDAnalysis
 from .. import _ANCHOR_UNIVERSES
 from ..lib import util
 from ..lib import distances
@@ -114,6 +113,7 @@ from . import flags
 from ..exceptions import NoDataError
 from . import topologyobjects
 from ._get_readers import get_writer_for
+from . import flags
 
 
 def _unpickle(uhash, ix):
@@ -304,11 +304,12 @@ class _MutableBase(object):
                 # older AtomGroup init method..
                 u = args[0][0].universe
             except (TypeError, IndexError, AttributeError):
+                from .universe import Universe
                 # Let's be generic and get the first argument that's either a
                 # Universe, a Group, or a Component, and go from there.
                 # This is where the UpdatingAtomGroup args get matched.
                 for arg in args+tuple(kwargs.values()):
-                    if isinstance(arg, (MDAnalysis.Universe, GroupBase,
+                    if isinstance(arg, (Universe, GroupBase,
                                         ComponentBase)):
                         u = arg.universe
                         break
@@ -698,7 +699,7 @@ class GroupBase(_MutableBase):
         .. versionchanged:: 0.8 Added *pbc* keyword
         """
         atomgroup = self.atoms
-        pbc = kwargs.pop('pbc', MDAnalysis.core.flags['use_pbc'])
+        pbc = kwargs.pop('pbc', flags['use_pbc'])
 
         if pbc:
             x = atomgroup.pack_into_box(inplace=False)
@@ -735,7 +736,7 @@ class GroupBase(_MutableBase):
         .. versionchanged:: 0.8 Added *pbc* keyword
         """
         atomgroup = self.atoms
-        pbc = kwargs.pop('pbc', MDAnalysis.core.flags['use_pbc'])
+        pbc = kwargs.pop('pbc', flags['use_pbc'])
 
         if pbc:
             x = atomgroup.pack_into_box(inplace=False)


### PR DESCRIPTION
Inspired by the following thread: https://mail.python.org/pipermail/python-dev/2018-May/153296.html

Changes made in this Pull Request:
 - remove toplevel import of MDAnalysis in groups.py

On a core i7-4600 with an SSD, this reduced the import times of MDAnalysis to under
a second. Tested with `time python -c 'import MDAnalysis'`.  

*0.18.0*: ~1.4s
*this*: 0.6s

PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [ ] Issue raised/referenced?
