### PR TITLE
BUG: improve Windows PDB file handling

### DIFF
--- a/package/MDAnalysis/coordinates/PDB.py
+++ b/package/MDAnalysis/coordinates/PDB.py
@@ -316,6 +316,11 @@ class PDBReader(base.ReaderBase):
             models.append(0)
         if len(crysts) == len(models):
             offsets = [min(a, b) for a, b in zip(models, crysts)]
+            if len(offsets) == 1 and offsets[0] < 0:
+                    err_msg = '''This should ONLY happen on
+                                 Windows; see PR#2034.'''
+                    assert os.name == 'nt', err_msg
+                    offsets[0] = 0
         else:
             offsets = models
         # Position of the start of each frame

--- a/testsuite/MDAnalysisTests/core/test_atomselections.py
+++ b/testsuite/MDAnalysisTests/core/test_atomselections.py
@@ -344,9 +344,6 @@ class TestSelectionsAMBER(object):
         assert_equal(sel.names, ['HH31', 'HH32', 'HH33', 'HB1', 'HB2', 'HB3'])
 
 
-@pytest.mark.xfail(os.name == 'nt',
-                   strict=True,
-                   reason="Not supported on Windows yet.")
 class TestSelectionsNAMD(object):
     @pytest.fixture()
     def universe(self):

--- a/testsuite/MDAnalysisTests/utils/test_modelling.py
+++ b/testsuite/MDAnalysisTests/utils/test_modelling.py
@@ -141,9 +141,6 @@ def u_water():
 
 
 class TestMerge(object):
-    @pytest.mark.xfail(os.name == 'nt',
-                       strict=True,
-                       reason="Setup fixtures fail on Windows.")
     def test_merge(self, u_protein, u_ligand, u_water, tmpdir):
         ids_before = [a.index for u in [u_protein, u_ligand, u_water] for a in u.atoms]
         # Do the merge
@@ -182,26 +179,17 @@ class TestMerge(object):
         ids_new2 = [a.index for a in u.atoms]
         assert_equal(ids_new, ids_new2)
 
-    @pytest.mark.xfail(os.name == 'nt',
-                       strict=True,
-                       reason="Setup fixtures fail on Windows.")
     def test_merge_same_universe(self, u_protein):
         u0 = MDAnalysis.Merge(u_protein.atoms, u_protein.atoms, u_protein.atoms)
         assert_equal(len(u0.atoms), 3 * len(u_protein.atoms))
         assert_equal(len(u0.residues), 3 * len(u_protein.residues))
         assert_equal(len(u0.segments), 3 * len(u_protein.segments))
 
-    @pytest.mark.xfail(os.name == 'nt',
-                       strict=True,
-                       reason="Setup fixtures fail on Windows.")
     def test_residue_references(self, u_protein, u_ligand):
         m = Merge(u_protein.atoms, u_ligand.atoms)
         assert_equal(m.atoms.residues[0].universe, m,
                      "wrong universe reference for residues after Merge()")
 
-    @pytest.mark.xfail(os.name == 'nt',
-                       strict=True,
-                       reason="Setup fixtures fail on Windows.")
     def test_segment_references(self, u_protein, u_ligand):
         m = Merge(u_protein.atoms, u_ligand.atoms)
         assert_equal(m.atoms.segments[0].universe, m,
@@ -215,9 +203,6 @@ class TestMerge(object):
         with pytest.raises(TypeError):
             Merge(['1', 2])
 
-    @pytest.mark.xfail(os.name == 'nt',
-                       strict=True,
-                       reason="Setup fixtures fail on Windows.")
     def test_emptyAG_ValueError(self, u_protein):
         a = AtomGroup([], u_protein)
         b = AtomGroup([], u_protein)
@@ -251,9 +236,6 @@ class TestMergeTopology(object):
         # One of these bonds isn't in the merged Universe
         assert(len(ag2[0].bonds) - 1 == len(u_merge.atoms[20].bonds))
 
-    @pytest.mark.xfail(os.name == 'nt',
-                       strict=True,
-                       reason="Setup fixtures fail on Windows.")
     def test_merge_with_topology_from_different_universes(self, u, u_ligand):
         u_merge = MDAnalysis.Merge(u.atoms[:110], u_ligand.atoms)
 


### PR DESCRIPTION
* patch Windows file PDB handling behavior
such that 9 unit tests that were either
failing or erroring (currently xfailed
for Windows) now pass

* this should reduce appveyor
xfails from `21` to `12`, with no
errors or real failures

* I'm admittedly a little uncomfortable
with all the tweaks needed for PDB
file handling on Windows, but the seeking
around really isn't that portable as
previously discussed; my main concern
is that I'm micro-adjusting such
that unit tests pass--hopefully our tests
are sufficiently diverse that I can't
overspecialize the windows handling
such that it works on our tests
but not in the wild
