### PR TITLE
Around keyword can use KDTree for periodic boundary conditions

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -20,6 +20,8 @@ The rules for this file:
 
 Enhancements
 
+  * Modified around selections to work with KDTree and periodic boundary
+    conditions (PR #2022)
   * Added augment functionality to create relevant images of particles 
     in the vicinity of central cell to handle periodic boundary
     conditions (PR #1977) 


### PR DESCRIPTION
Around keyword only used _apply_distmat if periodic keyword was active. Both brute force and kdtree routines can be used now for PBC and non-PBC calculations

Fixes  partly #974 

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
