### PR TITLE
BUG: duecredit should now be imported properly on Windows

### DIFF
--- a/package/MDAnalysis/due.py
+++ b/package/MDAnalysis/due.py
@@ -68,7 +68,11 @@ try:
                  as (os_dot_fork, os_dot_popen):
                 import duecredit
         else:
-            with patch('os.fork') as os_dot_fork, patch('os.popen') as os_dot_popen:
+            if not os.name == 'nt':
+                with patch('os.fork') as os_dot_fork, patch('os.popen') as os_dot_popen:
+                    import duecredit
+            else:
+                # Windows doesn't have os.fork
                 import duecredit
 
     from duecredit import due, BibTeX, Doi, Url


### PR DESCRIPTION
Fixes #1909 

As noted in that linked issue, I suspect we should probably just use `multiprocessing` for all platforms as a cleaner solution that doesn't check operating system & so on.

This should bring the Windows test failures down from about 35 to 22 if appveyor agrees with me.