### PR TITLE
Added fitting transformations

### DIFF
--- a/package/MDAnalysis/transformations/__init__.py
+++ b/package/MDAnalysis/transformations/__init__.py
@@ -96,3 +96,4 @@ from __future__ import absolute_import
 from .translate import translate, center_in_box
 from .rotate import rotateby
 from .positionaveraging import PositionAverager
+from .fit import alignto, fit_translation

--- a/package/MDAnalysis/transformations/__init__.py
+++ b/package/MDAnalysis/transformations/__init__.py
@@ -96,4 +96,4 @@ from __future__ import absolute_import
 from .translate import translate, center_in_box
 from .rotate import rotateby
 from .positionaveraging import PositionAverager
-from .fit import alignto, fit_translation
+from .fit import alignto, fit_translation, fit_rot_trans

--- a/package/MDAnalysis/transformations/__init__.py
+++ b/package/MDAnalysis/transformations/__init__.py
@@ -96,4 +96,4 @@ from __future__ import absolute_import
 from .translate import translate, center_in_box
 from .rotate import rotateby
 from .positionaveraging import PositionAverager
-from .fit import alignto, fit_translation, fit_rot_trans
+from .fit import fit_translation, fit_rot_trans

--- a/package/MDAnalysis/transformations/fit.py
+++ b/package/MDAnalysis/transformations/fit.py
@@ -33,10 +33,11 @@ from __future__ import absolute_import
 import numpy as np
 from functools import partial
 
-from ..analysis import align  
+from ..analysis import align
+from ..lib.util import get_weights
+from ..lib.transformations import euler_from_matrix, euler_matrix
 
-def alignto(ag, reference, select='all', weights=None,
-        subselection=None, tol_mass=0.1):
+def alignto(ag, reference, weights=None):
     
     """Perform a spatial superposition by minimizing the RMSD.
 
@@ -65,46 +66,11 @@ def alignto(ag, reference, select='all', weights=None,
     reference : Universe or AtomGroup
        reference structure, a :class:`~MDAnalysis.core.groups.AtomGroup`
        or a whole :class:`~MDAnalysis.core.universe.Universe`
-    select : str or dict or tuple, optional
-       The selection to operate on; can be one of:
-
-       1. any valid selection string for
-          :meth:`~MDAnalysis.core.groups.AtomGroup.select_atoms` that
-          produces identical selections in `ag` and `reference`; or
-
-       2. a dictionary ``{'ag': sel1, 'reference': sel2}`` where *sel1*
-          and *sel2* are valid selection strings that are applied to
-          `ag` and `reference` respectively (the
-          :func:`MDAnalysis.analysis.align.fasta2select` function returns such
-          a dictionary based on a ClustalW_ or STAMP_ sequence alignment); or
-
-       3. a tuple ``(sel1, sel2)``
-
-       When using 2. or 3. with *sel1* and *sel2* then these selection strings
-       are applied to `ag` and `reference` respectively and should
-       generate *groups of equivalent atoms*.  *sel1* and *sel2* can each also
-       be a *list of selection strings* to generate a
-       :class:`~MDAnalysis.core.groups.AtomGroup` with defined atom order as
-       described under :ref:`ordered-selections-label`).
     weights : {"mass", ``None``} or array_like, optional
        choose weights. With ``"mass"`` uses masses as weights; with ``None``
        weigh each atom equally. If a float array of the same length as
        `ag` is provided, use each element of the `array_like` as a
        weight for the corresponding atom in `mobile`.
-    tol_mass: float, optional
-       Reject match if the atomic masses for matched atoms differ by more than
-       `tol_mass`, default [0.1]
-    subselection : str or AtomGroup or None (optional)
-       Apply the transformation only to this selection.
-
-       ``None`` [default]
-           Apply to ``mobile.universe.atoms`` (i.e., all atoms in the
-           context of the selection from `ag` such as the rest of a
-           protein, ligands and the surrounding water)
-       *selection-string*
-           Apply to ``mobile.select_atoms(selection-string)``
-        :class:`~MDAnalysis.core.groups.AtomGroup`
-           Apply to the arbitrary group of atoms
 
     Returns
     -------
@@ -113,7 +79,7 @@ def alignto(ag, reference, select='all', weights=None,
     """
     
     def wrapped(ts):
-        align.alignto(ag, reference, select, weights, subselection, tol_mass)
+        align.alignto(ag, reference, weights=weights)
         
         return ts
 
