### PR TITLE
Added compound parameter to *Group.center_of_mass()

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,13 +13,14 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-??/??/18 tylerjereddy, richardjgowers, palnabarun, orbeckst, kain88-de
+??/??/18 tylerjereddy, richardjgowers, palnabarun, orbeckst, kain88-de, zemanj
 
   * 0.18.1
 
 Enhancements
   * Added various duecredit stubs
   * Import time reduced by a factor two (PR #1881)
+  * added compound kwarg to center, centroid, center_of_geometry, center_of_mass (PR #1903)
 
 Fixes
   * Fixed order of indices in Angle/Dihedral/Improper repr

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -630,7 +630,7 @@ class GroupBase(_MutableBase):
 
         Returns
         -------
-        center : numpy.ndarray with dtype=numpy.float32
+        center : numpy.ndarray
             Position vector(s) of the weighted center(s) of the group.
             If `compound` was set to 'group', the output will be a single
             position vector.
@@ -669,9 +669,7 @@ class GroupBase(_MutableBase):
                 coords = atoms.pack_into_box(inplace=False)
             else:
                 coords = atoms.positions
-            centers = np.average(coords, weights=weights, axis=0)
-            return centers.astype(np.float32) #TODO: check if astype() is really required (according to the numpy manual: no)
-
+            return np.average(coords, weights=weights, axis=0)
         elif compound.lower() == 'residues':
             compound_indices = atoms.resindices
             n_compounds = atoms.n_residues
@@ -690,7 +688,7 @@ class GroupBase(_MutableBase):
         if weights is not None:
             weights = weights[sort_indices]
         # Allocate output array:
-        centers = np.zeros((n_compounds, 3), dtype=np.float32)
+        centers = np.zeros((n_compounds, 3), dtype=coords.dtype)
         # Get sizes of compounds:
         unique_compound_indices, compound_sizes = np.unique(compound_indices,
                                                             return_counts=True)
@@ -738,7 +736,7 @@ class GroupBase(_MutableBase):
 
         Returns
         -------
-        center : numpy.ndarray with dtype=numpy.float32
+        center : numpy.ndarray
             Position vector(s) of the geometric center(s) of the group.
             If `compound` was set to 'group', the output will be a single
             position vector.

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -649,7 +649,7 @@ class GroupBase(_MutableBase):
             xyz = atoms.positions
 
         if compound.lower() == 'group':
-            return np.average(xyz, weights=weights, axis=0)
+            return np.average(xyz, weights=weights, axis=0).astype(np.float32)
         elif compound.lower() == 'residues':
             compound_indices = atoms.resindices
             n_compounds = atoms.n_residues

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -697,7 +697,7 @@ class GroupBase(_MutableBase):
         for compound_size in unique_compound_sizes:
             compound_mask = compound_sizes == compound_size
             _compound_indices = unique_compound_indices[compound_mask]
-            atoms_mask = np.isin(compound_indices, _compound_indices)
+            atoms_mask = np.in1d(compound_indices, _compound_indices)
             _coords = coords[atoms_mask].reshape((-1, compound_size, 3))
             if weights is None:
                 _centers = _coords.mean(axis=1)

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -113,7 +113,6 @@ from . import flags
 from ..exceptions import NoDataError
 from . import topologyobjects
 from ._get_readers import get_writer_for
-from . import flags
 
 
 def _unpickle(uhash, ix):
@@ -996,7 +995,7 @@ class GroupBase(_MutableBase):
         center of geometry.
 
         `box` allows a unit cell to be given for the transformation. If not
-        specified, an the dimensions information from the current Timestep will
+        specified, the dimensions information from the current Timestep will
         be used.
 
         .. note::
@@ -1018,7 +1017,7 @@ class GroupBase(_MutableBase):
         elif compound.lower() == 'fragments':
             objects = atomgroup.fragments
         else:
-            raise ValueError("Unrecognised compound definition: {0}"
+            raise ValueError("Unrecognized compound definition: {0}"
                              "Please use one of 'group' 'residues' 'segments'"
                              "or 'fragments'".format(compound))
 
@@ -1028,7 +1027,7 @@ class GroupBase(_MutableBase):
         elif center.lower() in ('cog', 'centroid', 'centerofgeometry'):
             centers = np.vstack([o.atoms.center_of_geometry() for o in objects])
         else:
-            raise ValueError("Unrecognised center definition: {0}"
+            raise ValueError("Unrecognized center definition: {0}"
                              "Please use one of 'com' or 'cog'".format(center))
         centers = centers.astype(np.float32)
 

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -49,7 +49,7 @@ from numpy.lib.utils import deprecate
 
 from . import flags
 from ..lib.util import cached, convert_aa_code, iterable
-from ..lib import transformations, mdamath
+from ..lib import distances, transformations, mdamath
 from ..exceptions import NoDataError, SelectionError
 from .topologyobjects import TopologyGroup
 from . import selection
@@ -780,19 +780,42 @@ class Masses(AtomAttr):
 
         return masses
 
-    def center_of_mass(group, pbc=None):
-        """Center of mass of the Group.
+    def center_of_mass(group, compound='group', pbc=None):
+        """Center of mass of (compounds of) the group.
+
+        Computes the center of mass of *unique* atoms of the group.
+        Centers of mass per residue or per segment can be obtained by setting
+        the `compound` parameter accordingly.
 
         Parameters
         ----------
+        compound : {'group', 'segments', 'residues'}, optional
+            If 'group', the center of mass of all atoms in the group will be
+            returned as a single position vector.
+            Else, the centers of mass of each segment or residue will be
+            returned as an array of position vectors, i.e. a 2d array.
+            Note that, in any case, *only* the positions and masses of atoms
+            *belonging to the group* will be taken into account.
+            [``'group'``]
         pbc : bool, optional
-            If ``True``, move all atoms within the primary unit cell before
-            calculation. [``False``]
+            If ``True`` and `compound` is 'group', move all atoms to the primary
+            unit cell before calculation.
+            If ``True`` and `compund` is 'segments' or 'residues', the centers
+            of mass of each compound will be calculated without moving any
+            atoms to keep the compounds intact. Instead, the resulting
+            center-of-mass position vectors will be moved to the primary unit
+            cell after calculation.
+            [``False``]
 
         Returns
         -------
-        center : ndarray
-            center of group given masses as weights
+        center : numpy.ndarray with dtype=numpy.float32
+            Position vector(s) of the center(s) of mass of the group.
+            If `compound` was set to 'group', the output will be a single
+            position vector.
+            If `compund` was set to 'segments' or 'residues', the output will
+            be a 2d array of shape ``(n, 3)`` where ``n`` is the number
+            compounds.
 
         Note
         ----
@@ -801,9 +824,50 @@ class Masses(AtomAttr):
 
 
         .. versionchanged:: 0.8 Added `pbc` parameter
+        .. versionchanged:: 0.18.0 Added `compound` parameter
         """
-        return group.atoms.center(weights=group.atoms.masses,
-                                  pbc=pbc)
+        atoms = group.atoms.unique
+        # COM of the whole group:
+        if compound == 'group':
+            return atoms.center(weights=atoms.masses, pbc=pbc)
+        # If COMs per compound are requested, get their number and indices:
+        elif compound.lower() == 'residues':
+            compound_indices = atoms.resindices
+            n_compounds = atoms.n_residues
+        elif compound.lower() == 'segments':
+            compound_indices = atoms.segindices
+            n_compounds = atoms.n_segments
+        else:
+            raise ValueError("Unrecognized compound definition: {}\nPlease use"
+                             " one of 'group', 'residues', or 'segments'."
+                             "".format(compound))
+        # Sort positions and masses by compound index:
+        sort_indices = np.argsort(compound_indices)
+        compound_indices = compound_indices[sort_indices]
+        positions = atoms.positions[sort_indices]
+        masses = atoms.masses[sort_indices]
+        # Allocate output array:
+        coms = np.zeros((n_compounds, 3), dtype=np.float32)
+        # Get sizes of compounds:
+        unique_compound_indices, compound_sizes = np.unique(compound_indices,
+                                                            return_counts=True)
+        unique_compound_sizes = np.unique(compound_sizes)
+        # Compute COMs per compound for each compound size:
+        for compound_size in unique_compound_sizes:
+            compound_mask = compound_sizes == compound_size
+            _compound_indices = unique_compound_indices[compound_mask]
+            atoms_mask = np.isin(compound_indices, _compound_indices)
+            _positions = positions[atoms_mask].reshape((-1, compound_size, 3))
+            _masses = masses[atoms_mask].reshape((-1, compound_size))
+            _coms = (_positions * _masses[:, :, None]).sum(axis=1)
+            _coms /= _masses.sum(axis=1)[:, None]
+            coms[compound_mask] = _coms
+        # Apply periodic boundary conditions if requested:
+        if pbc is None:
+            pbc = flags['use_pbc']
+        if pbc:
+            coms = distances.apply_PBC(coms, group.dimensions)
+        return coms
 
     transplants[GroupBase].append(
         ('center_of_mass', center_of_mass))

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -807,7 +807,7 @@ class Masses(AtomAttr):
 
         Returns
         -------
-        center : numpy.ndarray with dtype=numpy.float32
+        center : numpy.ndarray
             Position vector(s) of the center(s) of mass of the group.
             If `compound` was set to 'group', the output will be a single
             position vector.

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -780,10 +780,10 @@ class Masses(AtomAttr):
 
         return masses
 
-    def center_of_mass(group, compound='group', pbc=None):
+    def center_of_mass(group, pbc=None, compound='group'):
         """Center of mass of (compounds of) the group.
 
-        Computes the center of mass of *unique* atoms of the group.
+        Computes the center of mass of atoms in the group.
         Centers of mass per residue or per segment can be obtained by setting
         the `compound` parameter accordingly.
 
@@ -823,9 +823,9 @@ class Masses(AtomAttr):
 
 
         .. versionchanged:: 0.8 Added `pbc` parameter
-        .. versionchanged:: 0.18.0 Added `compound` parameter
+        .. versionchanged:: 0.19.0 Added `compound` parameter
         """
-        atoms = group.atoms.unique
+        atoms = group.atoms
         return atoms.center(weights=atoms.masses, pbc=pbc, compound=compound)
 
     transplants[GroupBase].append(

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -49,7 +49,7 @@ from numpy.lib.utils import deprecate
 
 from . import flags
 from ..lib.util import cached, convert_aa_code, iterable
-from ..lib import distances, transformations, mdamath
+from ..lib import transformations, mdamath
 from ..exceptions import NoDataError, SelectionError
 from .topologyobjects import TopologyGroup
 from . import selection
@@ -789,6 +789,14 @@ class Masses(AtomAttr):
 
         Parameters
         ----------
+        pbc : bool, optional
+            If ``True`` and `compound` is 'group', move all atoms to the primary
+            unit cell before calculation.
+            If ``True`` and `compound` is 'segments' or 'residues', the centers
+            of mass of each compound will be calculated without moving any
+            atoms to keep the compounds intact. Instead, the resulting
+            center-of-mass position vectors will be moved to the primary unit
+            cell after calculation.
         compound : {'group', 'segments', 'residues'}, optional
             If 'group', the center of mass of all atoms in the atomgroup will
             be returned as a single position vector. Else, the centers of mass
@@ -796,15 +804,6 @@ class Masses(AtomAttr):
             vectors, i.e. a 2d array. Note that, in any case, *only* the
             positions of atoms *belonging to the atomgroup* will be
             taken into account.
-        pbc : bool, optional
-            If ``True`` and `compound` is 'group', move all atoms to the primary
-            unit cell before calculation.
-            If ``True`` and `compund` is 'segments' or 'residues', the centers
-            of mass of each compound will be calculated without moving any
-            atoms to keep the compounds intact. Instead, the resulting
-            center-of-mass position vectors will be moved to the primary unit
-            cell after calculation.
-            [``False``]
 
         Returns
         -------
@@ -812,7 +811,7 @@ class Masses(AtomAttr):
             Position vector(s) of the center(s) of mass of the group.
             If `compound` was set to 'group', the output will be a single
             position vector.
-            If `compund` was set to 'segments' or 'residues', the output will
+            If `compound` was set to 'segments' or 'residues', the output will
             be a 2d array of shape ``(n, 3)`` where ``n`` is the number
             compounds.
 

--- a/testsuite/MDAnalysisTests/core/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/core/test_atomgroup.py
@@ -899,11 +899,29 @@ class TestAtomGroup(object):
 
     def test_center_of_geometry(self, ag):
         assert_almost_equal(ag.center_of_geometry(),
-                                  np.array([-0.04223963, 0.0141824, -0.03505163], dtype=np.float32))
+                            [-0.04223963, 0.0141824, -0.03505163], decimal=5)
 
     def test_center_of_mass(self, ag):
         assert_almost_equal(ag.center_of_mass(),
-                                  np.array([-0.01094035, 0.05727601, -0.12885778]))
+                            [-0.01094035, 0.05727601, -0.12885778], decimal=5)
+
+    @pytest.mark.parametrize('name, compound', (('resids', 'residues'),
+                                                ('segids', 'segments')))
+    def test_center_of_geometry_compounds(self, ag, name, compound):
+        ref = [a.center_of_geometry() for a in ag.groupby(name).values()]
+        cog = ag.center_of_geometry(compound=compound)
+        assert_almost_equal(cog, ref, decimal=5)
+
+    @pytest.mark.parametrize('name, compound', (('resids', 'residues'),
+                                                ('segids', 'segments')))
+    def test_center_of_mass_compounds(self, ag, name, compound):
+        ref = [a.center_of_mass() for a in ag.groupby(name).values()]
+        com = ag.center_of_mass(compound=compound)
+        assert_almost_equal(com, ref, decimal=5)
+
+    def test_center_wrong_compound(self, ag):
+        with pytest.raises(ValueError):
+            ag.center(weights=None, compound="foo")
 
     def test_coordinates(self, ag):
         assert_almost_equal(

--- a/testsuite/MDAnalysisTests/core/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/core/test_atomgroup.py
@@ -905,28 +905,38 @@ class TestAtomGroup(object):
         assert_almost_equal(ag.center_of_mass(),
                             [-0.01094035, 0.05727601, -0.12885778], decimal=5)
 
-    @pytest.mark.parametrize('pbc', (True, False))
     @pytest.mark.parametrize('name, compound', (('resids', 'residues'),
                                                 ('segids', 'segments')))
-    def test_center_of_geometry_compounds(self, ag, pbc, name, compound):
-        ag.universe.dimensions = [50, 50, 50, 90, 90, 90]
+    def test_center_of_geometry_compounds(self, ag, name, compound):
         ref = [a.center_of_geometry() for a in ag.groupby(name).values()]
-        if pbc:
-            ref = np.asarray(ref, dtype=np.float32)
-            ref = distances.apply_PBC(ref, ag.dimensions)
-        cog = ag.center_of_geometry(pbc=pbc, compound=compound)
+        cog = ag.center_of_geometry(compound=compound)
         assert_almost_equal(cog, ref, decimal=5)
 
-    @pytest.mark.parametrize('pbc', (True, False))
     @pytest.mark.parametrize('name, compound', (('resids', 'residues'),
                                                 ('segids', 'segments')))
-    def test_center_of_mass_compounds(self, ag, pbc, name, compound):
-        ag.universe.dimensions = [50, 50, 50, 90, 90, 90]
+    def test_center_of_mass_compounds(self, ag, name, compound):
         ref = [a.center_of_mass() for a in ag.groupby(name).values()]
-        if pbc:
-            ref = np.asarray(ref, dtype=np.float32)
-            ref = distances.apply_PBC(ref, ag.dimensions)
-        com = ag.center_of_mass(pbc=pbc, compound=compound)
+        com = ag.center_of_mass(compound=compound)
+        assert_almost_equal(com, ref, decimal=5)
+
+    @pytest.mark.parametrize('name, compound', (('resids', 'residues'),
+                                                ('segids', 'segments')))
+    def test_center_of_geometry_compounds_pbc(self, ag, name, compound):
+        ag.dimensions = [50, 50, 50, 90, 90, 90]
+        ref = [a.center_of_geometry() for a in ag.groupby(name).values()]
+        ref = distances.apply_PBC(np.asarray(ref, dtype=np.float32),
+                                  ag.dimensions)
+        cog = ag.center_of_geometry(pbc=True, compound=compound)
+        assert_almost_equal(cog, ref, decimal=5)
+
+    @pytest.mark.parametrize('name, compound', (('resids', 'residues'),
+                                                ('segids', 'segments')))
+    def test_center_of_mass_compounds_pbc(self, ag, name, compound):
+        ag.dimensions = [50, 50, 50, 90, 90, 90]
+        ref = [a.center_of_mass() for a in ag.groupby(name).values()]
+        ref = distances.apply_PBC(np.asarray(ref, dtype=np.float32),
+                                  ag.dimensions)
+        com = ag.center_of_mass(pbc=True, compound=compound)
         assert_almost_equal(com, ref, decimal=5)
 
     def test_center_wrong_compound(self, ag):
@@ -1053,6 +1063,7 @@ class TestAtomGroup(object):
 
     def test_packintobox_noshape(self, universe):
         ag = universe.atoms[:10]
+        ag.dimensions = np.zeros(6)
         with pytest.raises(ValueError):
             ag.pack_into_box()
 

--- a/testsuite/MDAnalysisTests/core/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/core/test_atomgroup.py
@@ -33,7 +33,7 @@ from numpy.testing import (
 )
 
 import MDAnalysis as mda
-from MDAnalysis.lib import transformations
+from MDAnalysis.lib import distances, transformations
 from MDAnalysis.core.topologyobjects import (
     Bond,
     Angle,
@@ -905,18 +905,28 @@ class TestAtomGroup(object):
         assert_almost_equal(ag.center_of_mass(),
                             [-0.01094035, 0.05727601, -0.12885778], decimal=5)
 
+    @pytest.mark.parametrize('pbc', (True, False))
     @pytest.mark.parametrize('name, compound', (('resids', 'residues'),
                                                 ('segids', 'segments')))
-    def test_center_of_geometry_compounds(self, ag, name, compound):
+    def test_center_of_geometry_compounds(self, ag, pbc, name, compound):
+        ag.universe.dimensions = [50, 50, 50, 90, 90, 90]
         ref = [a.center_of_geometry() for a in ag.groupby(name).values()]
-        cog = ag.center_of_geometry(compound=compound)
+        if pbc:
+            ref = np.asarray(ref, dtype=np.float32)
+            ref = distances.apply_PBC(ref, ag.dimensions)
+        cog = ag.center_of_geometry(pbc=pbc, compound=compound)
         assert_almost_equal(cog, ref, decimal=5)
 
+    @pytest.mark.parametrize('pbc', (True, False))
     @pytest.mark.parametrize('name, compound', (('resids', 'residues'),
                                                 ('segids', 'segments')))
-    def test_center_of_mass_compounds(self, ag, name, compound):
+    def test_center_of_mass_compounds(self, ag, pbc, name, compound):
+        ag.universe.dimensions = [50, 50, 50, 90, 90, 90]
         ref = [a.center_of_mass() for a in ag.groupby(name).values()]
-        com = ag.center_of_mass(compound=compound)
+        if pbc:
+            ref = np.asarray(ref, dtype=np.float32)
+            ref = distances.apply_PBC(ref, ag.dimensions)
+        com = ag.center_of_mass(pbc=pbc, compound=compound)
         assert_almost_equal(com, ref, decimal=5)
 
     def test_center_wrong_compound(self, ag):


### PR DESCRIPTION
Added `compound` parameter to `MDAnalysis.core.topologyattrs.center_of_mass()` to support COM calculation per residue or per segment.
The idea to add the `compound` parameter is to achieve what has been requested in issue #1053,
and is in analogy to the `compound` parameter in `MDAnalysis.core.groups.GroupBase.wrap()`.

For now, this is just a suggestion, and I'd appreciate some feedback on how to make this bulletproof, regarding both its mode of operation and implementation.

Fixes #1053

Changes made in this Pull Request:
 - Added `compound` parameter to `center_of_mass()`
 - Unified mode of operation for ``pbc=True`` and ``pbc=False`` to take only unique atoms into account. *This issue should be discussed in more detail.*

PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
