### PR TITLE
corrected rotateby transformation calculation

### DIFF
--- a/package/MDAnalysis/transformations/rotate.py
+++ b/package/MDAnalysis/transformations/rotate.py
@@ -37,20 +37,26 @@ from functools import partial
 from ..lib.transformations import rotation_matrix
 from ..lib.util import get_weights
 
-def rotateby(angle, direction, point=None, weights=None, wrap=False, ag=None):
+def rotateby(angle, direction, point=None, ag=None, weights=None, wrap=False):
     '''
     Rotates the trajectory by a given angle on a given axis. The axis is defined by 
     the user, combining the direction vector and a point. This point can be the center
     of geometry or the center of mass of a user defined AtomGroup, or a list defining custom
-    coordinates. 
-    e.g. rotate the coordinates by 90 degrees on a x axis centered on a given atom group:
+    coordinates.
+    
+    Examples
+    --------
+    
+    e.g. rotate the coordinates by 90 degrees on a axis formed by the [0,0,1] vector and 
+    the center of geometry of a given AtomGroup:
     
     .. code-block:: python
     
         ts = u.trajectory.ts
         angle = 90
         ag = u.atoms()
-        rotated = MDAnalysis.transformations.rotate(angle, ag)(ts)
+        d = [0,0,1]
+        rotated = MDAnalysis.transformations.rotate(angle, direction=d, ag=ag)(ts)
     
     e.g. rotate the coordinates by a custom axis:
     
@@ -60,7 +66,7 @@ def rotateby(angle, direction, point=None, weights=None, wrap=False, ag=None):
         angle = 90
         p = [1,2,3]
         d = [0,0,1]
-        rotated = MDAnalysis.transformations.rotate(angle, point=point, direction=d)(ts) 
+        rotated = MDAnalysis.transformations.rotate(angle, direction=d, point=point)(ts) 
     
     Parameters
     ----------
@@ -97,10 +103,18 @@ def rotateby(angle, direction, point=None, weights=None, wrap=False, ag=None):
 
     '''
     angle = np.deg2rad(angle)
+    try:
+        direction = np.asarray(direction, np.float32)
+        if direction.shape != (3, ) and direction.shape != (1, 3):
+            raise ValueError('{} is not a valid direction'.format(direction))
+        direction = direction.reshape(3, )
+    except ValueError:
+        raise ValueError('{} is not a valid direction'.format(direction))
     if point:
         point = np.asarray(point, np.float32)
         if point.shape != (3, ) and point.shape != (1, 3):
             raise ValueError('{} is not a valid point'.format(point))
+        point = point.reshape(3, )
     elif ag:
         try:
             atoms = ag.atoms

--- a/package/MDAnalysis/transformations/rotate.py
+++ b/package/MDAnalysis/transformations/rotate.py
@@ -21,12 +21,14 @@
 #
 
 """\
-Rotate trajectory --- :mod:`MDAnalysis.transformations.translate`
-=================================================================
+Trajectory rotation --- :mod:`MDAnalysis.transformations.rotate`
+================================================================
 
 Rotates the coordinates by a given angle arround an axis formed by a direction and a
 point 
-    
+
+.. autofunction:: rotateby
+
 """
 from __future__ import absolute_import
 
