### PR TITLE
TST: improve Win compatibility of lammps DCD writer testing

### DIFF
--- a/testsuite/MDAnalysisTests/coordinates/test_lammps.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_lammps.py
@@ -279,11 +279,13 @@ class TestLAMMPSDCDWriter(RefLAMMPSDataDCD):
     def test_Writer(self, u, tmpdir, n_frames=3):
         ext = os.path.splitext(self.trajectory)[1]
         outfile = str(tmpdir.join('lammps-writer-test' + ext))
-        W = mda.Writer(outfile, n_atoms=u.atoms.n_atoms,
-                       format=self.format)
-        with u.trajectory.OtherWriter(outfile) as w:
+
+        with mda.Writer(outfile,
+                        n_atoms=u.atoms.n_atoms,
+                        format=self.format) as w:
             for ts in u.trajectory[:n_frames]:
                 w.write(ts)
+
         short = mda.Universe(self.topology, outfile)
         assert_equal(short.trajectory.n_frames, n_frames,
                      err_msg="number of frames mismatch")


### PR DESCRIPTION
This may or may not be a controversial adjustment to the unit test involved; as the note in my code adjustment indicates, the unit test appears to be accidentally testing for POSIX-specific behavior that isn't necessarily directly related to the LAMMPS Writer.

On the other hand, the way the files behave on Windows vs. POSIX could mean that the user may have a different experience opening files & interacting with MDAnalysis, though I'm not sure there's much we can do about that, though I could be wrong.

Maybe I'm just not getting it though -- why would a user (or unit tester) want to open the same file object for trajectory writing twice in the same control flow context?

Locally this shifts Windows failures 20 -> 19.
