### PR TITLE
Benchmarks for Topology.guess_bonds

### DIFF
--- a/benchmarks/benchmarks/ag_methods.py
+++ b/benchmarks/benchmarks/ag_methods.py
@@ -24,8 +24,11 @@ class AtomGroupMethodsBench(object):
         self.u = MDAnalysis.Universe(GRO)
         self.ag = self.u.atoms[:num_atoms]
         self.weights = np.ones(num_atoms)
-        self.vdwradii = {'NA':1.0,
-                         'M':1.0}
+        self.vdwradii = {'H':1.0,
+                         'C':1.0,
+                         'N':1.0,
+                         'O':1.0,
+                         'DUMMY':1.0}
         self.rot_matrix = np.ones((3,3))
         self.trans = np.ones((4,4))
 

--- a/benchmarks/benchmarks/topology.py
+++ b/benchmarks/benchmarks/topology.py
@@ -1,0 +1,32 @@
+import MDAnalysis
+import numpy as np
+from MDAnalysis.topology import guessers
+
+try:
+    from MDAnalysisTests.datafiles import GRO
+    from MDAnalysis.exceptions import NoDataError
+except:
+    pass
+
+class TopologyGuessBench(object):
+    """Benchmarks for individual
+    topology functions
+    """
+    params = (10, 100, 1000, 10000)
+    param_names = ['num_atoms']
+    
+    def setup(self, num_atoms):
+        self.u = MDAnalysis.Universe(GRO)
+        self.ag = self.u.atoms[:num_atoms]
+        self.vdwradii = {'H':1.0,
+                         'C':1.0,
+                         'N':1.0,
+                         'O':1.0,
+                         'DUMMY':1.0}
+
+    def time_guessbonds(self, num_atoms):
+        """Benchmark for guessing bonds"""
+        guessers.guess_bonds(self.ag, self.ag.positions,
+                             box=self.ag.dimensions,
+                             vdwradii=self.vdwradii)
+


### PR DESCRIPTION
So I noticed benchmark in ag_methods for guess_bonds was failing due to definition of vdwradii. Also the method guess_bonds in atomgroup evaluates bonds, angles and dihedrals in a single function. I think it would be better if individual functions can be benchmarked, which would give more access to which functions need special attention. In this regard, I added a topology.py, which should be filled with other functions in topology folder.

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
