### PR TITLE
enforced double precision calculations in *Group.center()

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -32,6 +32,9 @@ Enhancements
   * Added *Group.copy() methods returning an identical copy of the respective
     group (PR #1922)
   * Use a faster function to deduplicate indices (PR #1951)
+  * Calculations in *Group.center() are performed in double precision (#PR1936)
+  * Functions in lib.distances accept coordinate arrays of arbitrary dtype
+    (PR #1936)
 
 Fixes
   * rewind in the SingleFrameReader now reads the frame from the file (Issue #1929)

--- a/package/MDAnalysis/lib/distances.py
+++ b/package/MDAnalysis/lib/distances.py
@@ -228,11 +228,11 @@ def distance_array(reference, configuration, box=None, result=None, backend="ser
     Parameters
     ----------
     reference : numpy.ndarray
-        Reference coordinate array of shape ``(n, 3)``, will be converted to
-        ``dtype=numpy.float32``.
+        Reference coordinate array of shape ``(n, 3)`` (``dtype`` is arbitrary,
+        will be converted to ``dtype=numpy.float32`` internally)
     configuration : numpy.ndarray
-        Configuration coordinate array of shape ``(m, 3)``, will be converted to
-        ``dtype=numpy.float32``.
+        Configuration coordinate array of shape ``(m, 3)`` (``dtype`` is
+        arbitrary, will be converted to ``dtype=numpy.float32`` internally)
     box : numpy.ndarray or None
         Dimensions of the cell; if provided, the minimum image convention is
         applied. The dimensions must be provided in the same format as returned
@@ -263,7 +263,7 @@ def distance_array(reference, configuration, box=None, result=None, backend="ser
     .. versionchanged:: 0.13.0
        Added *backend* keyword.
     .. versionchanged:: 0.19.0
-       Added input array dtype conversion to ``numpy.float32``.
+       Internal dtype conversion of input coordinates to ``numpy.float32``.
     """
     ref = reference.astype(np.float32, order='C', copy=True)
     conf = configuration.astype(np.float32, order='C', copy=True)
@@ -318,8 +318,8 @@ def self_distance_array(reference, box=None, result=None, backend="serial"):
     Parameters
     ----------
     reference : numpy.ndarray
-        Reference coordinate array with ``N=len(ref)`` coordinates, will be
-        converted to ``dtype=numpy.float32``.
+        Reference coordinate array with ``N=len(ref)`` coordinates (``dtype`` is
+        arbitrary, will be converted to ``dtype=numpy.float32`` internally)
     box : numpy.ndarray or None
         Dimensions of the cell; if provided, the minimum image convention is
         applied. The dimensions must be provided in the same format as returned
@@ -355,7 +355,7 @@ def self_distance_array(reference, box=None, result=None, backend="serial"):
     .. versionchanged:: 0.13.0
        Added *backend* keyword.
     .. versionchanged:: 0.19.0
-       Added input array dtype conversion to ``numpy.float32``.
+       Internal dtype conversion of input coordinates to ``numpy.float32``.
     """
     ref = reference.astype(np.float32, order='C', copy=True)
 
@@ -406,7 +406,8 @@ def transform_RtoS(inputcoords, box, backend="serial"):
     Parameters
     ----------
     inputcoords : array
-        A (3,) coordinate or (n x 3) array of coordinates, type ``np.float32``.
+        A (3,) coordinate or (n x 3) array of coordinates (``dtype`` is
+        arbitrary, will be converted to ``dtype=numpy.float32`` internally)
     box : array
         The unitcell dimesions for this system.
         The dimensions must be provided in the same format as returned
@@ -423,8 +424,10 @@ def transform_RtoS(inputcoords, box, backend="serial"):
 
     .. versionchanged:: 0.13.0
        Added *backend* keyword.
+    .. versionchanged:: 0.19.0
+       Internal dtype conversion of input coordinates to ``numpy.float32``.
     """
-    coords = inputcoords.copy('C')
+    coords = inputcoords.astype(np.float32, order='C', copy=True)
 
     is_1d = False  # True if only one vector coordinate
     if len(coords.shape) == 1:
@@ -465,7 +468,8 @@ def transform_StoR(inputcoords, box, backend="serial"):
     Parameters
     ----------
     inputcoords : array
-        A (3,) coordinate or (n x 3) array of coordinates, type ``np.float32``.
+        A (3,) coordinate or (n x 3) array of coordinates (``dtype`` is
+        arbitrary, will be converted to ``dtype=numpy.float32`` internally)
     box : array
         The unitcell dimesions for this system.
         The dimensions must be provided in the same format as returned
@@ -483,9 +487,10 @@ def transform_StoR(inputcoords, box, backend="serial"):
 
     .. versionchanged:: 0.13.0
        Added *backend* keyword.
+    .. versionchanged:: 0.19.0
+       Internal dtype conversion of input coordinates to ``numpy.float32``.
     """
-    _check_array_dtype(inputcoords, 'S')
-    coords = inputcoords.copy('C')
+    coords = inputcoords.astype(np.float32, order='C', copy=True)
 
     is_1d = False  # True if only one vector coordinate
     if len(coords.shape) == 1:
@@ -533,9 +538,11 @@ def calc_bonds(coords1, coords2, box=None, result=None, backend="serial"):
     Parameters
     ----------
     coords1 : array
-        An array of coordinates for one half of the bond.
+        An array of coordinates for one half of the bond (``dtype`` is
+        arbitrary, will be converted to ``dtype=numpy.float32`` internally)
     coords2 : array
-        An array of coordinates for the other half of bond
+        An array of coordinates for the other half of bond (``dtype`` is
+        arbitrary, will be converted to ``dtype=numpy.float32`` internally)
     box : array
         The unitcell dimesions for this system.
         The dimensions must be provided in the same format as returned
@@ -558,9 +565,11 @@ def calc_bonds(coords1, coords2, box=None, result=None, backend="serial"):
     .. versionadded:: 0.8
     .. versionchanged:: 0.13.0
        Added *backend* keyword.
+    .. versionchanged:: 0.19.0
+       Internal dtype conversion of input coordinates to ``numpy.float32``.
     """
-    atom1 = coords1.copy('C')
-    atom2 = coords2.copy('C')
+    atom1 = coords1.astype(np.float32, order='C', copy=True)
+    atom2 = coords2.astype(np.float32, order='C', copy=True)
 
     _check_array(atom1, 'atom1')
     _check_array(atom2, 'atom2')
@@ -618,11 +627,14 @@ def calc_angles(coords1, coords2, coords3, box=None, result=None, backend="seria
     Parameters
     ----------
     coords1 : numpy.ndarray
-        Coordinate array of one side of angles.
+        Coordinate array of one side of angles (``dtype`` is arbitrary, will be
+        converted to ``dtype=numpy.float32`` internally)
     coords2 : numpy.ndarray
-        Coordinate array of apex of angles.
+        Coordinate array of apex of angles (``dtype`` is arbitrary, will be
+        converted to ``dtype=numpy.float32`` internally)
     coords3 : numpy.ndarray
-        Coordinate array of other side of angles.
+        Coordinate array of other side of angles (``dtype`` is arbitrary, will be
+        converted to ``dtype=numpy.float32`` internally)
     box : numpy.ndarray, optional
         The unitcell dimesions for this system.
         The dimensions must be provided in the same format as returned
@@ -647,10 +659,12 @@ def calc_angles(coords1, coords2, coords3, box=None, result=None, backend="seria
        Added optional box argument to account for periodic boundaries in calculation
     .. versionchanged:: 0.13.0
        Added *backend* keyword.
+    .. versionchanged:: 0.19.0
+       Internal dtype conversion of input coordinates to ``numpy.float32``.
     """
-    atom1 = coords1.copy('C')
-    atom2 = coords2.copy('C')
-    atom3 = coords3.copy('C')
+    atom1 = coords1.astype(np.float32, order='C', copy=True)
+    atom2 = coords2.astype(np.float32, order='C', copy=True)
+    atom3 = coords3.astype(np.float32, order='C', copy=True)
     numatom = atom1.shape[0]
 
     _check_array(atom1, 'coords1')
@@ -717,13 +731,17 @@ def calc_dihedrals(coords1, coords2, coords3, coords4, box=None, result=None,
     Parameters
     ----------
     coords1 : array
-        Coordinate array of 1st atom in dihedrals.
+        Coordinate array of 1st atom in dihedrals (``dtype`` is arbitrary, will
+        be converted to ``dtype=numpy.float32`` internally)
     coords2 : array
-        Coordinate array of 2nd atom in dihedrals.
+        Coordinate array of 2nd atom in dihedrals (``dtype`` is arbitrary, will
+        be converted to ``dtype=numpy.float32`` internally)
     coords3 : array
-        Coordinate array of 3rd atom in dihedrals.
+        Coordinate array of 3rd atom in dihedrals (``dtype`` is arbitrary, will
+        be converted to ``dtype=numpy.float32`` internally)
     coords4 : array
-        Coordinate array of 4th atom in dihedrals.
+        Coordinate array of 4th atom in dihedrals (``dtype`` is arbitrary, will
+        be converted to ``dtype=numpy.float32`` internally)
     box : array
         The unitcell dimesions for this system.
         The dimensions must be provided in the same format as returned
@@ -750,11 +768,13 @@ def calc_dihedrals(coords1, coords2, coords3, coords4, box=None, result=None,
        Renamed from calc_torsions to calc_dihedrals
     .. versionchanged:: 0.13.0
        Added *backend* keyword.
+    .. versionchanged:: 0.19.0
+       Internal dtype conversion of input coordinates to ``numpy.float32``.
     """
-    atom1 = coords1.copy('C')
-    atom2 = coords2.copy('C')
-    atom3 = coords3.copy('C')
-    atom4 = coords4.copy('C')
+    atom1 = coords1.astype(np.float32, order='C', copy=True)
+    atom2 = coords2.astype(np.float32, order='C', copy=True)
+    atom3 = coords3.astype(np.float32, order='C', copy=True)
+    atom4 = coords4.astype(np.float32, order='C', copy=True)
 
     _check_array(atom1, 'atom1')
     _check_array(atom2, 'atom2')
@@ -803,8 +823,8 @@ def apply_PBC(incoords, box, backend="serial"):
     Parameters
     ----------
     incoords : numpy.ndarray
-        Coordinate array of shape ``(n, 3)``, will be converted to
-        ``dtype=numpy.float32``.
+        Coordinate array of shape ``(n, 3)`` (``dtype`` is arbitrary, will be
+        converted to ``dtype=numpy.float32`` internally)
     box : array
         The unitcell dimesions for this system; can be either orthogonal or
         triclinic information. The dimensions must be provided in the same
@@ -826,7 +846,7 @@ def apply_PBC(incoords, box, backend="serial"):
     .. versionchanged:: 0.13.0
        Added *backend* keyword.
     .. versionchanged:: 0.19.0
-       Added input array dtype conversion to ``numpy.float32``.
+       Internal dtype conversion of input coordinates to ``numpy.float32``.
     """
     coords = incoords.astype(np.float32, order='C', copy=True)
 

--- a/package/MDAnalysis/lib/distances.py
+++ b/package/MDAnalysis/lib/distances.py
@@ -227,27 +227,29 @@ def distance_array(reference, configuration, box=None, result=None, backend="ser
 
     Parameters
     ----------
-    reference : numpy.array of numpy.float32
-        Reference coordinate array.
-    configuration : numpy.array of numpy.float32
-        Configuration coordinate array.
-    box : numpy.array or None
+    reference : numpy.ndarray
+        Reference coordinate array of shape ``(n, 3)``, will be converted to
+        ``dtype=numpy.float32``.
+    configuration : numpy.ndarray
+        Configuration coordinate array of shape ``(m, 3)``, will be converted to
+        ``dtype=numpy.float32``.
+    box : numpy.ndarray or None
         Dimensions of the cell; if provided, the minimum image convention is
         applied. The dimensions must be provided in the same format as returned
         by by :attr:`MDAnalysis.coordinates.base.Timestep.dimensions`: ``[lx,
         ly, lz, alpha, beta, gamma]``.
-    result : numpy.array of numpy.float64, optional
+    result : numpy.ndarray(dtype=numpy.float64), optional
         Preallocated result array which must have the
         shape ``(len(ref), len(conf))`` and ``dtype=numpy.float64``.
         Avoids creating the array which saves time when the function
         is called repeatedly. [``None``]
-    backend
+    backend : str
         Select the type of acceleration; "serial" is always available. Other
         possibilities are "OpenMP" (OpenMP).
 
     Returns
     -------
-    d : numpy.array
+    d : numpy.ndarray
         ``(len(reference),len(configuration))`` numpy array with the distances
         ``d[i,j]`` between reference coordinates `i` and configuration
         coordinates `j`.
@@ -260,9 +262,11 @@ def distance_array(reference, configuration, box=None, result=None, backend="ser
 
     .. versionchanged:: 0.13.0
        Added *backend* keyword.
+    .. versionchanged:: 0.19.0
+       Added input array dtype conversion to ``numpy.float32``.
     """
-    ref = reference.copy('C')
-    conf = configuration.copy('C')
+    ref = reference.astype(np.float32, order='C', copy=True)
+    conf = configuration.astype(np.float32, order='C', copy=True)
 
     _check_array(conf, 'conf')
     _check_array(ref, 'ref')
@@ -313,25 +317,25 @@ def self_distance_array(reference, box=None, result=None, backend="serial"):
 
     Parameters
     ----------
-    reference : array
-        Reference coordinate array with ``N=len(ref)`` coordinates.
-    box : array or None
+    reference : numpy.ndarray
+        Reference coordinate array with ``N=len(ref)`` coordinates, will be
+        converted to ``dtype=numpy.float32``.
+    box : numpy.ndarray or None
         Dimensions of the cell; if provided, the minimum image convention is
         applied. The dimensions must be provided in the same format as returned
         by :attr:`MDAnalysis.coordinates.base.Timestep.dimensions`: ``[lx,
         ly, lz, alpha, beta, gamma]``.
-    result : array, optional
-        Preallocated result array which must have the shape
-        ``(N*(N-1)/2,)`` and dtype ``numpy.float64``. Avoids creating
-        the array which saves time when the function is called
-        repeatedly. [``None``]
-    backend
+    result : numpy.ndarray(dtype=numpy.float64), optional
+        Preallocated result array which must have the shape ``(N*(N-1)/2,)`` and
+        dtype ``numpy.float64``. Avoids creating the array which saves time when
+        the function is called repeatedly. [``None``]
+    backend : str
         Select the type of acceleration; "serial" is always available. Other
         possibilities are "OpenMP" (OpenMP).
 
     Returns
     -------
-    d : array
+    d : numpy.ndarray
         ``N*(N-1)/2`` numpy 1D array with the distances dist[i,j] between ref
         coordinates i and j at position d[k]. Loop through d:
 
@@ -345,13 +349,15 @@ def self_distance_array(reference, box=None, result=None, backend="serial"):
     Note
     ----
     This method is slower than it could be because internally we need to make
-    copies of the coordinate arrays.
+    copies of the coordinate array.
 
 
     .. versionchanged:: 0.13.0
        Added *backend* keyword.
+    .. versionchanged:: 0.19.0
+       Added input array dtype conversion to ``numpy.float32``.
     """
-    ref = reference.copy('C')
+    ref = reference.astype(np.float32, order='C', copy=True)
 
     _check_array(ref, 'ref')
 
@@ -406,7 +412,7 @@ def transform_RtoS(inputcoords, box, backend="serial"):
         The dimensions must be provided in the same format as returned
         by :attr:`MDAnalysis.coordinates.base.Timestep.dimensions`: ``[lx,
         ly, lz, alpha, beta, gamma]``.
-    backend
+    backend : str
         Select the type of acceleration; "serial" is always available. Other
         possibilities are "OpenMP" (OpenMP).
 
@@ -465,7 +471,7 @@ def transform_StoR(inputcoords, box, backend="serial"):
         The dimensions must be provided in the same format as returned
         by :attr:`MDAnalysis.coordinates.base.Timestep.dimensions`: ``[lx,
         ly, lz, alpha, beta, gamma]``.
-    backend
+    backend : str
         Select the type of acceleration; "serial" is always available. Other
         possibilities are "OpenMP" (OpenMP).
 
@@ -539,7 +545,7 @@ def calc_bonds(coords1, coords2, box=None, result=None, backend="serial"):
         Preallocated result array which must be same length as coord
         arrays and ``dtype=numpy.float64``. Avoids creating the
         array which saves time when the function is called repeatedly. [None]
-    backend
+    backend : str
         Select the type of acceleration; "serial" is always available. Other
         possibilities are "OpenMP" (OpenMP).
 
@@ -611,29 +617,29 @@ def calc_angles(coords1, coords2, coords3, box=None, result=None, backend="seria
 
     Parameters
     ----------
-    coords1 : array
+    coords1 : numpy.ndarray
         Coordinate array of one side of angles.
-    coords2 : array
+    coords2 : numpy.ndarray
         Coordinate array of apex of angles.
-    coords3 : array
+    coords3 : numpy.ndarray
         Coordinate array of other side of angles.
-    box : array
+    box : numpy.ndarray, optional
         The unitcell dimesions for this system.
         The dimensions must be provided in the same format as returned
         by :attr:`MDAnalysis.coordinates.base.Timestep.dimensions`: ``[lx,
         ly, lz, alpha, beta, gamma]``.
-    result : array, optional
+    result : numpy.ndarray, optional
         Preallocated result array which must be same length as coord
         arrays and ``dtype=numpy.float64``. Avoids creating the
         array which saves time when the function is called repeatedly. [None]
-    backend
+    backend : str
         Select the type of acceleration; "serial" is always available. Other
         possibilities are "OpenMP" (OpenMP).
 
     Returns
     -------
-    angles : array
-        A numpy.array of angles in radians.
+    angles : numpy.ndarray
+        An array of angles in radians.
 
 
     .. versionadded:: 0.8
@@ -727,7 +733,7 @@ def calc_dihedrals(coords1, coords2, coords3, coords4, box=None, result=None,
         Preallocated result array which must be same length as coord
         arrays and ``dtype=numpy.float64``. Avoids creating the
         array which saves time when the function is called repeatedly. [None]
-    backend
+    backend : str
         Select the type of acceleration; "serial" is always available. Other
         possibilities are "OpenMP" (OpenMP).
 
@@ -796,21 +802,22 @@ def apply_PBC(incoords, box, backend="serial"):
 
     Parameters
     ----------
-    coords : array
-        Coordinate array (of type numpy.float32).
+    incoords : numpy.ndarray
+        Coordinate array of shape ``(n, 3)``, will be converted to
+        ``dtype=numpy.float32``.
     box : array
         The unitcell dimesions for this system; can be either orthogonal or
         triclinic information. The dimensions must be provided in the same
         format as returned by
         :attr:`MDAnalysis.coordinates.base.Timestep.dimensions`: ``[lx, ly, lz,
         alpha, beta, gamma]``.
-    backend
-        Select the type of acceleration; "serial" is always available. Other
-        possibilities are "OpenMP" (OpenMP).
+    backend : str
+        Select the type of acceleration; ``"serial"`` is always available. Other
+        possibilities are ``"OpenMP"`` (OpenMP).
 
     Returns
     -------
-    newcoords : array
+    newcoords : numpy.ndarray(dtype=numpy.float32)
         Coordinates that are now all within the primary unit cell, as defined
         by box.
 
@@ -818,8 +825,10 @@ def apply_PBC(incoords, box, backend="serial"):
     .. versionadded:: 0.8
     .. versionchanged:: 0.13.0
        Added *backend* keyword.
+    .. versionchanged:: 0.19.0
+       Added input array dtype conversion to ``numpy.float32``.
     """
-    coords = incoords.copy('C')
+    coords = incoords.astype(np.float32, order='C', copy=True)
 
     _check_array(coords, 'coords')
 

--- a/testsuite/MDAnalysisTests/lib/test_distances.py
+++ b/testsuite/MDAnalysisTests/lib/test_distances.py
@@ -27,19 +27,13 @@ from numpy.testing import assert_equal
 
 import MDAnalysis as mda
 
-def test_transform_StoR_pass():
+@pytest.mark.parametrize('coord_dtype', (np.float32, np.float64))
+def test_transform_StoR_pass(coord_dtype):
     box = np.array([10, 7, 3, 45, 60, 90], dtype=np.float32)
-    s = np.array([[0.5, -0.1, 0.5]], dtype=np.float32)
+    s = np.array([[0.5, -0.1, 0.5]], dtype=coord_dtype)
 
     original_r = np.array([[ 5.75,  0.36066014, 0.75000012]], dtype=np.float32)
 
     test_r = mda.lib.distances.transform_StoR(s, box)
 
     assert_equal(original_r, test_r)
-
-def test_transform_StoR_fail():
-    box = np.array([10, 7, 3, 45, 60, 90], dtype=np.float32)
-    s = np.array([[0.5, -0.1, 0.5]])
-
-    with pytest.raises(TypeError, match='S must be of type float32'):
-        r = mda.lib.distances.transform_StoR(s, box)


### PR DESCRIPTION
Fixes #1930 (at least in part)

Changes made in this Pull Request:
 - enforced calculations in `*Group.center()` to be performed in double precision
 - for compatibility reasons, added automatic type conversion to `dtype=np.float32` for input coordinate arrays of `lib.distances.apply_PBC()`, `lib.distances.distance_array()`, and `lib.distances.self_distance_array()`
 - arrays returned by `*Group.center()` will be of `dtype=np.float64` unless ``(compound != 'group' and pbc==True)``. This exception could be eliminated by providing a double-precision version of `lib.distances.apply_PBC()`.

PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