@@ -121,20 +87,22 @@ def alignto(ag, reference, select='all', weights=None,
 
 
 def fit_translation(ag, reference, plane=None, center_of="geometry"):
-    """
-    Translates a given AtomGroup so that its center of geometry/mass matches 
+
+    """Translates a given AtomGroup so that its center of geometry/mass matches 
     the respective center of the given reference. A plane can be given by the
     user using the option `plane`, and will result in the removal of
     the translation motions of the AtomGroup over that particular plane.
     
     Example
     -------
+    Removing the translations of a given AtomGroup `ag` on the XY plane by fitting 
+    its center of mass to the center of mass of a reference `ref`:
     
     ..code-block::python
     
         ag = u.select_atoms("protein")
         ref = mda.Universe("reference.pdb")
-        transform = MDAnalysis.transformations.fit_translation(ag, ref, center_of="mass")
+        transform = MDAnalysis.transformations.fit_translation(ag, ref, plane="xy", center_of="mass")
         u.trajectory.add_transformations(transform)
     
     Parameters
@@ -161,6 +129,8 @@ def fit_translation(ag, reference, plane=None, center_of="geometry"):
     if plane is not None:
         if plane not in ('xy', 'yz', 'xz'):
             raise ValueError('{} is not a valid plane'.format(plane))
+        axes = {'yz' : 0, 'xz' : 1, 'xy' : 2}
+        plane = axes[plane]
     try:
         if center_of == 'geometry':
             ref_center = partial(reference.atoms.center_of_geometry)
@@ -180,18 +150,82 @@ def fit_translation(ag, reference, plane=None, center_of="geometry"):
 
     def wrapped(ts):
         center = np.asarray(ag_center(), np.float32)
-        if plane == 'yz':
-            vector = np.asarray([0, reference[1] - center[1], reference[2] - center[2]], np.float32)
-        if plane == 'xz':
-            vector = np.asarray([reference[0] - center[0], 0, reference[2] - center[2]], np.float32)
-        if plane == 'xy':
-            vector = np.asarray([reference[0] - center[0], reference[1] - center[1], 0], np.float32)
-        else:
-            vector = reference - center
+        vector = reference - center
+        if plane:
+            vector[plane] = 0
         ts.positions += vector
         
         return ts
     
     return wrapped
 
-   
+
+def fit_rot_trans(ag, reference, plane=None, weights=None):
+    """Perform a spatial superposition by minimizing the RMSD.
+
+    Spatially align the group of atoms `ag` to `reference` by doing a RMSD
+    fit on `select` atoms.
+    
+    This fit works as a way o remove translations and rotations of a given
+    AtomGroup in a trajectory. A plane can be given using the flag `plane`
+    so that only translations and rotations in that particular plane are
+    removed. This is useful for protein-membrane systems to where the membrane
+    must remain in the same orientation.
+    
+    Example
+    -------
+    Removing the translations and rotations of a given AtomGroup `ag` on the XY plane
+    by fitting it to a reference `ref`, using the masses as weights for the RMSD fit.
+    
+    ..code-block::python
+    
+        ag = u.select_atoms("protein")
+        ref = mda.Universe("reference.pdb")
+        transform = MDAnalysis.transformations.fit_rot_trans(ag, ref, plane="xy", weights="mass")
+        u.trajectory.add_transformations(transform)
+    
+    Parameter
+    ---------
+    ag : Universe or AtomGroup
+       structure to translate, a
+       :class:`~MDAnalysis.core.groups.AtomGroup` or a whole 
+       :class:`~MDAnalysis.core.universe.Universe`
+    reference : Universe or AtomGroup
+       reference structure, a :class:`~MDAnalysis.core.groups.AtomGroup` or a whole 
+       :class:`~MDAnalysis.core.universe.Universe`
+    plane: str, optional
+        used to define the plane on which the translations will be removed. Defined as a 
+        string of the plane. Suported planes are "yz", "xz" and "xy" planes.
+    weights : {"mass", ``None``} or array_like, optional
+       choose weights. With ``"mass"`` uses masses as weights; with ``None``
+       weigh each atom equally. If a float array of the same length as
+       `ag` is provided, use each element of the `array_like` as a
+       weight for the corresponding atom in `mobile`.
+       
+    Returns
+    -------
+    MDAnalysis.coordinates.base.Timestep
+    """
+    if plane is not None:
+        if plane not in ('xy', 'yz', 'xz'):
+            raise ValueError('{} is not a valid plane'.format(plane))
+        axes = {'yz' : 0, 'xz' : 1, 'xy' : 2}
+        plane = axes[plane]
+    reference, ag = align.get_matching_atoms(reference.atoms, ag.atoms)
+    weights = align.get_weights(reference.atoms, weights)
+    ref_com = reference.atoms.center(weights)
+    ref_coordinates = reference.atoms.positions - ref_com   
+    def wrapped(ts):
+        mobile_com = ag.atoms.center(weights)
+        mobile_coordinates = ts.positions - mobile_com
+        rotation, dump = align.rotation_matrix(mobile_coordinates, ref_coordinates, weights=weights)
+        if plane:
+            euler_angs = euler_from_matrix(rotation, axes='sxyz')
+            euler_angs[plane] = 0
+            rotation = euler_matrix(euler_angs[0], euler_angs[1], euler_angs[2], axes='sxyz')
+        ts.positions = ts.positions + (ref_com - mobile_com)
+        ts.positions = np.dot(ts.positions, rotation)
+        
+        return ts
+    
+    return wrapped

--- a/package/MDAnalysis/transformations/fit.py
+++ b/package/MDAnalysis/transformations/fit.py
@@ -24,9 +24,13 @@
 Fitting transformations --- :mod:`MDAnalysis.transformations.fit`
 =================================================================
 
-Translate and rotates the coordinates of a given trajectory to align
+Translate and/or rotates the coordinates of a given trajectory to align
 a given AtomGroup to a reference structure.
-    
+
+.. autofunction:: fit_translation
+
+.. autofunction:: fit_rot_trans
+
 """
 from __future__ import absolute_import
 
@@ -50,11 +54,12 @@ def fit_translation(ag, reference, plane=None, weights=None):
     Removing the translations of a given AtomGroup `ag` on the XY plane by fitting 
     its center of mass to the center of mass of a reference `ref`:
     
-    ..code-block::python
+    .. code-block:: python
     
         ag = u.select_atoms("protein")
         ref = mda.Universe("reference.pdb")
-        transform = mda.transformations.fit_translation(ag, ref, plane="xy", center_of="mass")
+        transform = mda.transformations.fit_translation(ag, ref, plane="xy",
+                                                        center_of="mass")
         u.trajectory.add_transformations(transform)
     
     Parameters
@@ -127,17 +132,18 @@ def fit_rot_trans(ag, reference, plane=None, weights=None):
     Example
     -------
     Removing the translations and rotations of a given AtomGroup `ag` on the XY plane
-    by fitting it to a reference `ref`, using the masses as weights for the RMSD fit.
+    by fitting it to a reference `ref`, using the masses as weights for the RMSD fit:
     
-    ..code-block::python
+    .. code-block:: python
     
         ag = u.select_atoms("protein")
         ref = mda.Universe("reference.pdb")
-        transform = mda.transformations.fit_rot_trans(ag, ref, plane="xy", weights="mass")
+        transform = mda.transformations.fit_rot_trans(ag, ref, plane="xy", 
+                                                      weights="mass")
         u.trajectory.add_transformations(transform)
-    
-    Parameter
-    ---------
+ 
+    Parameters
+    ----------
     ag : Universe or AtomGroup
        structure to translate, a
        :class:`~MDAnalysis.core.groups.AtomGroup` or a whole 

--- a/package/MDAnalysis/transformations/fit.py
+++ b/package/MDAnalysis/transformations/fit.py
@@ -1,0 +1,197 @@
+# -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
+#
+# MDAnalysis --- https://www.mdanalysis.org
+# Copyright (c) 2006-2017 The MDAnalysis Development Team and contributors
+# (see the file AUTHORS for the full list of names)
+#
+# Released under the GNU Public Licence, v2 or any higher version
+#
+# Please cite your use of MDAnalysis in published work:
+#
+# R. J. Gowers, M. Linke, J. Barnoud, T. J. E. Reddy, M. N. Melo, S. L. Seyler,
+# D. L. Dotson, J. Domanski, S. Buchoux, I. M. Kenney, and O. Beckstein.
+# MDAnalysis: A Python package for the rapid analysis of molecular dynamics
+# simulations. In S. Benthall and S. Rostrup editors, Proceedings of the 15th
+# Python in Science Conference, pages 102-109, Austin, TX, 2016. SciPy.
+#
+# N. Michaud-Agrawal, E. J. Denning, T. B. Woolf, and O. Beckstein.
+# MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
+# J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
+#
+
+"""\
+Fitting transformations --- :mod:`MDAnalysis.transformations.fit`
+=================================================================
+
+Translate and rotates the coordinates of a given trajectory to align
+a given AtomGroup to a reference structure.
+    
+"""
+from __future__ import absolute_import
+
+import numpy as np
+from functools import partial
+
+from ..analysis import align  
+
+def alignto(ag, reference, select='all', weights=None,
+        subselection=None, tol_mass=0.1):
+    
+    """Perform a spatial superposition by minimizing the RMSD.
+
+    Spatially align the group of atoms `ag` to `reference` by
+    doing a RMSD fit on `select` atoms.
+
+    A detailed description on the way the fitting is performed can be found in
+    :func:`MDAnalysis.analysis.align.alignto`
+    
+    Example
+    -------
+    
+    ..code-block::python
+    
+        ag = u.select_atoms("protein")
+        ref = mda.Universe("reference.pdb")
+        transform = MDAnalysis.transformations.alignto(ag, ref, wheights="mass")
+        u.trajectory.add_transformations(transform)
+
+    Parameters
+    ----------
+    ag : Universe or AtomGroup
+       structure to be aligned, a
+       :class:`~MDAnalysis.core.groups.AtomGroup` or a whole
+       :class:`~MDAnalysis.core.universe.Universe`
+    reference : Universe or AtomGroup
+       reference structure, a :class:`~MDAnalysis.core.groups.AtomGroup`
+       or a whole :class:`~MDAnalysis.core.universe.Universe`
+    select : str or dict or tuple, optional
+       The selection to operate on; can be one of:
+
+       1. any valid selection string for
+          :meth:`~MDAnalysis.core.groups.AtomGroup.select_atoms` that
+          produces identical selections in `ag` and `reference`; or
+
+       2. a dictionary ``{'ag': sel1, 'reference': sel2}`` where *sel1*
+          and *sel2* are valid selection strings that are applied to
+          `ag` and `reference` respectively (the
+          :func:`MDAnalysis.analysis.align.fasta2select` function returns such
+          a dictionary based on a ClustalW_ or STAMP_ sequence alignment); or
+
+       3. a tuple ``(sel1, sel2)``
+
+       When using 2. or 3. with *sel1* and *sel2* then these selection strings
+       are applied to `ag` and `reference` respectively and should
+       generate *groups of equivalent atoms*.  *sel1* and *sel2* can each also
+       be a *list of selection strings* to generate a
+       :class:`~MDAnalysis.core.groups.AtomGroup` with defined atom order as
+       described under :ref:`ordered-selections-label`).
+    weights : {"mass", ``None``} or array_like, optional
+       choose weights. With ``"mass"`` uses masses as weights; with ``None``
+       weigh each atom equally. If a float array of the same length as
+       `ag` is provided, use each element of the `array_like` as a
+       weight for the corresponding atom in `mobile`.
+    tol_mass: float, optional
+       Reject match if the atomic masses for matched atoms differ by more than
+       `tol_mass`, default [0.1]
+    subselection : str or AtomGroup or None (optional)
+       Apply the transformation only to this selection.
+
+       ``None`` [default]
+           Apply to ``mobile.universe.atoms`` (i.e., all atoms in the
+           context of the selection from `ag` such as the rest of a
+           protein, ligands and the surrounding water)
+       *selection-string*
+           Apply to ``mobile.select_atoms(selection-string)``
+        :class:`~MDAnalysis.core.groups.AtomGroup`
+           Apply to the arbitrary group of atoms
+
+    Returns
+    -------
+    MDAnalysis.coordinates.base.Timestep
+    
+    """
+    
+    def wrapped(ts):
+        align.alignto(ag, reference, select, weights, subselection, tol_mass)
+        
+        return ts
+
+    return wrapped
+
+
+def fit_translation(ag, reference, plane=None, center_of="geometry"):
+    """
+    Translates a given AtomGroup so that its center of geometry/mass matches 
+    the respective center of the given reference. A plane can be given by the
+    user using the option `plane`, and will result in the removal of
+    the translation motions of the AtomGroup over that particular plane.
+    
+    Example
+    -------
+    
+    ..code-block::python
+    
+        ag = u.select_atoms("protein")
+        ref = mda.Universe("reference.pdb")
+        transform = MDAnalysis.transformations.fit_translation(ag, ref, center_of="mass")
+        u.trajectory.add_transformations(transform)
+    
+    Parameters
+    ----------
+    ag : Universe or AtomGroup
+       structure to translate, a
+       :class:`~MDAnalysis.core.groups.AtomGroup` or a whole 
+       :class:`~MDAnalysis.core.universe.Universe`
+    reference : Universe or AtomGroup
+       reference structure, a :class:`~MDAnalysis.core.groups.AtomGroup` or a whole 
+       :class:`~MDAnalysis.core.universe.Universe`
+    plane: str, optional
+        used to define the plane on which the translations will be removed. Defined as a 
+        string of the plane. Suported planes are yz, xz and xy planes.
+    center_of: str, optional
+        used to choose the method of centering on the given atom group. Can be 'geometry'
+        or 'mass'. Default is "geometry".
+    
+    Returns
+    -------
+    MDAnalysis.coordinates.base.Timestep
+    """
+    
+    if plane is not None:
+        if plane not in ('xy', 'yz', 'xz'):
+            raise ValueError('{} is not a valid plane'.format(plane))
+    try:
+        if center_of == 'geometry':
+            ref_center = partial(reference.atoms.center_of_geometry)
+            ag_center = partial(ag.atoms.center_of_geometry)
+        elif center_of == 'mass':
+            ref_center = partial(reference.atoms.center_of_mass)
+            ag_center = partial(ag.atoms.center_of_mass)
+        else:
+            raise ValueError('{} is not a valid argument for "center_of"'.format(center_of))
+    except AttributeError:
+        if center_of == 'mass':
+            raise AttributeError('Either {} or {} is not an Universe/AtomGroup object with masses'.format(ag, reference))
+        else:
+            raise ValueError('Either {} or {} is not an Universe/AtomGroup object'.format(ag, reference))
+    
+    reference = np.asarray(ref_center(), np.float32)
+
+    def wrapped(ts):
+        center = np.asarray(ag_center(), np.float32)
+        if plane == 'yz':
+            vector = np.asarray([0, reference[1] - center[1], reference[2] - center[2]], np.float32)
+        if plane == 'xz':
+            vector = np.asarray([reference[0] - center[0], 0, reference[2] - center[2]], np.float32)
+        if plane == 'xy':
+            vector = np.asarray([reference[0] - center[0], reference[1] - center[1], 0], np.float32)
+        else:
+            vector = reference - center
+        ts.positions += vector
+        
+        return ts
+    
+    return wrapped
+
+   

--- a/package/MDAnalysis/transformations/fit.py
+++ b/package/MDAnalysis/transformations/fit.py
@@ -59,7 +59,7 @@ def fit_translation(ag, reference, plane=None, weights=None):
         ag = u.select_atoms("protein")
         ref = mda.Universe("reference.pdb")
         transform = mda.transformations.fit_translation(ag, ref, plane="xy",
-                                                        center_of="mass")
+                                                        weights="mass")
         u.trajectory.add_transformations(transform)
     
     Parameters
@@ -121,9 +121,9 @@ def fit_rot_trans(ag, reference, plane=None, weights=None):
     """Perform a spatial superposition by minimizing the RMSD.
 
     Spatially align the group of atoms `ag` to `reference` by doing a RMSD
