### PR TITLE
TST: add codecov to appveyor CI run

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -48,7 +48,7 @@ install:
     # see: https://github.com/swistakm/pyimgui/blob/master/.appveyor.yml
     - cp "c:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\include\stdint.h" "C:\Users\appveyor\AppData\Local\Programs\Common\Microsoft\Visual C++ for Python\9.0\VC\include\stdint.h"
     - ps: conda config --append channels conda-forge
-    - ps: conda create -n testing python=$env:PYTHON_VERSION pip setuptools wheel cython mock six biopython networkx joblib matplotlib scipy vs2015_runtime pytest mmtf-python GridDataFormats hypothesis
+    - ps: conda create -n testing python=$env:PYTHON_VERSION pip setuptools wheel cython mock six biopython networkx joblib matplotlib scipy vs2015_runtime pytest mmtf-python GridDataFormats hypothesis pytest-cov codecov
     - cmd: C:\conda\envs\testing\Scripts\pip.exe install gsd==1.5.2 duecredit
     - cmd: C:\conda\envs\testing\Scripts\activate testing
 
@@ -60,7 +60,8 @@ test_script:
     - cmd: cd ..\testsuite
     - cmd: C:\conda\envs\testing\python.exe setup.py develop --no-deps --user 3>&1
     - cmd: cd MDAnalysisTests
-    - cmd: C:\conda\envs\testing\Scripts\pytest.exe --disable-pytest-warnings 3>&1
+    - cmd: C:\conda\envs\testing\Scripts\pytest.exe --cov=MDAnalysis --disable-pytest-warnings 3>&1
+    - cmd: codecov
 
 after_build:
     # cache cleanup


### PR DESCRIPTION
Fixes #2037.

I tried to do something similar to the codecov reporting we do with Travis; the idea is to explore code paths that may be unique to  Windows for test reports -- see, for example #2034, where CI fails because we don't flush through the windows code paths with codecov yet.

This may take a few iterations  to get right with the CI I suppose.

I think the preferred way to invoke codecov is actually a little different form this now, but I figured I may as well just do what we do on Travis & see if that works.