### PR TITLE
Introduces user defined grid for density calculations

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,6 +12,10 @@ image:
 
 environment:
     global:
+        CONDA_CHANNELS: conda-forge
+        CONDA_DEPENDENCIES: pip setuptools wheel cython mock six biopython networkx joblib matplotlib scipy vs2015_runtime pytest mmtf-python GridDataFormats hypothesis pytest-cov codecov
+        PIP_DEPENDENCIES: gsd==1.5.2 duecredit
+        DEBUG: "False"
         MINGW_64: C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin
         OPENBLAS_64: https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-5f998ef_gcc7_1_0_win64.zip
         APPVEYOR_SAVE_CACHE_ON_ERROR: true
@@ -19,17 +23,15 @@ environment:
         TEST_TIMEOUT: 1000
         PYTHON: "C:\\conda"
         MINICONDA_VERSION: "latest"
-        CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"
 
     matrix:
-
         - PYTHON_VERSION: 3.6
           PYTHON_ARCH: 64
           MSVC_VERSION: "Visual Studio 10 Win64"
 
 init:
-    - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
-    - "ECHO \"%APPVEYOR_SCHEDULED_BUILD%\""
+    - ps: Write-Host ${env:PYTHON} ${env:PYTHON_VERSION} ${env:PYTHON_ARCH}
+    - ps: Write-Host ${env:APPVEYOR_SCHEDULED_BUILD}
     # cancel build if newer one is submitted; complicated
     # details for getting this to work are credited to JuliaLang
     # developers
@@ -41,26 +43,23 @@ init:
 
 install:
     # set up a conda env
-    - "git clone --depth 1 git://github.com/astropy/ci-helpers.git"
-    - "powershell ci-helpers/appveyor/install-miniconda.ps1"
-    - SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%
+    - ps: git clone -q --depth 1 git://github.com/astropy/ci-helpers.git
+    - ps: ci-helpers/appveyor/install-miniconda.ps1
+    - ps: $env:PATH = "${env:PYTHON};${env:PYTHON}\Scripts;" + $env:PATH
     # deal with missing stdint.h as previously described
-    # see: https://github.com/swistakm/pyimgui/blob/master/.appveyor.yml
-    - cp "c:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\include\stdint.h" "C:\Users\appveyor\AppData\Local\Programs\Common\Microsoft\Visual C++ for Python\9.0\VC\include\stdint.h"
-    - ps: conda config --append channels conda-forge
-    - ps: conda create -n testing python=$env:PYTHON_VERSION pip setuptools wheel cython mock six biopython networkx joblib matplotlib scipy vs2015_runtime pytest mmtf-python GridDataFormats hypothesis pytest-cov codecov
-    - cmd: C:\conda\envs\testing\Scripts\pip.exe install gsd==1.5.2 duecredit
-    - cmd: C:\conda\envs\testing\Scripts\activate testing
+    # see https://github.com/swistakm/pyimgui/blob/master/.appveyor.yml
+    - ps: cp "C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\include\stdint.h" "C:\Users\appveyor\AppData\Local\Programs\Common\Microsoft\Visual C++ for Python\9.0\VC\include\stdint.h"
+    - ps: activate test
 
 build_script:
     - cmd: cd package
-    - cmd: C:\conda\envs\testing\python.exe setup.py develop --no-deps --user 3>&1
+    - cmd: C:\conda\envs\test\python.exe setup.py develop --no-deps --user 3>&1
 
 test_script:
     - cmd: cd ..\testsuite
-    - cmd: C:\conda\envs\testing\python.exe setup.py develop --no-deps --user 3>&1
+    - cmd: C:\conda\envs\test\python.exe setup.py develop --no-deps --user 3>&1
     - cmd: cd MDAnalysisTests