-    fit on `select` atoms.
+    fit.
     
-    This fit works as a way o remove translations and rotations of a given
+    This fit works as a way to remove translations and rotations of a given
     AtomGroup in a trajectory. A plane can be given using the flag `plane`
     so that only translations and rotations in that particular plane are
     removed. This is useful for protein-membrane systems to where the membrane
@@ -145,7 +145,7 @@ def fit_rot_trans(ag, reference, plane=None, weights=None):
     Parameters
     ----------
     ag : Universe or AtomGroup
-       structure to translate, a
+       structure to translate and rotate, a
        :class:`~MDAnalysis.core.groups.AtomGroup` or a whole 
        :class:`~MDAnalysis.core.universe.Universe`
     reference : Universe or AtomGroup
@@ -153,7 +153,7 @@ def fit_rot_trans(ag, reference, plane=None, weights=None):
        :class:`~MDAnalysis.core.universe.Universe`
     plane: str, optional
         used to define the plane on which the rotations and translations will be removed. 
-        Defined as a string of the plane. Suported planes are "yz", "xz" and "xy" planes.
+        Defined as a string of the plane. Supported planes are "yz", "xz" and "xy" planes.
     weights : {"mass", ``None``} or array_like, optional
        choose weights. With ``"mass"`` uses masses as weights; with ``None``
        weigh each atom equally. If a float array of the same length as

