### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+**Expected behavior**
+
+A clear and concise description of what you want to do and what you think should happen. (Code to reproduce the behavior can be added below).
+
+
+**Actual behavior**
+
+What happened instead. Add as much detail as you can. Include (copy and paste) stack traces and any output.
+
+
+**Code to reproduce the behavior**
+
+Show us how to reproduce the failiure. If you can, use trajectory files from the test data.
+
+``` python
+import MDAnalysis as mda
+from MDAnalysis.tests.datafiles import PSF, DCD,  GRO, PDB, TPR, XTC, TRR,  PRMncdf, NCDF
+
+u = mda.Universe(PSF, DCD)
+
+....
+
+```
+
+**Currently version of MDAnalysis**
+
+- Which version are you using? (run `python -c "import MDAnalysis as mda; print(mda.__version__)"`)
+- Which version of Python (`python -V`)?
+- Which operating system?

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/questions.md
+++ b/.github/ISSUE_TEMPLATE/questions.md
@@ -1,0 +1,24 @@
+---
+name: Questions
+about: If you want to ask a question please use the mailing list!
+
+---
+
+If you have a **QUESTION** such as 
+
+- how to use MDAnalysis in general
+- how to accomplish something specific,
+- what output means
+- ... or similar questions related to USING MDAnalysis 
+
+then please *ask this question on the user mailing list*
+
+   https://groups.google.com/forum/#!forum/mdnalysis-discussion
+
+The issue tracker is meant for DEFECTS ("BUGS"), new FEATURES, and decisions on the API. In order to keep the volume of work on the issue tracker manageable for our volunteer developers, we will IMMEDIATELY CLOSE ISSUES THAT ARE BETTER ANSWERED ON THE USER MAILINGLIST.
+
+We really appreciate you as a user getting in touch with us --- no matter what you want to discuss. But we need your help keeping the amount of work manageable so please use the mailing list for questions and the issue tracker for code-related issues.
+
+Thank you!
+
+The MDAnalysis Development Team


### PR DESCRIPTION
GitHub provides more fine grained control over issue templates. I used our standard template for *Bug report*, used their suggestion for *Feature request*, and created one for *Questions* which tells people to use the mailing list!