### PR TITLE
fix #1942

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,8 +73,6 @@ matrix:
            INSTALL_HOLE="false"
   allow_failures:
     - env: NUMPY_VERSION=dev EVENT_TYPE="cron"
-    - env: PYTHON_VERSION=3.4
-    - os: osx
 
 before_install:
   # Workaround for Travis CI macOS bug (https://github.com/travis-ci/travis-ci/issues/6307)

--- a/package/MDAnalysis/lib/formats/src/xdrfile.c
+++ b/package/MDAnalysis/lib/formats/src/xdrfile.c
@@ -46,13 +46,12 @@
 
 #include <sys/types.h>
 
-#ifdef __unix__
-    #include <unistd.h>
+#ifdef _WIN32
+#  include <io.h>
+#else /* __unix__ */
+#  include <unistd.h>
 #endif
 
-#ifdef _WIN32
-    #include <io.h>
-#endif
 
 #ifdef HAVE_RPC_XDR_H
 #  include <rpc/rpc.h>
@@ -2605,12 +2604,10 @@ xdrstdio_putbytes (XDR *xdrs, char *addr, unsigned int len)
 static off_t
 xdrstdio_getpos (XDR *xdrs)
 {
-    #ifdef __unix__
-    return ftello((FILE *) xdrs->x_private);
-    #endif
-
     #ifdef _WIN32
     return _ftelli64((FILE *) xdrs->x_private);
+    #else /* __unix__ */
+    return ftello((FILE *) xdrs->x_private);
     #endif
 }
 
@@ -2623,13 +2620,13 @@ xdrstdio_setpos (XDR *xdrs, off_t pos, int whence)
     /* We return errno relying on the fact that it is never set to 0 on
      * success, which means that if an error occurrs it'll never be the same
      * as exdrOK, and xdr_seek won't be confused.*/
-    #ifdef __unix__
+    #ifdef _WIN32
+	return _fseeki64((FILE *) xdrs->x_private, pos, whence) < 0 ? errno : exdrOK;
+    #else /*  __unix__ */
 	return fseeko((FILE *) xdrs->x_private, pos, whence) < 0 ? errno : exdrOK;
     #endif
 
-    #ifdef _WIN32
-	return _fseeki64((FILE *) xdrs->x_private, pos, whence) < 0 ? errno : exdrOK;
-    #endif
+
 }
 
 

--- a/testsuite/MDAnalysisTests/coordinates/base.py
+++ b/testsuite/MDAnalysisTests/coordinates/base.py
@@ -209,14 +209,14 @@ class BaseReaderTest(object):
         reader.add_auxiliary('lowf', ref.aux_lowf, dt=ref.aux_lowf_dt, initial_time=0, time_selector=None)
         reader.add_auxiliary('highf', ref.aux_highf, dt=ref.aux_highf_dt, initial_time=0, time_selector=None)
         return reader
-    
+
     @staticmethod
     @pytest.fixture()
     def transformed(ref):
         transformed = ref.reader(ref.trajectory)
         transformed.add_transformations(translate([1,1,1]), translate([0,0,0.33]))
         return transformed
-    
+
     def test_n_atoms(self, ref, reader):
         assert_equal(reader.n_atoms, ref.n_atoms)
 
@@ -346,15 +346,15 @@ class BaseReaderTest(object):
         for ts in reader[:-1]:
             pass
         assert_equal(reader.frame, 0)
-        
+
     def test_transformations_iter(self, ref, transformed):
         # test one iteration and see if the transformations are applied
         v1 = np.float32((1,1,1))
-        v2 = np.float32((0,0,0.33)) 
+        v2 = np.float32((0,0,0.33))
         for i, ts in enumerate(transformed):
             idealcoords = ref.iter_ts(i).positions + v1 + v2
             assert_array_almost_equal(ts.positions, idealcoords, decimal=ref.prec)
-    
+
     def test_transformations_2iter(self, ref, transformed):
         # Are the transformations applied and
         # are the coordinates "overtransformed"?
@@ -364,10 +364,10 @@ class BaseReaderTest(object):
         for i, ts in enumerate(transformed):
             idealcoords.append(ref.iter_ts(i).positions + v1 + v2)
             assert_array_almost_equal(ts.positions, idealcoords[i], decimal=ref.prec)
-            
+
         for i, ts in enumerate(transformed):
             assert_almost_equal(ts.positions, idealcoords[i], decimal=ref.prec)
-            
+
     def test_transformations_slice(self, ref, transformed):
         # Are the transformations applied when iterating over a slice of the trajectory?
         v1 = np.float32((1,1,1))
@@ -375,8 +375,8 @@ class BaseReaderTest(object):
         for i,ts in enumerate(transformed[2:3:1]):
             idealcoords = ref.iter_ts(ts.frame).positions + v1 + v2
             assert_array_almost_equal(ts.positions, idealcoords, decimal = ref.prec)
