### PR TITLE
clean up warnings in tests

### DIFF
--- a/testsuite/MDAnalysisTests/core/test_atom.py
+++ b/testsuite/MDAnalysisTests/core/test_atom.py
@@ -22,6 +22,8 @@
 
 from __future__ import absolute_import
 
+import warnings
+
 import MDAnalysis as mda
 import numpy as np
 import pytest
@@ -120,7 +122,9 @@ class TestAtomNoForceNoVel(object):
     @staticmethod
     @pytest.fixture()
     def a():
-        u = mda.Universe(XYZ_mini)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', UserWarning)
+            u = mda.Universe(XYZ_mini)
         return u.atoms[0]
 
     def test_velocity_fail(self, a):

--- a/testsuite/MDAnalysisTests/core/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/core/test_atomgroup.py
@@ -24,6 +24,7 @@ from __future__ import division, absolute_import
 from glob import glob
 import itertools
 from os import path
+import warnings
 
 import numpy as np
 
@@ -102,7 +103,9 @@ class TestAtomGroupWriting(object):
 
     def test_write_no_args(self, u, tmpdir):
         with tmpdir.as_cwd():
-            u.atoms.write()
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore', UserWarning)
+                u.atoms.write()
             files = glob('*')
             assert len(files) == 1
 
@@ -149,7 +152,9 @@ class _WriteAtoms(object):
         return mda.Universe(outfile, convert_units=True)
 
     def test_write_atoms(self, universe, outfile):
-        universe.atoms.write(outfile)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', UserWarning)
+            universe.atoms.write(outfile)
         u2 = self.universe_from_tmp(outfile)
         assert_almost_equal(
             universe.atoms.positions, u2.atoms.positions,
@@ -164,7 +169,9 @@ class _WriteAtoms(object):
 
     def test_write_selection(self, universe, outfile):
         CA = universe.select_atoms('name CA')
-        CA.write(outfile)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', UserWarning)
+            CA.write(outfile)
         u2 = self.universe_from_tmp(outfile)
         # check EVERYTHING, otherwise we might get false positives!
         CA2 = u2.atoms
@@ -176,8 +183,10 @@ class _WriteAtoms(object):
 
     def test_write_Residue(self, universe, outfile):
         G = universe.select_atoms('segid 4AKE and resname ARG').residues[-2].atoms  # 2nd but last Arg
-        G.write(outfile)
-        u2 = self.universe_from_tmp(outfile)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', UserWarning)
+            G.write(outfile)
+            u2 = self.universe_from_tmp(outfile)
         # check EVERYTHING, otherwise we might get false positives!
         G2 = u2.atoms
         assert len(u2.atoms) == len(G.atoms), "written R206 Residue does not " \
@@ -188,8 +197,10 @@ class _WriteAtoms(object):
 
     def test_write_ResidueGroup(self, universe, outfile):
         G = universe.select_atoms('segid 4AKE and resname LEU')
-        G.write(outfile)
-        u2 = self.universe_from_tmp(outfile)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', UserWarning)
+            G.write(outfile)
+            u2 = self.universe_from_tmp(outfile)
         G2 = u2.atoms
         assert len(u2.atoms) == len(G.atoms), "written LEU ResidueGroup does " \
                                               "not match original ResidueGroup"
@@ -199,7 +210,9 @@ class _WriteAtoms(object):
 
     def test_write_Segment(self, universe, outfile):
         G = universe.select_atoms('segid 4AKE')
-        G.write(outfile)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', UserWarning)
+            G.write(outfile)
         u2 = self.universe_from_tmp(outfile)
         G2 = u2.atoms
         assert len(u2.atoms) == len(G.atoms), "written s4AKE segment does not" \
@@ -210,7 +223,8 @@ class _WriteAtoms(object):
 
     def test_write_Universe(self, universe, outfile):
         U = universe
-        with mda.Writer(outfile) as W:
+        with mda.Writer(outfile) as W, warnings.catch_warnings():
+            warnings.simplefilter('ignore', UserWarning)
             W.write(U)
         u2 = self.universe_from_tmp(outfile)
         assert len(u2.atoms) == len(U.atoms), "written 4AKE universe does not" \
@@ -829,7 +843,8 @@ class TestPBCFlag(object):
 def test_instantselection_termini():
     """Test that instant selections work, even for residues that are also termini (Issue 70)"""
     universe = mda.Universe(PSF, DCD)
-    assert_equal(universe.residues[20].CA.name, 'CA', "CA of MET21 is not selected correctly")
+    with pytest.deprecated_call():
+        assert_equal(universe.residues[20].CA.name, 'CA', "CA of MET21 is not selected correctly")
     del universe
 
 
@@ -861,7 +876,8 @@ class TestAtomGroup(object):
                      universe.atoms.ix[0:8:2])
 
     def test_getitem_str(self, universe):
