### PR TITLE
Modified the distance function in RDF

### DIFF
--- a/benchmarks/benchmarks/analysis/rdf.py
+++ b/benchmarks/benchmarks/analysis/rdf.py
@@ -17,21 +17,23 @@ class SimpleRdfBench(object):
     """
 
     params = ([20,75,200],
-              [[0,5], [0,15], [0,20]])
+              [[0,5], [0,15], [0,20]],
+              [1, 100, 1000, 10000])
 
     param_names = ['nbins',
-                   'range_val']
+                   'range_val',
+                   'natoms']
 
-    def setup(self, nbins, range_val):
+    def setup(self, nbins, range_val, natoms):
         
         self.sel_str = 'name OW'
 
         self.u = MDAnalysis.Universe(TPR, XTC)
 
         try:
-            self.sel = self.u.select_atoms(self.sel_str)[:200]
+            self.sel = self.u.select_atoms(self.sel_str)[:natoms]
         except AttributeError:
-            self.sel = self.u.selectAtoms(self.sel_str)[:200]
+            self.sel = self.u.selectAtoms(self.sel_str)[:natoms]
 
         # do not include initialization of the
         # InterRDF object in the benchmark itself

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -21,10 +21,13 @@ The rules for this file:
 
 Enhancements
 
+
   * Replaced multiple apply (_apply_distmat, _apply_kdtree)
     methods in distance based selections with
     lib.distances.capped_distance for automatic selection of
     distance evaluation method. (PR #2035)
+  * Modified analysis.rdf.InterRDF to use lib.distances.capped_distance
+    to handle rdf calculations for large systems. (PR #2013)
   * Added return_distances argument in lib.distances.capped_distances
     to evaluate and return distances only when required. Modified
     the optimization rules in lib.distances._determine_method for

--- a/package/MDAnalysis/analysis/rdf.py
+++ b/package/MDAnalysis/analysis/rdf.py
@@ -235,7 +235,6 @@ class InterRDF(AnalysisBase):
 
 class InterRDF_s(AnalysisBase):
     """Site-specific intermolecular pair distribution function
-
     Arguments
     ---------
     u : Universe
@@ -254,48 +253,32 @@ class InterRDF_s(AnalysisBase):
     step : int (optional)
           The step size through the trajectory in frames (default is
           every frame)
-
     Example
     -------
-
     First create the :class:`InterRDF_s` object, by supplying one Universe and
     one list of pairs of AtomGroups, then use the :meth:`~InterRDF_s.run`
     method::
-
       from MDAnalysisTests.datafiles import GRO_MEMPROT, XTC_MEMPROT
       u = mda.Universe(GRO_MEMPROT, XTC_MEMPROT)
-
       s1 = u.select_atoms('name ZND and resid 289')
       s2 = u.select_atoms('(name OD1 or name OD2) and resid 51 and sphzone 5.0 (resid 289)')
       s3 = u.select_atoms('name ZND and (resid 291 or resid 292)')
       s4 = u.select_atoms('(name OD1 or name OD2) and sphzone 5.0 (resid 291)')
       ags = [[s1, s2], [s3, s4]]
-
       rdf = InterRDF_s(u, ags)
       rdf.run()
-
     Results are available through the :attr:`bins` and :attr:`rdf` attributes::
-
       plt.plot(rdf.bins, rdf.rdf[0][0][0])
-
     (Which plots the rdf between the first atom in ``s1`` and the first atom in
     ``s2``)
-
     To generate the *cumulative distribution function* (cdf), use the
     :meth:`~InterRDF_s.get_cdf` method ::
-
       cdf = rdf.get_cdf()
-
     Results are available through the :attr:'cdf' attribute::
-
       plt.plot(rdf.bins, rdf.cdf[0][0][0])
-
     (Which plots the cdf between the first atom in ``s1`` and the first atom in
     ``s2``)
-
-
     .. versionadded:: 0.19.0