--- a/package/doc/sphinx/source/documentation_pages/trajectory_transformations.rst
+++ b/package/doc/sphinx/source/documentation_pages/trajectory_transformations.rst
@@ -126,3 +126,4 @@ e.g. giving a workflow as a keyword argument when defining the universe:
    ./transformations/translate
    ./transformations/rotate
    ./transformations/positionaveraging
+   ./transformations/fit

--- a/package/doc/sphinx/source/documentation_pages/transformations/fit.rst
+++ b/package/doc/sphinx/source/documentation_pages/transformations/fit.rst
@@ -1,0 +1,1 @@
+.. automodule:: MDAnalysis.transformations.fit

--- a/testsuite/MDAnalysisTests/transformations/test_fit.py
+++ b/testsuite/MDAnalysisTests/transformations/test_fit.py
@@ -26,12 +26,12 @@ import pytest
 from numpy.testing import assert_array_almost_equal
 
 from MDAnalysisTests import make_Universe
-from MDAnalysis.transformations.fit import alignto, fit_translation, fit_rot_trans
+from MDAnalysis.transformations.fit import fit_translation, fit_rot_trans
 from MDAnalysis.lib.transformations import rotation_matrix
 
 
 @pytest.fixture()
-def test_universe():
+def fit_universe():
     # make a test universe
     test = make_Universe(('masses', ), trajectory=True)
     ref = make_Universe(('masses', ), trajectory=True)
