### PR TITLE
BUG: fix Windows file permission setting in test_universe

### DIFF
--- a/testsuite/MDAnalysisTests/core/test_universe.py
+++ b/testsuite/MDAnalysisTests/core/test_universe.py
@@ -25,6 +25,7 @@ from __future__ import absolute_import, print_function
 from six.moves import cPickle
 
 import os
+import subprocess
 
 try:
     from cStringIO import StringIO
@@ -168,7 +169,12 @@ class TestUniverseCreation(object):
         temp_file = os.path.join(temp_dir.name, 'permission.denied.tpr')
         with open(temp_file, 'w'):
             pass
-        os.chmod(temp_file, 0o200)
+
+        if os.name == 'nt':
+            subprocess.call("icacls {filename} /deny Users:RX".format(filename=temp_file),
+                            shell=True)
+        else:
+            os.chmod(temp_file, 0o200)
         try:
             mda.Universe(os.path.join(temp_dir.name, 'permission.denied.tpr'))
         except IOError as e:


### PR DESCRIPTION
* test_Universe_invalidpermissionfile_IE_msg unit test now
properly sets Windows file permission to deny read access

Reliably denying user access to a file on Windows from Python is tricky at best. [`chmod` docs](https://docs.python.org/2/library/os.html#os.chmod) clearly indicate that you can only adjust the read-only bit on Windows so I went with using `icacls` from `subprocess` instead, after a bit of research, which seems to work locally.

This should reduce Appveyor CI suite failures from 16 -> 15.

We should probably also migrate to using the pytest `tmpfile`  machinery here, but I did  not want to complicate the code review with both a Windows bug fix & code modernization at the same time.