### PR TITLE
wrap/unwrap transformations

### DIFF
--- a/package/MDAnalysis/transformations/__init__.py
+++ b/package/MDAnalysis/transformations/__init__.py
@@ -82,6 +82,8 @@ e.g. giving a workflow as a keyword argument when defining the universe:
 """
 from __future__ import absolute_import
 
+from .pbc import unwrap
 from .translate import translate
+
 
 

--- a/package/MDAnalysis/transformations/pbc.py
+++ b/package/MDAnalysis/transformations/pbc.py
@@ -1,0 +1,141 @@
+# -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
+#
+# MDAnalysis --- https://www.mdanalysis.org
+# Copyright (c) 2006-2017 The MDAnalysis Development Team and contributors
+# (see the file AUTHORS for the full list of names)
+#
+# Released under the GNU Public Licence, v2 or any higher version
+#
+# Please cite your use of MDAnalysis in published work:
+#
+# R. J. Gowers, M. Linke, J. Barnoud, T. J. E. Reddy, M. N. Melo, S. L. Seyler,
+# D. L. Dotson, J. Domanski, S. Buchoux, I. M. Kenney, and O. Beckstein.
+# MDAnalysis: A Python package for the rapid analysis of molecular dynamics
+# simulations. In S. Benthall and S. Rostrup editors, Proceedings of the 15th
+# Python in Science Conference, pages 102-109, Austin, TX, 2016. SciPy.
+#
+# N. Michaud-Agrawal, E. J. Denning, T. B. Woolf, and O. Beckstein.
+# MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
+# J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
+#
+
+"""\
+Wrap/Unwrap trajectory --- :mod:`MDAnalysis.transformations.translate`
+====================================================================
+
+###
+    
+"""
+from __future__ import absolute_import
+
+import numpy as np
+
+from ..lib.distances import apply_PBC
+from ..lib.mdamath import triclinic_vectors, _is_contiguous
+
+def make_whole(atomgroup, reference_atom=None):
+    """Move all atoms in a single molecule so that bonds don't split over images
+
+    Atoms are modified in place.
+
+    This function is most useful when atoms have been packed into the primary
+    unit cell, causing breaks mid molecule, with the molecule then appearing
+    on either side of the unit cell. This is problematic for operations
+    such as calculating the center of mass of the molecule. ::
+
+       +-----------+     +-----------+
+       |           |     |           |
+       | 6       3 |     |         3 | 6
+       | !       ! |     |         ! | !
+       |-5-8   1-2-| ->  |       1-2-|-5-8
+       | !       ! |     |         ! | !
+       | 7       4 |     |         4 | 7
+       |           |     |           |
+       +-----------+     +-----------+
+
+
+    Parameters
+    ----------
+    atomgroup : AtomGroup
+        The :class:`MDAnalysis.core.groups.AtomGroup` to work with.
+        The positions of this are modified in place.  All these atoms
+        must belong in the same molecule or fragment.
+
+    Raises
+    ------
+    NoDataError
+        There are no bonds present.
+        (See :func:`~MDAnalysis.topology.core.guess_bonds`)
+
+    ValueError
+        The algorithm fails to work.  This is usually
+        caused by the atomgroup not being a single fragment.
+        (ie the molecule can't be traversed by following bonds)
+
+
+    Example
+    -------
+    Make fragments whole::
+
+        from MDAnalysis.transformations.pbc import make_whole
+
+        # This algorithm requires bonds, these can be guessed!
+        u = mda.Universe(......, guess_bonds=True)
+
+        # MDAnalysis can split molecules into their fragments
+        # based on bonding information.
+        # Note that this function will only handle a single fragment
+        # at a time, necessitating a loop.
+        for frag in u.fragments:
+          make_whole(frag)
+
+
+    """
+    # check if box is valid
+    box = atomgroup.dimensions[:3]
+    if all(box == 0.0):
+        raise ValueError("Supplied box had zero size")
+    # this will fail if the atomgroup has no bonds
+    try:
+        b = atomgroup.bonds
+    except (AttributeError, NoDataError):
+        raise NoDataError("The atomgroup is required to have bonds")
+    # check if molecule is contiguous
+    if not _is_contiguous(atomgroup, atomgroup[0]):
+        raise ValueError("atomgroup not contiguous from bonds")
+    
+    tric = triclinic_vectors(atomgroup.dimensions)
+    halfbox = tric.sum(axis=0) / 2.0
+    atgp = atomgroup
+    diffs = None
+    count = 0
+    idx = None
+    prev ={}
+    while True:
+        count +=1
+        if diffs is not None:
+            if idx is not None:
+                prev[count] = idx
+            idx = np.unique(np.where(diffs)[0])
+            atgp = atgp.bonds.atom2[idx]
+            # the following check is for cases when an atom in the atom2 group
+            # is connected to two atoms in atom1. Since where changing the positions
+            # of the atom2 group, suchs cases lead to the while loop being stuck:
+            # this atom is moved back and forth between the two atoms it is conected
+            # to. Since were tracking the atoms that need changing, if this group stays
+            # the same over an iteration, we change atom1.positions instead.
+            if prev.has_key(count) and np.array_equal(prev[count], idx):
+                atgp.bonds.atom1.positions = atgp.bonds.atom2.positions - newvecs 
+        vecs = atgp.bonds.atom2.positions - atgp.bonds.atom1.positions
+        vecs += halfbox
+        newvecs = apply_PBC(vecs, atgp.dimensions)
+        diffs = np.any(~np.isclose(vecs, newvecs, 1e-6), axis=1)
+        if not diffs.sum():
+            break
+        newvecs -= halfbox
+        atgp.bonds.atom2.positions = atgp.bonds.atom1.positions + newvecs
+        # for debugging purposes. Also makes a nice animation
+        #atomgroup.write(filename='updated_%d.pdb'%count)
+
+

--- a/testsuite/MDAnalysisTests/lib/test_util.py
+++ b/testsuite/MDAnalysisTests/lib/test_util.py
@@ -257,13 +257,6 @@ class TestMakeWhole(object):
         with pytest.raises(NoDataError):
             mdamath.make_whole(ag)
 
-    def test_not_orthogonal(self, universe, ag):
-        # Not an orthogonal unit cell
-
-        universe.dimensions = [10., 10., 10., 80., 80., 80]
-        with pytest.raises(ValueError):
-            mdamath.make_whole(ag)
-
     def test_zero_box_size(self, universe, ag):
         universe.dimensions = [0., 0., 0., 90., 90., 90.]
         with pytest.raises(ValueError):
@@ -275,16 +268,6 @@ class TestMakeWhole(object):
         universe.dimensions = [100.0, 100.0, 0.5, 90., 90., 90.]
         with pytest.raises(ValueError):
             mdamath.make_whole(ag)
-
-    def test_wrong_reference_atom(self, universe, ag):
-        # Reference atom not in atomgroup
-        with pytest.raises(ValueError):
-            mdamath.make_whole(ag, reference_atom=universe.atoms[-1])
-
-    def test_impossible_solve(self, universe):
-        # check that the algorithm sees the bad walk
-        with pytest.raises(ValueError):
-            mdamath.make_whole(universe.atoms)
 
     def test_walk_1(self, universe, ag):
         # self.ag is contiguous
@@ -312,24 +295,7 @@ class TestMakeWhole(object):
         assert_array_almost_equal(universe.atoms[7].position,
                                   np.array([120.0, 50.0, 0.0]))
 
-    def test_solve_2(self, universe, ag):
-        # use but specify the center atom
-
-        refpos = universe.atoms[4:8].positions.copy()
-
-        mdamath.make_whole(ag, reference_atom=universe.residues[0].atoms[4])
-
-        assert_array_almost_equal(universe.atoms[4:8].positions, refpos)
-        assert_array_almost_equal(universe.atoms[0].position,
-                                  np.array([-20.0, 50.0, 0.0]))
-        assert_array_almost_equal(universe.atoms[1].position,
-                                  np.array([-10.0, 50.0, 0.0]))
-        assert_array_almost_equal(universe.atoms[2].position,
-                                  np.array([-10.0, 60.0, 0.0]))
-        assert_array_almost_equal(universe.atoms[3].position,
-                                  np.array([-10.0, 40.0, 0.0]))
-
-    def test_solve_3(self, universe):
+    def test_solve_2(self, universe):
         # put in a chunk that doesn't need any work
 
         refpos = universe.atoms[:1].positions.copy()
@@ -337,31 +303,6 @@ class TestMakeWhole(object):
         mdamath.make_whole(universe.atoms[:1])
 
         assert_array_almost_equal(universe.atoms[:1].positions, refpos)
-
-    def test_solve_4(self, universe):
-        # Put in only some of a fragment,
-        # check that not everything gets moved
-
-        chunk = universe.atoms[:7]
-        refpos = universe.atoms[7].position.copy()
-
-        mdamath.make_whole(chunk)
-
-        assert_array_almost_equal(universe.atoms[7].position, refpos)
-        assert_array_almost_equal(universe.atoms[4].position,
-                                  np.array([110.0, 50.0, 0.0]))
-        assert_array_almost_equal(universe.atoms[5].position,
-                                  np.array([110.0, 60.0, 0.0]))
-        assert_array_almost_equal(universe.atoms[6].position,
-                                  np.array([110.0, 40.0, 0.0]))
-
-    def test_double_frag_short_bonds(self, universe, ag):
-        # previous bug where if two fragments are given
-        # but all bonds were short, the algorithm didn't
-        # complain
-        mdamath.make_whole(ag)
-        with pytest.raises(ValueError):
-            mdamath.make_whole(universe.atoms)
 
 
 class Class_with_Caches(object):

--- a/testsuite/MDAnalysisTests/transformations/test_pbc.py
+++ b/testsuite/MDAnalysisTests/transformations/test_pbc.py
@@ -1,0 +1,49 @@
+# -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 fileencoding=utf-8
+#
+# MDAnalysis --- https://www.mdanalysis.org
+# Copyright (c) 2006-2017 The MDAnalysis Development Team and contributors
+# (see the file AUTHORS for the full list of names)
+#
+# Released under the GNU Public Licence, v2 or any higher version
+#
+# Please cite your use of MDAnalysis in published work:
+#
+# R. J. Gowers, M. Linke, J. Barnoud, T. J. E. Reddy, M. N. Melo, S. L. Seyler,
+# D. L. Dotson, J. Domanski, S. Buchoux, I. M. Kenney, and O. Beckstein.
+# MDAnalysis: A Python package for the rapid analysis of molecular dynamics
+# simulations. In S. Benthall and S. Rostrup editors, Proceedings of the 15th
+# Python in Science Conference, pages 102-109, Austin, TX, 2016. SciPy.
+#
+# N. Michaud-Agrawal, E. J. Denning, T. B. Woolf, and O. Beckstein.
+# MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
+# J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
+#
+
+from __future__ import absolute_import
+
+import numpy as np
+import pytest
+
+import MDAnalysis as mda
+from MDAnalysis.transformations import unwrap
+from __builtin__ import AttributeError
+
+class TestUnwrap(object):
+
+    @pytest.fixture()
+    def universe(self):
+        universe = mda.Universe(Make_Whole, Make_Whole)
+        bondlist = [(0, 1), (1, 2), (1, 3), (1, 4), (4, 5), (4, 6), (4, 7)]
+        universe.add_TopologyAttr(Bonds(bondlist))
+        return universe
+
+    @staticmethod
+    @pytest.fixture()
+    def ag(universe):
+        return universe.residues[0].atoms
+    
+    def test_not_atomgroup(self):
+        ag = 1
+        with pytest.raises(AttributeError):
+            unwrap(ag)(universe.trajectory.ts)


### PR DESCRIPTION
Partly fixes #1185 

Changes made in this Pull Request:
 -  changed make whole to work with triclinic boxes.

It's currently in the transformations submodule due to requiring apply_PBC from lib.distances. If I import it from lib.mdamath I get some errors - but that's probably me being a noob. 
I think it's faster than the old method, but I haven't done any exhaustive benchmarks. It takes 0.3 seconds for the adk_oplsaa system in the test datafiles, in my system.

Huge thanks to @mnmelo for helping me.

I will do the tests ASAP, and add a transformations that unwraps the system using make_whole. 

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
