### PR TITLE
Solution to problem for running chain-reader in parallel

### DIFF
--- a/package/MDAnalysis/coordinates/XDR.py
+++ b/package/MDAnalysis/coordinates/XDR.py
@@ -194,7 +194,8 @@ class XDRBaseReader(base.ReaderBase):
         if not (ctime_ok and size_ok and n_atoms_ok):
             warnings.warn("Reload offsets from trajectory\n "
                           "ctime or size or n_atoms did not match")
-            self._read_offsets(store=True)
+#            self._read_offsets(store=True)
+# This line creates race condition when several processes are going to read from the same XTC file.
         else:
             self._xdr.set_offsets(data['offsets'])
 


### PR DESCRIPTION
Fixes #

Changes made in this Pull Request:
 - This PR removes the line #197 in XDR.py since it lead to race condition when several processes are working on the same XTC files at the same time.


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced? #1988 