-        ag1 = universe.atoms['HT1']
+        with pytest.deprecated_call():
+            ag1 = universe.atoms['HT1']
         # select_atoms always returns an AtomGroup even if single result
         ag2 = universe.select_atoms('name HT1')[0]
         assert_equal(ag1, ag2)

--- a/testsuite/MDAnalysisTests/core/test_topologyattrs.py
+++ b/testsuite/MDAnalysisTests/core/test_topologyattrs.py
@@ -282,7 +282,8 @@ class TestResnames(TestResidueAttr):
     def test_residuegroup_getattr_single(self):
         u = make_Universe(('resnames',))
 
-        res = u.residues.RsB
+        with pytest.deprecated_call():
+            res = u.residues.RsB
 
         assert isinstance(res, groups.Residue)
         assert res == u.residues[1]
@@ -291,7 +292,8 @@ class TestResnames(TestResidueAttr):
         u = make_Universe(('resnames',))
         u.residues[:10].resnames = 'ABC'
 
-        rg = u.residues.ABC
+        with pytest.deprecated_call():
+            rg = u.residues.ABC
 
         assert isinstance(rg, groups.ResidueGroup)
         assert len(rg) == 10
@@ -301,11 +303,11 @@ class TestResnames(TestResidueAttr):
         with pytest.raises(AttributeError):
             getattr(u.residues, 'foo')
 
-
     def test_segment_getattr_singular(self):
         u = make_Universe(('resnames',))
 
-        res = u.segments[0].RsB
+        with pytest.deprecated_call():
+            res = u.segments[0].RsB
 
         assert isinstance(res, groups.Residue)
         assert res == u.residues[1]
@@ -314,7 +316,8 @@ class TestResnames(TestResidueAttr):
         u = make_Universe(('resnames',))
         u.residues[:3].resnames = 'bar'
 
-        rg = u.segments[0].bar
+        with pytest.deprecated_call():
+            rg = u.segments[0].bar
 
         assert isinstance(rg, groups.ResidueGroup)
         assert len(rg) == 3

--- a/testsuite/MDAnalysisTests/core/test_universe.py
+++ b/testsuite/MDAnalysisTests/core/test_universe.py
@@ -23,7 +23,7 @@ from __future__ import absolute_import, print_function
 
 
 from six.moves import cPickle
-
+import warnings
 import os
 
 try:
@@ -86,12 +86,16 @@ class TestUniverseCreation(object):
         assert_equal(len(u.atoms), 3341, "Loading universe failed somehow")
 
     def test_load_topology_stringio(self):
-        u = mda.Universe(StringIO(CHOL_GRO), format='GRO')
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', UserWarning)
+            u = mda.Universe(StringIO(CHOL_GRO), format='GRO')
         assert_equal(len(u.atoms), 8, "Loading universe from StringIO failed somehow")
         assert_equal(u.trajectory.ts.positions[0], np.array([65.580002, 29.360001, 40.050003], dtype=np.float32))
 
     def test_load_trajectory_stringio(self):
-        u = mda.Universe(StringIO(CHOL_GRO), StringIO(CHOL_GRO),  format='GRO', topology_format='GRO')
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', UserWarning)
+            u = mda.Universe(StringIO(CHOL_GRO), StringIO(CHOL_GRO),  format='GRO', topology_format='GRO')
         assert_equal(len(u.atoms), 8, "Loading universe from StringIO failed somehow")
 
     def test_make_universe_no_args(self):
@@ -346,19 +350,24 @@ class TestGuessBonds(object):
 
     def test_universe_guess_bonds_no_vdwradii(self):
         """Make a Universe that has atoms with unknown vdwradii."""
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError), warnings.catch_warnings():
+            warnings.simplefilter('ignore', UserWarning)
             mda.Universe(two_water_gro_nonames, guess_bonds = True)
 
     def test_universe_guess_bonds_with_vdwradii(self, vdw):
         """Unknown atom types, but with vdw radii here to save the day"""
-        u = mda.Universe(two_water_gro_nonames, guess_bonds=True,
-                                vdwradii=vdw)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', UserWarning)
+            u = mda.Universe(two_water_gro_nonames, guess_bonds=True,
+                             vdwradii=vdw)
         self._check_universe(u)
         assert u.kwargs['guess_bonds']
         assert_equal(vdw, u.kwargs['vdwradii'])
 
     def test_universe_guess_bonds_off(self):
-        u = mda.Universe(two_water_gro_nonames, guess_bonds=False)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', UserWarning)
+            u = mda.Universe(two_water_gro_nonames, guess_bonds=False)
 
         for attr in ('bonds', 'angles', 'dihedrals'):
             assert not hasattr(u, attr)
@@ -390,14 +399,18 @@ class TestGuessBonds(object):
         self._check_atomgroup(ag, u)
 
     def test_atomgroup_guess_bonds_no_vdwradii(self):
