### PR TITLE
updated GitHub template for issues

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,10 +6,10 @@ Thanks for contributing to MDAnalysis!
 
 If you've found a defect with MDAnalysis we'd love to know so we can fix it.  Please follow the Issue template so we can quickly diagnose the problem, in particular the piece of code that causes the problem.
 
-If your issue isn't a defect with the code and instead you require help using MDAnalysis, drop by the [discussion board](http://help.mdanalysis.org).
+If your issue isn't a defect with the code and instead you require help using MDAnalysis, drop by the [discussion board](https://groups.google.com/forum/#!forum/mdnalysis-discussion).
 
 #### Contributing code
 
 If you're contributing code, please check out the [Style guide](https://github.com/MDAnalysis/mdanalysis/wiki/Style-Guide).
 
-MDAnalysis devs are most easily reached through the [development board](http://developers.mdanalysis.org).
+MDAnalysis devs are most easily reached through the [development board](https://groups.google.com/forum/#!forum/mdnalysis-devel).

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,3 +1,31 @@
+<!-- 
+
+If you have a QUESTION such as 
+
+- how to use MDAnalysis in general
+- how to accomplish something specific,
+- what output means
+- ... or similar questions related to USING MDAnalysis 
+
+then please *ask this question on the user mailing list*
+
+   https://groups.google.com/forum/#!forum/mdnalysis-discussion
+
+The issue tracker is meant for DEFECTS ("BUGS"), new FEATURES, and
+decisions on the API. In order to keep the volume of work on the issue
+tracker manageable for our volunteer developers, we will IMMEDIATELY
+CLOSE ISSUES THAT ARE BETTER ANSWERED ON THE USER MAILINGLIST.
+
+We really appreciate you as a user getting in touch with us --- no 
+matter what you want to discuss. But we need your help keeping the 
+amount of work manageable so please use the mailing list for questions 
+and the issue tracker for code-related issues.
+
+Thank you!
+
+The MDAnalysis Development Team
+
+-->
 ### Expected behaviour
 
 
@@ -17,3 +45,4 @@ u = mda.Universe(top, trj)
 
 ### Currently version of MDAnalysis:
 (run `python -c "import MDAnalysis as mda; print(mda.__version__)"`)
+


### PR DESCRIPTION
- add comment that tells user to use the mailing list for questions and
  says that issues with question will be closed
- changed links to user and developer list in CONTRIBUTING to the Google Groups
  so that we use SSL links instead the forwards to help.mdanalysis.org and developers.mdanalysis.org

[skip ci]