-
     """
     def __init__(self, u, ags,
                  nbins=75, range=(0.0, 15.0), density=True, **kwargs):
@@ -320,7 +303,6 @@ class InterRDF_s(AnalysisBase):
         self.count = count_list
         self.edges = edges
         self.bins = 0.5 * (edges[:-1] + edges[1:])
-        self._maxrange = self.rdf_settings['range'][1]
 
         # Need to know average volume
         self.volume = 0.0
@@ -328,13 +310,8 @@ class InterRDF_s(AnalysisBase):
 
     def _single_frame(self):
         for i, (ag1, ag2) in enumerate(self.ags):
-            pairs, dist = distances.capped_distance(ag1.positions,
-                                                   ag2.positions,
-                                                   self._maxrange,
-                                                   box=self.u.dimensions)
-            result = np.ones((len(self.ag1), len(self.ag2)), dtype=np.float64)
-            result *= self._maxrange + 1.0
-            result[tuple(zip(*pairs))] = dist
+            result=distances.distance_array(ag1.positions, ag2.positions,
+                                            box=self.u.dimensions)
             for j in range(ag1.n_atoms):
                 for k in range(ag2.n_atoms):
                     count = np.histogram(result[j, k], **self.rdf_settings)[0]
@@ -373,15 +350,12 @@ class InterRDF_s(AnalysisBase):
 
     def get_cdf(self):
         """Calculate the cumulative distribution functions (CDF) for all sites.
-
         Note that this is the actual count within a given radius, i.e.,
         :math:`N(r)`.
-
         Returns
         -------
               cdf : list
                       list of arrays with the same structure as :attr:`rdf`
-
         """
         # Calculate cumulative distribution function
         # Empty list to restore CDF

--- a/package/MDAnalysis/analysis/rdf.py
+++ b/package/MDAnalysis/analysis/rdf.py
@@ -235,6 +235,7 @@ class InterRDF(AnalysisBase):
 
 class InterRDF_s(AnalysisBase):
     """Site-specific intermolecular pair distribution function
+
     Arguments
     ---------
     u : Universe
@@ -253,32 +254,48 @@ class InterRDF_s(AnalysisBase):
     step : int (optional)
           The step size through the trajectory in frames (default is
           every frame)
+
     Example
     -------
+
     First create the :class:`InterRDF_s` object, by supplying one Universe and
     one list of pairs of AtomGroups, then use the :meth:`~InterRDF_s.run`
     method::
+
       from MDAnalysisTests.datafiles import GRO_MEMPROT, XTC_MEMPROT
       u = mda.Universe(GRO_MEMPROT, XTC_MEMPROT)
+
       s1 = u.select_atoms('name ZND and resid 289')
       s2 = u.select_atoms('(name OD1 or name OD2) and resid 51 and sphzone 5.0 (resid 289)')
       s3 = u.select_atoms('name ZND and (resid 291 or resid 292)')
       s4 = u.select_atoms('(name OD1 or name OD2) and sphzone 5.0 (resid 291)')
       ags = [[s1, s2], [s3, s4]]
+
       rdf = InterRDF_s(u, ags)
       rdf.run()
+
     Results are available through the :attr:`bins` and :attr:`rdf` attributes::
+
       plt.plot(rdf.bins, rdf.rdf[0][0][0])
+
     (Which plots the rdf between the first atom in ``s1`` and the first atom in
     ``s2``)
+
     To generate the *cumulative distribution function* (cdf), use the
     :meth:`~InterRDF_s.get_cdf` method ::
+
       cdf = rdf.get_cdf()
+
     Results are available through the :attr:'cdf' attribute::
+
       plt.plot(rdf.bins, rdf.cdf[0][0][0])
+
     (Which plots the cdf between the first atom in ``s1`` and the first atom in
     ``s2``)
+
+
     .. versionadded:: 0.19.0
+
     """
     def __init__(self, u, ags,
                  nbins=75, range=(0.0, 15.0), density=True, **kwargs):

--- a/package/MDAnalysis/lib/distances.py
+++ b/package/MDAnalysis/lib/distances.py
@@ -583,7 +583,11 @@ def _bruteforce_capped(reference, configuration, max_cutoff,
          is set to ``True``
 
     """
+<<<<<<< d2e22ffb0cb46af5266e39b940d7f00c1ca293c1
     pairs, distance = [], []
+=======
+
+>>>>>>> modified capped function for faster computations, added search_tree in pkdtree, added tests, updated Changlog
     reference = np.asarray(reference, dtype=np.float32)
     configuration = np.asarray(configuration, dtype=np.float32)
 
