### PR TITLE
Uses faster distance evaluations in Individual methods in Capped Function

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -24,9 +24,9 @@ Enhancements
   * Added return_distances argument in lib.distances.capped_distances
     to evaluate and return distances only when required. Modified
     the optimization rules in lib.distances._determine_method for
-    faster computations.
+    faster computations. (PR #2041)
   * Added method search_tree in lib.pkdtree to find all the pairs between
-    two kdtrees.
+    two kdtrees. (PR #2041)
   * Added a wrapper of lib.nsgrid in lib.distances.self_capped_distance
     and lib.distances.capped_distanceto automatically chose the fastest
     method for distance based calculations. (PR #2008)  

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -21,6 +21,12 @@ The rules for this file:
 
 Enhancements
 
+  * Added return_distances argument in lib.distances.capped_distances
+    to evaluate and return distances only when required. Modified
+    the optimization rules in lib.distances._determine_method for
+    faster computations.
+  * Added method search_tree in lib.pkdtree to find all the pairs between
+    two kdtrees.
   * Added a wrapper of lib.nsgrid in lib.distances.self_capped_distance
     and lib.distances.capped_distanceto automatically chose the fastest
     method for distance based calculations. (PR #2008)  

--- a/package/MDAnalysis/lib/distances.py
+++ b/package/MDAnalysis/lib/distances.py
@@ -557,7 +557,7 @@ def _determine_method(reference, configuration, max_cutoff, min_cutoff=None,
         else:
             tribox = triclinic_vectors(box)
             size = tribox.max(axis=0) - tribox.min(axis=0)
-        if np.any(max_cutoff > 0.2*size):
+        if np.any(max_cutoff > 0.3*size):
             return methods['bruteforce']
         else:
             return methods['nsgrid']

--- a/package/MDAnalysis/lib/distances.py
+++ b/package/MDAnalysis/lib/distances.py
@@ -541,7 +541,7 @@ def _determine_method(reference, configuration, max_cutoff, min_cutoff=None,
 
     if len(reference) < 10 or len(configuration) < 10:
         return methods['bruteforce']
-    elif len(reference)*len(configuration) > 1e7:
+    elif len(reference)*len(configuration) > 1e8:
         # CAUTION : for large datasets, shouldnt go into 'bruteforce'
         # in any case. Arbitrary number, but can be characterized
         return methods['nsgrid']

--- a/package/MDAnalysis/lib/distances.py
+++ b/package/MDAnalysis/lib/distances.py
@@ -541,6 +541,10 @@ def _determine_method(reference, configuration, max_cutoff, min_cutoff=None,
 
     if len(reference) < 10 or len(configuration) < 10:
         return methods['bruteforce']
+    elif len(reference)*len(configuration) > 1e7:
+        # CAUTION : for large datasets, shouldnt go into 'bruteforce'
+        # in any case. Arbitrary number, but can be characterized
+        return methods['nsgrid']
     else:
         if box is None:
             min_dim = np.array([reference.min(axis=0),

--- a/package/MDAnalysis/lib/distances.py
+++ b/package/MDAnalysis/lib/distances.py
@@ -541,7 +541,7 @@ def _determine_method(reference, configuration, max_cutoff, min_cutoff=None,
 
     if len(reference) < 10 or len(configuration) < 10:
         return methods['bruteforce']
-    elif len(reference)*len(configuration) > 1e8:
+    elif len(reference)*len(configuration) >= 1e8:
         # CAUTION : for large datasets, shouldnt go into 'bruteforce'
         # in any case. Arbitrary number, but can be characterized
         return methods['nsgrid']

--- a/package/MDAnalysis/lib/pkdtree.py
+++ b/package/MDAnalysis/lib/pkdtree.py
@@ -117,7 +117,6 @@ class PeriodicKDTree(object):
         --------
         MDAnalysis.lib._augment.augment_coordinates
 
-
         """
         # If no cutoff distance is provided but PBC aware
         if self.pbc and (cutoff is None):
@@ -242,6 +241,13 @@ class PeriodicKDTree(object):
         Searches all the pairs within radius between ``centers``
         and ``coords``
 
+        ``coords`` are the already initialized coordinates in the tree
+        during ``set_coords(coords, cutoff)``.
+         ``centers`` are wrapped around the primary unit cell
+        if PBC is desired. Minimum image convention (PBC) is
+        activated if ``box`` argument is provided during
+        class initialization
+
         Parameters
         ----------
         centers: array_like (N,3)
@@ -253,6 +259,12 @@ class PeriodicKDTree(object):
         -------
         pairs : array
           all the pairs between ``coords`` and ``centers``
+
+        Note
+        ----
+        This method constructs another tree from the ``centers``
+        and queries the previously built tree (Built in
+        ``PeriodicKDTree.set_coords(...)``)
         """
 
         if not self._built:

--- a/testsuite/MDAnalysisTests/lib/test_distances.py
+++ b/testsuite/MDAnalysisTests/lib/test_distances.py
@@ -195,8 +195,8 @@ def test_method_selfselection(box, npoints, cutoff, meth):
                          [(1, 0.02, '_bruteforce_capped'),
                           (1, 0.2, '_bruteforce_capped'),
                           (200, 0.02, '_nsgrid_capped'),
-                          (200, 0.3, '_bruteforce_capped'),
-                          (10000, 0.3, '_nsgrid_capped')])
+                          (200, 0.35, '_bruteforce_capped'),
+                          (10000, 0.35, '_nsgrid_capped')])
 def test_method_selection(box, npoints, cutoff, meth):
     np.random.seed(90003)
     points = (np.random.uniform(low=0, high=1.0,

--- a/testsuite/MDAnalysisTests/lib/test_distances.py
+++ b/testsuite/MDAnalysisTests/lib/test_distances.py
@@ -142,7 +142,6 @@ def test_capped_distance_return(npoints, box, query, method, min_cutoff):
     assert_equal(np.sort(found_pairs, axis=0), np.sort(indices[1], axis=0))
 
 
-
 @pytest.mark.parametrize('npoints', npoints_1)
 @pytest.mark.parametrize('box', boxes_1)
 @pytest.mark.parametrize('method', method_1)
@@ -196,7 +195,7 @@ def test_method_selfselection(box, npoints, cutoff, meth):
                          [(1, 0.02, '_bruteforce_capped'),
                           (1, 0.2, '_bruteforce_capped'),
                           (200, 0.02, '_nsgrid_capped'),
-                          (200, 0.2, '_nsgrid_capped')])
+                          (200, 0.3, '_bruteforce_capped')])
 def test_method_selection(box, npoints, cutoff, meth):
     np.random.seed(90003)
     points = (np.random.uniform(low=0, high=1.0,

--- a/testsuite/MDAnalysisTests/lib/test_distances.py
+++ b/testsuite/MDAnalysisTests/lib/test_distances.py
@@ -195,7 +195,8 @@ def test_method_selfselection(box, npoints, cutoff, meth):
                          [(1, 0.02, '_bruteforce_capped'),
                           (1, 0.2, '_bruteforce_capped'),
                           (200, 0.02, '_nsgrid_capped'),
-                          (200, 0.3, '_bruteforce_capped')])
+                          (200, 0.3, '_bruteforce_capped'),
+                          (10000, 0.3, '_nsgrid_capped')])
 def test_method_selection(box, npoints, cutoff, meth):
     np.random.seed(90003)
     points = (np.random.uniform(low=0, high=1.0,

--- a/testsuite/MDAnalysisTests/lib/test_distances.py
+++ b/testsuite/MDAnalysisTests/lib/test_distances.py
@@ -103,6 +103,46 @@ def test_capped_distance_checkbrute(npoints, box, query, method, min_cutoff):
 
     assert_equal(np.sort(found_pairs, axis=0), np.sort(indices[1], axis=0))
 
+# for coverage
+@pytest.mark.parametrize('npoints', npoints_1)
+@pytest.mark.parametrize('box', boxes_1)
+@pytest.mark.parametrize('query', query_1)
+@pytest.mark.parametrize('method', method_1)
+@pytest.mark.parametrize('min_cutoff', min_cutoff_1)
+def test_capped_distance_return(npoints, box, query, method, min_cutoff):
+    np.random.seed(90003)
+    points = (np.random.uniform(low=0, high=1.0,
+                        size=(npoints, 3))*(boxes_1[0][:3])).astype(np.float32)
+    max_cutoff = 0.3
+    # capped distance should be able to handle array of vectors
+    # as well as single vectors.
+    pairs = mda.lib.distances.capped_distance(query,
+                                                    points,
+                                                    max_cutoff,
+                                                    min_cutoff=min_cutoff,
+                                                    box=box,
+                                                    method=method,
+                                                    return_distances=False)
+
+    if pairs.shape != (0, ):
+        found_pairs = pairs[:, 1]
+    else:
+        found_pairs = list()
+
+    if(query.shape[0] == 3):
+        query = query.reshape((1, 3))
+
+    distances = mda.lib.distances.distance_array(query,
+                                                 points, box=box)
+
+    if min_cutoff is None:
+        min_cutoff = 0.
+    indices = np.where((distances < max_cutoff) & (distances > min_cutoff))
+
+    assert_equal(np.sort(found_pairs, axis=0), np.sort(indices[1], axis=0))
+
+
+
 @pytest.mark.parametrize('npoints', npoints_1)
 @pytest.mark.parametrize('box', boxes_1)
 @pytest.mark.parametrize('method', method_1)
@@ -139,10 +179,8 @@ def test_self_capped_distance(npoints, box, method, min_cutoff):
 @pytest.mark.parametrize('npoints,cutoff,meth',
                          [(1, 0.02, '_bruteforce_capped_self'),
                           (1, 0.2, '_bruteforce_capped_self'),
-                          (6000, 0.02, '_pkdtree_capped_self'),
-                          (6000, 0.2, '_pkdtree_capped_self'),
-                          (200000, 0.02, '_pkdtree_capped_self'),
-                          (200000, 0.2, '_bruteforce_capped_self')])
+                          (600, 0.02, '_pkdtree_capped_self'),
+                          (600, 0.2, '_nsgrid_capped_self')])
 def test_method_selfselection(box, npoints, cutoff, meth):
     np.random.seed(90003)
     points = (np.random.uniform(low=0, high=1.0,
@@ -157,10 +195,8 @@ def test_method_selfselection(box, npoints, cutoff, meth):
 @pytest.mark.parametrize('npoints,cutoff,meth',
                          [(1, 0.02, '_bruteforce_capped'),
                           (1, 0.2, '_bruteforce_capped'),
-                          (6000, 0.02, '_pkdtree_capped'),
-                          (6000, 0.2, '_pkdtree_capped'),
-                          (200000, 0.02, '_pkdtree_capped'),
-                          (200000, 0.2, '_bruteforce_capped')])
+                          (200, 0.02, '_nsgrid_capped'),
+                          (200, 0.2, '_nsgrid_capped')])
 def test_method_selection(box, npoints, cutoff, meth):
     np.random.seed(90003)
     points = (np.random.uniform(low=0, high=1.0,

--- a/testsuite/MDAnalysisTests/lib/test_pkdtree.py
+++ b/testsuite/MDAnalysisTests/lib/test_pkdtree.py
@@ -127,3 +127,27 @@ def test_ckd_searchpairs_nopbc(radius, result):
     tree.set_coords(coords)
     indices = tree.search_pairs(radius)
     assert_equal(indices, result)
+
+
+@pytest.mark.parametrize('b, q, result', (
+                         ([10, 10, 10, 90, 90, 90], [0.5, -0.1, 1.1], []),
+                         ([10, 10, 10, 90, 90, 90], [2.1, -3.1, 0.1], [[0, 2],
+                                                                       [0, 3],
+                                                                       [0, 4]]),
+                         ([10, 10, 10, 90, 90, 90], [[2.1, -3.1, 0.1],
+                                                     [0.5, 0.5, 0.5]], [[0, 2],
+                                                                        [0, 3],
+                                                                        [0, 4],
+                                                                        [1, 1]]),
+                         ([10, 10, 10, 45, 60, 90], [2.1, -3.1, 0.1], [[0, 2],
+                                                                       [0, 3]])
+                         ))
+def test_searchtree(b, q, result):
+    b = np.array(b, dtype=np.float32)
+    cutoff = 3.0
+    coords = transform_StoR(f_dataset, b)
+    q = transform_StoR(np.array(q, dtype=np.float32), b)
+    tree = PeriodicKDTree(box=b)
+    tree.set_coords(coords, cutoff=cutoff)
+    pairs = tree.search_tree(q, cutoff)
+    assert_equal(pairs, result)

--- a/testsuite/MDAnalysisTests/lib/test_pkdtree.py
+++ b/testsuite/MDAnalysisTests/lib/test_pkdtree.py
@@ -119,6 +119,7 @@ def test_searchpairs(b, radius, result):
         indices = tree.search_pairs(radius)
         assert_equal(len(indices), len(result))
 
+
 @pytest.mark.parametrize('radius, result', ((0.1, []),
                                             (0.3, [[0, 2]])))
 def test_ckd_searchpairs_nopbc(radius, result):


### PR DESCRIPTION
Hi, So earlier the methods were written to handle large data sets, for instance loop over every coordinate in ``distance_array``, which is not very pythonic as well as looping over numpy array is also not a good idea if the main motive is to increase the performance. Now that we have the framework in place, and since other methods are better after a certain size of data (which is easily handled by sparse matrix), it is better to switch to populating the full ``MXN`` matrix without worrying about the memory constraints. 

Changes made in this Pull Request:
 - Modified _bruteforce_capped, _pkdtree_capped, _bruteforce_capped_self for faster distance evaluations
- Added keyword ``return_distances`` in capped_function which calculates distance between pairs only when it is desired (therefore decreasing the number of computations where we are concerned only with indices)
- Added ``search_tree`` method in lib.pkdtree which directly gives the pairs between a query and search dataset (and is faster than searching over every indices) 


PR Checklist
------------
 - [x ] Tests?
 - [x ] Docs?
 - [x ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