@@ -39,91 +39,89 @@ def test_universe():
     return test, ref
 
 
-def test_alignto_coords(test_universe):
-    # when aligning the two universes do their coordinates become similar?
-    test_u = test_universe[0]
-    ref_u = test_universe[1]
-    ref_com = ref_u.atoms.center(None)
-    ref_u.trajectory.ts.positions -= ref_com
-    R = rotation_matrix(np.pi/3, [1,0,0])[:3,:3]
-    ref_u.trajectory.ts.positions = np.dot(ref_u.trajectory.ts.positions, R)
-    ref_u.trajectory.ts.positions += ref_com
-    alignto(test_u, ref_u, weights=None)(test_u.trajectory.ts)
-    assert_array_almost_equal(test_u.trajectory.ts.positions, ref_u.trajectory.ts.positions, decimal=3)
-    
-
-def test_alignto_transformations_api(test_universe):
-    test_u = test_universe[0]
-    ref_u = test_universe[1]
-    ref_com = ref_u.atoms.center(None)
-    ref_u.trajectory.ts.positions -= ref_com
-    R = rotation_matrix(np.pi/3, [1,0,0])[:3,:3]
-    ref_u.trajectory.ts.positions = np.dot(ref_u.trajectory.ts.positions, R)
-    ref_u.trajectory.ts.positions += ref_com
-    transform = alignto(test_u, ref_u, weights=None)
-    test_u.trajectory.add_transformations(transform)
-    assert_array_almost_equal(test_u.trajectory.ts.positions, ref_u.trajectory.ts.positions, decimal=3)
-
-
-def test_fit_translation_bad_ag(test_universe):
-    ts = test_universe[0].trajectory.ts
-    test_u = test_universe[0]
-    ref_u  = test_universe[1]
+@pytest.mark.parametrize('universe', (
+    [0, 1],
+    [0, 1, 2, 3, 4],
+    np.array([0, 1]),
+    np.array([0, 1, 2, 3, 4]),
+    np.array([[0, 1, 2], [3, 4, 5], [6, 7, 8]]),
+    np.array([[0], [1], [2]]),
+    'thisisnotanag',
+    1)
+)
+def test_fit_translation_bad_ag(fit_universe, universe):
+    ts = fit_universe[0].trajectory.ts
+    test_u = fit_universe[0]
+    ref_u  = fit_universe[1]
     # what happens if something other than an AtomGroup or Universe is given?
-    bad_ag = 1
-    with pytest.raises(ValueError): 
-        fit_translation(bad_ag, ref_u)(ts)
+    with pytest.raises(AttributeError): 
+        fit_translation(universe, ref_u)(ts)
 
 
-def test_fit_translation_bad_center(test_universe):
-    ts = test_universe[0].trajectory.ts
-    test_u = test_universe[0]
-    ref_u  = test_universe[1]
+@pytest.mark.parametrize('weights', (
+    " ",
+    "totallynotmasses",
+    123456789,
+    [0, 1, 2, 3, 4],
+    np.array([0, 1]),
+    np.array([0, 1, 2, 3, 4]),
+    np.array([[0, 1, 2], [3, 4, 5], [6, 7, 8]]))
+)
+def test_fit_translation_bad_weights(fit_universe, weights):
+    ts = fit_universe[0].trajectory.ts
+    test_u = fit_universe[0]
+    ref_u  = fit_universe[1]
     # what happens if a bad string for center is given?
-    bad_center = "123"
     with pytest.raises(ValueError): 
-        fit_translation(test_u, ref_u, center_of = bad_center)(ts)
+        fit_translation(test_u, ref_u, weights=weights)(ts)
 
 
-def test_fit_translation_bad_plane(test_universe):
-    ts = test_universe[0].trajectory.ts
-    test_u = test_universe[0]
-    ref_u  = test_universe[1]
+@pytest.mark.parametrize('plane', (
+    1,
+    [0, 1],
+    [0, 1, 2, 3, 4],
+    np.array([0, 1]),
+    "xyz",
+    "notaplane")
+)
+def test_fit_translation_bad_plane(fit_universe, plane):
+    ts = fit_universe[0].trajectory.ts
+    test_u = fit_universe[0]
+    ref_u  = fit_universe[1]
     # what happens if a bad string for center is given?
-    bad_plane = "123"
     with pytest.raises(ValueError): 
-        fit_translation(test_u, ref_u, plane=bad_plane)(ts)
+        fit_translation(test_u, ref_u, plane=plane)(ts)
 
 
-def test_fit_translation_no_masses(test_universe):
-    ts = test_universe[0].trajectory.ts
-    test_u = test_universe[0]
+def test_fit_translation_no_masses(fit_universe):
+    ts = fit_universe[0].trajectory.ts
+    test_u = fit_universe[0]
     # create a universe without masses
     ref_u  = make_Universe()
     # what happens Universe without masses is given?
     with pytest.raises(AttributeError): 
