### PR TITLE
TST: test_unique_int_1d now enforces int64 type

### DIFF
--- a/testsuite/MDAnalysisTests/lib/test_cutil.py
+++ b/testsuite/MDAnalysisTests/lib/test_cutil.py
@@ -37,5 +37,5 @@ from MDAnalysis.lib._cutil import unique_int_1d
     [1, 2, 2, 6, 4, 4, ],  # duplicates, non-monotonic
 ))
 def test_unique_int_1d(values):
-    array = np.array(values, dtype=int)
+    array = np.array(values, dtype=np.int64)
     assert_equal(unique_int_1d(array), np.unique(array))


### PR DESCRIPTION
* the Cython function `unique_int_1d()` is clearly
defined and documented to accept an int64 argument
type, but its associated unit test was not enforcing
this type, which caused 6 test failures on the Windows
platform

* locally, this branch reduces Windows test failures from
30 to 24 (make sure appveyor reflects that before merging)

* this appears to match the solution discussed by @jbarnoud 
and @richardjgowers in the linked issue, though broader enforcement
of integer typing in the package is arguably out of scope
for this fix

Fixes #1962 