@@ -41,8 +43,8 @@ def rotateby(angle, direction, point=None, ag=None, weights=None, wrap=False):
     '''
     Rotates the trajectory by a given angle on a given axis. The axis is defined by 
     the user, combining the direction vector and a point. This point can be the center
-    of geometry or the center of mass of a user defined AtomGroup, or a list defining custom
-    coordinates.
+    of geometry or the center of mass of a user defined AtomGroup, or an array defining 
+    custom coordinates.
     
     Examples
     --------
@@ -74,10 +76,14 @@ def rotateby(angle, direction, point=None, ag=None, weights=None, wrap=False):
         rotation angle in degrees
     direction: array-like
         vector that will define the direction of a custom axis of rotation from the
-        provided point.
+        provided point. Expected shapes are (3, ) or (1, 3). 
     ag: AtomGroup, optional
-        use the eighted center of an AtomGroup as the point from where the rotation axis
-        will be defined
+        use the weighted center of an AtomGroup as the point from where the rotation axis
+        will be defined. If no AtomGroup is given, the `point` argument becomes mandatory
+    point: array-like, optional
+        list of the coordinates of the point from where a custom axis of rotation will
+        be defined. Expected shapes are (3, ) or (1, 3). If no point is given, the
+        `ag` argument becomes mandatory.
     weights: {"mass", ``None``} or array_like, optional
         define the weights of the atoms when calculating the center of the AtomGroup.
         With ``"mass"`` uses masses as weights; with ``None`` weigh each atom equally.
@@ -88,13 +94,10 @@ def rotateby(angle, direction, point=None, ag=None, weights=None, wrap=False):
         If `True`, all the atoms from the given AtomGroup will be moved to the unit cell
         before calculating the center of mass or geometry. Default is `False`, no changes
         to the atom coordinates are done before calculating the center of the AtomGroup. 
-    point: array-like, optional
-        list of the coordinates of the point from where a custom axis of rotation will
-        be defined. 
 
     Returns
     -------
-    :class:`~MDAnalysis.coordinates.base.Timestep` object
+    MDAnalysis.coordinates.base.Timestep
     
     Warning
     -------
@@ -110,7 +113,7 @@ def rotateby(angle, direction, point=None, ag=None, weights=None, wrap=False):
         direction = direction.reshape(3, )
     except ValueError:
         raise ValueError('{} is not a valid direction'.format(direction))
-    if point:
+    if point is not None:
         point = np.asarray(point, np.float32)
         if point.shape != (3, ) and point.shape != (1, 3):
             raise ValueError('{} is not a valid point'.format(point))

--- a/package/MDAnalysis/transformations/rotate.py
+++ b/package/MDAnalysis/transformations/rotate.py
@@ -119,8 +119,11 @@ def rotateby(angle, direction, point=None, center="geometry", wrap=False, ag=Non
             position = center_method()
         else:
             position = point
-        rotation = rotation_matrix(angle, direction, position)[:3, :3]
+        matrix = rotation_matrix(angle, direction, position)
+        rotation = matrix[:3, :3]
+        translation = matrix[:3, 3]
         ts.positions= np.dot(ts.positions, rotation)
+        ts.positions += translation
         
         return ts
     

--- a/package/MDAnalysis/transformations/rotate.py
+++ b/package/MDAnalysis/transformations/rotate.py
@@ -103,14 +103,16 @@ def rotateby(angle, direction, point=None, weights=None, wrap=False, ag=None):
             raise ValueError('{} is not a valid point'.format(point))
     elif ag:
         try:
-            weights = get_weights(ag.atoms, weights=weights)
-        except (ValueError, TypeError):
-            raise ValueError("weights must be {'mass', None} or an iterable of the "
-                            "same size as the atomgroup.")
-        try:
-            center_method = partial(ag.atoms.center, weights, pbc=wrap)    
+            atoms = ag.atoms
         except AttributeError:
             raise ValueError('{} is not an AtomGroup object'.format(ag))
+        else:
+            try:
+                weights = get_weights(atoms, weights=weights)
+            except (ValueError, TypeError):
+                raise TypeError("weights must be {'mass', None} or an iterable of the "
+                                "same size as the atomgroup.")
+        center_method = partial(atoms.center, weights, pbc=wrap)
     else:
         raise ValueError('A point or an AtomGroup must be specified')
     

--- a/package/MDAnalysis/transformations/rotate.py
+++ b/package/MDAnalysis/transformations/rotate.py
@@ -36,7 +36,7 @@ from functools import partial
 
 from ..lib.transformations import rotation_matrix
 
-def rotateby(angle, direction, point=None, center="geometry", wrap=False, ag=None):
+def rotateby(angle, direction, point=None, center_of="geometry", wrap=False, ag=None):
     '''
     Rotates the trajectory by a given angle on a given axis. The axis is defined by 
     the user, combining the direction vector and a point. This point can be the center
