### PR TITLE
BUG: fix several Windows test failures with int64 type enforcement

### DIFF
--- a/package/MDAnalysis/core/selection.py
+++ b/package/MDAnalysis/core/selection.py
@@ -220,7 +220,7 @@ class ByResSelection(UnarySelection):
 
     def apply(self, group):
         res = self.sel.apply(group)
-        unique_res = unique_int_1d(res.resids)
+        unique_res = unique_int_1d(res.resids.astype(np.int64))
         mask = np.in1d(group.resids, unique_res)
 
         return group[mask].unique


### PR DESCRIPTION
This should drop windows failures down from 24 to 16 on appveyor
