### PR TITLE
tests and updated docs for analysis.data

### DIFF
--- a/package/MDAnalysis/analysis/data/filenames.py
+++ b/package/MDAnalysis/analysis/data/filenames.py
@@ -19,8 +19,7 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-"""
-Analysis data files
+"""Analysis data files
 ===================
 
 :mod:`MDAnalysis.analysis.data` contains data files that are used as part of
@@ -37,11 +36,38 @@ Data files
 
    Reference Ramachandran histogram for :class:`MDAnalysis.analysis.dihedrals.Ramachandran`.
    The data were calculated on a data set of 500 PDB structures taken from [Lovell2003]_.
+   This is a numpy array in the :math:`\phi` and :math:`psi` backbone dihedral angles.
+
+   Load and plot it with ::
+
+      import numpy as np
+      import matplotlib.pyplot as plt
+      from MDAnalysis.analysis.data.filenames import Rama_ref
+      X, Y = np.meshgrid(np.arange(-180, 180, 4), np.arange(-180, 180, 4))
+      Z = np.load(Rama_ref)
+      ax.contourf(X, Y, Z, levels=[1, 17, 15000])
+
+   The given levels will draw contours that contain 90% and 99% of the data
+   points. See the :ref:`Ramachandran plot figure <figure-ramachandran>` as an
+   example.
 
 .. data:: Janin_ref
 
-   Reference Ramachandran histogram for :class:`MDAnalysis.analysis.dihedrals.Ramachandran`.
+   Reference Janin histogram for :class:`MDAnalysis.analysis.dihedrals.Janin`.
    The data were calculated on a data set of 500 PDB structures taken from [Lovell2003]_.
+   This is a numpy array in the :math:`\chi_1` and :math:`chi_2` sidechain dihedral angles.
+
+   Load and plot it with ::
+
+      import numpy as np
+      import matplotlib.pyplot as plt
+      from MDAnalysis.analysis.data.filenames import Janin_ref
+      X, Y = np.meshgrid(np.arange(-180, 180, 4), np.arange(-180, 180, 4))
+      Z = np.load(Janin_ref)
+      ax.contourf(X, Y, Z, levels=[1, 6, 600])
+
+   The given levels will draw contours that contain 90% and 98% of the
+   data. See the :ref:`Janin plot figure <figure-janin>` as an example.
 
 """
 from __future__ import absolute_import

--- a/testsuite/MDAnalysisTests/analysis/test_data.py
+++ b/testsuite/MDAnalysisTests/analysis/test_data.py
@@ -21,28 +21,12 @@
 #
 from __future__ import absolute_import
 
-import pytest
 from numpy.testing import assert_equal
-
-
-def test_import():
-    try:
-        import MDAnalysis.tests.datafiles
-    except ImportError:
-        pytest.fail("Failed to 'import MDAnalysis.tests.datafiles --- install MDAnalysisTests")
-
+import pytest
 
 def test_all_exports():
-    import MDAnalysisTests.datafiles
-    missing = [name for name in dir(MDAnalysisTests.datafiles)
+    from MDAnalysis.analysis.data import filenames
+    missing = [name for name in dir(filenames)
                if
-               not name.startswith('_') and name not in MDAnalysisTests.datafiles.__all__ and name != 'absolute_import']
+               not name.startswith('_') and name not in filenames.__all__ and name != 'absolute_import']
     assert_equal(missing, [], err_msg="Variables need to be added to __all__.")
-
-
-def test_export_variables():
-    import MDAnalysisTests.datafiles
-    import MDAnalysis.tests.datafiles
-    missing = [name for name in MDAnalysisTests.datafiles.__all__
-               if name not in dir(MDAnalysis.tests.datafiles)]
-    assert_equal(missing, [], err_msg="Variables not exported to MDAnalysis.tests.datafiles")


### PR DESCRIPTION
Updates to the merged PR #2033, which introduced a data section for analysis

- add docs explaining data and showing example use
- simple test for loading all data in analysis.data.filenames (analysis/test_data.py)
- replaced assert_array_equal with assert_equal in utils/test_datafiles.py, which I used
  as a template


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
