### PR TITLE
BUG: test_persistent_offsets_readonly Windows fix

### DIFF
--- a/testsuite/MDAnalysisTests/coordinates/test_xdr.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_xdr.py
@@ -28,6 +28,7 @@ import errno
 import numpy as np
 import os
 import shutil
+import subprocess
 
 from numpy.testing import (assert_equal, assert_almost_equal)
 
@@ -768,7 +769,14 @@ class _GromacsReader_offsets(object):
 
     def test_persistent_offsets_readonly(self, tmpdir):
         shutil.copy(self.filename, str(tmpdir))
-        os.chmod(str(tmpdir), 0o555)
+
+        if os.name == 'nt':
+            # Windows platform has a unique way to deny write access
+            subprocess.call("icacls {fname} /deny Users:W".format(fname=tmpdir),
+                            shell=True)
+        else:
+            os.chmod(str(tmpdir), 0o555)
+
         filename = str(tmpdir.join(os.path.basename(self.filename)))
         # try to write a offsets file
         self._reader(filename)


### PR DESCRIPTION
* test_persistent_offsets_readonly() now properly denies
write access to the test file on Windows

This fix is similar to the one in #2014; it should reduce Appveyor test failures from 16->14, or 15->13 after the linked PR is merged.