### PR TITLE
BUG: libdcd now properly handles missing input file on Windows

### DIFF
--- a/package/MDAnalysis/lib/formats/libdcd.pyx
+++ b/package/MDAnalysis/lib/formats/libdcd.pyx
@@ -292,6 +292,8 @@ cdef class DCDFile:
             self.close()
 
         if mode == 'r':
+            if not path.isfile(self.fname):
+                raise IOError("DCD file does not exist")
             fio_mode = FIO_READ
         elif mode == 'w':
             fio_mode = FIO_WRITE


### PR DESCRIPTION
For whatever reason it seems that Windows needs a bit of extra logic in the `libdcd` Cython code to verify that an input file actually exists & to raise the appropriate Exception that our unit testing expects.

Locally, this reduces failures from 17->16 on Windows.

The original failing test was `test_raise_not_existing()` in `test_libdcd.py`.