-            
-        
+
+
     def test_transformations_switch_frame(self, ref, transformed):
         # This test checks if the transformations are applied and if the coordinates
         # "overtransformed" on different situations
@@ -388,10 +388,10 @@ class BaseReaderTest(object):
             assert_array_almost_equal(transformed[0].positions, first_ideal, decimal = ref.prec)
             second_ideal = ref.iter_ts(1).positions + v1 + v2
             assert_array_almost_equal(transformed[1].positions, second_ideal, decimal = ref.prec)
-            
+
             # What if we comeback to the previous frame?
             assert_array_almost_equal(transformed[0].positions, first_ideal, decimal = ref.prec)
-            
+
             # How about we switch the frame to itself?
             assert_array_almost_equal(transformed[0].positions, first_ideal, decimal = ref.prec)
         else:
@@ -405,20 +405,20 @@ class BaseReaderTest(object):
         ideal_coords = ref.iter_ts(0).positions + v1 + v2
         transformed.rewind()
         assert_array_almost_equal(transformed[0].positions, ideal_coords, decimal = ref.prec)
-    
+
     def test_transformations_copy(self,ref,transformed):
         # this test checks if transformations are carried over a copy and if the
         # coordinates of the copy are equal to the original's
         v1 = np.float32((1,1,1))
         v2 = np.float32((0,0,0.33))
         new = transformed.copy()
-        assert_equal(transformed.transformations, new.transformations, 
+        assert_equal(transformed.transformations, new.transformations,
                      "transformations are not equal")
         for i, ts in enumerate(new):
             ideal_coords = ref.iter_ts(i).positions + v1 + v2
             assert_array_almost_equal(ts.positions, ideal_coords, decimal = ref.prec)
-            
-        
+
+
     def test_add_another_transformations_raises_ValueError(self, transformed):
         # After defining the transformations, the workflow cannot be changed
         with pytest.raises(ValueError):
@@ -438,6 +438,15 @@ class MultiframeReaderTest(BaseReaderTest):
         ts = reader[ref.jump_to_frame.frame]
         assert_timestep_almost_equal(ts, ref.jump_to_frame,
                                      decimal=ref.prec)
+
+    def test_frame_jump_issue1942(self, ref, reader):
+        """Test for issue 1942 (especially XDR on macOS)"""
+        reader.rewind()
+        try:
+            for ii in range(ref.n_frames + 2):
+                reader[0]
+        except StopIteration:
+            pytest.fail("Frame-seeking wrongly iterated (#1942)")
 
     def test_next_gives_second_frame(self, ref, reader):
         reader = ref.reader(ref.trajectory)
@@ -623,14 +632,14 @@ class BaseTimestepTest(object):
     unitcell = np.array([10., 11., 12., 90., 90., 90.])
     ref_volume = 1320.  # what the volume is after setting newbox
     uni_args = None
-        
+
     @pytest.fixture()
     def ts(self):
         ts = self.Timestep(self.size)
         ts.frame += 1
         ts.positions = self.refpos
         return ts
-        
+
     def test_getitem(self, ts):
         assert_equal(ts[1], self.refpos[1])
 
@@ -978,13 +987,13 @@ class BaseTimestepTest(object):
 
     def _check_npint_slice(self, name, ts):
         for integers in [np.byte, np.short, np.intc, np.int_, np.longlong,
-                         np.intp, np.int8, np.int16, np.int32, np.int64, 
+                         np.intp, np.int8, np.int16, np.int32, np.int64,
                          np.ubyte, np.ushort, np.uintc, np.ulonglong,
                          np.uintp, np.uint8, np.uint16, np.uint32, np.uint64]:
             sl = slice(1, 2, 1)
             ts2 = ts.copy_slice(slice(integers(1), integers(2), integers(1)))
             self._check_slice(ts, ts2, sl)
-        
+
     def _check_slice(self, ts1, ts2, sl):
         if ts1.has_positions:
             assert_array_almost_equal(ts1.positions[sl], ts2.positions)


### PR DESCRIPTION
Fixes #1942 

Commit 8572d796a95e92bbdaa827325a1ae82e1664dcba broke XTC/TRR reading on macOS.
This fixes this issue. Only the development version 0.18.1-dev was affected;
the released 0.18.0 did NOT have this bug.

Changes made in this Pull Request:
 - add test for #1942 (although, many XDR tests failed on macOS)
 - make sure that the xdr functions call *some* ftello() or fseeko() function (basically, only special case WIN32 and use the unix-like functions as default)


PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated? — no, this bug was not in 0.18.0
 - [x] Issue raised/referenced?
