### PR TITLE
Assigning positions on memory reader is persistent

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -27,9 +27,9 @@ Enhancements
     lib.distance.self_capped_distance (PR # 2006)
   * Added lib.distances.self_capped_distance to internally select the
     optimized method for distance evaluations of coordinates with itself. (PR # 2006)
-  * Added augment functionality to create relevant images of particles 
+  * Added augment functionality to create relevant images of particles
     in the vicinity of central cell to handle periodic boundary
-    conditions (PR #1977) 
+    conditions (PR #1977)
   * Added lib.distances.capped_distance function to quickly calculate all distances
     up to a given maximum distance (PR #1941)
   * Added a rotation coordinate transformation (PR #1937)
@@ -58,7 +58,7 @@ Enhancements
     generated with gromacs -noappend (PR #1728)
   * MDAnalysis.lib.mdamath now supports triclinic boxes and rewrote in Cython (PR #1965)
   * AtomGroup.write can write a trajectory of selected frames (Issue #1037)
-  * Added dihedrals.py with Ramachandran class to analysis module 
+  * Added analysis.dihedrals with Ramachandran class to analysis module (PR #1997)
 
 Fixes
   * rewind in the SingleFrameReader now reads the frame from the file (Issue #1929)
@@ -76,6 +76,8 @@ Fixes
   * Zero length TopologyGroup now return proper shape array via to_indices
     (Issue #1974)
   * Added periodic boundary box support to the Tinker file reader (Issue #2001)
+  * Modifying coordinates by assignation is consistently persistent when using
+    the memory reader (Issue #2018)
 
 Changes
   * TopologyAttrs are now statically typed (Issue #1876)

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -278,7 +278,7 @@ class Timestep(object):
 
         # set up aux namespace for adding auxiliary data
         self.aux = Namespace()
-        
+
 
     @classmethod
     def from_timestep(cls, other, **kwargs):
@@ -589,7 +589,7 @@ class Timestep(object):
 
 
         .. versionchanged:: 0.11.0
-           Now can raise :exc`NoDataError` when no position data present
+           Now can raise :exc:`NoDataError` when no position data present
         """
         if self.has_positions:
             return self._pos
@@ -932,7 +932,7 @@ class FrameIteratorSliced(FrameIteratorBase):
         else:
             # The range is empty.
             return 0
-    
+
     def __iter__(self):
         for i in range(self.start, self.stop, self.step):
             yield self.trajectory[i]
@@ -960,7 +960,7 @@ class FrameIteratorSliced(FrameIteratorBase):
                 start = max(0, start)
             else:
                 stop = max(0, stop)
-            
+
             new_slice = slice(start, stop, step)
             return FrameIteratorSliced(self.trajectory, new_slice)
         else:
@@ -1402,9 +1402,9 @@ class ProtoReader(six.with_metaclass(_Readermeta, IOBase)):
         else:
             for auxname in self.aux_list:
                 ts = self._auxs[auxname].update_ts(ts)
-            
+
             ts = self._apply_transformations(ts)
-                
+
         return ts
 
     def __next__(self):
@@ -1561,9 +1561,9 @@ class ProtoReader(six.with_metaclass(_Readermeta, IOBase)):
         ts = self._read_frame(frame)  # pylint: disable=assignment-from-no-return
         for aux in self.aux_list:
             ts = self._auxs[aux].update_ts(ts)
-            
+
         ts = self._apply_transformations(ts)
-                
+
         return ts
 
     def _sliced_iter(self, start, stop, step):
@@ -1945,67 +1945,67 @@ class ProtoReader(six.with_metaclass(_Readermeta, IOBase)):
             auxnames = self.aux_list
         descriptions = [self._auxs[aux].get_description() for aux in auxnames]
         return descriptions
-    
+
     @property
     def transformations(self):
         """ Returns the list of transformations"""
         return self._transformations
-    
+
     @transformations.setter
     def transformations(self, transformations):
         if not self._transformations:
             self._transformations = transformations
         else:
             raise ValueError("Transformations are already set")
-        
+
     def add_transformations(self, *transformations):
         """ Add all transformations to be applied to the trajectory.
-        
+
         This function take as list of transformations as an argument. These
         transformations are functions that will be called by the Reader and given
         a :class:`Timestep` object as argument, which will be transformed and returned
         to the Reader.
-        The transformations can be part of the :mod:`~MDAnalysis.transformations` 
-        module, or created by the user, and are stored as a list `transformations`. 
+        The transformations can be part of the :mod:`~MDAnalysis.transformations`
+        module, or created by the user, and are stored as a list `transformations`.
         This list can only be modified once, and further calls of this function will
         raise an exception.
-        
+
         .. code-block:: python
-                         
+
           u = MDAnalysis.Universe(topology, coordinates)
           workflow = [some_transform, another_transform, this_transform]
           u.trajectory.add_transformations(*workflow)
-        
+
         Parameters
         ----------
         transform_list : list
             list of all the transformations that will be applied to the coordinates
-            
+
         See Also
         --------
         :mod:`MDAnalysis.transformations`
         """
-        
+
         try:
             self.transformations = transformations
         except ValueError:
-            raise ValueError("Can't add transformations again. Please create new Universe object")  
+            raise ValueError("Can't add transformations again. Please create new Universe object")
         else:
             self.ts = self._apply_transformations(self.ts)
-                
-             
+
+
         # call reader here to apply the newly added transformation on the
         # current loaded frame?
-        
+
     def _apply_transformations(self, ts):
         """Applies all the transformations given by the user """
-        
+
         for transform in self.transformations:
             ts = transform(ts)
-        
+
         return ts
-            
-    
+
+
 
 class ReaderBase(ProtoReader):
     """Base class for trajectory readers that extends :class:`ProtoReader` with a
@@ -2245,7 +2245,7 @@ class SingleFrameReaderBase(ProtoReader):
         # since the transformations have already been applied to the frame
         # simply copy the property
         new.transformations = self.transformations
-        
+
         return new
 
     def _read_first_frame(self):  # pragma: no cover
@@ -2279,30 +2279,30 @@ class SingleFrameReaderBase(ProtoReader):
         # self.filename. Explicitly setting it to the null action in case
         # the IOBase.close method is ever changed from that.
         pass
-    
+
     def add_transformations(self, *transformations):
         """ Add all transformations to be applied to the trajectory.
-        
+
         This function take as list of transformations as an argument. These
         transformations are functions that will be called by the Reader and given
         a :class:`Timestep` object as argument, which will be transformed and returned
         to the Reader.
-        The transformations can be part of the :mod:`~MDAnalysis.transformations` 
-        module, or created by the user, and are stored as a list `transformations`. 
+        The transformations can be part of the :mod:`~MDAnalysis.transformations`
+        module, or created by the user, and are stored as a list `transformations`.
         This list can only be modified once, and further calls of this function will
         raise an exception.
-        
+
         .. code-block:: python
-                         
+
           u = MDAnalysis.Universe(topology, coordinates)
           workflow = [some_transform, another_transform, this_transform]
           u.trajectory.add_transformations(*workflow)
-        
+
         Parameters
         ----------
         transform_list : list
             list of all the transformations that will be applied to the coordinates
-            
+
         See Also
         --------
         :mod:`MDAnalysis.transformations`
@@ -2311,7 +2311,7 @@ class SingleFrameReaderBase(ProtoReader):
         #to avoid unintended behaviour where the coordinates of each frame are transformed
         #multiple times when iterating over the trajectory.
         #In this method, the trajectory is modified all at once and once only.
-        
+
         super(SingleFrameReaderBase, self).add_transformations(*transformations)
         for transform in self.transformations:
             self.ts = transform(self.ts)
@@ -2320,5 +2320,5 @@ class SingleFrameReaderBase(ProtoReader):
         """ Applies the transformations to the timestep."""
         # Overrides :meth:`~MDAnalysis.coordinates.base.ProtoReader.add_transformations`
         # to avoid applying the same transformations multiple times on each frame
-        
+
         return ts

--- a/package/MDAnalysis/coordinates/memory.py
+++ b/package/MDAnalysis/coordinates/memory.py
@@ -33,8 +33,8 @@ Reading trajectories from memory --- :mod:`MDAnalysis.coordinates.memory`
 .. versionadded:: 0.16.0
 
 The module contains a trajectory reader that operates on an array in
-memory, rather than reading from file. This makes it possible to use
-operate on raw coordinate using existing MDAnalysis tools. In
+memory, rather than reading from file. This makes it possible to
+operate on raw coordinates using existing MDAnalysis tools. In
 addition, it allows the user to make changes to the coordinates in a
 trajectory (e.g. through
 :attr:`MDAnalysis.core.groups.AtomGroup.positions`) without having
@@ -215,8 +215,8 @@ class Timestep(base.Timestep):
         of the array. The :meth:`replace_positions_array` method should only be
         used to set the positions to a different frame in
         :meth:`MemoryReader._read_next_timestep`; there, the memory reader sets
-        the positions to a view to the correct frame.  Modifying the positions
-        for a given frames should be done with the :attr:`positions` attribute
+        the positions to a view of the correct frame.  Modifying the positions
+        for a given frame should be done with the :attr:`positions` attribute
         that does not break the link between the array of positions in the time
         step and the :attr:`MemoryReader.coordinate_array`.
 

--- a/package/MDAnalysis/coordinates/memory.py
+++ b/package/MDAnalysis/coordinates/memory.py
@@ -197,12 +197,12 @@ class Timestep(base.Timestep):
 
     Compared to the base :class:`base.Timestep`, this version
     (:class:`memory.Timestep`) has an additional
-    :meth:`replace_positions_array` method, which replaces the array of
+    :meth:`_replace_positions_array` method, which replaces the array of
     positions while the :attr:`positions` property replaces the content of the
     array.
 
     """
-    def replace_positions_array(self, new):
+    def _replace_positions_array(self, new):
         """Replace the array of positions
 
         Replaces the array of positions by another array.
@@ -210,9 +210,9 @@ class Timestep(base.Timestep):
 
         Note
         ----
-        The behavior of :meth:`replace_positions_array` is different from the
+        The behavior of :meth:`_replace_positions_array` is different from the
         behavior of the :attr:`position` property that replaces the **content**
-        of the array. The :meth:`replace_positions_array` method should only be
+        of the array. The :meth:`_replace_positions_array` method should only be
         used to set the positions to a different frame in
         :meth:`MemoryReader._read_next_timestep`; there, the memory reader sets
         the positions to a view of the correct frame.  Modifying the positions
@@ -482,7 +482,7 @@ class MemoryReader(base.ProtoReader):
         basic_slice = ([slice(None)]*(f_index) +
                        [self.ts.frame] +
                        [slice(None)]*(2-f_index))
-        ts.replace_positions_array(self.coordinate_array[basic_slice])
+        ts._replace_positions_array(self.coordinate_array[basic_slice])
 
         ts.time = self.ts.frame*self.dt
         return ts

--- a/package/MDAnalysis/coordinates/memory.py
+++ b/package/MDAnalysis/coordinates/memory.py
@@ -193,26 +193,35 @@ from . import base
 
 
 class Timestep(base.Timestep):
-    """
-    Timestep for the :class:`MemoryReader`
+    """Timestep for the :class:`MemoryReader`
 
-    Compared to the base :class:`base.Timestep`, this version has an additional
-    :meth:`replace_positions_array` method. This property replaces the array of
-    positions, while the :attr:`positions` property replaces the content of the
+    Compared to the base :class:`base.Timestep`, this version
+    (:class:`memory.Timestep`) has an additional
+    :meth:`replace_positions_array` method, which replaces the array of
+    positions while the :attr:`positions` property replaces the content of the
     array.
+
     """
     def replace_positions_array(self, new):
         """Replace the array of positions
 
-        Replaces the array of positions by an other array. This is different
-        from the bahavior of the :attr:`position` property that replaces the
-        **content** of the array. The :meth:`replace_positions_array` method
-        should only be used to set the positions to a different frame; there,
-        the memory reader sets the positions to a view to the correct frame.
-        Modifying the positions for a given frames should be done with the
-        :attr:`positions` attribute that do not break the link between the
-        array of positions in the time step and the
-        :attr:`MemoryReader.coordinate_array`.
+        Replaces the array of positions by another array.
+
+
+        Note
+        ----
+        The behavior of :meth:`replace_positions_array` is different from the
+        behavior of the :attr:`position` property that replaces the **content**
+        of the array. The :meth:`replace_positions_array` method should only be
+        used to set the positions to a different frame in
+        :meth:`MemoryReader._read_next_timestep`; there, the memory reader sets
+        the positions to a view to the correct frame.  Modifying the positions
+        for a given frames should be done with the :attr:`positions` attribute
+        that does not break the link between the array of positions in the time
+        step and the :attr:`MemoryReader.coordinate_array`.
+
+
+        .. versionadded:: 0.19.0
         """
         self.has_positions = True
         self._pos = new
@@ -267,6 +276,7 @@ class MemoryReader(base.ProtoReader):
         At the moment, only a fixed `dimension` is supported, i.e., the same
         unit cell for all frames in `coordinate_array`. See issue `#1041`_.
 
+
         .. _`#1041`: https://github.com/MDAnalysis/mdanalysis/issues/1041
 
         .. versionchanged:: 0.18.1
@@ -278,13 +288,16 @@ class MemoryReader(base.ProtoReader):
         self.filename = filename
         self.stored_order = order
 
-        # See Issue #1685. The block below checks if the coordinate array passed is of shape (N, 3) and if it is, the coordiante array is reshaped to (1, N, 3)
+        # See Issue #1685. The block below checks if the coordinate array
+        # passed is of shape (N, 3) and if it is, the coordiante array is
+        # reshaped to (1, N, 3)
         try:
             if len(coordinate_array.shape) == 2 and coordinate_array.shape[1] == 3:
                     coordinate_array = coordinate_array[np.newaxis, :, :]
         except AttributeError as e:
-            raise TypeError("The input has to be a numpy.ndarray that corresponds to the layout specified by the 'order' keyword."
-                )
+            raise TypeError("The input has to be a numpy.ndarray that "
+                            "corresponds to the layout specified by the "
+                            "'order' keyword.")
 
         self.set_array(coordinate_array, order)
         self.n_frames = \
@@ -488,30 +501,30 @@ class MemoryReader(base.ProtoReader):
                     nframes=self.n_frames,
                     natoms=self.n_atoms
                 ))
-    
+
     def add_transformations(self, *transformations):
         """ Add all transformations to be applied to the trajectory.
-        
+
         This function take as list of transformations as an argument. These
         transformations are functions that will be called by the Reader and given
         a :class:`Timestep` object as argument, which will be transformed and returned
         to the Reader.
-        The transformations can be part of the :mod:`~MDAnalysis.transformations` 
-        module, or created by the user, and are stored as a list `transformations`. 
+        The transformations can be part of the :mod:`~MDAnalysis.transformations`
+        module, or created by the user, and are stored as a list `transformations`.
         This list can only be modified once, and further calls of this function will
         raise an exception.
-        
+
         .. code-block:: python
-                         
+
           u = MDAnalysis.Universe(topology, coordinates)
           workflow = [some_transform, another_transform, this_transform]
           u.trajectory.add_transformations(*workflow)
-        
+
         Parameters
         ----------
         transform_list : list
             list of all the transformations that will be applied to the coordinates
-            
+
         See Also
         --------
         :mod:`MDAnalysis.transformations`
@@ -520,7 +533,7 @@ class MemoryReader(base.ProtoReader):
         #to avoid unintended behaviour where the coordinates of each frame are transformed
         #multiple times when iterating over the trajectory.
         #In this method, the trajectory is modified all at once and once only.
-        
+
         super(MemoryReader, self).add_transformations(*transformations)
         for i, ts in enumerate(self):
             for transform in self.transformations:
@@ -530,5 +543,5 @@ class MemoryReader(base.ProtoReader):
         """ Applies the transformations to the timestep."""
         # Overrides :meth:`~MDAnalysis.coordinates.base.ProtoReader.add_transformations`
         # to avoid applying the same transformations multiple times on each frame
-        
+
         return ts

--- a/testsuite/MDAnalysisTests/coordinates/test_memory.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_memory.py
@@ -29,7 +29,7 @@ from MDAnalysisTests.datafiles import DCD, PSF
 from MDAnalysisTests.coordinates.base import (BaseReference,
                                               MultiframeReaderTest)
 from MDAnalysis.coordinates.memory import Timestep
-from numpy.testing import assert_equal
+from numpy.testing import assert_equal, assert_almost_equal
 
 
 class MemoryReference(BaseReference):
@@ -193,3 +193,10 @@ class TestMemoryReader(MultiframeReaderTest):
         coordinates = np.random.uniform(size=(100, ref.universe.atoms.n_atoms, 3)).cumsum(0)
         universe = mda.Universe(ref.universe.filename, coordinates, format=MemoryReader)
         assert_equal(universe.trajectory.get_array().dtype, np.dtype('float32'))
+
+    def test_position_assignation(self, reader):
+        # When coordinates are assigned to a timestep, is the change persistent?
+        new_positions = np.ones_like(reader.ts.positions, dtype=np.float32)
+        reader.ts.positions = new_positions
+        reader[0]
+        assert_almost_equal(reader.ts.positions, new_positions)


### PR DESCRIPTION
Fixes #2018

Assigning an array to ts.positions with the memory reader does not break
the link to trajectory.coordinate_array anymore. That link needs to be
reset when switching to a new frame. This is done with the new method
ts.replace_position_array.


PR Checklist
------------
 - [X] Tests?
 - [X] Docs?
 - [X] CHANGELOG updated?
 - [X] Issue raised/referenced?
