### PR TITLE
Rotation transformation

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -19,6 +19,7 @@ The rules for this file:
   * 0.18.1
 
 Enhancements
+  * Added a rotation coordinate transformation
   * Added a on-the-fly trajectory transformations API and a coordinate translation
   	function (Issue #786)
   * Added various duecredit stubs

--- a/package/MDAnalysis/transformations/__init__.py
+++ b/package/MDAnalysis/transformations/__init__.py
@@ -53,6 +53,8 @@ See `MDAnalysis.transformations.translate` for a simple example.
 Currently implemented transformations are:
     
     - translate: translate the coordinates of a given trajectory frame by a given vector.
+    - rotate: rotates the coordinates by a given angle arround an axis formed by a direction 
+      and a point
     
     
 
@@ -83,5 +85,7 @@ e.g. giving a workflow as a keyword argument when defining the universe:
 from __future__ import absolute_import
 
 from .translate import translate
+from .rotate import rotate
+
 
 

--- a/package/MDAnalysis/transformations/__init__.py
+++ b/package/MDAnalysis/transformations/__init__.py
@@ -85,7 +85,7 @@ e.g. giving a workflow as a keyword argument when defining the universe:
 from __future__ import absolute_import
 
 from .translate import translate
-from .rotate import rotate
+from .rotate import rotateby
 
 
 

--- a/package/MDAnalysis/transformations/rotate.py
+++ b/package/MDAnalysis/transformations/rotate.py
@@ -36,7 +36,7 @@ import numpy as np
 from ..lib.transformations import rotation_matrix
 from ..core.groups import AtomGroup
 
-def rotateby(angle, direction, center="geometry", pbc=None, ag=None, position=[]):
+def rotateby(angle, direction, center="geometry", pbc=None, ag=None, position=None):
     '''
     Rotates the trajectory by a given angle on a given axis. The axis is defined by 
     the user, combining the direction vector and a position. This position can be the center
@@ -87,7 +87,7 @@ def rotateby(angle, direction, center="geometry", pbc=None, ag=None, position=[]
     
     '''
     pbc_arg = pbc
-    if len(position)>2:
+    if position and len(position)>2:
         position = position
     elif isinstance(ag, AtomGroup):
         if center == "geometry":

--- a/package/MDAnalysis/transformations/rotate.py
+++ b/package/MDAnalysis/transformations/rotate.py
@@ -43,7 +43,7 @@ def rotateby(angle, direction, point=None, center="geometry", pbc=False, ag=None
     the user, combining the direction vector and a point. This point can be the center
     of geometry or the center of mass of a user defined AtomGroup, or a list defining custom
     coordinates. 
-    e.g. rotate the coordinates by pi/2 on a x axis centered on a given atom group:
+    e.g. rotate the coordinates by 90 degrees on a x axis centered on a given atom group:
     
     .. code-block:: python
     

--- a/package/MDAnalysis/transformations/rotate.py
+++ b/package/MDAnalysis/transformations/rotate.py
@@ -86,16 +86,16 @@ def rotateby(angle, direction, center="geometry", pbc=None, ag=None, position=[]
     :class:`~MDAnalysis.coordinates.base.Timestep` object
     
     '''
-    theta = np.float32(angle)
-    vector = np.float32(direction)
+    theta = angle
+    vector = direction
     pbc_arg = pbc
     if len(position)>2:
-        position = np.float32(position)
+        position = position
     elif isinstance(ag, AtomGroup):
         if center == "geometry":
-            position = ag.center_of_geometry(pbc = pbc_arg)
+            position = ag.center_of_geometry(pbc=pbc_arg)
         elif center == "mass":
-            position = ag.center_of_mass(pbc = pbc_arg)
+            position = ag.center_of_mass(pbc=pbc_arg)
         else:
             raise ValueError('{} is not a valid argument for center'.format(center))
     else:

--- a/package/MDAnalysis/transformations/rotate.py
+++ b/package/MDAnalysis/transformations/rotate.py
@@ -35,9 +35,8 @@ import numpy as np
 from functools import partial
 
 from ..lib.transformations import rotation_matrix
-from ..core.groups import AtomGroup
 
-def rotateby(angle, direction, point=None, center="geometry", pbc=False, ag=None):
+def rotateby(angle, direction, point=None, center="geometry", wrap=False, ag=None):
     '''
     Rotates the trajectory by a given angle on a given axis. The axis is defined by 
     the user, combining the direction vector and a point. This point can be the center
@@ -75,7 +74,7 @@ def rotateby(angle, direction, point=None, center="geometry", pbc=False, ag=None
     center: str, optional
         used to choose the method of centering on the given atom group. Can be 'geometry'
         or 'mass'
-    pbc: bool, optional
+    wrap: bool, optional
         If `True`, all the atoms from the given AtomGroup will be moved to the unit cell
         before calculating the center of mass or geometry. Default is `False`, no changes
         to the atom coordinates are done before calculating the center of the AtomGroup. 
@@ -93,7 +92,7 @@ def rotateby(angle, direction, point=None, center="geometry", pbc=False, ag=None
     after rotating the trajectory.
 
     '''
-    pbc_arg = pbc
+    pbc_arg = wrap
     angle = np.deg2rad(angle)
     if point:
         point = np.asarray(point, np.float32)

--- a/package/MDAnalysis/transformations/rotate.py
+++ b/package/MDAnalysis/transformations/rotate.py
@@ -1,0 +1,115 @@
+# -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
+#
+# MDAnalysis --- https://www.mdanalysis.org
+# Copyright (c) 2006-2017 The MDAnalysis Development Team and contributors
+# (see the file AUTHORS for the full list of names)
+#
+# Released under the GNU Public Licence, v2 or any higher version
+#
+# Please cite your use of MDAnalysis in published work:
+#
+# R. J. Gowers, M. Linke, J. Barnoud, T. J. E. Reddy, M. N. Melo, S. L. Seyler,
+# D. L. Dotson, J. Domanski, S. Buchoux, I. M. Kenney, and O. Beckstein.
+# MDAnalysis: A Python package for the rapid analysis of molecular dynamics
+# simulations. In S. Benthall and S. Rostrup editors, Proceedings of the 15th
+# Python in Science Conference, pages 102-109, Austin, TX, 2016. SciPy.
+#
+# N. Michaud-Agrawal, E. J. Denning, T. B. Woolf, and O. Beckstein.
+# MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
+# J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
+#
+
+"""\
+Rotate trajectory --- :mod:`MDAnalysis.transformations.translate`
+=================================================================
+
+Rotates the coordinates by a given angle arround an axis formed by a direction and a
+point 
+    
+"""
+from __future__ import absolute_import
+
+import math
+import numpy as np
+
+from ..lib.transformations import rotation_matrix
+from ..core.groups import AtomGroup
+
+def rotate(angle, direction, center="geometry", **kwargs):
+    '''
+    Rotates the trajectory by a given angle on a given axis. The axis is defined by 
+    the user, combining the direction vector and a position. This position can be the center
+    of geometry or the center of mass of a user defined AtomGroup, or a list defining custom
+    coordinates. 
+    e.g. rotate the coordinates by pi/2 on a x axis centered on a given atom group:
+    
+    .. code-block:: python
+    
+        ts = u.trajectory.ts
+        angle = math.pi/2
+        ag = u.atoms()
+        rotated = MDAnalysis.transformations.rotate(angle, a)(ts)
+    
+    e.g. rotate the coordinates by a custom axis:
+    
+    .. code-block:: python
+
+        ts = u.trajectory.ts
+        angle = math.pi/2
+        p = [1,2,3]
+        d = [0,0,1]
+        rotated = MDAnalysis.transformations.rotate(angle, point=point, direction=d)(ts) 
+    
+    Parameters
+    ----------
+    angle: float
+        rotation angle in radians
+    direction: list
+        vector that will define the direction of a custom axis of rotation from the
+        provided point.
+    ag: AtomGroup, optional
+        use this to define the center of mass or geometry as the point from where the
+        rotation axis will be defined
+    center: str, optional
+        used to choose the method of centering on the given atom group. Can be 'geometry'
+        or 'mass'
+    pbc: bool or None, optional
+        If True, all the atoms from the given AtomGroup will be moved to the unit cell
+        before calculating the center
+    point: list, optional
+        list of the coordinates of the point from where a custom axis of rotation will
+        be defined. 
+    ts: Timestep
+        frame that will be transformed
+
+    Returns
+    -------
+    :class:`~MDAnalysis.coordinates.base.Timestep` object
+    
+    '''
+    theta = np.float32(angle)
+    vector = np.float32(direction)
+    position = kwargs.pop("position", [])
+    ag = kwargs.pop("ag", None)
+    pbc_arg = kwargs.pop("pbc", None)
+    if len(position)>2:
+        position = np.float32(position)
+    elif isinstance(ag, AtomGroup):
+        if center == "geometry":
+            position = ag.center_of_geometry(pbc = pbc_arg)
+        elif center == "mass":
+            position = ag.center_of_mass(pbc = pbc_arg)
+        else:
+            raise ValueError('{} is not a valid argument for center'.format(center))
+    else:
+        raise ValueError('A position or an AtomGroup must be specified') 
+    
+    def wrapper(ts):
+        rotation = rotation_matrix(theta, vector, position)[:3, :3]
+        ts.positions= np.dot(ts.positions, rotation)
+        
+        return ts
+    
+    return wrapper
+    

--- a/package/MDAnalysis/transformations/rotate.py
+++ b/package/MDAnalysis/transformations/rotate.py
@@ -36,7 +36,7 @@ import numpy as np
 from ..lib.transformations import rotation_matrix
 from ..core.groups import AtomGroup
 
-def rotate(angle, direction, center="geometry", **kwargs):
+def rotateby(angle, direction, center="geometry", pbc=None, ag=None, position=[]):
     '''
     Rotates the trajectory by a given angle on a given axis. The axis is defined by 
     the user, combining the direction vector and a position. This position can be the center
@@ -49,7 +49,7 @@ def rotate(angle, direction, center="geometry", **kwargs):
         ts = u.trajectory.ts
         angle = math.pi/2
         ag = u.atoms()
-        rotated = MDAnalysis.transformations.rotate(angle, a)(ts)
+        rotated = MDAnalysis.transformations.rotate(angle, ag)(ts)
     
     e.g. rotate the coordinates by a custom axis:
     
@@ -77,11 +77,9 @@ def rotate(angle, direction, center="geometry", **kwargs):
     pbc: bool or None, optional
         If True, all the atoms from the given AtomGroup will be moved to the unit cell
         before calculating the center
-    point: list, optional
+    position: list, optional
         list of the coordinates of the point from where a custom axis of rotation will
         be defined. 
-    ts: Timestep
-        frame that will be transformed
 
     Returns
     -------
@@ -90,9 +88,7 @@ def rotate(angle, direction, center="geometry", **kwargs):
     '''
     theta = np.float32(angle)
     vector = np.float32(direction)
-    position = kwargs.pop("position", [])
-    ag = kwargs.pop("ag", None)
-    pbc_arg = kwargs.pop("pbc", None)
+    pbc_arg = pbc
     if len(position)>2:
         position = np.float32(position)
     elif isinstance(ag, AtomGroup):

--- a/package/MDAnalysis/transformations/rotate.py
+++ b/package/MDAnalysis/transformations/rotate.py
@@ -86,8 +86,6 @@ def rotateby(angle, direction, center="geometry", pbc=None, ag=None, position=[]
     :class:`~MDAnalysis.coordinates.base.Timestep` object
     
     '''
-    theta = angle
-    vector = direction
     pbc_arg = pbc
     if len(position)>2:
         position = position
@@ -102,7 +100,7 @@ def rotateby(angle, direction, center="geometry", pbc=None, ag=None, position=[]
         raise ValueError('A position or an AtomGroup must be specified') 
     
     def wrapper(ts):
-        rotation = rotation_matrix(theta, vector, position)[:3, :3]
+        rotation = rotation_matrix(angle, direction, position)[:3, :3]
         ts.positions= np.dot(ts.positions, rotation)
         
         return ts

--- a/package/MDAnalysis/transformations/rotate.py
+++ b/package/MDAnalysis/transformations/rotate.py
@@ -99,11 +99,11 @@ def rotateby(angle, direction, center="geometry", pbc=None, ag=None, position=[]
     else:
         raise ValueError('A position or an AtomGroup must be specified') 
     
-    def wrapper(ts):
+    def wrapped(ts):
         rotation = rotation_matrix(angle, direction, position)[:3, :3]
         ts.positions= np.dot(ts.positions, rotation)
         
         return ts
     
-    return wrapper
+    return wrapped
     

--- a/testsuite/MDAnalysisTests/transformations/test_rotate.py
+++ b/testsuite/MDAnalysisTests/transformations/test_rotate.py
@@ -120,7 +120,7 @@ def test_rotateby_atomgroup_cog_pbc(rotate_universes):
     center_pos = selection.center_of_geometry(pbc=True)
     matrix = rotation_matrix(np.deg2rad(angle), vector, center_pos)[:3, :3]
     ref.positions = np.dot(ref.positions, matrix)
-    transformed = rotateby(angle, vector, ag=selection, center='geometry', pbc=True)(trans) 
+    transformed = rotateby(angle, vector, ag=selection, center='geometry', wrap=True)(trans) 
     assert_array_almost_equal(transformed.positions, ref.positions, decimal=6)
 
 def test_rotateby_atomgroup_com_pbc(rotate_universes):
@@ -136,7 +136,7 @@ def test_rotateby_atomgroup_com_pbc(rotate_universes):
     center_pos = selection.center_of_mass(pbc=True)
     matrix = rotation_matrix(np.deg2rad(angle), vector, center_pos)[:3, :3]
     ref.positions = np.dot(ref.positions, matrix)
-    transformed = rotateby(angle, vector, ag=selection, center='mass', pbc=True)(trans) 
+    transformed = rotateby(angle, vector, ag=selection, center='mass', wrap=True)(trans) 
     assert_array_almost_equal(transformed.positions, ref.positions, decimal=6)
     
 def test_rotateby_bad_ag(rotate_universes):
@@ -169,7 +169,7 @@ def test_rotateby_bad_pbc(rotate_universes):
     angle = 90
     vector = [0, 0, 1]
     with pytest.raises(ValueError): 
-        rotateby(angle, vector, ag = ag, pbc=True)(ts)
+        rotateby(angle, vector, ag = ag, wrap=True)(ts)
 
 def test_rotateby_bad_center(rotate_universes):
     # this universe as a box size zero

--- a/testsuite/MDAnalysisTests/transformations/test_rotate.py
+++ b/testsuite/MDAnalysisTests/transformations/test_rotate.py
@@ -1,0 +1,56 @@
+# -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 fileencoding=utf-8
+#
+# MDAnalysis --- https://www.mdanalysis.org
+# Copyright (c) 2006-2017 The MDAnalysis Development Team and contributors
+# (see the file AUTHORS for the full list of names)
+#
+# Released under the GNU Public Licence, v2 or any higher version
+#
+# Please cite your use of MDAnalysis in published work:
+#
+# R. J. Gowers, M. Linke, J. Barnoud, T. J. E. Reddy, M. N. Melo, S. L. Seyler,
+# D. L. Dotson, J. Domanski, S. Buchoux, I. M. Kenney, and O. Beckstein.
+# MDAnalysis: A Python package for the rapid analysis of molecular dynamics
+# simulations. In S. Benthall and S. Rostrup editors, Proceedings of the 15th
+# Python in Science Conference, pages 102-109, Austin, TX, 2016. SciPy.
+#
+# N. Michaud-Agrawal, E. J. Denning, T. B. Woolf, and O. Beckstein.
+# MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
+# J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
+#
+
+from __future__ import absolute_import
+
+import numpy as np
+import pytest
+import math
+from numpy.testing import assert_array_almost_equal
+
+import MDAnalysis as mda
+from MDAnalysis.transformations import rotate
+from MDAnalysis.lib.transformations import rotation_matrix
+from MDAnalysisTests.datafiles import GRO
+
+def test_translate_custom_position():
+    u = mda.Universe(GRO)
+    vector = np.float32([1,0,0])
+    pos = np.float32([0,0,0])
+    matrix = rotation_matrix(math.pi/2, vector, pos)[:3, :3]
+    ref = u.trajectory.ts
+    ref.positions = np.dot(ref.positions, matrix)
+    transformed = rotate(math.pi/2, vector, position = pos)(ref) 
+    assert_array_almost_equal(transformed, ref.positions, decimal=6)
+    
+def test_translate_atomgroup():
+    u = mda.Universe(GRO)
+    vector = np.float32([1,0,0])
+    ref_pos = np.float32([52.953686, 44.179996, 29.397898])
+    matrix = rotation_matrix(math.pi/2, vector, ref_pos)[:3, :3]
+    ref = u.trajectory.ts
+    ref.positions = np.dot(ref.positions, matrix)
+    selection = u.atoms.select_atoms('resid 1')
+    transformed = rotate(math.pi/2, vector, ag = selection, center='geometry')(ref) 
+    assert_array_almost_equal(transformed, ref.positions, decimal=6)
+    
+    

--- a/testsuite/MDAnalysisTests/transformations/test_rotate.py
+++ b/testsuite/MDAnalysisTests/transformations/test_rotate.py
@@ -28,21 +28,21 @@ import math
 from numpy.testing import assert_array_almost_equal
 
 import MDAnalysis as mda
-from MDAnalysis.transformations import rotate
+from MDAnalysis.transformations import rotateby
 from MDAnalysis.lib.transformations import rotation_matrix
 from MDAnalysisTests.datafiles import GRO
 
-def test_translate_custom_position():
+def test_rotate_custom_position():
     u = mda.Universe(GRO)
     vector = np.float32([1,0,0])
     pos = np.float32([0,0,0])
     matrix = rotation_matrix(math.pi/2, vector, pos)[:3, :3]
     ref = u.trajectory.ts
     ref.positions = np.dot(ref.positions, matrix)
-    transformed = rotate(math.pi/2, vector, position = pos)(ref) 
+    transformed = rotateby(math.pi/2, vector, position = pos)(ref) 
     assert_array_almost_equal(transformed, ref.positions, decimal=6)
     
-def test_translate_atomgroup():
+def test_rotate_atomgroup():
     u = mda.Universe(GRO)
     vector = np.float32([1,0,0])
     ref_pos = np.float32([52.953686, 44.179996, 29.397898])
@@ -50,7 +50,7 @@ def test_translate_atomgroup():
     ref = u.trajectory.ts
     ref.positions = np.dot(ref.positions, matrix)
     selection = u.atoms.select_atoms('resid 1')
-    transformed = rotate(math.pi/2, vector, ag = selection, center='geometry')(ref) 
+    transformed = rotateby(math.pi/2, vector, ag = selection, center='geometry')(ref) 
     assert_array_almost_equal(transformed, ref.positions, decimal=6)
     
     

--- a/testsuite/MDAnalysisTests/transformations/test_rotate.py
+++ b/testsuite/MDAnalysisTests/transformations/test_rotate.py
@@ -31,6 +31,7 @@ from MDAnalysis.transformations import rotateby
 from MDAnalysis.lib.transformations import rotation_matrix
 from MDAnalysisTests import make_Universe
 
+@pytest.fixture()
 def rotateby_universes():
     # create the Universe objects for the tests
     reference = make_Universe(trajectory=True)

--- a/testsuite/MDAnalysisTests/transformations/test_rotate.py
+++ b/testsuite/MDAnalysisTests/transformations/test_rotate.py
@@ -39,8 +39,30 @@ def rotate_universes():
     transformed.trajectory.ts.dimensions = np.array([372., 373., 374., 90, 90, 90])
     return reference, transformed
 
+def test_rotation_matrix():
+    # test if the rotation_matrix function is working properly
+    # simple angle and unit vector on origin
+    angle = 180
+    vector = [0, 0, 1]
+    pos = [0, 0, 0]
+    ref_matrix = np.asarray([[-1, 0, 0],
+                             [0, -1, 0],
+                             [0, 0, 1]], np.float64)
+    matrix = rotation_matrix(np.deg2rad(angle), vector, pos)[:3, :3]
+    assert_array_almost_equal(matrix, ref_matrix, decimal=6)
+    # another angle in a custom axis
+    angle = 60
+    vector = [1, 2, 3]
+    pos = [1, 2, 3]
+    ref_matrix = np.asarray([[ 0.53571429, -0.6229365 ,  0.57005291],
+                             [ 0.76579365,  0.64285714, -0.01716931],
+                             [-0.35576719,  0.44574074,  0.82142857]], np.float64)
+    matrix = rotation_matrix(np.deg2rad(angle), vector, pos)[:3, :3]
+    assert_array_almost_equal(matrix, ref_matrix, decimal=6)
+    
+
 def test_rotateby_custom_position(rotate_universes):
-    # what happens when we use a custom position for the axis of rotation?
+    # what happens when we use a custom point for the axis of rotation?
     ref_u = rotate_universes[0]
     trans_u = rotate_universes[1]
     trans = trans_u.trajectory.ts
@@ -50,7 +72,7 @@ def test_rotateby_custom_position(rotate_universes):
     angle = 90
     matrix = rotation_matrix(np.deg2rad(angle), vector, pos)[:3, :3]
     ref.positions = np.dot(ref.positions, matrix)
-    transformed = rotateby(angle, vector, position=pos)(trans)
+    transformed = rotateby(angle, vector, point=pos)(trans)
     assert_array_almost_equal(transformed.positions, ref.positions, decimal=6)
     
 def test_rotateby_atomgroup_cog_nopbc(rotate_universes):
@@ -136,7 +158,7 @@ def test_rotateby_bad_position(rotate_universes):
     vector = [0, 0, 1]
     bad_position = [1]
     with pytest.raises(ValueError): 
-        rotateby(angle, vector, position=bad_position)(ts)
+        rotateby(angle, vector, point=bad_position)(ts)
     
 def test_rotateby_bad_pbc(rotate_universes):    
     # this universe as a box size zero
@@ -176,7 +198,7 @@ def test_rotateby_no_args(rotate_universes):
     ts = rotate_universes[0].trajectory.ts
     angle = 90
     vector = [0, 0, 1]
-    # if no position or AtomGroup are passed to the function
+    # if no point or AtomGroup are passed to the function
     # it should raise a ValueError
     with pytest.raises(ValueError): 
         rotateby(angle, vector)(ts)


### PR DESCRIPTION
Adds a rotation transformation to the transformations module

Changes made in this Pull Request:
 - trajectory coordinates may now be rotated by a given angle and an axis. The axis
   is formed by a given position or the center of mass/(geometry of an AtomGroup
- added tests for both ways of defining a position


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [ ] Issue raised/referenced?
