### PR TITLE
more GRO benchmarks

### DIFF
--- a/benchmarks/benchmarks/GRO.py
+++ b/benchmarks/benchmarks/GRO.py
@@ -2,12 +2,20 @@ from __future__ import division, absolute_import, print_function
 
 import numpy as np
 from MDAnalysis.coordinates.GRO import GROReader
+from MDAnalysis.topology.GROParser import GROParser
 from MDAnalysisTests.datafiles import GRO
+import MDAnalysis as mda
 
 class GROReadBench(object):
 
-    def time_read_GRO_file(self):
-        """Benchmark reading of standard test
-        suite GRO file.
-        """
+    def time_read_GRO_coordinates(self):
+        """Benchmark reading of standard testsuite GRO file."""
         GROReader(GRO)
+
+    def time_parse_GRO_file(self):
+        with GROParser(GRO) as p:
+            top = p.parse()
+
+    def time_create_GRO_universe(self):
+        """Time to create MDA Universe of GRO"""
+        u = mda.Universe(GRO)


### PR DESCRIPTION
Adds more GRO benchmarks.

In general, formats should probably have benchmarks like this, one for Reader, one for Parser, then one for Universe (which is mostly the sum of the two).

One question, what happens with asv if a benchmark can't run because of API changes?