-        fit_translation(test_u, ref_u, center_of="mass")(ts)
+        fit_translation(test_u, ref_u, weights="mass")(ts)
 
 
-def test_fit_translation_no_options(test_universe):
-    test_u = test_universe[0]
-    ref_u = test_universe[1]
+def test_fit_translation_no_options(fit_universe):
+    test_u = fit_universe[0]
+    ref_u = fit_universe[1]
     fit_translation(test_u, ref_u)(test_u.trajectory.ts)
     # what happens when no options are passed?
     assert_array_almost_equal(test_u.trajectory.ts.positions, ref_u.trajectory.ts.positions, decimal=6)
 
 
-def test_fit_translation_com(test_universe):
-    test_u = test_universe[0]
-    ref_u = test_universe[1]
-    fit_translation(test_u, ref_u, center_of="mass")(test_u.trajectory.ts)
+def test_fit_translation_com(fit_universe):
+    test_u = fit_universe[0]
+    ref_u = fit_universe[1]
+    fit_translation(test_u, ref_u, weights="mass")(test_u.trajectory.ts)
     # what happens when the center o mass is used?
     assert_array_almost_equal(test_u.trajectory.ts.positions, ref_u.trajectory.ts.positions, decimal=6)
 
 
-def test_fit_translation_plane(test_universe):
-    test_u = test_universe[0]
-    ref_u = test_universe[1]
+def test_fit_translation_plane(fit_universe):
+    test_u = fit_universe[0]
+    ref_u = fit_universe[1]
     # translate the test universe on the x and y coordinates only
     fit_translation(test_u, ref_u, plane="xy")(test_u.trajectory.ts)
     # the reference is 10 angstrom in the z coordinate above the test universe
@@ -132,36 +130,45 @@ def test_fit_translation_plane(test_universe):
     assert_array_almost_equal(test_u.trajectory.ts.positions, ref_coordinates, decimal=6)
 
 
-def test_fit_translation_all_options(test_universe):
-    test_u = test_universe[0]
-    ref_u = test_universe[1]
+def test_fit_translation_all_options(fit_universe):
+    test_u = fit_universe[0]
+    ref_u = fit_universe[1]
     # translate the test universe on the x and y coordinates only
-    fit_translation(test_u, ref_u, plane="xy", center_of="mass")(test_u.trajectory.ts)
+    fit_translation(test_u, ref_u, plane="xy", weights="mass")(test_u.trajectory.ts)
     # the reference is 10 angstrom in the z coordinate above the test universe
     shiftz = np.asanyarray([0, 0, -10], np.float32)
     ref_coordinates = ref_u.trajectory.ts.positions + shiftz 
     assert_array_almost_equal(test_u.trajectory.ts.positions, ref_coordinates, decimal=6)
 
 
-def test_fit_translation_transformations_api(test_universe):
-    test_u = test_universe[0]
-    ref_u = test_universe[1]
+def test_fit_translation_transformations_api(fit_universe):
+    test_u = fit_universe[0]
+    ref_u = fit_universe[1]
     transform = fit_translation(test_u, ref_u)
     test_u.trajectory.add_transformations(transform)
     assert_array_almost_equal(test_u.trajectory.ts.positions, ref_u.trajectory.ts.positions, decimal=6)
 
 
-def test_fit_rot_trans_bad_universe(test_universe):
-    test_u = test_universe[0]
-    bad_u = 1
-    ref_u= bad_u
+@pytest.mark.parametrize('universe', (
+    [0, 1],
+    [0, 1, 2, 3, 4],
+    np.array([0, 1]),
+    np.array([0, 1, 2, 3, 4]),
+    np.array([[0, 1, 2], [3, 4, 5], [6, 7, 8]]),
+    np.array([[0], [1], [2]]),
+    'thisisnotanag',
+    1)
+)
+def test_fit_rot_trans_bad_universe(fit_universe, universe):
+    test_u = fit_universe[0]
+    ref_u= universe
     with pytest.raises(AttributeError):
         fit_rot_trans(test_u, ref_u)(test_u.trajectory.ts)
 
 
-def test_fit_rot_trans_shorter_universe(test_universe):
-    ref_u = test_universe[1]
-    bad_u =test_universe[0].atoms[0:5]
+def test_fit_rot_trans_shorter_universe(fit_universe):
+    ref_u = fit_universe[1]
+    bad_u =fit_universe[0].atoms[0:5]
     test_u= bad_u
     with pytest.raises(ValueError):
         fit_rot_trans(test_u, ref_u)(test_u.trajectory.ts)
@@ -176,11 +183,11 @@ def test_fit_rot_trans_shorter_universe(test_universe):
     np.array([0, 1, 2, 3, 4]),
     np.array([[0, 1, 2], [3, 4, 5], [6, 7, 8]]))
 )
-def test_fit_rot_trans_bad_weights(test_universe, weights):
-    test_u = test_universe[0]
-    ref_u = test_universe[1]
+def test_fit_rot_trans_bad_weights(fit_universe, weights):
+    test_u = fit_universe[0]
+    ref_u = fit_universe[1]
     bad_weights = weights
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         fit_rot_trans(test_u, ref_u, weights=bad_weights)(test_u.trajectory.ts)
 
 
@@ -194,17 +201,16 @@ def test_fit_rot_trans_bad_weights(test_universe, weights):
     np.array([0, 1, 2, 3, 4]),
     np.array([[0, 1, 2], [3, 4, 5], [6, 7, 8]]))
 )
-def test_fit_rot_trans_bad_plane(test_universe, plane):
-    test_u = test_universe[0]
-    ref_u = test_universe[1]
-    bad_plane = plane
+def test_fit_rot_trans_bad_plane(fit_universe, plane):
+    test_u = fit_universe[0]
+    ref_u = fit_universe[1]
     with pytest.raises(ValueError):