-        u = mda.Universe(two_water_gro_nonames)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', UserWarning)
+            u = mda.Universe(two_water_gro_nonames)
 
         ag = u.atoms[:3]
         with pytest.raises(ValueError):
             ag.guess_bonds()
 
     def test_atomgroup_guess_bonds_with_vdwradii(self, vdw):
-        u = mda.Universe(two_water_gro_nonames)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', UserWarning)
+            u = mda.Universe(two_water_gro_nonames)
 
         ag = u.atoms[:3]
         ag.guess_bonds(vdwradii=vdw)
@@ -599,15 +612,21 @@ class TestAddTopologyAttr(object):
 class TestAllCoordinatesKwarg(object):
     @pytest.fixture(scope='class')
     def u_GRO_TRR(self):
-        return mda.Universe(GRO, TRR)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', UserWarning)
+            return mda.Universe(GRO, TRR)
 
     @pytest.fixture(scope='class')
     def u_GRO_TRR_allcoords(self):
-        return mda.Universe(GRO, TRR, all_coordinates=True)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', UserWarning)
+            return mda.Universe(GRO, TRR, all_coordinates=True)
 
     @pytest.fixture(scope='class')
     def u_GRO(self):
-        return mda.Universe(GRO)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', UserWarning)
+            return mda.Universe(GRO)
 
     def test_all_coordinates_length(self, u_GRO_TRR, u_GRO_TRR_allcoords):
         # length with all_coords should be +1

--- a/testsuite/MDAnalysisTests/import/fork_called.py
+++ b/testsuite/MDAnalysisTests/import/fork_called.py
@@ -22,6 +22,9 @@
 from __future__ import absolute_import, print_function
 import os
 import mock
+import warnings
+
+warnings.simplefilter('ignore', ImportWarning)
 
 """Tests whether os.fork() is called as a side effect when importing MDAnalysis.
 See PR #1794 for details."""

--- a/testsuite/MDAnalysisTests/import/test_import.py
+++ b/testsuite/MDAnalysisTests/import/test_import.py
@@ -23,37 +23,43 @@ from __future__ import absolute_import, print_function
 import sys
 import os
 import subprocess
+import warnings
 
 """Test if importing MDAnalysis has unwanted side effects (PR #1794)."""
 
 class TestMDAImport(object):
     # Tests concerning importing MDAnalysis.
     def test_os_dot_fork_not_called(self):
-        # Importing MDAnalysis shall not trigger calls to os.fork (see PR #1794)
-        # This test has to run in a separate Python instance to ensure that
-        # no previously imported modules interfere with it. It is therefore
-        # offloaded to the script "fork_called.py".
-        loc = os.path.dirname(os.path.realpath(__file__))
-        script = os.path.join(loc, 'fork_called.py')
-        encoding = sys.stdout.encoding
-        if encoding is None:
-            encoding = "utf-8"
-        # If the script we are about to call fails, we want its stderr to show
-        # up in the pytest log. This is accomplished by redirecting the stderr
-        # of the subprocess to its stdout and catching the raised
-        # CalledProcessError. That error's output member then contains the
-        # failed script's stderr and we can print it:
-        try:
-            out = subprocess.check_output([sys.executable, script],
-                                          stderr=subprocess.STDOUT)\
-                                         .decode(encoding)
-        except subprocess.CalledProcessError as err:
-            print(err.output)
-            raise(err)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', ImportWarning)
+            # Importing MDAnalysis shall not trigger calls to os.fork (see PR #1794)
+            # This test has to run in a separate Python instance to ensure that
+            # no previously imported modules interfere with it. It is therefore
+            # offloaded to the script "fork_called.py".
+            loc = os.path.dirname(os.path.realpath(__file__))
+            script = os.path.join(loc, 'fork_called.py')
+            encoding = sys.stdout.encoding
+            if encoding is None:
+                encoding = "utf-8"
+            # If the script we are about to call fails, we want its stderr to show
+            # up in the pytest log. This is accomplished by redirecting the stderr
+            # of the subprocess to its stdout and catching the raised
+            # CalledProcessError. That error's output member then contains the
+            # failed script's stderr and we can print it:
+            try:
+                out = subprocess.check_output([sys.executable, script],
+                                            stderr=subprocess.STDOUT)\
+                                            .decode(encoding)
+            except subprocess.CalledProcessError as err:
+                print(err.output)
+                raise(err)
 
     def test_os_dot_fork_not_none(self):
         # In MDAnalysis.core.universe, os.fork is set to None prior to importing
         # the uuid module and restored afterwards (see PR #1794 for details).
         # This tests asserts that os.fork has been restored.
-        import MDAnalysis
-        assert os.fork is not None
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', ImportWarning)
+            warnings.simplefilter('ignore', RuntimeWarning)
+            import MDAnalysis
+            assert os.fork is not None


### PR DESCRIPTION

Changes made in this Pull Request:
 - silence user warnings
 - test for deprecation warnings

No more warnings are issues on python  3 for tests in code

PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