-    - cmd: C:\conda\envs\testing\Scripts\pytest.exe --cov=MDAnalysis --disable-pytest-warnings 3>&1
+    - cmd: C:\conda\envs\test\Scripts\pytest.exe --cov=MDAnalysis --disable-pytest-warnings 3>&1
     - cmd: codecov
 
 after_build:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ env:
     # Run a coverage test for most versions
     - CODECOV="true" SETUP_CMD="${PYTEST_FLAGS} --cov=MDAnalysis"
     - PYTHON_VERSION=3.6 CODECOV="true" SETUP_CMD="${PYTEST_FLAGS} --cov=MDAnalysis"
-    - PYTHON_VERSION=3.4 CODECOV="true" SETUP_CMD="${PYTEST_FLAGS} --cov=MDAnalysis"
+    - PYTHON_VERSION=3.4 NUMPY_VERSION=1.14 CODECOV="true" SETUP_CMD="${PYTEST_FLAGS} --cov=MDAnalysis"
     - PYTHON_VERSION=2.7 CODECOV="true" SETUP_CMD="${PYTEST_FLAGS} --cov=MDAnalysis"
     - NUMPY_VERSION=1.10.4
     - NUMPY_VERSION=dev  EVENT_TYPE="cron"

--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -106,7 +106,9 @@ Chronological list of authors
   - Shujie Fan
   - Andrew R. McCluskey
   - Henry Mull
-  
+  - Irfan Alibay
+
+
 External code
 -------------
 

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -15,13 +15,11 @@ The rules for this file:
 ------------------------------------------------------------------------------
 ??/??/18 tylerjereddy, richardjgowers, palnabarun, orbeckst, kain88-de, zemanj,
          VOD555, davidercruz, jbarnoud, ayushsuhane, hfmull, micaela-matta,
-         sebastien.buchoux, arm61, p-j-smith
+         sebastien.buchoux, arm61, p-j-smith, IAlibay
 
   * 0.18.1
 
 Enhancements
-
-
   * Replaced multiple apply (_apply_distmat, _apply_kdtree)
     methods in distance based selections with
     lib.distances.capped_distance for automatic selection of
