### PR TITLE
made test_dres_convergence less likely to fail

### DIFF
--- a/package/MDAnalysis/analysis/encore/dimensionality_reduction/src/spe.c
+++ b/package/MDAnalysis/analysis/encore/dimensionality_reduction/src/spe.c
@@ -193,10 +193,8 @@ double CStochasticProximityEmbedding(
     double t = 0.0;
     double finalstress = 0.0;
 
-    srand(time(NULL)+getpid()*getpid());
     /* random init of d */
-
-
+    srand(time(NULL)+getpid()*getpid());
     for (int i=0; i<nelem*dim; i++) {
         d_coords[i] = (double) rand() / (double) RAND_MAX;
     }
@@ -228,8 +226,8 @@ double CStochasticProximityEmbedding(
             }
         }
         lam = lam - (maxlam - minlam) / (double)(ncycle - 1);
-        if (i % stressfreq == 0 && i != 0 && stressfreq > 0)
-	  printf("Cycle %d - Residual stress: %.3f, lambda %.3f\n", i, neighbours_stress(s, d_coords, dim, nelem, rco),lam);
+        //if (i % stressfreq == 0 && i != 0 && stressfreq > 0)
+	    //printf("Cycle %d - Residual stress: %.3f, lambda %.3f\n", i, neighbours_stress(s, d_coords, dim, nelem, rco),lam);
     }
     finalstress = neighbours_stress(s, d_coords, dim, nelem, rco);
     //printf("Calculation finished. - Residual stress: %.3f\n", finalstress);

--- a/testsuite/MDAnalysisTests/analysis/test_encore.py
+++ b/testsuite/MDAnalysisTests/analysis/test_encore.py
@@ -305,10 +305,27 @@ inconsistent results")
                                 err_msg="Unexpected value for Clustering Ensemble similarity in convergence estimation")
 
     def test_dres_convergence(self, ens1):
-        expected_values = [ 0.3, 0.]
+        # Due to encore.dres_convergence() involving random numbers, the
+        # following assertion is allowed to fail once. This significantly
+        # reduces the probability of a random test failure.
+        expected_values = [0.3, 0.]
         results = encore.dres_convergence(ens1, 10)
-        assert_almost_equal(results[:,0], expected_values, decimal=1,
-                            err_msg="Unexpected value for Dim. reduction Ensemble similarity in convergence estimation")
+        try:
+            assert_almost_equal(results[:,0], expected_values, decimal=1)
+        except AssertionError:
+            # Random test failure is very rare, but repeating the failed test
+            # just once would only assert that the test passes with 50%
+            # probability. To be a little safer, we raise a warning and repeat
+            # the test 10 times:
+            warnings.warn(message="Test 'test_dres_convergence' failed, "
+                                  "repeating test 10 times.",
+                          category=RuntimeWarning)
+            for i in range(10):
+                results = encore.dres_convergence(ens1, 10)
+                assert_almost_equal(results[:,0], expected_values, decimal=1,
+                                    err_msg="Unexpected value for Dim. "
+                                            "reduction Ensemble similarity in "
+                                            "convergence estimation")
 
     def test_hes_error_estimation(self, ens1):
         expected_average = 10


### PR DESCRIPTION
Fixes #1931

Changes made in this Pull Request:
 - If `MDAnalysisTests.analysis.test_encore.TestEncore.test_dres_convergence` fails, a `RuntimeWarning` is thrown and the test is repeated 10 times.
 - Commented out `printf(...)` in `CStochasticProximityEmbedding()`


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?
