### PR TITLE
fix MODEL and step in PDBWriter

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -44,6 +44,7 @@ Fixes
   * Fixed inconsistent handling of groups with/without duplicates in
     pack_into_box() (Issue #1911)
   * Fixed format of MODEL number in PDB file writing (Issue #1950)
+  * PDBWriter now properly sets start value
 
 Changes
   * TopologyAttrs are now statically typed (Issue #1876)

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -43,6 +43,7 @@ Fixes
   * Groups passed to select_atoms() are now type checked (Issue #1852)
   * Fixed inconsistent handling of groups with/without duplicates in
     pack_into_box() (Issue #1911)
+  * Fixed format of MODEL number in PDB file writing (Issue #1950)
 
 Changes
   * TopologyAttrs are now statically typed (Issue #1876)

--- a/package/MDAnalysis/coordinates/PDB.py
+++ b/package/MDAnalysis/coordinates/PDB.py
@@ -436,6 +436,18 @@ class PDBWriter(base.WriterBase):
 
     Note
     ----
+    Writing bonds currently only works when writing a whole :class:`Universe`
+    and if bond information is available in the topology.  (For selections
+    smaller than the whole :class:`Universe`, the atom numbering in the CONECT_
+    records would not match the numbering of the atoms in the new PDB file and
+    therefore a :exc:`NotImplementedError` is raised.)
+
+    The maximum frame number that can be stored in a PDB file is 9999 and it
+    will wrap around (see :meth:`MODEL` for further details).
+
+
+    See Also
+    --------
     This class is identical to :class:`MultiPDBWriter` with the one
     exception that it defaults to writing single-frame PDB files as if
     `multiframe` = ``False`` was selected.
@@ -521,7 +533,8 @@ class PDBWriter(base.WriterBase):
         filename: str
            name of output file
         start: int (optional)
-           starting timestep
+           starting timestep (the first frame will have MODEL number `start` + 1
+           because the PDB standard prescribes MODEL numbers starting at 1)
         step: int (optional)
            skip between subsequent timesteps
         remarks: str (optional)
@@ -541,15 +554,6 @@ class PDBWriter(base.WriterBase):
            ``False``: write a single frame to the file; ``True``: create a
            multi frame PDB file in which frames are written as MODEL_ ... ENDMDL_
            records. If ``None``, then the class default is chosen.    [``None``]
-
-        Note
-        ----
-        Writing bonds currently only works when writing a whole
-        :class:`Universe` and if bond information is available in the topology.
-        (For selections smaller than the whole :class:`Universe`, the atom
-        numbering in the CONECT_ records would not match the numbering of the
-        atoms in the new PDB file and therefore a :exc:`NotImplementedError` is
-        raised.)
 
 
         .. _CONECT: http://www.wwpdb.org/documentation/format32/sect10.html#CONECT
@@ -571,11 +575,10 @@ class PDBWriter(base.WriterBase):
         self._multiframe = self.multiframe if multiframe is None else multiframe
         self.bonds = bonds
 
-        self.frames_written = 0
         if start < 0:
             raise ValueError("'Start' must be a positive value")
 
-        self.start = start
+        self.start =  self.frames_written = start
         self.step = step
         self.remarks = remarks
 
@@ -596,7 +599,7 @@ class PDBWriter(base.WriterBase):
 
     def _write_pdb_title(self):
         if self._multiframe:
-            self.TITLE("MDANALYSIS FRAMES FROM {0:d}, SKIP {1:d}: {2!s}"
+            self.TITLE("MDANALYSIS FRAMES FROM {0:d}, STEP {1:d}: {2!s}"
                        "".format(self.start, self.step, self.remarks))
         else:
             self.TITLE("MDANALYSIS FRAME {0:d}: {1!s}"
@@ -762,7 +765,7 @@ class PDBWriter(base.WriterBase):
         or a :class:`~MDAnalysis.core.universe.Universe`.
 
         The method writes the frames from the one specified as *start* until
-        the end, using a step of *skip* (*start* and *skip* are set in the
+        the end, using a step of *step* (*start* and *step* are set in the
         constructor). Thus, if *u* is a Universe then ::
 
            u.trajectory[-2]
@@ -771,7 +774,7 @@ class PDBWriter(base.WriterBase):
 
         will write a PDB trajectory containing the last 2 frames and ::
 
-           pdb = PDBWriter("out.pdb", u.atoms.n_atoms, start=12, skip=2)
+           pdb = PDBWriter("out.pdb", u.atoms.n_atoms, start=12, step=2)
            pdb.write_all_timesteps(u)
 
         will be writing frames 12, 14, 16, ...
@@ -989,10 +992,21 @@ class PDBWriter(base.WriterBase):
     def MODEL(self, modelnumber):
         """Write the MODEL_ record.
 
+        .. note::
+
+           The maximum MODEL number is limited to 9999 in the PDB
+           standard (i.e., 4 digits). If frame numbers are larger than
+           9999, they will wrap around, i.e., 9998, 9999, 0, 1, 2, ...
+
+
         .. _MODEL: http://www.wwpdb.org/documentation/format32/sect9.html#MODEL
 
+
+        .. versionchanged:: 0.18.1
+           Maximum model number is enforced.
+
         """
-        self.pdbfile.write(self.fmt['MODEL'].format(modelnumber))
+        self.pdbfile.write(self.fmt['MODEL'].format(int(str(modelnumber)[-4:])))
 
     def END(self):
         """Write END_ record.

--- a/package/MDAnalysis/coordinates/PDB.py
+++ b/package/MDAnalysis/coordinates/PDB.py
@@ -466,7 +466,7 @@ class PDBWriter(base.WriterBase):
         'COMPND': "COMPND    {0}\n",
         'HEADER': "HEADER    {0}\n",
         'TITLE': "TITLE     {0}\n",
-        'MODEL': "MODEL     {0:5d}\n",
+        'MODEL': "MODEL     {0:>4d}\n",
         'NUMMDL': "NUMMDL    {0:5d}\n",
         'ENDMDL': "ENDMDL\n",
         'END': "END\n",

--- a/testsuite/MDAnalysisTests/coordinates/test_pdb.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_pdb.py
@@ -149,116 +149,113 @@ class TestExtendedPDBReader(_SingleFrameReader):
         assert_equal(u[4].resid, 10000, "can't read a five digit resid")
 
 
-class TestPDBWriter(TestCase):
-    def setUp(self):
-        self.universe = mda.Universe(PSF, PDB_small)
-        self.universe2 = mda.Universe(PSF, DCD)
-        # 3 decimals in PDB spec
-        # http://www.wwpdb.org/documentation/format32/sect9.html#ATOM
-        self.prec = 3
-        ext = ".pdb"
-        self.tmpdir = tempdir.TempDir()
-        self.outfile = self.tmpdir.name + '/primitive-pdb-writer' + ext
-        self.u_no_resnames = make_Universe(['names', 'resids'],
-                                           trajectory=True)
-        self.u_no_resids = make_Universe(['names', 'resnames'],
-                                         trajectory=True)
-        self.u_no_names = make_Universe(['resids', 'resnames'],
-                                        trajectory=True)
+class TestPDBWriter(object):
+    # 3 decimals in PDB spec
+    # http://www.wwpdb.org/documentation/format32/sect9.html#ATOM
+    prec = 3
+    ext = ".pdb"
 
-    def tearDown(self):
-        try:
-            os.unlink(self.outfile)
-        except OSError:
-            pass
-        del self.universe, self.universe2
-        del self.u_no_resnames, self.u_no_resids, self.u_no_names
-        del self.tmpdir
+    @pytest.fixture
+    def universe(self):
+        return mda.Universe(PSF, PDB_small)
 
-    def test_writer(self):
+    @pytest.fixture
+    def universe2(self):
+        return mda.Universe(PSF, DCD)
+
+    @pytest.fixture
+    def outfile(self, tmpdir):
+        return str(tmpdir.mkdir("PDBWriter").join('primitive-pdb-writer' + self.ext))
+
+    @pytest.fixture
+    def u_no_resnames(self):
+        return make_Universe(['names', 'resids'], trajectory=True)
+
+    @pytest.fixture
+    def u_no_resids(self):
+        return make_Universe(['names', 'resnames'], trajectory=True)
+
+    @pytest.fixture
+    def u_no_names(self):
+        return make_Universe(['resids', 'resnames'], trajectory=True)
+
+
+    def test_writer(self, universe, outfile):
         "Test writing from a single frame PDB file to a PDB file." ""
-        self.universe.atoms.write(self.outfile)
-        u = mda.Universe(PSF, self.outfile)
+        universe.atoms.write(outfile)
+        u = mda.Universe(PSF, outfile)
         assert_almost_equal(u.atoms.positions,
-                            self.universe.atoms.positions, self.prec,
+                            universe.atoms.positions, self.prec,
                             err_msg="Writing PDB file with PDBWriter "
                                     "does not reproduce original coordinates")
 
-    def test_writer_no_resnames(self):
-        self.u_no_resnames.atoms.write(self.outfile)
-        u = mda.Universe(self.outfile)
-        expected = np.array(['UNK'] * self.u_no_resnames.atoms.n_atoms)
+    def test_writer_no_resnames(self, u_no_resnames, outfile):
+        u_no_resnames.atoms.write(outfile)
+        u = mda.Universe(outfile)
+        expected = np.array(['UNK'] * u_no_resnames.atoms.n_atoms)
         assert_equal(u.atoms.resnames, expected)
 
-
-    def test_writer_no_resids(self):
-        self.u_no_resids.atoms.write(self.outfile)
-        u = mda.Universe(self.outfile)
+    def test_writer_no_resids(self, u_no_resids, outfile):
+        u_no_resids.atoms.write(outfile)
+        u = mda.Universe(outfile)
         expected = np.ones((25,))
         assert_equal(u.residues.resids, expected)
 
-
-    def test_writer_no_atom_names(self):
-        self.u_no_names.atoms.write(self.outfile)
-        u = mda.Universe(self.outfile)
-        expected = np.array(['X'] * self.u_no_names.atoms.n_atoms)
+    def test_writer_no_atom_names(self, u_no_names, outfile):
+        u_no_names.atoms.write(outfile)
+        u = mda.Universe(outfile)
+        expected = np.array(['X'] * u_no_names.atoms.n_atoms)
         assert_equal(u.atoms.names, expected)
 
-
-    def test_writer_no_altlocs(self):
-        self.u_no_names.atoms.write(self.outfile)
-        u = mda.Universe(self.outfile)
-        expected = np.array([''] * self.u_no_names.atoms.n_atoms)
+    def test_writer_no_altlocs(self, u_no_names, outfile):
+        u_no_names.atoms.write(outfile)
+        u = mda.Universe(outfile)
+        expected = np.array([''] * u_no_names.atoms.n_atoms)
         assert_equal(u.atoms.altLocs, expected)
 
-
-    def test_writer_no_icodes(self):
-        self.u_no_names.atoms.write(self.outfile)
-        u = mda.Universe(self.outfile)
-        expected = np.array([''] * self.u_no_names.atoms.n_atoms)
+    def test_writer_no_icodes(self, u_no_names, outfile):
+        u_no_names.atoms.write(outfile)
+        u = mda.Universe(outfile)
+        expected = np.array([''] * u_no_names.atoms.n_atoms)
         assert_equal(u.atoms.icodes, expected)
 
-
-    def test_writer_no_segids(self):
-        self.u_no_names.atoms.write(self.outfile)
-        u = mda.Universe(self.outfile)
-        expected = np.array(['SYSTEM'] * self.u_no_names.atoms.n_atoms)
+    def test_writer_no_segids(self, u_no_names, outfile):
+        u_no_names.atoms.write(outfile)
+        u = mda.Universe(outfile)
+        expected = np.array(['SYSTEM'] * u_no_names.atoms.n_atoms)
         assert_equal([atom.segid for atom in u.atoms], expected)
 
-
-    def test_writer_no_occupancies(self):
-        self.u_no_names.atoms.write(self.outfile)
-        u = mda.Universe(self.outfile)
-        expected = np.ones(self.u_no_names.atoms.n_atoms)
+    def test_writer_no_occupancies(self, u_no_names, outfile):
+        u_no_names.atoms.write(outfile)
+        u = mda.Universe(outfile)
+        expected = np.ones(u_no_names.atoms.n_atoms)
         assert_equal(u.atoms.occupancies, expected)
 
-
-    def test_writer_no_tempfactors(self):
-        self.u_no_names.atoms.write(self.outfile)
-        u = mda.Universe(self.outfile)
-        expected = np.zeros(self.u_no_names.atoms.n_atoms)
+    def test_writer_no_tempfactors(self, u_no_names, outfile):
+        u_no_names.atoms.write(outfile)
+        u = mda.Universe(outfile)
+        expected = np.zeros(u_no_names.atoms.n_atoms)
         assert_equal(u.atoms.tempfactors, expected)
 
-    def test_write_single_frame_Writer(self):
+    def test_write_single_frame_Writer(self, universe2, outfile):
         """Test writing a single frame from a DCD trajectory to a PDB using
         MDAnalysis.Writer (Issue 105)"""
-        u = self.universe2
-        W = mda.Writer(self.outfile)
+        u = universe2
         u.trajectory[50]
-        W.write(u.select_atoms('all'))
-        W.close()
-        u2 = mda.Universe(self.outfile)
+        with  mda.Writer(outfile) as W:
+            W.write(u.select_atoms('all'))
+        u2 = mda.Universe(outfile)
         assert_equal(u2.trajectory.n_frames,
                      1,
                      err_msg="The number of frames should be 1.")
 
-    def test_write_single_frame_AtomGroup(self):
+    def test_write_single_frame_AtomGroup(self, universe2, outfile):
         """Test writing a single frame from a DCD trajectory to a PDB using
         AtomGroup.write() (Issue 105)"""
-        u = self.universe2
+        u = universe2
         u.trajectory[50]
-        u.atoms.write(self.outfile)
-        u2 = mda.Universe(PSF, self.outfile)
+        u.atoms.write(outfile)
+        u2 = mda.Universe(PSF, outfile)
         assert_equal(u2.trajectory.n_frames,
                      1,
                      err_msg="Output PDB should only contain a single frame")
@@ -267,38 +264,35 @@ class TestPDBWriter(TestCase):
                                                "agree with original coordinates from frame %d" %
                                                u.trajectory.frame)
 
-    def test_check_coordinate_limits_min(self):
+    def test_check_coordinate_limits_min(self, universe, outfile):
         """Test that illegal PDB coordinates (x <= -999.9995 A) are caught
         with ValueError (Issue 57)"""
-        # modify coordinates so we need our own copy or we could mess up
-        # parallel tests
-        u = mda.Universe(PSF, PDB_small)
+        # modify coordinates (universe needs to be a per-function fixture)
+        u = universe
         u.atoms[2000].position = [0, -999.9995, 22.8]
         with pytest.raises(ValueError):
-            u.atoms.write(self.outfile)
+            u.atoms.write(outfile)
 
-    def test_check_coordinate_limits_max(self):
+    def test_check_coordinate_limits_max(self, universe, outfile):
         """Test that illegal PDB coordinates (x > 9999.9995 A) are caught
         with ValueError (Issue 57)"""
-        # modify coordinates so we need our own copy or we could mess up
-        # parallel tests
-        u = mda.Universe(PSF, PDB_small)
+        # modify coordinates (universe needs to be a per-function fixture)
+        u = universe
         # OB: 9999.99951 is not caught by '<=' ?!?
         u.atoms[1000].position = [90.889, 9999.9996, 12.2]
         with pytest.raises(ValueError):
-            u.atoms.write(self.outfile)
-        del u
+            u.atoms.write(outfile)
 
-    def test_check_HEADER_TITLE_multiframe(self):
+    def test_check_HEADER_TITLE_multiframe(self, universe2, outfile):
         """Check whether HEADER and TITLE are written just once in a multi-
         frame PDB file (Issue 741)"""
-        u = mda.Universe(PSF, DCD)
+        u = universe2
         protein = u.select_atoms("protein and name CA")
-        with mda.Writer(self.outfile, multiframe=True) as pdb:
+        with mda.Writer(outfile, multiframe=True) as pdb:
             for ts in u.trajectory[:5]:
                 pdb.write(protein)
 
-        with open(self.outfile) as f:
+        with open(outfile) as f:
             got_header = 0
             got_title = 0
             for line in f:
@@ -309,11 +303,13 @@ class TestPDBWriter(TestCase):
                     got_title += 1
                     assert got_title <= 1, "There should be only one TITLE."
 
-    def test_check_MODEL_multiframe(self, maxframes=12):
+    @pytest.mark.parametrize("startframe,maxframes",
+                             [(0, 12), (9997, 12)])
+    def test_check_MODEL_multiframe(self, universe2, outfile, startframe, maxframes):
         """Check whether MODEL number is in the right column (Issue #1950)"""
-        u = mda.Universe(PSF, DCD)
+        u = universe2
         protein = u.select_atoms("protein and name CA")
-        with mda.Writer(self.outfile, multiframe=True) as pdb:
+        with mda.Writer(outfile, multiframe=True, start=startframe) as pdb:
             for ts in u.trajectory[:maxframes]:
                 pdb.write(protein)
 
@@ -323,11 +319,18 @@ class TestPDBWriter(TestCase):
                     if line.startswith("MODEL"):
                         yield line
 
-        MODEL_lines = list(get_MODEL_lines(self.outfile))
+        MODEL_lines = list(get_MODEL_lines(outfile))
 
         assert len(MODEL_lines) == maxframes
-        for model, line in enumerate(MODEL_lines, start=1):
-            assert line[10:14] == "{0:>4d}".format(model)
+        for model, line in enumerate(MODEL_lines, start=startframe+1):
+            # test that only the right-most 4 digits are stored (rest must be space)
+            # line[10:14] == '9999' or '   1'
+
+            # test appearance with white space
+            assert line[5:14] == "{0:>9d}".format(int(str(model)[-4:]))
+
+            # test number (only last 4 digits)
+            assert int(line[10:14]) == model % 10000
 
 
 class TestMultiPDBReader(TestCase):


### PR DESCRIPTION
Fixes #1950 

Changes made in this Pull Request:
 - fix MODEL record writing (columns 11-14 only)
 - make MODEL number only 4 digits max and wrap around
 - fix use of `step`

PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