@@ -71,7 +71,7 @@ def rotateby(angle, direction, point=None, center="geometry", wrap=False, ag=Non
     ag: AtomGroup, optional
         use this to define the center of mass or geometry as the point from where the
         rotation axis will be defined
-    center: str, optional
+    center_of: str, optional
         used to choose the method of centering on the given atom group. Can be 'geometry'
         or 'mass'
     wrap: bool, optional
@@ -100,14 +100,14 @@ def rotateby(angle, direction, point=None, center="geometry", wrap=False, ag=Non
             raise ValueError('{} is not a valid point'.format(point))
     elif ag:
         try:
-            if center == 'geometry':
+            if center_of == 'geometry':
                 center_method = partial(ag.center_of_geometry, pbc=pbc_arg)
-            elif center == 'mass':
+            elif center_of == 'mass':
                 center_method = partial(ag.center_of_mass, pbc=pbc_arg)
             else:
-                raise ValueError('{} is not a valid argument for center'.format(center))
+                raise ValueError('{} is not a valid argument for center'.format(center_of))
         except AttributeError:
-            if center == 'mass':
+            if center_of == 'mass':
                 raise AttributeError('{} is not an AtomGroup object with masses'.format(ag))
             else:
                 raise ValueError('{} is not an AtomGroup object'.format(ag))
@@ -120,7 +120,7 @@ def rotateby(angle, direction, point=None, center="geometry", wrap=False, ag=Non
         else:
             position = point
         matrix = rotation_matrix(angle, direction, position)
-        rotation = matrix[:3, :3]
+        rotation = matrix[:3, :3].T
         translation = matrix[:3, 3]
         ts.positions= np.dot(ts.positions, rotation)
         ts.positions += translation

--- a/package/doc/sphinx/source/documentation_pages/trajectory_transformations.rst
+++ b/package/doc/sphinx/source/documentation_pages/trajectory_transformations.rst
@@ -96,3 +96,4 @@ e.g. giving a workflow as a keyword argument when defining the universe:
 .. toctree::
    
    ./transformations/translate
+   ./transformations/rotate

--- a/package/doc/sphinx/source/documentation_pages/transformations/rotate.rst
+++ b/package/doc/sphinx/source/documentation_pages/transformations/rotate.rst
@@ -1,0 +1,1 @@
+.. automodule:: MDAnalysis.transformations.rotate

--- a/testsuite/MDAnalysisTests/transformations/test_rotate.py
+++ b/testsuite/MDAnalysisTests/transformations/test_rotate.py
@@ -70,8 +70,10 @@ def test_rotateby_custom_position(rotate_universes):
     vector = [1,0,0]
     pos = [0,0,0]
     angle = 90
-    matrix = rotation_matrix(np.deg2rad(angle), vector, pos)[:3, :3]
-    ref.positions = np.dot(ref.positions, matrix)
+    matrix = rotation_matrix(np.deg2rad(angle), vector, pos)
+    rotation = matrix[:3, :3]
+    translation = matrix[:3, 3]
+    ref.positions = np.dot(ref.positions, rotation) + translation
     transformed = rotateby(angle, vector, point=pos)(trans)
     assert_array_almost_equal(transformed.positions, ref.positions, decimal=6)
     
@@ -85,8 +87,10 @@ def test_rotateby_atomgroup_cog_nopbc(rotate_universes):
     center_pos = [6,7,8]
     vector = [1,0,0]
     angle = 90
-    matrix = rotation_matrix(np.deg2rad(angle), vector, center_pos)[:3, :3]
-    ref.positions = np.dot(ref.positions, matrix)
+    matrix = rotation_matrix(np.deg2rad(angle), vector, center_pos)
+    rotation = matrix[:3, :3]
+    translation = matrix[:3, 3]
+    ref.positions = np.dot(ref.positions, rotation) + translation
     selection = trans_u.residues[0].atoms
     transformed = rotateby(angle, vector, ag=selection, center='geometry')(trans) 
     assert_array_almost_equal(transformed.positions, ref.positions, decimal=6)
@@ -102,8 +106,10 @@ def test_rotateby_atomgroup_com_nopbc(rotate_universes):
     angle = 90
     selection = trans_u.residues[0].atoms
     center_pos = selection.center_of_mass()
-    matrix = rotation_matrix(np.deg2rad(angle), vector, center_pos)[:3, :3]
-    ref.positions = np.dot(ref.positions, matrix)
+    matrix = rotation_matrix(np.deg2rad(angle), vector, center_pos)
+    rotation = matrix[:3, :3]
+    translation = matrix[:3, 3]
+    ref.positions = np.dot(ref.positions, rotation) + translation
     transformed = rotateby(angle, vector, ag=selection, center='mass')(trans) 
     assert_array_almost_equal(transformed.positions, ref.positions, decimal=6)
     
@@ -118,8 +124,10 @@ def test_rotateby_atomgroup_cog_pbc(rotate_universes):
     angle = 90
     selection = trans_u.residues[0].atoms
     center_pos = selection.center_of_geometry(pbc=True)
-    matrix = rotation_matrix(np.deg2rad(angle), vector, center_pos)[:3, :3]
-    ref.positions = np.dot(ref.positions, matrix)
+    matrix = rotation_matrix(np.deg2rad(angle), vector, center_pos)
+    rotation = matrix[:3, :3]
+    translation = matrix[:3, 3]
+    ref.positions = np.dot(ref.positions, rotation) + translation
     transformed = rotateby(angle, vector, ag=selection, center='geometry', wrap=True)(trans) 
     assert_array_almost_equal(transformed.positions, ref.positions, decimal=6)
 
@@ -134,8 +142,10 @@ def test_rotateby_atomgroup_com_pbc(rotate_universes):
     angle = 90
     selection = trans_u.residues[0].atoms
     center_pos = selection.center_of_mass(pbc=True)
-    matrix = rotation_matrix(np.deg2rad(angle), vector, center_pos)[:3, :3]
-    ref.positions = np.dot(ref.positions, matrix)
+    matrix = rotation_matrix(np.deg2rad(angle), vector, center_pos)
+    rotation = matrix[:3, :3]
+    translation = matrix[:3, 3]
+    ref.positions = np.dot(ref.positions, rotation) + translation
     transformed = rotateby(angle, vector, ag=selection, center='mass', wrap=True)(trans) 
     assert_array_almost_equal(transformed.positions, ref.positions, decimal=6)
     

--- a/testsuite/MDAnalysisTests/transformations/test_rotate.py
+++ b/testsuite/MDAnalysisTests/transformations/test_rotate.py
@@ -39,6 +39,7 @@ def rotate_universes():
     transformed.trajectory.ts.dimensions = np.array([372., 373., 374., 90, 90, 90])
     return reference, transformed
 
+
 def test_rotation_matrix():
     # test if the rotation_matrix function is working properly
     # simple angle and unit vector on origin
@@ -74,7 +75,8 @@ def test_rotateby_custom_position(rotate_universes):
     ref_u.atoms.transform(matrix)
     transformed = rotateby(angle, vector, point=pos)(trans)
     assert_array_almost_equal(transformed.positions, ref.positions, decimal=6)
-    
+
+
 def test_rotateby_atomgroup_cog_nopbc(rotate_universes):
     # what happens when we rotate arround the center of geometry of a residue
     # without pbc?
@@ -91,6 +93,7 @@ def test_rotateby_atomgroup_cog_nopbc(rotate_universes):
     transformed = rotateby(angle, vector, ag=selection, weights=None)(trans) 
     assert_array_almost_equal(transformed.positions, ref.positions, decimal=6)
 
+
 def test_rotateby_atomgroup_com_nopbc(rotate_universes):
     # what happens when we rotate arround the center of mass of a residue
     # without pbc?
@@ -106,6 +109,7 @@ def test_rotateby_atomgroup_com_nopbc(rotate_universes):
     ref_u.atoms.transform(matrix)
     transformed = rotateby(angle, vector, ag=selection, weights='mass')(trans) 
     assert_array_almost_equal(transformed.positions, ref.positions, decimal=6)
+
     
 def test_rotateby_atomgroup_cog_pbc(rotate_universes):
     # what happens when we rotate arround the center of geometry of a residue
@@ -123,6 +127,7 @@ def test_rotateby_atomgroup_cog_pbc(rotate_universes):
     transformed = rotateby(angle, vector, ag=selection, weights=None, wrap=True)(trans) 
     assert_array_almost_equal(transformed.positions, ref.positions, decimal=6)
 
+
 def test_rotateby_atomgroup_com_pbc(rotate_universes):
     # what happens when we rotate arround the center of mass of a residue
     # with pbc?
@@ -138,8 +143,19 @@ def test_rotateby_atomgroup_com_pbc(rotate_universes):
     ref_u.atoms.transform(matrix)
     transformed = rotateby(angle, vector, ag=selection, weights='mass', wrap=True)(trans) 
     assert_array_almost_equal(transformed.positions, ref.positions, decimal=6)
-    
-def test_rotateby_bad_ag(rotate_universes):
+
+
+@pytest.mark.parametrize('ag', (
+    [0, 1],
+    [0, 1, 2, 3, 4],
+    np.array([0, 1]),
+    np.array([0, 1, 2, 3, 4]),
+    np.array([[0, 1, 2], [3, 4, 5], [6, 7, 8]]),
+    np.array([[0], [1], [2]]),
+    'thisisnotanag',
+    1)
+)
+def test_rotateby_bad_ag(rotate_universes, ag):
     # this universe as a box size zero
     ts = rotate_universes[0].trajectory.ts
     ag = rotate_universes[0].residues[0].atoms
@@ -150,24 +166,56 @@ def test_rotateby_bad_ag(rotate_universes):
     with pytest.raises(ValueError): 
         rotateby(angle, vector, ag = bad_ag)(ts)
 
-def test_rotateby_bad_position(rotate_universes):
+
+@pytest.mark.parametrize('point', (
+    [0, 1],
+    [0, 1, 2, 3, 4],
+    np.array([0, 1]),
+    np.array([0, 1, 2, 3, 4]),
+    np.array([[0, 1, 2], [3, 4, 5], [6, 7, 8]]),
+    np.array([[0], [1], [2]]),
+    'thisisnotapoint',
+    1)
+)
+def test_rotateby_bad_point(rotate_universes, point):
     # this universe as a box size zero
     ts = rotate_universes[0].trajectory.ts
     # what if the box is in the wrong format?
     angle = 90
     vector = [0, 0, 1]
-    bad_position = [1]
+    bad_position = point
     with pytest.raises(ValueError): 
         rotateby(angle, vector, point=bad_position)(ts)
-    
+
+
+@pytest.mark.parametrize('direction', (
+    [0, 1],
+    [0, 1, 2, 3, 4],
+    np.array([0, 1]),
+    np.array([0, 1, 2, 3, 4]),
+    np.array([[0, 1, 2], [3, 4, 5], [6, 7, 8]]),
+    np.array([[0], [1], [2]]),
+    'thisisnotadirection',
+    1)
+)
+def test_rotateby_bad_direction(rotate_universes, direction):
+    # this universe as a box size zero
+    ts = rotate_universes[0].trajectory.ts
+    # what if the box is in the wrong format?
+    angle = 90
+    point = [0, 0, 0]
+    with pytest.raises(ValueError): 
+        rotateby(angle, direction, point=point)(ts)
+
+
 def test_rotateby_bad_pbc(rotate_universes):    
     # this universe as a box size zero
     ts = rotate_universes[0].trajectory.ts
     ag = rotate_universes[0].residues[0].atoms
     # is pbc passed to the center methods?
     # if yes it should raise an exception for boxes that are zero in size
+    vector = [1, 0, 0]
     angle = 90
-    vector = [0, 0, 1]
     with pytest.raises(ValueError): 
         rotateby(angle, vector, ag = ag, wrap=True)(ts)
 
@@ -191,6 +239,7 @@ def test_rotateby_bad_weights(rotate_universes, weights):
     bad_weights = " "
     with pytest.raises(TypeError): 
         rotateby(angle, vector, ag = ag, weights=bad_weights)(ts)
+
     
 def test_rotateby_no_masses(rotate_universes):   
     # this universe as a box size zero
@@ -202,6 +251,7 @@ def test_rotateby_no_masses(rotate_universes):
     bad_center = "mass"
     with pytest.raises(TypeError): 
         rotateby(angle, vector, ag = ag, weights=bad_center)(ts)
+
 
 def test_rotateby_no_args(rotate_universes):
     # this universe as a box size zero

--- a/testsuite/MDAnalysisTests/transformations/test_rotate.py
+++ b/testsuite/MDAnalysisTests/transformations/test_rotate.py
@@ -61,19 +61,41 @@ def test_rotation_matrix():
     matrix = rotation_matrix(np.deg2rad(angle), vector, pos)[:3, :3]
     assert_array_almost_equal(matrix, ref_matrix, decimal=6)
     
-
-def test_rotateby_custom_position(rotate_universes):
+@pytest.mark.parametrize('point', (
+    np.asarray([0, 0, 0]),
+    np.asarray([[0, 0, 0]]))
+)
+def test_rotateby_custom_point(rotate_universes, point):
     # what happens when we use a custom point for the axis of rotation?
     ref_u = rotate_universes[0]
     trans_u = rotate_universes[1]
     trans = trans_u.trajectory.ts
     ref = ref_u.trajectory.ts
-    vector = [1,0,0]
-    pos = [0,0,0]
+    vector = [1, 0, 0]
+    pos = point.reshape(3, )
     angle = 90
     matrix = rotation_matrix(np.deg2rad(angle), vector, pos)
     ref_u.atoms.transform(matrix)
-    transformed = rotateby(angle, vector, point=pos)(trans)
+    transformed = rotateby(angle, vector, point=point)(trans)
+    assert_array_almost_equal(transformed.positions, ref.positions, decimal=6)
+
+
+@pytest.mark.parametrize('vector', (
+    np.asarray([1, 0, 0]),
+    np.asarray([[1, 0, 0]]))
+)
+def test_rotateby_vector(rotate_universes, vector):
+    # what happens when we use a custom point for the axis of rotation?
+    ref_u = rotate_universes[0]
+    trans_u = rotate_universes[1]
+    trans = trans_u.trajectory.ts
+    ref = ref_u.trajectory.ts
+    point = [0, 0, 0]
+    angle = 90
+    vec = vector.reshape(3, )
+    matrix = rotation_matrix(np.deg2rad(angle), vec, point)
+    ref_u.atoms.transform(matrix)
+    transformed = rotateby(angle, vector, point=point)(trans)
     assert_array_almost_equal(transformed.positions, ref.positions, decimal=6)
 
 

--- a/testsuite/MDAnalysisTests/transformations/test_rotate.py
+++ b/testsuite/MDAnalysisTests/transformations/test_rotate.py
@@ -88,7 +88,7 @@ def test_rotateby_atomgroup_cog_nopbc(rotate_universes):
     matrix = rotation_matrix(np.deg2rad(angle), vector, center_pos)
     ref_u.atoms.transform(matrix)
     selection = trans_u.residues[0].atoms
-    transformed = rotateby(angle, vector, ag=selection, center_of='geometry')(trans) 
+    transformed = rotateby(angle, vector, ag=selection, weights=None)(trans) 
     assert_array_almost_equal(transformed.positions, ref.positions, decimal=6)
 
 def test_rotateby_atomgroup_com_nopbc(rotate_universes):
@@ -104,7 +104,7 @@ def test_rotateby_atomgroup_com_nopbc(rotate_universes):
     center_pos = selection.center_of_mass()
     matrix = rotation_matrix(np.deg2rad(angle), vector, center_pos)
     ref_u.atoms.transform(matrix)
-    transformed = rotateby(angle, vector, ag=selection, center_of='mass')(trans) 
+    transformed = rotateby(angle, vector, ag=selection, weights='mass')(trans) 
     assert_array_almost_equal(transformed.positions, ref.positions, decimal=6)
     
 def test_rotateby_atomgroup_cog_pbc(rotate_universes):
@@ -120,7 +120,7 @@ def test_rotateby_atomgroup_cog_pbc(rotate_universes):
     center_pos = selection.center_of_geometry(pbc=True)
     matrix = rotation_matrix(np.deg2rad(angle), vector, center_pos)
     ref_u.atoms.transform(matrix)
-    transformed = rotateby(angle, vector, ag=selection, center_of='geometry', wrap=True)(trans) 
+    transformed = rotateby(angle, vector, ag=selection, weights=None, wrap=True)(trans) 
     assert_array_almost_equal(transformed.positions, ref.positions, decimal=6)
 
 def test_rotateby_atomgroup_com_pbc(rotate_universes):
@@ -136,7 +136,7 @@ def test_rotateby_atomgroup_com_pbc(rotate_universes):
     center_pos = selection.center_of_mass(pbc=True)
     matrix = rotation_matrix(np.deg2rad(angle), vector, center_pos)
     ref_u.atoms.transform(matrix)
-    transformed = rotateby(angle, vector, ag=selection, center_of='mass', wrap=True)(trans) 
+    transformed = rotateby(angle, vector, ag=selection, weights='mass', wrap=True)(trans) 
     assert_array_almost_equal(transformed.positions, ref.positions, decimal=6)
     
 def test_rotateby_bad_ag(rotate_universes):
@@ -147,7 +147,7 @@ def test_rotateby_bad_ag(rotate_universes):
     angle = 90
     vector = [0, 0, 1]
     bad_ag = 1
-    with pytest.raises(ValueError): 
+    with pytest.raises(AttributeError): 
         rotateby(angle, vector, ag = bad_ag)(ts)
 
 def test_rotateby_bad_position(rotate_universes):
@@ -180,7 +180,7 @@ def test_rotateby_bad_center(rotate_universes):
     vector = [0, 0, 1]
     bad_center = " "
     with pytest.raises(ValueError): 
-        rotateby(angle, vector, ag = ag, center_of=bad_center)(ts)
+        rotateby(angle, vector, ag = ag, weights=bad_center)(ts)
     
 def test_rotateby_no_masses(rotate_universes):   
     # this universe as a box size zero
@@ -190,8 +190,8 @@ def test_rotateby_no_masses(rotate_universes):
     angle = 90
     vector = [0, 0, 1]
     bad_center = "mass"
-    with pytest.raises(AttributeError): 
-        rotateby(angle, vector, ag = ag, center_of=bad_center)(ts)
+    with pytest.raises(ValueError): 
+        rotateby(angle, vector, ag = ag, weights=bad_center)(ts)
 
 def test_rotateby_no_args(rotate_universes):
     # this universe as a box size zero

--- a/testsuite/MDAnalysisTests/transformations/test_rotate.py
+++ b/testsuite/MDAnalysisTests/transformations/test_rotate.py
@@ -171,16 +171,26 @@ def test_rotateby_bad_pbc(rotate_universes):
     with pytest.raises(ValueError): 
         rotateby(angle, vector, ag = ag, wrap=True)(ts)
 
-def test_rotateby_bad_center(rotate_universes):
+
+@pytest.mark.parametrize('weights', (
+    " ",
+    "totallynotmasses",
+    123456789,
+    [0, 1, 2, 3, 4],
+    np.array([0, 1]),
+    np.array([0, 1, 2, 3, 4]),
+    np.array([[0, 1, 2], [3, 4, 5], [6, 7, 8]]))
+)
+def test_rotateby_bad_weights(rotate_universes, weights):
     # this universe as a box size zero
     ts = rotate_universes[0].trajectory.ts
     ag = rotate_universes[0].residues[0].atoms
     # what if a wrong center type name is passed?
     angle = 90
     vector = [0, 0, 1]
-    bad_center = " "
+    bad_weights = " "
     with pytest.raises(ValueError): 
-        rotateby(angle, vector, ag = ag, weights=bad_center)(ts)
+        rotateby(angle, vector, ag = ag, weights=bad_weights)(ts)
     
 def test_rotateby_no_masses(rotate_universes):   
     # this universe as a box size zero

--- a/testsuite/MDAnalysisTests/transformations/test_rotate.py
+++ b/testsuite/MDAnalysisTests/transformations/test_rotate.py
@@ -147,7 +147,7 @@ def test_rotateby_bad_ag(rotate_universes):
     angle = 90
     vector = [0, 0, 1]
     bad_ag = 1
-    with pytest.raises(AttributeError): 
+    with pytest.raises(ValueError): 
         rotateby(angle, vector, ag = bad_ag)(ts)
 
 def test_rotateby_bad_position(rotate_universes):
@@ -189,7 +189,7 @@ def test_rotateby_bad_weights(rotate_universes, weights):
     angle = 90
     vector = [0, 0, 1]
     bad_weights = " "
-    with pytest.raises(ValueError): 
+    with pytest.raises(TypeError): 
         rotateby(angle, vector, ag = ag, weights=bad_weights)(ts)
     
 def test_rotateby_no_masses(rotate_universes):   
@@ -200,7 +200,7 @@ def test_rotateby_no_masses(rotate_universes):
     angle = 90
     vector = [0, 0, 1]
     bad_center = "mass"
-    with pytest.raises(ValueError): 
+    with pytest.raises(TypeError): 
         rotateby(angle, vector, ag = ag, weights=bad_center)(ts)
 
 def test_rotateby_no_args(rotate_universes):

--- a/testsuite/MDAnalysisTests/transformations/test_rotate.py
+++ b/testsuite/MDAnalysisTests/transformations/test_rotate.py
@@ -71,9 +71,7 @@ def test_rotateby_custom_position(rotate_universes):
     pos = [0,0,0]
     angle = 90
     matrix = rotation_matrix(np.deg2rad(angle), vector, pos)
-    rotation = matrix[:3, :3]
-    translation = matrix[:3, 3]
-    ref.positions = np.dot(ref.positions, rotation) + translation
+    ref_u.atoms.transform(matrix)
     transformed = rotateby(angle, vector, point=pos)(trans)
     assert_array_almost_equal(transformed.positions, ref.positions, decimal=6)
     
@@ -88,11 +86,9 @@ def test_rotateby_atomgroup_cog_nopbc(rotate_universes):
     vector = [1,0,0]
     angle = 90
     matrix = rotation_matrix(np.deg2rad(angle), vector, center_pos)
-    rotation = matrix[:3, :3]
-    translation = matrix[:3, 3]
-    ref.positions = np.dot(ref.positions, rotation) + translation
+    ref_u.atoms.transform(matrix)
     selection = trans_u.residues[0].atoms
-    transformed = rotateby(angle, vector, ag=selection, center='geometry')(trans) 
+    transformed = rotateby(angle, vector, ag=selection, center_of='geometry')(trans) 
     assert_array_almost_equal(transformed.positions, ref.positions, decimal=6)
 
 def test_rotateby_atomgroup_com_nopbc(rotate_universes):
@@ -107,10 +103,8 @@ def test_rotateby_atomgroup_com_nopbc(rotate_universes):
     selection = trans_u.residues[0].atoms
     center_pos = selection.center_of_mass()
     matrix = rotation_matrix(np.deg2rad(angle), vector, center_pos)
-    rotation = matrix[:3, :3]
-    translation = matrix[:3, 3]
-    ref.positions = np.dot(ref.positions, rotation) + translation
-    transformed = rotateby(angle, vector, ag=selection, center='mass')(trans) 
+    ref_u.atoms.transform(matrix)
+    transformed = rotateby(angle, vector, ag=selection, center_of='mass')(trans) 
     assert_array_almost_equal(transformed.positions, ref.positions, decimal=6)
     
 def test_rotateby_atomgroup_cog_pbc(rotate_universes):
@@ -125,10 +119,8 @@ def test_rotateby_atomgroup_cog_pbc(rotate_universes):
     selection = trans_u.residues[0].atoms
     center_pos = selection.center_of_geometry(pbc=True)
     matrix = rotation_matrix(np.deg2rad(angle), vector, center_pos)
-    rotation = matrix[:3, :3]
-    translation = matrix[:3, 3]
-    ref.positions = np.dot(ref.positions, rotation) + translation
-    transformed = rotateby(angle, vector, ag=selection, center='geometry', wrap=True)(trans) 
+    ref_u.atoms.transform(matrix)
+    transformed = rotateby(angle, vector, ag=selection, center_of='geometry', wrap=True)(trans) 
     assert_array_almost_equal(transformed.positions, ref.positions, decimal=6)
 
 def test_rotateby_atomgroup_com_pbc(rotate_universes):
@@ -143,10 +135,8 @@ def test_rotateby_atomgroup_com_pbc(rotate_universes):
     selection = trans_u.residues[0].atoms
     center_pos = selection.center_of_mass(pbc=True)
     matrix = rotation_matrix(np.deg2rad(angle), vector, center_pos)
-    rotation = matrix[:3, :3]
-    translation = matrix[:3, 3]
-    ref.positions = np.dot(ref.positions, rotation) + translation
-    transformed = rotateby(angle, vector, ag=selection, center='mass', wrap=True)(trans) 
+    ref_u.atoms.transform(matrix)
+    transformed = rotateby(angle, vector, ag=selection, center_of='mass', wrap=True)(trans) 
     assert_array_almost_equal(transformed.positions, ref.positions, decimal=6)
     
 def test_rotateby_bad_ag(rotate_universes):
@@ -190,7 +180,7 @@ def test_rotateby_bad_center(rotate_universes):
     vector = [0, 0, 1]
     bad_center = " "
     with pytest.raises(ValueError): 
-        rotateby(angle, vector, ag = ag, center=bad_center)(ts)
+        rotateby(angle, vector, ag = ag, center_of=bad_center)(ts)
     
 def test_rotateby_no_masses(rotate_universes):   
     # this universe as a box size zero
@@ -201,7 +191,7 @@ def test_rotateby_no_masses(rotate_universes):
     vector = [0, 0, 1]
     bad_center = "mass"
     with pytest.raises(AttributeError): 
-        rotateby(angle, vector, ag = ag, center=bad_center)(ts)
+        rotateby(angle, vector, ag = ag, center_of=bad_center)(ts)
 
 def test_rotateby_no_args(rotate_universes):
     # this universe as a box size zero


### PR DESCRIPTION
Changes made in this Pull Request:
 - when rotating a given atomgroup from a different point than the origin, the rotation calculation is wrong


PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
