### PR TITLE
add sitemap.xml to sphinx docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ env:
     - CONDA_DEPENDENCIES="${CONDA_MIN_DEPENDENCIES} seaborn>=0.7.0 clustalw=2.1 netcdf4 scikit-learn coveralls"
     - CONDA_CHANNELS='biobuilds conda-forge'
     - CONDA_CHANNEL_PRIORITY=True
-    - PIP_DEPENDENCIES="duecredit"
+    - PIP_DEPENDENCIES="duecredit sphinx-sitemap"
     - NUMPY_VERSION=stable
     - INSTALL_HOLE="true"
 

--- a/maintainer/adapt_sitemap.py
+++ b/maintainer/adapt_sitemap.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+#
+#
+# Adjust path in sitemap.xml
+
+from __future__ import print_function
+
+from xml.etree import ElementTree
+import argparse
+
+# defaults for MDAnalysis, see https://github.com/MDAnalysis/mdanalysis/pull/1890
+# and https://github.com/MDAnalysis/MDAnalysis.github.io/issues/78
+
+RELEASE_URL = "https://www.mdanalysis.org/docs/"
+DEVELOP_URL = "https://www.mdanalysis.org/mdanalysis/"
+
+# change if sitemaps.org updates their schema
+NAMESPACE = {"sitemaps": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+
+def replace_loc(tree, search, replace, namespace=NAMESPACE):
+    root = tree.getroot()
+    urls = root.findall("sitemaps:url", namespace)
+    if len(urls) == 0:
+        raise ValueError("No sitemaps:url element found: check if the namespace in the XML file "
+                         "is still xmlns='{0[sitemaps]}'".format(namespace))
+    for url in urls:
+        loc = url.find("sitemaps:loc", namespace)
+        try:
+            loc.text = loc.text.replace(search, replace)
+        except AttributError:
+            raise ValueError("No sitemaps:loc element found: check if the namespace in the XML file "
+                             "is still xmlns='{0[sitemaps]}'".format(namespace))
+    return tree
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Change top level loc in sitemap.',
+                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
+    parser.add_argument('sitemap', metavar="FILE",
+                        help="path to sitemap.xml file, will be changed in place")
+    parser.add_argument('--output', '-o', metavar="FILE",
+                        default="sitemap_release.xml",
+                        help="write altered XML to output FILE")
+    parser.add_argument("--search", "-s", metavar="URL",
+                        default=DEVELOP_URL,
+                        help="search this URL in the loc elements")
+    parser.add_argument("--replace", "-r", metavar="URL",
+                        default=RELEASE_URL,
+                        help="replace the searched URL with this URL in the loc elements")
+    args = parser.parse_args()
+
+
+    with open(args.sitemap) as xmlfile:
+        tree = ElementTree.parse(xmlfile)
+
+    tree = replace_loc(tree, args.search, args.replace)
+
+    with open(args.output, "wb") as xmlfile:
+        tree.write(xmlfile, encoding="utf-8", xml_declaration=True,
+                   default_namespace=NAMESPACE['sitemaps'])
+
+    print("adapt_sitemap.py: Created output file {} with change in loc:".format(args.output))
+    print("adapt_sitemap.py: {0} --> {1}".format(args.search, args.replace))

--- a/package/doc/sphinx/source/conf.py
+++ b/package/doc/sphinx/source/conf.py
@@ -42,10 +42,11 @@ extensions = ['sphinx.ext.autodoc', 'sphinx.ext.intersphinx',
 mathjax_path = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML'
 
 # for sitemap with https://github.com/jdillard/sphinx-sitemap
-# NOTE: This sitemap is only correct for the release doccs. The development docs
-#       are served from https://www.mdanalysis.org/mdanalysis/ and the sitemap.xml
-#       will NOT be correct for the development docs.
-site_url = "https://www.mdanalysis.org/docs/"
+# NOTE: This sitemap is only correct for the DEVELOPMENT doccs. The RELEASE docs
+#       are served from https://www.mdanalysis.org/docs/ and the sitemap.xml
+#       is manually fixed when deploying the release docs with the
+#       maintainer/deploy_master_docs.sh script
+site_url = "https://www.mdanalysis.org/mdanalysis/"
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/package/doc/sphinx/source/conf.py
+++ b/package/doc/sphinx/source/conf.py
@@ -36,9 +36,16 @@ sys.path.insert(0, os.path.abspath('../../..'))
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.intersphinx',
               'sphinx.ext.mathjax', 'sphinx.ext.viewcode',
               'sphinx.ext.napoleon', 'sphinx.ext.todo',
+              'sphinx_sitemap',
               'alabaster']
 
 mathjax_path = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML'
+
+# for sitemap with https://github.com/jdillard/sphinx-sitemap
+# NOTE: This sitemap is only correct for the release doccs. The development docs
+#       are served from https://www.mdanalysis.org/mdanalysis/ and the sitemap.xml
+#       will NOT be correct for the development docs.
+site_url = "https://www.mdanalysis.org/docs/"
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
- install https://github.com/jdillard/sphinx-sitemap with pip
- create sitemap.xml that is correct for the RELEASE docs
  (it is incorrect for the development docs but we do not want to
  index the devdocs anyway... but we could change it so that by default
  it is correct for devdocs and then we fix sitemap.xml when we manually
  add the release docs with the maintainer/deploy_master_docs.sh script)
- see https://github.com/MDAnalysis/MDAnalysis.github.io/issues/78
