### PR TITLE
fixed make_whole only working on 0 base AtomGroups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,6 +76,7 @@ matrix:
 
   allow_failures:
     - env: NUMPY_VERSION=dev EVENT_TYPE="cron"
+    - env: NAME="Lint"
 
 before_install:
   # Workaround for Travis CI macOS bug (https://github.com/travis-ci/travis-ci/issues/6307)

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ matrix:
 
     - env: NAME="Lint"
            PYLINTRC="${TRAVIS_BUILD_DIR}/package/.pylintrc"
-           MAIN_CMD="pylint package/MDAnalysis && pylint testsuite/MDAnalysisTests"
+           MAIN_CMD="pylint --rcfile=$PYLINTRC package/MDAnalysis && pylint --rcfile=$PYLINTRC testsuite/MDAnalysisTests"
            SETUP_CMD=""
            BUILD_CMD=""
            CONDA_DEPENDENCIES=""

--- a/testsuite/MDAnalysisTests/lib/test_util.py
+++ b/testsuite/MDAnalysisTests/lib/test_util.py
@@ -41,7 +41,9 @@ from MDAnalysis.core.topologyattrs import Bonds
 from MDAnalysis.exceptions import NoDataError, DuplicateWarning
 
 
-from MDAnalysisTests.datafiles import Make_Whole, TPR, GRO, fullerene
+from MDAnalysisTests.datafiles import (
+    Make_Whole, TPR, GRO, fullerene, two_water_gro,
+)
 
 
 def convert_aa_code_long_data():
@@ -263,6 +265,16 @@ class TestMakeWhole(object):
 
         assert_array_almost_equal(ag.positions, refpos)
 
+    def test_scrambled_ag(self, universe):
+        # if order of atomgroup is mixed
+        ag = universe.atoms[[1, 3, 2, 4, 0, 6, 5, 7]]
+
+        mdamath.make_whole(ag)
+
+        # artificial system which uses 1nm bonds, so
+        # largest bond should be 20A
+        assert ag.bonds.values().max() < 20.1
+
     @staticmethod
     @pytest.fixture()
     def ag(universe):
@@ -383,6 +395,14 @@ class TestMakeWhole(object):
         mdamath.make_whole(u.atoms)
 
         assert_array_almost_equal(u.atoms.bonds.values(), blengths, decimal=self.prec)
+
+    def test_make_whole_multiple_molecules(self):
+        u = mda.Universe(two_water_gro, guess_bonds=True)
+
+        for f in u.atoms.fragments:
+            mdamath.make_whole(f)
+
+        assert u.atoms.bonds.values().max() < 2.0
 
 class Class_with_Caches(object):
     def __init__(self):


### PR DESCRIPTION
@jbarnoud the bug you found was actually worse than initially thought.  `bonds.to_indices` gave the global index of the atoms involved, whereas indexing `.positions` uses local indices (ie the index within the AtomGroup)