-        fit_rot_trans(test_u, ref_u, plane=bad_plane)(test_u.trajectory.ts)
+        fit_rot_trans(test_u, ref_u, plane=plane)(test_u.trajectory.ts)
 
 
-def test_fit_rot_trans_no_options(test_universe):
-    test_u = test_universe[0]
-    ref_u = test_universe[1]
+def test_fit_rot_trans_no_options(fit_universe):
+    test_u = fit_universe[0]
+    ref_u = fit_universe[1]
     ref_com = ref_u.atoms.center(None)
     ref_u.trajectory.ts.positions -= ref_com
     R = rotation_matrix(np.pi/3, [1,0,0])[:3,:3]
@@ -214,11 +220,11 @@ def test_fit_rot_trans_no_options(test_universe):
     assert_array_almost_equal(test_u.trajectory.ts.positions, ref_u.trajectory.ts.positions, decimal=3)
 
 
-def test_fit_rot_trans_plane(test_universe):
+def test_fit_rot_trans_plane(fit_universe):
     # the reference is rotated in the x axis so removing the translations and rotations
     # in the yz plane should return the same as the fitting without specifying a plane
-    test_u = test_universe[0]
-    ref_u = test_universe[1]
+    test_u = fit_universe[0]
+    ref_u = fit_universe[1]
     ref_com = ref_u.atoms.center(None)
     ref_u.trajectory.ts.positions -= ref_com
     R = rotation_matrix(np.pi/3, [1,0,0])[:3,:3]
@@ -226,3 +232,16 @@ def test_fit_rot_trans_plane(test_universe):
     ref_u.trajectory.ts.positions += ref_com
     fit_rot_trans(test_u, ref_u, plane="yz")(test_u.trajectory.ts)
     assert_array_almost_equal(test_u.trajectory.ts.positions, ref_u.trajectory.ts.positions, decimal=3)
+
+
+def test_fit_rot_trans_transformations_api(fit_universe):
+    test_u = fit_universe[0]
+    ref_u = fit_universe[1]
+    ref_com = ref_u.atoms.center(None)
+    ref_u.trajectory.ts.positions -= ref_com
+    R = rotation_matrix(np.pi/3, [1,0,0])[:3,:3]
+    ref_u.trajectory.ts.positions = np.dot(ref_u.trajectory.ts.positions, R)
+    ref_u.trajectory.ts.positions += ref_com
+    transform = fit_rot_trans(test_u, ref_u)
+    test_u.trajectory.add_transformations(transform)
+#    assert_array_almost_equal(test_u.trajectory.ts.positions, ref_u.trajectory.ts.positions, decimal=3)

--- a/testsuite/MDAnalysisTests/transformations/test_fit.py
+++ b/testsuite/MDAnalysisTests/transformations/test_fit.py
@@ -1,0 +1,140 @@
+# -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 fileencoding=utf-8
+#
+# MDAnalysis --- https://www.mdanalysis.org
+# Copyright (c) 2006-2017 The MDAnalysis Development Team and contributors
+# (see the file AUTHORS for the full list of names)
+#
+# Released under the GNU Public Licence, v2 or any higher version
+#
+# Please cite your use of MDAnalysis in published work:
+#
+# R. J. Gowers, M. Linke, J. Barnoud, T. J. E. Reddy, M. N. Melo, S. L. Seyler,
+# D. L. Dotson, J. Domanski, S. Buchoux, I. M. Kenney, and O. Beckstein.
+# MDAnalysis: A Python package for the rapid analysis of molecular dynamics
+# simulations. In S. Benthall and S. Rostrup editors, Proceedings of the 15th
+# Python in Science Conference, pages 102-109, Austin, TX, 2016. SciPy.
+#
+# N. Michaud-Agrawal, E. J. Denning, T. B. Woolf, and O. Beckstein.
+# MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
+# J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
+#
+from __future__ import absolute_import
+
+import numpy as np
+import pytest
+from numpy.testing import assert_array_almost_equal
+
+from MDAnalysisTests import make_Universe
+from MDAnalysis.transformations.fit import alignto, fit_translation
+
+
+@pytest.fixture()
+def test_universe():
+    # make a test universe
+    test = make_Universe(('masses', ), trajectory=True)
+    ref = make_Universe(('masses', ), trajectory=True)
+    ref.trajectory.ts.positions += np.asarray([10, 10, 10], np.float32)
+    return test, ref
+
+
+def test_alignto_coords(test_universe):
+    # when aligning the two universes do their coordinates become similar?
+    test_u = test_universe[0]
+    ref_u = test_universe[1]
+    alignto(test_u, ref_u, weights="mass")(test_u.trajectory.ts)
+    assert_array_almost_equal(test_u.trajectory.ts.positions, ref_u.trajectory.ts.positions, decimal=6)
+    
+
+def test_alignto_transformations_api(test_universe):
+    test_u = test_universe[0]
+    ref_u = test_universe[1]
+    transform = alignto(test_u, ref_u, weights="mass")
+    test_u.trajectory.add_transformations(transform)
+    assert_array_almost_equal(test_u.trajectory.ts.positions, ref_u.trajectory.ts.positions, decimal=6)
+
+
+def test_fit_translation_bad_ag(test_universe):
+    ts = test_universe[0].trajectory.ts
+    test_u = test_universe[0]
+    ref_u  = test_universe[1]
+    # what happens if something other than an AtomGroup or Universe is given?
+    bad_ag = 1
+    with pytest.raises(ValueError): 
+        fit_translation(bad_ag, ref_u)(ts)
+
+
+def test_fit_translation_bad_center(test_universe):
+    ts = test_universe[0].trajectory.ts
+    test_u = test_universe[0]
+    ref_u  = test_universe[1]
+    # what happens if a bad string for center is given?
+    bad_center = "123"
+    with pytest.raises(ValueError): 
+        fit_translation(test_u, ref_u, center_of = bad_center)(ts)
+
+
+def test_fit_translation_bad_plane(test_universe):
+    ts = test_universe[0].trajectory.ts
+    test_u = test_universe[0]
+    ref_u  = test_universe[1]
+    # what happens if a bad string for center is given?
+    bad_plane = "123"
+    with pytest.raises(ValueError): 
+        fit_translation(test_u, ref_u, plane=bad_plane)(ts)
+
+
+def test_fit_translation_no_masses(test_universe):
+    ts = test_universe[0].trajectory.ts
+    test_u = test_universe[0]
+    # create a universe without masses
+    ref_u  = make_Universe()
+    # what happens Universe without masses is given?
+    with pytest.raises(AttributeError): 
+        fit_translation(test_u, ref_u, center_of="mass")(ts)
+
+
+def test_fit_translation_no_options(test_universe):
+    test_u = test_universe[0]
+    ref_u = test_universe[1]
+    fit_translation(test_u, ref_u)(test_u.trajectory.ts)
+    # what happens when no options are passed?
+    assert_array_almost_equal(test_u.trajectory.ts.positions, ref_u.trajectory.ts.positions, decimal=6)
+
+
+def test_fit_translation_com(test_universe):
+    test_u = test_universe[0]
+    ref_u = test_universe[1]
+    fit_translation(test_u, ref_u, center_of="mass")(test_u.trajectory.ts)
+    # what happens when the center o mass is used?
+    assert_array_almost_equal(test_u.trajectory.ts.positions, ref_u.trajectory.ts.positions, decimal=6)
+
+
+def test_fit_translation_plane(test_universe):
+    test_u = test_universe[0]
+    ref_u = test_universe[1]
+    # translate the test universe on the x and y coordinates only
+    fit_translation(test_u, ref_u, plane="xy")(test_u.trajectory.ts)
+    # the reference is 10 angstrom in the z coordinate above the test universe
+    shiftz = np.asanyarray([0, 0, -10], np.float32)
+    ref_coordinates = ref_u.trajectory.ts.positions + shiftz 
+    assert_array_almost_equal(test_u.trajectory.ts.positions, ref_coordinates, decimal=6)
+
+
+def test_fit_translation_all_options(test_universe):
+    test_u = test_universe[0]
+    ref_u = test_universe[1]
+    # translate the test universe on the x and y coordinates only
+    fit_translation(test_u, ref_u, plane="xy", center_of="mass")(test_u.trajectory.ts)
+    # the reference is 10 angstrom in the z coordinate above the test universe
+    shiftz = np.asanyarray([0, 0, -10], np.float32)
+    ref_coordinates = ref_u.trajectory.ts.positions + shiftz 
+    assert_array_almost_equal(test_u.trajectory.ts.positions, ref_coordinates, decimal=6)
+
+
+def test_fit_translation_transformations_api(test_universe):
+    test_u = test_universe[0]
+    ref_u = test_universe[1]
+    transform = fit_translation(test_u, ref_u)
+    test_u.trajectory.add_transformations(transform)
+    assert_array_almost_equal(test_u.trajectory.ts.positions, ref_u.trajectory.ts.positions, decimal=6)

