### PR TITLE
Use stricter type for pkdtree indices

### DIFF
--- a/package/MDAnalysis/lib/pkdtree.py
+++ b/package/MDAnalysis/lib/pkdtree.py
@@ -192,7 +192,7 @@ class PeriodicKDTree(object):
                                                       radius))
             self._indices = np.array(list(
                                      itertools.chain.from_iterable(indices)),
-                                     dtype=np.int)
+                                     dtype=np.int64)
         self._indices = np.asarray(unique_int_1d(self._indices))
         return self._indices
 


### PR DESCRIPTION
Using consistently np.int64 for the indices used in pkdtree avoids type
errors when using unique_int_1d. This should reduce the number of
failing tests on windows.


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
