### PR TITLE
Add a faster function to deduplicate indices

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -31,7 +31,7 @@ Enhancements
   * Added boolean property *Group.isunique (PR #1922)
   * Added *Group.copy() methods returning an identical copy of the respective
     group (PR #1922)
-  * Improves performances when accessing groups (PR #1951)
+  * Use a faster function to deduplicate indices (PR #1951)
 
 Fixes
   * rewind in the SingleFrameReader now reads the frame from the file (Issue #1929)

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -14,7 +14,7 @@ The rules for this file:
 
 ------------------------------------------------------------------------------
 ??/??/18 tylerjereddy, richardjgowers, palnabarun, orbeckst, kain88-de, zemanj,
-         VOD555, davidercruz
+         VOD555, davidercruz, jbarnoud
 
   * 0.18.1
 
@@ -31,6 +31,7 @@ Enhancements
   * Added boolean property *Group.isunique (PR #1922)
   * Added *Group.copy() methods returning an identical copy of the respective
     group (PR #1922)
+  * Improves performances when accessing groups (PR #1951)
 
 Fixes
   * rewind in the SingleFrameReader now reads the frame from the file (Issue #1929)

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -103,8 +103,7 @@ from numpy.lib.utils import deprecate
 
 from .. import _ANCHOR_UNIVERSES
 from ..lib import util
-from ..lib.util import cached, warn_if_not_unique
-from ..lib.cutil import unique_int_1d
+from ..lib.util import cached, warn_if_not_unique, unique_int_1d
 from ..lib import distances
 from ..lib import transformations
 from ..selections import get_writer as get_selection_writer_for

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -104,6 +104,7 @@ from numpy.lib.utils import deprecate
 from .. import _ANCHOR_UNIVERSES
 from ..lib import util
 from ..lib.util import cached, warn_if_not_unique
+from ..lib.cutil import unique_int_1d
 from ..lib import distances
 from ..lib import transformations
 from ..selections import get_writer as get_selection_writer_for
@@ -1843,7 +1844,7 @@ class AtomGroup(GroupBase):
         """A sorted :class:`ResidueGroup` of the unique
         :class:`Residues<Residue>` present in the :class:`AtomGroup`.
         """
-        rg = self.universe.residues[np.unique(self.resindices)]
+        rg = self.universe.residues[unique_int_1d(self.resindices)]
         rg._cache['isunique'] = True
         rg._cache['unique'] = rg
         return rg
@@ -1890,7 +1891,7 @@ class AtomGroup(GroupBase):
         """A sorted :class:`SegmentGroup` of the unique segments present in the
         :class:`AtomGroup`.
         """
-        sg = self.universe.segments[np.unique(self.segindices)]
+        sg = self.universe.segments[unique_int_1d(self.segindices)]
         sg._cache['isunique'] = True
         sg._cache['unique'] = sg
         return sg
@@ -2402,7 +2403,7 @@ class AtomGroup(GroupBase):
                                                          accessors.keys()))
 
         return [self[levelindices == index] for index in
-                np.unique(levelindices)]
+                unique_int_1d(levelindices)]
 
     def guess_bonds(self, vdwradii=None):
         """Guess bonds that exist within this :class:`AtomGroup` and add them to
@@ -2675,7 +2676,7 @@ class ResidueGroup(GroupBase):
         """Get sorted :class:`SegmentGroup` of the unique segments present in
         the :class:`ResidueGroup`.
         """
-        sg = self.universe.segments[np.unique(self.segindices)]
+        sg = self.universe.segments[unique_int_1d(self.segindices)]
         sg._cache['isunique'] = True
         sg._cache['unique'] = sg
         return sg
@@ -2747,7 +2748,7 @@ class ResidueGroup(GroupBase):
         """
         if self.isunique:
             return self
-        _unique = self.universe.residues[np.unique(self.ix)]
+        _unique = self.universe.residues[unique_int_1d(self.ix)]
         # Since we know that _unique is a unique ResidueGroup, we set its
         # uniqueness caches from here:
         _unique._cache['isunique'] = True
@@ -2892,7 +2893,7 @@ class SegmentGroup(GroupBase):
         """
         if self.isunique:
             return self
-        _unique = self.universe.segments[np.unique(self.ix)]
+        _unique = self.universe.segments[unique_int_1d(self.ix)]
         # Since we know that _unique is a unique SegmentGroup, we set its
         # uniqueness caches from here:
         _unique._cache['isunique'] = True

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -740,7 +740,7 @@ class GroupBase(_MutableBase):
         # Get sizes of compounds:
         unique_compound_indices, compound_sizes = np.unique(compound_indices,
                                                             return_counts=True)
-        unique_compound_sizes = np.unique(compound_sizes)
+        unique_compound_sizes = unique_int_1d(compound_sizes)
         # Compute centers per compound for each compound size:
         for compound_size in unique_compound_sizes:
             compound_mask = compound_sizes == compound_size

--- a/package/MDAnalysis/core/selection.py
+++ b/package/MDAnalysis/core/selection.py
@@ -51,7 +51,7 @@ from numpy.lib.utils import deprecate
 from Bio.KDTree import KDTree
 
 from MDAnalysis.lib.pkdtree import PeriodicKDTree
-from MDAnalysis.lib.cutil import unique_int_1d
+from MDAnalysis.lib.util import unique_int_1d
 from MDAnalysis.core import flags
 from ..lib import distances
 from ..exceptions import SelectionError, NoDataError

--- a/package/MDAnalysis/core/selection.py
+++ b/package/MDAnalysis/core/selection.py
@@ -51,6 +51,7 @@ from numpy.lib.utils import deprecate
 from Bio.KDTree import KDTree
 
 from MDAnalysis.lib.pkdtree import PeriodicKDTree
+from MDAnalysis.lib.cutil import unique_int_1d
 from MDAnalysis.core import flags
 from ..lib import distances
 from ..exceptions import SelectionError, NoDataError
@@ -219,7 +220,7 @@ class ByResSelection(UnarySelection):
 
     def apply(self, group):
         res = self.sel.apply(group)
-        unique_res = np.unique(res.resids)
+        unique_res = unique_int_1d(res.resids)
         mask = np.in1d(group.resids, unique_res)
 
         return group[mask].unique
@@ -290,7 +291,9 @@ class AroundSelection(DistanceSelection):
             for atom in sel.positions:
                 kdtree.search(atom, self.cutoff)
                 found_indices.append(kdtree.get_indices())
-            unique_idx = np.unique(np.concatenate(found_indices))
+            unique_idx = unique_int_1d(
+                np.concatenate(found_indices).astype(np.int64)
+            )
 
         else:
             kdtree = PeriodicKDTree(box, bucket_size=10)

--- a/package/MDAnalysis/lib/NeighborSearch.py
+++ b/package/MDAnalysis/lib/NeighborSearch.py
@@ -32,7 +32,7 @@ from __future__ import absolute_import
 import numpy as np
 from Bio.KDTree import KDTree
 from MDAnalysis.lib.pkdtree import PeriodicKDTree
-from MDAnalysis.lib.cutil import unique_int_1d
+from MDAnalysis.lib.util import unique_int_1d
 
 from MDAnalysis.core.groups import AtomGroup, Atom
 

--- a/package/MDAnalysis/lib/NeighborSearch.py
+++ b/package/MDAnalysis/lib/NeighborSearch.py
@@ -32,6 +32,7 @@ from __future__ import absolute_import
 import numpy as np
 from Bio.KDTree import KDTree
 from MDAnalysis.lib.pkdtree import PeriodicKDTree
+from MDAnalysis.lib.cutil import unique_int_1d
 
 from MDAnalysis.core.groups import AtomGroup, Atom
 
@@ -94,7 +95,9 @@ class AtomNeighborSearch(object):
         for pos in positions:
             self.kdtree.search(pos, radius)
             indices.append(self.kdtree.get_indices())
-        unique_idx = np.unique([i for l in indices for i in l]).astype(np.int64)
+        unique_idx = unique_int_1d(
+            np.array([i for l in indices for i in l], dtype=np.int64)
+        )
         return self._index2level(unique_idx, level)
 
     def _index2level(self, indices, level):

--- a/package/MDAnalysis/lib/_cutil.pyx
+++ b/package/MDAnalysis/lib/_cutil.pyx
@@ -25,6 +25,8 @@ import cython
 import numpy as np
 cimport numpy as np
 
+__all__ = ['unique_int_1d', ]
+
 
 @cython.boundscheck(False) # turn off bounds-checking for entire function
 @cython.wraparound(False)  # turn off negative index wrapping for entire function

--- a/package/MDAnalysis/lib/_cutil.pyx
+++ b/package/MDAnalysis/lib/_cutil.pyx
@@ -30,7 +30,7 @@ __all__ = ['unique_int_1d', ]
 
 @cython.boundscheck(False) # turn off bounds-checking for entire function
 @cython.wraparound(False)  # turn off negative index wrapping for entire function
-def unique_int_1d(np.ndarray[np.int_t, ndim=1] values):
+def unique_int_1d(np.ndarray[np.int64_t, ndim=1] values):
     """
     Find the unique elements of a 1D array of integers.
 
@@ -51,7 +51,7 @@ def unique_int_1d(np.ndarray[np.int_t, ndim=1] values):
     cdef int i = 0
     cdef int j = 0
     cdef int n_values = values.shape[0]
-    cdef np.ndarray[np.int_t, ndim=1] result = np.empty(n_values, dtype=int)
+    cdef np.ndarray[np.int64_t, ndim=1] result = np.empty(n_values, dtype=np.int64)
 
     if n_values == 0:
         return result

--- a/package/MDAnalysis/lib/cutil.pyx
+++ b/package/MDAnalysis/lib/cutil.pyx
@@ -1,0 +1,68 @@
+# -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; -*-
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
+#
+# MDAnalysis --- https://www.mdanalysis.org
+# Copyright (c) 2006-2017 The MDAnalysis Development Team and contributors
+# (see the file AUTHORS for the full list of names)
+#
+# Released under the GNU Public Licence, v2 or any higher version
+#
+# Please cite your use of MDAnalysis in published work:
+#
+# R. J. Gowers, M. Linke, J. Barnoud, T. J. E. Reddy, M. N. Melo, S. L. Seyler,
+# D. L. Dotson, J. Domanski, S. Buchoux, I. M. Kenney, and O. Beckstein.
+# MDAnalysis: A Python package for the rapid analysis of molecular dynamics
+# simulations. In S. Benthall and S. Rostrup editors, Proceedings of the 15th
+# Python in Science Conference, pages 102-109, Austin, TX, 2016. SciPy.
+#
+# N. Michaud-Agrawal, E. J. Denning, T. B. Woolf, and O. Beckstein.
+# MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
+# J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
+#
+#
+
+import cython
+import numpy as np
+cimport numpy as np
+
+
+@cython.boundscheck(False) # turn off bounds-checking for entire function
+@cython.wraparound(False)  # turn off negative index wrapping for entire function
+def unique_int_1d(np.ndarray[np.int_t, ndim=1] values):
+    """
+    Find the unique elements of a 1D array of integers.
+
+    This function is optimal on sorted arrays.
+
+    Parameters
+    ----------
+    values: np.ndarray
+        1D array of int in which to find the unique values.
+
+    Returns
+    -------
+    np.ndarray
+
+    .. versionadded:: 0.19.0
+    """
+    cdef bint is_monotonic = True
+    cdef int i = 0
+    cdef int j = 0
+    cdef int n_values = values.shape[0]
+    cdef np.ndarray[np.int_t, ndim=1] result = np.empty(n_values, dtype=int)
+
+    if n_values == 0:
+        return result
+    
+    result[0] = values[0]
+    for i in range(1, n_values):
+        if values[i] != result[j]:
+            j += 1
+            result[j] = values[i]
+        if values[i] < values[i - 1]:
+            is_monotonic = False
+    result = result[:j + 1]
+    if not is_monotonic:
+        result.sort()
+        result = unique_int_1d(result)
+    return result

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -109,6 +109,7 @@ Containers and lists
 .. autofunction:: asiterable
 .. autofunction:: hasmethod
 .. autoclass:: Namespace
+.. autofunction:: unique_int_1d
 
 File parsing
 ------------
@@ -178,6 +179,7 @@ from numpy.testing import assert_equal
 import inspect
 
 from ..exceptions import StreamWarning, DuplicateWarning
+from ._cutil import *
 
 
 # Python 3.0, 3.1 do not have the builtin callable()

--- a/package/setup.py
+++ b/package/setup.py
@@ -339,8 +339,8 @@ def extensions(config):
                         include_dirs=include_dirs,
                         define_macros=define_macros,
                         extra_compile_args=extra_compile_args)
-    cutil = MDAExtension('MDAnalysis.lib.cutil',
-                         sources=['MDAnalysis/lib/cutil' + source_suffix],
+    cutil = MDAExtension('MDAnalysis.lib._cutil',
+                         sources=['MDAnalysis/lib/_cutil' + source_suffix],
                          include_dirs=include_dirs,
                          define_macros=define_macros,
                          extra_compile_args=extra_compile_args)

--- a/package/setup.py
+++ b/package/setup.py
@@ -339,6 +339,12 @@ def extensions(config):
                         include_dirs=include_dirs,
                         define_macros=define_macros,
                         extra_compile_args=extra_compile_args)
+    cutil = MDAExtension('MDAnalysis.lib.cutil',
+                         sources=['MDAnalysis/lib/cutil' + source_suffix],
+                         include_dirs=include_dirs,
+                         define_macros=define_macros,
+                         extra_compile_args=extra_compile_args)
+
 
     encore_utils = MDAExtension('MDAnalysis.analysis.encore.cutils',
                                 sources=['MDAnalysis/analysis/encore/cutils' + source_suffix],
@@ -361,7 +367,7 @@ def extensions(config):
                               extra_compile_args=extra_compile_args)
     pre_exts = [libdcd, distances, distances_omp, qcprot,
                 transformation, libmdaxdr, util, encore_utils,
-                ap_clustering, spe_dimred]
+                ap_clustering, spe_dimred, cutil]
 
     cython_generated = []
     if use_cython:

--- a/testsuite/MDAnalysisTests/lib/test_cutil.py
+++ b/testsuite/MDAnalysisTests/lib/test_cutil.py
@@ -1,0 +1,38 @@
+# -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 fileencoding=utf-8
+#
+# MDAnalysis --- https://www.mdanalysis.org
+# Copyright (c) 2006-2017 The MDAnalysis Development Team and contributors
+# (see the file AUTHORS for the full list of names)
+#
+# Released under the GNU Public Licence, v2 or any higher version
+#
+# Please cite your use of MDAnalysis in published work:
+#
+# R. J. Gowers, M. Linke, J. Barnoud, T. J. E. Reddy, M. N. Melo, S. L. Seyler,
+# D. L. Dotson, J. Domanski, S. Buchoux, I. M. Kenney, and O. Beckstein.
+# MDAnalysis: A Python package for the rapid analysis of molecular dynamics
+# simulations. In S. Benthall and S. Rostrup editors, Proceedings of the 15th
+# Python in Science Conference, pages 102-109, Austin, TX, 2016. SciPy.
+#
+# N. Michaud-Agrawal, E. J. Denning, T. B. Woolf, and O. Beckstein.
+# MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
+# J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
+#
+
+import pytest
+import numpy as np
+from numpy.testing import assert_equal
+
+from MDAnalysis.lib.cutil import unique_int_1d
+
+
+@pytest.mark.parametrize('values', (
+    [],  # empty array
+    [1, 1, 1, 1, ],  # all identical
+    [2, 3, 5, 7, ],  # all different, monotonic
+    [5, 2, 7, 3, ],  # all different, non-monotonic
+))
+def test_unique_int_1d(values):
+    array = np.array(values, dtype=int)
+    assert_equal(unique_int_1d(array), np.unique(array))

--- a/testsuite/MDAnalysisTests/lib/test_cutil.py
+++ b/testsuite/MDAnalysisTests/lib/test_cutil.py
@@ -19,6 +19,7 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
+from __future__ import absolute_import
 
 import pytest
 import numpy as np
@@ -32,6 +33,8 @@ from MDAnalysis.lib.cutil import unique_int_1d
     [1, 1, 1, 1, ],  # all identical
     [2, 3, 5, 7, ],  # all different, monotonic
     [5, 2, 7, 3, ],  # all different, non-monotonic
+    [1, 2, 2, 4, 4, 6, ],  # duplicates, monotonic
+    [1, 2, 2, 6, 4, 4, ],  # duplicates, non-monotonic
 ))
 def test_unique_int_1d(values):
     array = np.array(values, dtype=int)

--- a/testsuite/MDAnalysisTests/lib/test_cutil.py
+++ b/testsuite/MDAnalysisTests/lib/test_cutil.py
@@ -25,7 +25,7 @@ import pytest
 import numpy as np
 from numpy.testing import assert_equal
 
-from MDAnalysis.lib.cutil import unique_int_1d
+from MDAnalysis.lib._cutil import unique_int_1d
 
 
 @pytest.mark.parametrize('values', (


### PR DESCRIPTION
`mda.lib.cutil.unique_int_1d` takes a 1D array of integers and returns
an array of the unique values. It has similar perormances as
`np.unique` for randomly ordered values, but is faster for sorted values.

MDAnalysis needs to deduplicate arrays of indices for basic operations.
In most cases the indices are sorted so the deduplication can be done
in linear complexity. However, `np.unique` is a general function; it
systematically sorts the values with a quicksort, which makes the
complexity in the order of n log n.

`mda.lib.cutil.unique_int_1d` only works on 1D arrays of integer and
does not have the optional return values `np.unique` has. It assumes
first that the values are sorted and only sorts them if they happen not
to be.

The main reason to improve the performances of index deduplication is that basic operations such as `ag.residues` are significantly slower since we merged the new topology system. From profiling, deduplicating the index is what takes the most time in these operations. By having a specialized method, we improve the performance of these basic and very frequent operations.

A benchmark for the deduplication is available as a notebook: <https://gist.github.com/jbarnoud/134c0747e343f3d61762b93feeec5add>.

PR Checklist
------------
 - [X] Tests?
 - [X] Docs?
 - [X] CHANGELOG updated?
 - [ ] Issue raised/referenced?