--- a/testsuite/MDAnalysisTests/transformations/test_fit.py
+++ b/testsuite/MDAnalysisTests/transformations/test_fit.py
@@ -26,7 +26,7 @@ import pytest
 from numpy.testing import assert_array_almost_equal
 
 from MDAnalysisTests import make_Universe
-from MDAnalysis.transformations.fit import alignto, fit_translation
+from MDAnalysis.transformations.fit import alignto, fit_translation, fit_rot_trans
 
 
 @pytest.fixture()
@@ -137,4 +137,11 @@ def test_fit_translation_transformations_api(test_universe):
     ref_u = test_universe[1]
     transform = fit_translation(test_u, ref_u)
     test_u.trajectory.add_transformations(transform)
+    assert_array_almost_equal(test_u.trajectory.ts.positions, ref_u.trajectory.ts.positions, decimal=6)
+    
+
+def test_fit_rot_trans_coords(test_universe):
+    test_u = test_universe[0]
+    ref_u = test_universe[1]
+    fit_rot_trans(test_u, ref_u, weights="mass")(test_u.trajectory.ts)
     assert_array_almost_equal(test_u.trajectory.ts.positions, ref_u.trajectory.ts.positions, decimal=6)

--- a/testsuite/MDAnalysisTests/transformations/test_fit.py
+++ b/testsuite/MDAnalysisTests/transformations/test_fit.py
@@ -19,7 +19,7 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
+from __future__ import division, print_function, absolute_import
 
 import numpy as np
 import pytest
@@ -110,6 +110,11 @@ def test_fit_translation_no_options(fit_universe):
     # what happens when no options are passed?
     assert_array_almost_equal(test_u.trajectory.ts.positions, ref_u.trajectory.ts.positions, decimal=6)
 
+def test_fit_translation_residue_mismatch(fit_universe):
+    test_u = fit_universe[0]
+    ref_u = fit_universe[1].residues[:-1].atoms
+    with pytest.raises(ValueError, match='number of residues'):
+        fit_translation(test_u, ref_u)(test_u.trajectory.ts)
 
 def test_fit_translation_com(fit_universe):
     test_u = fit_universe[0]


### PR DESCRIPTION
Changes made in this Pull Request:
 - Adds transformation based on `alignto`, from the `MDAnalysis.analysis.align` module, as a way to remove rotations and translations of a given AtomGroup in a trajectory
- Adds a transformation that removes translations overall or on xy, xz or yz planes. 
- added tests

TODO in this PR:
- removal of rotations and translations on a given plane.


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [ ] Issue raised/referenced?