@@ -601,8 +605,12 @@ def _bruteforce_capped(reference, configuration, max_cutoff,
     else:
         mask = np.where((distance <= max_cutoff))
 
+<<<<<<< d2e22ffb0cb46af5266e39b940d7f00c1ca293c1
     if mask[0].size > 0:
         pairs = np.c_[mask[0], mask[1]]
+=======
+    pairs = np.c_[mask[0], mask[1]]
+>>>>>>> modified capped function for faster computations, added search_tree in pkdtree, added tests, updated Changlog
 
     if return_distances:
         distance = distance[mask]
@@ -905,6 +913,7 @@ def _bruteforce_capped_self(reference, max_cutoff, min_cutoff=None,
         reference = reference[None, :]
 
     N = len(reference)
+<<<<<<< d2e22ffb0cb46af5266e39b940d7f00c1ca293c1
     distvec = np.zeros((N*(N-1)//2), dtype=np.float64)
     self_distance_array(reference, box=box, result=distvec)
 
@@ -920,6 +929,25 @@ def _bruteforce_capped_self(reference, max_cutoff, min_cutoff=None,
         pairs = np.c_[mask[0], mask[1]]
         distance = distance[mask]
     return np.asarray(pairs), np.asarray(distance)
+=======
+    distance = np.zeros((N*(N-1)//2), dtype=np.float64)
+    self_distance_array(reference, box=box, result=distance)
+    if min_cutoff is not None:
+        idx = np.where((distance < max_cutoff) & (distance > min_cutoff))[0]
+    else:
+        idx = np.where((distance < max_cutoff))[0]
+
+    pairs, dist = [], []
+    k, count = 0, 0
+    for i in range(N):
+        for j in range(i+1, N):
+            if count < len(idx) and idx[count] == k:
+                pairs.append((i, j))
+                dist.append(distance[k])
+                count += 1
+            k += 1
+    return np.asarray(pairs), np.asarray(dist)
+>>>>>>> modified capped function for faster computations, added search_tree in pkdtree, added tests, updated Changlog
 
 
 def _pkdtree_capped_self(reference, max_cutoff, min_cutoff=None,

--- a/package/MDAnalysis/lib/distances.py
+++ b/package/MDAnalysis/lib/distances.py
@@ -583,11 +583,7 @@ def _bruteforce_capped(reference, configuration, max_cutoff,
          is set to ``True``
 
     """
-<<<<<<< d2e22ffb0cb46af5266e39b940d7f00c1ca293c1
     pairs, distance = [], []
-=======
-
->>>>>>> modified capped function for faster computations, added search_tree in pkdtree, added tests, updated Changlog
     reference = np.asarray(reference, dtype=np.float32)
     configuration = np.asarray(configuration, dtype=np.float32)
 
@@ -605,12 +601,8 @@ def _bruteforce_capped(reference, configuration, max_cutoff,
     else:
         mask = np.where((distance <= max_cutoff))
 
-<<<<<<< d2e22ffb0cb46af5266e39b940d7f00c1ca293c1
     if mask[0].size > 0:
         pairs = np.c_[mask[0], mask[1]]
-=======
-    pairs = np.c_[mask[0], mask[1]]
->>>>>>> modified capped function for faster computations, added search_tree in pkdtree, added tests, updated Changlog
 
     if return_distances:
         distance = distance[mask]
@@ -913,7 +905,6 @@ def _bruteforce_capped_self(reference, max_cutoff, min_cutoff=None,
         reference = reference[None, :]
 
     N = len(reference)
-<<<<<<< d2e22ffb0cb46af5266e39b940d7f00c1ca293c1
     distvec = np.zeros((N*(N-1)//2), dtype=np.float64)
     self_distance_array(reference, box=box, result=distvec)
 
@@ -929,25 +920,6 @@ def _bruteforce_capped_self(reference, max_cutoff, min_cutoff=None,
         pairs = np.c_[mask[0], mask[1]]
         distance = distance[mask]
     return np.asarray(pairs), np.asarray(distance)
-=======
-    distance = np.zeros((N*(N-1)//2), dtype=np.float64)
-    self_distance_array(reference, box=box, result=distance)
-    if min_cutoff is not None:
-        idx = np.where((distance < max_cutoff) & (distance > min_cutoff))[0]
-    else:
-        idx = np.where((distance < max_cutoff))[0]
-
-    pairs, dist = [], []
-    k, count = 0, 0
-    for i in range(N):
-        for j in range(i+1, N):
-            if count < len(idx) and idx[count] == k:
-                pairs.append((i, j))
-                dist.append(distance[k])
-                count += 1
-            k += 1
-    return np.asarray(pairs), np.asarray(dist)
->>>>>>> modified capped function for faster computations, added search_tree in pkdtree, added tests, updated Changlog
 
 
 def _pkdtree_capped_self(reference, max_cutoff, min_cutoff=None,


### PR DESCRIPTION
RDF in analysis.py currently uses  distance_array which becomes slow for large number of particles. Although it still uses the same distance array for small number of particles, it can also use KDTree for large number of particles to boost the performance.

PR Checklist
------------
 - [X ] Tests?
 - [X] Docs?
 - [X ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
