### PR TITLE
TST: skip gsd-based tests on Windows

### DIFF
--- a/testsuite/MDAnalysisTests/coordinates/test_gsd.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_gsd.py
@@ -27,12 +27,15 @@ from numpy.testing import assert_almost_equal
 from MDAnalysisTests.datafiles import GSD
 
 import MDAnalysis as mda
+import os
 
 
 @pytest.fixture
 def GSD_U():
     return mda.Universe(GSD)
 
+@pytest.mark.skipif(os.name == 'nt',
+                    reason="gsd not windows compatible")
 def test_gsd_positions(GSD_U):
     # first frame first particle
     ts = GSD_U.trajectory[0]
@@ -43,14 +46,20 @@ def test_gsd_positions(GSD_U):
     assert_almost_equal(GSD_U.atoms.positions[0],
                         [ -5.58348083,  -9.98546982, -10.17657185])
 
+@pytest.mark.skipif(os.name == 'nt',
+                    reason="gsd not windows compatible")
 def test_gsd_n_frames(GSD_U):
     assert len(GSD_U.trajectory) == 2
 
+@pytest.mark.skipif(os.name == 'nt',
+                    reason="gsd not windows compatible")
 def test_gsd_dimensions(GSD_U):
     ts = GSD_U.trajectory[0]
     assert_almost_equal(ts.dimensions,
                         [ 21.60000038,21.60000038,21.60000038,90.,90.,90.])
 
+@pytest.mark.skipif(os.name == 'nt',
+                    reason="gsd not windows compatible")
 def test_gsd_data_step(GSD_U):
     assert GSD_U.trajectory[0].data['step'] == 0
     assert GSD_U.trajectory[1].data['step'] == 500

--- a/testsuite/MDAnalysisTests/topology/test_gsd.py
+++ b/testsuite/MDAnalysisTests/topology/test_gsd.py
@@ -28,8 +28,11 @@ import MDAnalysis as mda
 from MDAnalysisTests.topology.base import ParserBase
 from MDAnalysisTests.datafiles import GSD
 from numpy.testing import assert_equal
+import os
 
 
+@pytest.mark.skipif(os.name == 'nt',
+                    reason="gsd not windows compatible")
 class TestGSDParser(ParserBase):
     parser = mda.topology.GSDParser.GSDParser
     ref_filename = GSD


### PR DESCRIPTION
As far as I can tell our `gsd` dependency is not Windows compatible so I've marked the corresponding unit tests for skipping based on platform.

If we agree that gsd isn't windows compatible, there's probably also some kind of documentation or warning related to import that might be suitable.