### PR TITLE
BUG: Force 64-bit storage for xdr file offsets

### DIFF
--- a/package/MDAnalysis/lib/formats/src/xdrfile.c
+++ b/package/MDAnalysis/lib/formats/src/xdrfile.c
@@ -45,6 +45,7 @@
 #endif
 
 #include <sys/types.h>
+#define _FILE_OFFSET_BITS 64
 
 #ifdef _WIN32
 #  include <io.h>
@@ -2518,8 +2519,8 @@ static int xdrstdio_getlong (XDR *, int32_t *);
 static int xdrstdio_putlong (XDR *, int32_t *);
 static int xdrstdio_getbytes (XDR *, char *, unsigned int);
 static int xdrstdio_putbytes (XDR *, char *, unsigned int);
-static off_t xdrstdio_getpos (XDR *);
-static int xdrstdio_setpos (XDR *, off_t, int);
+static int64_t xdrstdio_getpos (XDR *);
+static int xdrstdio_setpos (XDR *, int64_t, int);
 static void xdrstdio_destroy (XDR *);
 
 /*
@@ -2601,7 +2602,7 @@ xdrstdio_putbytes (XDR *xdrs, char *addr, unsigned int len)
 }
 
 
-static off_t
+static int64_t
 xdrstdio_getpos (XDR *xdrs)
 {
     #ifdef _WIN32
@@ -2612,7 +2613,7 @@ xdrstdio_getpos (XDR *xdrs)
 }
 
 static int
-xdrstdio_setpos (XDR *xdrs, off_t pos, int whence)
+xdrstdio_setpos (XDR *xdrs, int64_t pos, int whence)
 {
     /* A reason for failure can be filesystem limits on allocation units,
      * before the actual off_t overflow (ext3, with a 4K clustersize,
@@ -2640,7 +2641,7 @@ int xdr_seek(XDRFILE *xd, int64_t pos, int whence)
 /* Seeks to position in file */
 {
     int result;
-    if ((result = xdrstdio_setpos(xd->xdr, (off_t) pos, whence)) != 0)
+    if ((result = xdrstdio_setpos(xd->xdr, (int64_t) pos, whence)) != 0)
         return result;
 
     return exdrOK;


### PR DESCRIPTION
* Fixes Issue #2021 with Windows xdr large file
offset handling; should reduce appveyor failure
count from `13` -> `11` if no new issues
recently introduced in dev branch

* on the Windows platform xdr file offsets are now
forced to use a 64-bit storage type so that, for example,
file seeks beyond 4 GB are correctly reported

Fixes #2021 

There may be a better way to do this but `off64_t` wasn't being recognized on my Windows box despite including the type headers. 