@@ -80,10 +78,13 @@ Enhancements
   * Added dihedrals.py with Dihedral, Ramachandran, and Janin classes to
     analysis module (PR #1997, PR #2033)
   * Added the analysis.data module for reference data used in analysis (PR #2033)
+  * Added analysis.dihedrals with Ramachandran class to analysis module (PR #1997)
+  * Added augment functionality to create relevant images of particles 
   * Most functions in `MDanalysis.lib.distances` previously only accepting
     arrays of coordinates now also accept single coordinates as input (PR #2048)
   * Performance improvements to make_whole (PR #1965)
   * Performance improvements to fragment finding (PR #2028)
+  * Added user defined boxes in density code (PR #2005)
 
 Fixes
   * rewind in the SingleFrameReader now reads the frame from the file (Issue #1929)

--- a/package/MDAnalysis/analysis/density.py
+++ b/package/MDAnalysis/analysis/density.py
@@ -184,7 +184,6 @@ import logging
 
 logger = logging.getLogger("MDAnalysis.analysis.density")
 
-
 class Density(Grid):
     r"""Class representing a density on a regular cartesian grid.
 
@@ -277,7 +276,6 @@ class Density(Grid):
     See Also
     --------
     gridData.core.Grid : the base class of :class:`Density`.
-
 
     Examples
     --------
@@ -497,12 +495,66 @@ class Density(Grid):
             grid_type = 'histogram'
         return '<Density ' + grid_type + ' with ' + str(self.grid.shape) + ' bins>'
 
+
+def _set_user_grid(gridcenter, xdim, ydim, zdim, smin, smax):
+    """Helper function to set the grid dimensions to user defined values
+
+    Parameters
+    ----------
+    gridcenter : numpy ndarray, float32
+            3 element ndarray containing the x, y and z coordinates of the grid
+            box center
+    xdim : float
+            Box edge length in the x dimension
+    ydim : float
+            Box edge length in the y dimension
+    zdim : float
+            Box edge length in the y dimension
+    smin : numpy ndarray, float32
+            Minimum x,y,z coordinates for the input selection
+    smax : numpy ndarray, float32
+            Maximum x,y,z coordinates for the input selection
+
+    Returns
+    -------
+    umin : numpy ndarray, float32
+            Minimum x,y,z coordinates of the user defined grid
+    umax : numpy ndarray, float32
+            Maximum x,y,z coordinates of the user defined grid
+    """
+    # Check user inputs
+    try:
+        gridcenter = np.asarray(gridcenter, dtype=np.float32)
+    except ValueError:
+        raise ValueError("Non-number values assigned to gridcenter")
+    if gridcenter.shape != (3,):
+        raise ValueError("gridcenter must be a 3D coordinate")
+    try:
+        xyzdim = np.array([xdim, ydim, zdim], dtype=np.float32)
+    except ValueError:
+        raise ValueError("xdim, ydim, and zdim must be numbers")
+
+    # Set min/max by shifting by half the edge length of each dimension
+    umin = gridcenter - xyzdim/2
+    umax = gridcenter + xyzdim/2
+
+    # Here we test if coords of selection fall outside of the defined grid
+    # if this happens, we warn users they may want to resize their grids
+    if any(smin < umin) or any(smax > umax):
+        msg = ("Atom selection does not fit grid --- "
+               "you may want to define a larger box")
+        warnings.warn(msg)
+        logger.warning(msg)
+    return umin, umax
+
+
 def density_from_Universe(universe, delta=1.0, atomselection='name OH2',
                           start=None, stop=None, step=None,
                           metadata=None, padding=2.0, cutoff=0, soluteselection=None,
                           use_kdtree=True, update_selection=False,
                           verbose=None, interval=1, quiet=None,
-                          parameters=None):
+                          parameters=None,
+                          gridcenter=None, xdim=None, ydim=None, zdim=None):
     """Create a density grid from a :class:`MDAnalysis.Universe` object.
 
     The trajectory is read, frame by frame, and the atoms selected with `atomselection` are
@@ -527,7 +579,7 @@ def density_from_Universe(universe, delta=1.0, atomselection='name OH2',
             are passed through as they are.
     padding : float (optional)
             increase histogram dimensions by padding (on top of initial box size)
-            in Angstroem [2.0]
+            in Angstroem. Padding is ignored when setting a user defined grid. [2.0]
     soluteselection : str (optional)
             MDAnalysis selection for the solute, e.g. "protein" [``None``]
     cutoff : float (optional)
@@ -550,6 +602,18 @@ def density_from_Universe(universe, delta=1.0, atomselection='name OH2',
            Show status update every `interval` frame [1]
     parameters : dict (optional)
             `dict` with some special parameters for :class:`Density` (see docs)
+    gridcenter : numpy ndarray, float32 (optional)
+            3 element numpy array detailing the x, y and z coordinates of the
+            center of a user defined grid box in Angstroem [``None``]
+    xdim : float (optional)
+            User defined x dimension box edge in ångström; ignored if
+            gridcenter is ``None``
+    ydim : float (optional)
+            User defined y dimension box edge in ångström; ignored if
+            gridcenter is ``None``
+    zdim : float (optional)
+            User defined z dimension box edge in ångström; ignored if
+            gridcenter is ``None``
 
     Returns
     -------
@@ -595,6 +659,32 @@ def density_from_Universe(universe, delta=1.0, atomselection='name OH2',
     (Using the special case for the bulk with `soluteselection` and `cutoff`
     improves performance over the simple `update_selection` approach.)
 
+    If you are interested in explicitly setting a grid box of a given edge size
+    and origin, you can use the gridcenter and x/y/zdim arguments. For example
+    to plot the density of waters within 5 Å of a ligand (in this case the
+    ligand has been assigned the residue name "LIG") in a cubic grid with 20 Å
+    edges which is centered on the centre of mass (COM) of the ligand::
+
+      # Create a selection based on the ligand
+      ligand_selection = universe.select_atoms("resname LIG")
+
+      # Extract the COM of the ligand
+      ligand_COM = ligand_selection.center_of_mass()
+
+      # Generate a density of waters on a cubic grid centered on the ligand COM
+      # In this case, we update the atom selection as shown above.
+      water_density = density_from_Universe(universe, delta=1.0,
+                                            atomselection='name OW around 5 resname LIG',
+                                            update_selection=True,
+                                            gridcenter=ligand_COM,
+                                            xdim=20.0, ydim=20.0, zdim=20.0)
+
+      (It should be noted that the `padding` keyword is not used when a user
+      defined grid is assigned).
+
+    .. versionchanged:: 0.18.1
+       *gridcenter*, *xdim*, *ydim* and *zdim* keywords added to allow for user
+       defined boxes
     .. versionchanged:: 0.13.0
        *update_selection* and *quiet* keywords added
 
@@ -632,15 +722,23 @@ def density_from_Universe(universe, delta=1.0, atomselection='name OH2',
         warnings.warn(msg)
         logger.warning(msg)
 
-    # Make the box bigger to avoid as much as possible 'outlier'. This
-    # is important if the sites are defined at a high density: in this
-    # case the bulk regions don't have to be close to 1 * n0 but can
-    # be less. It's much more difficult to deal with outliers.  The
-    # ideal solution would use images: implement 'looking across the
-    # periodic boundaries' but that gets complicate when the box
-    # rotates due to RMS fitting.
-    smin = np.min(coord, axis=0) - padding
-    smax = np.max(coord, axis=0) + padding
+    if gridcenter is not None:
+        # Generate a copy of smin/smax from coords to later check if the
+        # defined box might be too small for the selection
+        smin = np.min(coord, axis=0)
+        smax = np.max(coord, axis=0)
+        # Overwrite smin/smax with user defined values
+        smin, smax = _set_user_grid(gridcenter, xdim, ydim, zdim, smin, smax)
+    else:
+        # Make the box bigger to avoid as much as possible 'outlier'. This
+        # is important if the sites are defined at a high density: in this
+        # case the bulk regions don't have to be close to 1 * n0 but can
+        # be less. It's much more difficult to deal with outliers.  The
+        # ideal solution would use images: implement 'looking across the
+        # periodic boundaries' but that gets complicate when the box
+        # rotates due to RMS fitting.
+        smin = np.min(coord, axis=0) - padding
+        smax = np.max(coord, axis=0) + padding
 
     BINS = fixedwidth_bins(delta, smin, smax)
     arange = np.vstack((BINS['min'], BINS['max']))

--- a/testsuite/MDAnalysisTests/analysis/test_density.py
+++ b/testsuite/MDAnalysisTests/analysis/test_density.py
@@ -26,6 +26,7 @@ from six.moves import zip
 import numpy as np
 import pytest
 import sys
+import warnings
 
 from numpy.testing import assert_equal, assert_almost_equal
 
@@ -128,12 +129,20 @@ class Test_density_from_Universe(object):
                       {'meandensity': 0.016764271713091212, },
                   'static_sliced':
                       {'meandensity': 0.016764270747693617, },
+                  'static_defined':
+                      {'meandensity': 0.0025000000000000005, },
+                  'static_defined_unequal':
+                      {'meandensity': 0.006125, },
                   'dynamic':
                       {'meandensity': 0.0012063418843728784, },
                   'notwithin':
                       {'meandensity': 0.015535385132107926, },
                   }
     cutoffs = {'notwithin': 4.0, }
+    gridcenters = {'static_defined': np.array([56.0, 45.0, 35.0]),
+                   'error1': np.array([56.0, 45.0]),
+                   'error2': [56.0, 45.0, "MDAnalysis"],
+                   }
     precision = 5
     outfile = 'density.dx'
 
@@ -157,7 +166,6 @@ class Test_density_from_Universe(object):
             D2 = MDAnalysis.analysis.density.Density(self.outfile)
             assert_almost_equal(D.grid, D2.grid, decimal=self.precision,
                                 err_msg="DX export failed: different grid sizes")
-
 
     def test_density_from_Universe(self, universe, tmpdir):
         self.check_density_from_Universe(
@@ -194,6 +202,72 @@ class Test_density_from_Universe(object):
             universe=universe,
             tmpdir=tmpdir
         )
+
+    def test_density_from_Universe_userdefn_eqbox(self, universe, tmpdir):
+        self.check_density_from_Universe(
+            self.selections['static'],
+            self.references['static_defined']['meandensity'],
+            gridcenter=self.gridcenters['static_defined'],
+            xdim=10.0,
+            ydim=10.0,
+            zdim=10.0,
+            universe=universe,
+            tmpdir=tmpdir
+        )
+
+    def test_density_from_Universe_userdefn_neqbox(self, universe, tmpdir):
+        self.check_density_from_Universe(
+            self.selections['static'],
+            self.references['static_defined_unequal']['meandensity'],
+            gridcenter=self.gridcenters['static_defined'],
+            xdim=10.0,
+            ydim=15.0,
+            zdim=20.0,
+            universe=universe,
+            tmpdir=tmpdir
+        )
+
+    def test_density_from_Universe_userdefn_boxshape(self, universe):
+        import MDAnalysis.analysis.density
+        D = MDAnalysis.analysis.density.density_from_Universe(
+            universe, atomselection=self.selections['static'],
+            delta=1.0, xdim=8.0, ydim=12.0, zdim=17.0,
+            gridcenter=self.gridcenters['static_defined'])
+        assert D.grid.shape == (8, 12, 17)
+
+    def test_density_from_Universe_userdefn_selwarning(self, universe):
+        import MDAnalysis.analysis.density
+        wmsg = ("Atom selection does not fit grid --- "
+                "you may want to define a larger box")
+        with pytest.warns(UserWarning) as record:
+            D = MDAnalysis.analysis.density.density_from_Universe(
+                universe, atomselection=self.selections['static'],
+                delta=1.0, xdim=1.0, ydim=2.0, zdim=2.0,
+                gridcenter=self.gridcenters['static_defined'])
+
+        assert len(record) == 2
+        assert str(record[1].message.args[0]) == wmsg
+
+    def test_density_from_Universe_userdefn_ValueErrors(self, universe):
+        import MDAnalysis.analysis.density
+        # Test len(gridcenter) != 3
+        with pytest.raises(ValueError):
+            D = MDAnalysis.analysis.density.density_from_Universe(
+                universe, atomselection=self.selections['static'],
+                delta=self.delta, xdim=10.0, ydim=10.0, zdim=10.0,
+                gridcenter=self.gridcenters['error1'])
+        # Test gridcenter includes non-numeric strings
+        with pytest.raises(ValueError):
+            D = MDAnalysis.analysis.density.density_from_Universe(
+                universe, atomselection=self.selections['static'],
+                delta=self.delta, xdim=10.0, ydim=10.0, zdim=10.0,
+                gridcenter=self.gridcenters['error2'])
+        # Test xdim != int or float
+        with pytest.raises(ValueError):
+            D = MDAnalysis.analysis.density.density_from_Universe(
+                universe, atomselection=self.selections['static'],
+                delta=self.delta, xdim="MDAnalysis", ydim=10.0, zdim=10.0,
+                gridcenter=self.gridcenters['static_defined'])
 
 
 class TestGridImport(object):


### PR DESCRIPTION
Partly addresses #1928 

Small modification to density_from_Universe to allow for a user defined box when creating density grids.

Changes made in this Pull Request:
 - Adds keywords gridcenter, xdim, ydim, and zdim.
 - Adds helper function _set_user_grid 

To do:
 - If of interest, also add this option to density_from_PDB

PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
