### PR TITLE
Simplified code in `lib.distances` a bit

### DIFF
--- a/package/MDAnalysis/lib/_cutil.pyx
+++ b/package/MDAnalysis/lib/_cutil.pyx
@@ -45,19 +45,20 @@ ctypedef cmap[int, intset] intmap
 @cython.boundscheck(False) # turn off bounds-checking for entire function
 @cython.wraparound(False)  # turn off negative index wrapping for entire function
 def unique_int_1d(np.int64_t[:] values):
-    """
-    Find the unique elements of a 1D array of integers.
+    """Find the unique elements of a 1D array of integers.
 
     This function is optimal on sorted arrays.
 
     Parameters
     ----------
-    values: np.ndarray of type int64
-        1D array of int in which to find the unique values.
+    values: numpy.ndarray
+        1D array of dtype ``numpy.int64`` in which to find the unique values.
 
     Returns
     -------
-    np.ndarray
+    numpy.ndarray
+        A deduplicated copy of `values`.
+
 
     .. versionadded:: 0.19.0
     """

--- a/package/MDAnalysis/lib/distances.py
+++ b/package/MDAnalysis/lib/distances.py
@@ -213,7 +213,7 @@ def _check_result_array(result, shape):
         raise ValueError("Result array has incorrect shape, should be {0}, got "
                          "{1}.".format(shape, result.shape))
     if result.dtype != np.float64:
-        raise TypeError("Result array must be of type numpy.float64, got {}"
+        raise TypeError("Result array must be of type numpy.float64, got {}."
                         "".format(result.dtype))
 # The following two lines would break a lot of tests. WHY?!
 #    if not coords.flags['C_CONTIGUOUS']:

--- a/package/MDAnalysis/lib/distances.py
+++ b/package/MDAnalysis/lib/distances.py
@@ -167,7 +167,7 @@ def _check_box(box):
          dtype ``numpy.float32``.
        * Now also returns the box in the format expected by low-level functions
          in :mod:`~MDAnalysis.lib.c_distances`.
-       * Removed obsolete `boxtype` ``tri_vecs_bad``.
+       * Removed obsolete box types ``tri_box`` and ``tri_vecs_bad``.
     """
     if box.dtype != np.float32:
         raise TypeError("Invalid box dtype. Must be numpy.float32, got {0}."
@@ -182,9 +182,9 @@ def _check_box(box):
     elif box.shape == (3, 3):
         # Check if triclinic box vectors are properly formatted:
         if np.all([box[0][1] == 0.0, box[0][2] == 0.0, box[1][2] == 0.0]):
-            return 'tri_box', box
+            return 'tri_vecs', box
         else:
-            return 'tri_box', triclinic_vectors(triclinic_box(box[0], box[1],
+            return 'tri_vecs', triclinic_vectors(triclinic_box(box[0], box[1],
                                                               box[2]))
     raise ValueError("Box input not recognized, must be an array of box "
                      "dimensions.")

--- a/package/MDAnalysis/lib/nsgrid.pyx
+++ b/package/MDAnalysis/lib/nsgrid.pyx
@@ -72,7 +72,7 @@ not reflect in the results.
 .. versionadded:: 0.19.0
 """
 
-from MDAnalysis.lib.distances import _check_array
+from MDAnalysis.lib.distances import _check_coord_array
 # Used to handle memory allocation
 from cpython.mem cimport PyMem_Malloc, PyMem_Realloc, PyMem_Free
 from libc.math cimport sqrt
@@ -767,7 +767,7 @@ cdef class FastNS(object):
         from MDAnalysis.lib.mdamath import triclinic_vectors
 
 
-        _check_array(coords, 'coords')
+        _check_coord_array(coords, 'coords')
 
         if np.allclose(box[:3], 0.0):
             raise ValueError("Any of the box dimensions cannot be 0")
@@ -850,7 +850,7 @@ cdef class FastNS(object):
 
         cdef real cutoff2 = self.cutoff * self.cutoff
         cdef ns_int npairs = 0
-        _check_array(search_coords, 'search_coords')
+        _check_coord_array(search_coords, 'search_coords')
 
         # Generate another grid to search
         searchcoords = np.ascontiguousarray(search_coords, dtype=np.float32)

--- a/package/MDAnalysis/lib/nsgrid.pyx
+++ b/package/MDAnalysis/lib/nsgrid.pyx
@@ -72,7 +72,6 @@ not reflect in the results.
 .. versionadded:: 0.19.0
 """
 
-from MDAnalysis.lib.distances import _check_coord_array
 # Used to handle memory allocation
 from cpython.mem cimport PyMem_Malloc, PyMem_Realloc, PyMem_Free
 from libc.math cimport sqrt
@@ -766,14 +765,15 @@ cdef class FastNS(object):
 
         from MDAnalysis.lib.mdamath import triclinic_vectors
 
-
-        _check_coord_array(coords, 'coords')
+        if (coords.ndim != 2 or coords.shape[1] != 3):
+            raise ValueError("coords must have a shape of (n, 3), got {}."
+                             "".format(coords.shape))
 
         if np.allclose(box[:3], 0.0):
             raise ValueError("Any of the box dimensions cannot be 0")
 
         self.periodic = pbc
-        self.coords = coords.copy()
+        self.coords = coords.astype(np.float32, order='C', copy=True)
 
         if box.shape != (3, 3):
             box = triclinic_vectors(box)
@@ -850,10 +850,13 @@ cdef class FastNS(object):
 
         cdef real cutoff2 = self.cutoff * self.cutoff
         cdef ns_int npairs = 0
-        _check_coord_array(search_coords, 'search_coords')
+
+        if (search_coords.ndim != 2 or search_coords.shape[1] != 3):
+            raise ValueError("search_coords must have a shape of (n, 3), got "
+                             "{}.".format(search_coords.shape))
 
         # Generate another grid to search
-        searchcoords = np.ascontiguousarray(search_coords, dtype=np.float32)
+        searchcoords = search_coords.astype(np.float32, order='C', copy=False)
         searchcoords_bbox = self.box.fast_put_atoms_in_bbox(searchcoords)
         searchgrid = NSGrid(searchcoords_bbox.shape[0], self.grid.cutoff, self.box, self.max_gridsize, force=True)
         searchgrid.fill_grid(searchcoords_bbox)

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -109,7 +109,7 @@ Containers and lists
 .. autofunction:: asiterable
 .. autofunction:: hasmethod
 .. autoclass:: Namespace
-.. autofunction:: unique_int_1d
+.. autofunction:: unique_int_1d(values)
 
 File parsing
 ------------
@@ -117,7 +117,6 @@ File parsing
 .. autoclass:: FORTRANReader
    :members:
 .. autodata:: FORTRAN_format_regex
-
 
 Data manipulation and handling
 ------------------------------
@@ -132,13 +131,10 @@ Strings
 .. autofunction:: parse_residue
 .. autofunction:: conv_float
 
-
 Class decorators
 ----------------
 
 .. autofunction:: cached
-
-
 
 Function decorators
 -------------------
@@ -146,7 +142,6 @@ Function decorators
 .. autofunction:: static_variables
 .. autofunction:: warn_if_not_unique
 .. autofunction:: check_coords
-
 
 Code management
 ---------------
@@ -167,8 +162,6 @@ Code management
    order to make :meth:`NamedStream.close` actually close the
    underlying stream and ``NamedStream.close(force=True)`` will also
    close it.
-
-
 """
 from __future__ import division, absolute_import
 import six
@@ -1585,28 +1578,29 @@ def unique_rows(arr, return_index=False):
 
 
 def blocks_of(a, n, m):
-    """Extract a view of (n, m) blocks along the diagonal of the array `a`
+    """Extract a view of ``(n, m)`` blocks along the diagonal of the array `a`.
 
     Parameters
     ----------
-    a : array_like
-        starting array
+    a : numpy.ndarray
+        Input array, must be C contiguous and at least 2D.
     n : int
-        size of block in first dimension
+        Size of block in first dimension.
     m : int
-        size of block in second dimension
+        Size of block in second dimension.
 
     Returns
     -------
-    (nblocks, n, m) : tuple
-          view of the original array, where nblocks is the number of times the
-          miniblock fits in the original.
+    view : numpy.ndarray
+        A view of the original array with shape ``(nblocks, n, m)``, where
+        ``nblocks`` is the number of times the miniblocks of shape ``(n, m)``
+        fit in the original.
 
     Raises
     ------
     ValueError
         If the supplied `n` and `m` don't divide `a` into an integer number
-        of blocks.
+        of blocks or if `a` is not C contiguous.
 
     Examples
     --------
@@ -1621,9 +1615,11 @@ def blocks_of(a, n, m):
 
     Notes
     -----
-    n, m must divide a into an identical integer number of blocks.
+    `n`, `m` must divide `a` into an identical integer number of blocks. Please
+    note that if the block size is larger than the input array, this number will
+    be zero, resulting in an empty view!
 
-    Uses strides so probably requires that the array is C contiguous.
+    Uses strides and therefore requires that the array is C contiguous.
 
     Returns a view, so editing this modifies the original array.
 
@@ -1634,6 +1630,8 @@ def blocks_of(a, n, m):
     # based on:
     # http://stackoverflow.com/a/10862636
     # but generalised to handle non square blocks.
+    if not a.flags['C_CONTIGUOUS']:
+        raise ValueError("Input array is not C contiguous.")
 
     nblocks = a.shape[0] // n
     nblocks2 = a.shape[1] // m
@@ -1795,6 +1793,7 @@ def warn_if_not_unique(groupmethod):
         :class:`~MDAnalysis.core.groups.ResidueGroup`, or
         :class:`~MDAnalysis.core.groups.SegmentGroup` of which the decorated
         method is a member contains duplicates.
+
 
     .. versionadded:: 0.19.0
     """

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -139,6 +139,15 @@ Class decorators
 .. autofunction:: cached
 
 
+
+Function decorators
+-------------------
+
+.. autofunction:: static_variables
+.. autofunction:: warn_if_not_unique
+.. autofunction:: check_coords
+
+
 Code management
 ---------------
 
@@ -1735,11 +1744,11 @@ def static_variables(**kwargs):
     Example
     -------
 
-    >>> @static(msg='foo calls', calls=0)
-    >>> def foo():
-    >>>     foo.calls += 1
-    >>>     print("{}: {}".format(foo.msg, foo.calls))
-    >>>
+    >>> @static_variables(msg='foo calls', calls=0)
+    ... def foo():
+    ...     foo.calls += 1
+    ...     print("{}: {}".format(foo.msg, foo.calls))
+    ...
     >>> foo()
     foo calls: 1
     >>> foo()
@@ -1747,7 +1756,7 @@ def static_variables(**kwargs):
 
 
     .. note:: Based on https://stackoverflow.com/a/279586
-        by user `Claudiu<https://stackoverflow.com/users/15055/claudiu>`
+        by `Claudiu <https://stackoverflow.com/users/15055/claudiu>`_
 
     .. versionadded:: 0.19.0
     """
@@ -1773,11 +1782,19 @@ def static_variables(**kwargs):
 
 @static_variables(warned=False)
 def warn_if_not_unique(groupmethod):
-    """Decorator triggering a :class:`DuplicateWarning` if the underlying group
-    is not unique.
+    """Decorator triggering a :class:`~MDAnalysis.exceptions.DuplicateWarning`
+    if the underlying group is not unique.
 
-    Assures that during execution of the decorated method, only the first of
+    Assures that during execution of the decorated method only the first of
     potentially multiple warnings concerning the uniqueness of groups is shown.
+
+    Raises
+    ------
+    :class:`~MDAnalysis.exceptions.DuplicateWarning`
+        If the :class:`~MDAnalysis.core.groups.AtomGroup`,
+        :class:`~MDAnalysis.core.groups.ResidueGroup`, or
+        :class:`~MDAnalysis.core.groups.SegmentGroup` of which the decorated
+        method is a member contains duplicates.
 
     .. versionadded:: 0.19.0
     """
@@ -1815,6 +1832,180 @@ def warn_if_not_unique(groupmethod):
             warn_if_not_unique.warned = False
         return result
     return wrapper
+
+
+def check_coords(*coord_names, **options):
+    """Decorator for automated coordinate array checking.
+
+    This decorator is intended for use especially in
+    :mod:`MDAnalysis.lib.distances`.
+    It takes an arbitrary number of positional arguments which must correspond
+    to names of positional arguments of the decorated function.
+    It then checks if the corresponding values are valid coordinate arrays.
+    If all these arrays are single coordinates (i.e., their shape is ``(3,)``),
+    the decorated function can optionally return a single coordinate (or angle)
+    instead of an array of coordinates (or angles). This can be used to enable
+    computations of single observables using functions originally designed to
+    accept only 2-d coordinate arrays.
+
+    The checks performed on each individual coordinate array are:
+
+    * Check that coordinate arrays are of type :class:`numpy.ndarray`.
+    * Check that coordinate arrays have a shape of ``(n, 3)`` (or ``(3,)`` if
+      single coordinates are allowed; see keyword argument `allow_single`).
+    * Automatic dtype conversion to ``numpy.float32``.
+    * Optional replacement by a copy; see keyword argument `enforce_copy` .
+    * If coordinate arrays aren't C-contiguous, they will be automatically
+      replaced by a C-contiguous copy.
+    * Optional check for equal length of all coordinate arrays; see optional
+      keyword argument `check_lengths_match`.
+
+    Parameters
+    ----------
+    *coord_names : tuple
+        Arbitrary number of strings corresponding to names of positional
+        arguments of the decorated function.
+    **options : dict, optional
+        * **enforce_copy** (:class:`bool`, optional) -- Enforce working on a
+          copy of the coordinate arrays. This is useful to ensure that the input
+          arrays are left unchanged. Default: ``True``
+        * **allow_single** (:class:`bool`, optional) -- Allow the input
+          coordinate array to be a single coordinate with shape ``(3,)``.
+        * **convert_single** (:class:`bool`, optional) -- If ``True``, single
+          coordinate arrays will be converted to have a shape of ``(1, 3)``.
+          Only has an effect if `allow_single` is ``True``. Default: ``True``
+        * **reduce_result_if_single** (:class:`bool`, optional) -- If ``True``
+          and *all* input coordinates are single, a decorated function ``func``
+          will return ``func()[0]`` instead of ``func()``. Only has an effect if
+          `allow_single` is ``True``. Default: ``True``
+        * **check_lengths_match** (:class:`bool`, optional) -- If ``True``, a
+          :class:`ValueError` is raised if not all coordinate arrays contain the
+          same number of coordinates. Default: ``True``
+
+    Raises
+    ------
+    ValueError
+        If the decorator is used without positional arguments (for development
+        purposes only).
+
+        If any of the positional arguments supplied to the decorator doesn't
+        correspond to a name of any of the decorated function's positional
+        arguments.
+
+        If any of the coordinate arrays has a wrong shape.
+    TypeError
+        If any of the coordinate arrays is not a :class:`numpy.ndarray`.
+
+        If the dtype of any of the coordinate arrays is not convertible to
+          ``numpy.float32``.
+
+    Example
+    -------
+
+    >>> @check_coords('coords1', 'coords2')
+    ... def coordsum(coords1, coords2):
+    ...     assert coords1.dtype == np.float32
+    ...     assert coords2.flags['C_CONTIGUOUS']
+    ...     return coords1 + coords2
+    ...
+    >>> # automatic dtype conversion:
+    >>> coordsum(np.zeros(3, dtype=np.int64), np.ones(3))
+    array([1., 1., 1.], dtype=float32)
+    >>>
+    >>> # automatic handling of non-contiguous arrays:
+    >>> coordsum(np.zeros(3), np.ones(6)[::2])
+    array([1., 1., 1.], dtype=float32)
+    >>>
+    >>> # automatic shape checking:
+    >>> coordsum(np.zeros(3), np.ones(6))
+    ValueError: coordsum(): coords2.shape must be (3,) or (n, 3), got (6,).
+
+
+    .. versionadded:: 0.19.0
+    """
+    enforce_copy = options.get('enforce_copy', True)
+    allow_single = options.get('allow_single', True)
+    convert_single = options.get('convert_single', True)
+    reduce_result_if_single = options.get('reduce_result_if_single', True)
+    check_lengths_match = options.get('check_lengths_match',
+                                     len(coord_names) > 1)
+    if not coord_names:
+        raise ValueError("Decorator check_coords() cannot be used without "
+                         "positional arguments.")
+    def check_coords_decorator(func):
+        fname = func.__name__
+        code = func.__code__
+        ndefaults = len(func.__defaults__) if func.__defaults__ else 0
+        # Create a tuple of positional argument names:
+        nposargs = code.co_argcount - ndefaults
+        posargnames = code.co_varnames[:nposargs]
+        # The check_coords() decorator is designed to work only for positional
+        # arguments:
+        for name in coord_names:
+            if name not in posargnames:
+                raise ValueError("In decorator check_coords(): Name '{}' "
+                                 "doesn't correspond to any positional "
+                                 "argument of the decorated function {}()."
+                                 "".format(name, func.__name__))
+
+        def _check_coords(coords, argname):
+            if not isinstance(coords, np.ndarray):
+                raise TypeError("{}(): Parameter '{}' must be a numpy.ndarray, "
+                                "got {}.".format(fname, argname, type(coords)))
+            is_single = False
+            if allow_single:
+                if (coords.ndim not in (1, 2)) or (coords.shape[-1] != 3):
+                    raise ValueError("{}(): {}.shape must be (3,) or (n, 3), "
+                                     "got {}.".format(fname, argname,
+                                                      coords.shape))
+                if coords.ndim == 1:
+                    is_single = True
+                    if convert_single:
+                        coords = coords[None, :]
+            else:
+                if (coords.ndim != 2) or (coords.shape[1] != 3):
+                    raise ValueError("{}(): {}.shape must be (n, 3), got {}."
+                                     "".format(fname, argname, coords.shape))
+            try:
+                coords = coords.astype(np.float32, order='C', copy=enforce_copy)
+            except ValueError:
+                raise TypeError("{}(): {}.dtype must be convertible to float32,"
+                                " got {}.".format(fname, argname, coords.dtype))
+            return coords, is_single
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            args = list(args)
+            ncoords = []
+            all_single = allow_single
+            for name in coord_names:
+                idx = posargnames.index(name)
+                if idx < len(args):
+                    args[idx], is_single = _check_coords(args[idx], name)
+                    all_single &= is_single
+                    ncoords.append(args[idx].shape[0])
+                else:
+                    try:
+                        kwargs[name], is_single = _check_coords(kwargs[name], name)
+                        all_single &= is_single
+                        ncoords.append(kwargs[name].shape[0])
+                    except KeyError:
+                        # If we end up here, func() has been called with missing
+                        # positional arguments. We don't want to catch that
+                        # error here.
+                        pass
+            if check_lengths_match and ncoords:
+                if ncoords.count(ncoords[0]) != len(ncoords):
+                    raise ValueError("{}(): {} must contain the same number of "
+                                     "coordinates, got {}."
+                                     "".format(fname, ", ".join(coord_names),
+                                               ncoords))
+            # If all input coordinate arrays were 1-d, so should be the output:
+            if all_single and reduce_result_if_single:
+                return func(*args, **kwargs)[0]
+            return func(*args, **kwargs)
+        return wrapper
+    return check_coords_decorator
 
 
 #------------------------------------------------------------------

--- a/testsuite/MDAnalysisTests/analysis/test_distances.py
+++ b/testsuite/MDAnalysisTests/analysis/test_distances.py
@@ -51,7 +51,7 @@ class TestContactMatrix(object):
     @staticmethod
     @pytest.fixture()
     def box():
-        return np.array([10, 10, 10], dtype=np.float32)
+        return np.array([10, 10, 10, 90, 90, 90], dtype=np.float32)
     
     @staticmethod
     @pytest.fixture()

--- a/testsuite/MDAnalysisTests/core/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/core/test_atomgroup.py
@@ -1250,7 +1250,7 @@ class TestAtomGroup(object):
         u.trajectory.rewind()  # just to make sure...
         ag = u.atoms[1000:2000:200]
         # Provide arbitrary box
-        box = np.array([5., 5., 5.], dtype=np.float32)
+        box = np.array([5., 5., 5., 90., 90., 90.], dtype=np.float32)
         # Expected folded coordinates
         packed_coords = np.array([[3.94543672, 2.5939188, 2.73179913],
                                   [3.21632767, 0.879035, 0.32085133],

--- a/testsuite/MDAnalysisTests/lib/test_augment.py
+++ b/testsuite/MDAnalysisTests/lib/test_augment.py
@@ -83,8 +83,8 @@ def test_augment(b, q, res):
         aug = np.sort(aug, axis=0)
     else:
         aug = list()
-    cs = transform_StoR(np.array(res, dtype=np.float32), b)
-    if cs.size > 0:
+    if len(res) > 0:
+        cs = transform_StoR(np.array(res, dtype=np.float32), b)
         cs = np.sort(cs, axis=0)
     else:
         cs = list()

--- a/testsuite/MDAnalysisTests/lib/test_distances.py
+++ b/testsuite/MDAnalysisTests/lib/test_distances.py
@@ -27,6 +27,55 @@ from numpy.testing import assert_equal, assert_almost_equal
 
 import MDAnalysis as mda
 
+
+class TestCheckBox(object):
+
+    prec = 7
+    ref_ortho = np.ones(3, dtype=np.float32)
+    ref_tri_vecs = np.array([[1, 0, 0], [0, 1, 0], [0, 2 ** 0.5, 2 ** 0.5]],
+                            dtype=np.float32)
+
+    @pytest.mark.parametrize('box',
+        (np.ones(3, dtype=np.float32),
+         np.array([1, 1, 1, 90, 90, 90], dtype=np.float32),
+         np.identity(3, dtype=np.float32),
+         np.roll(np.identity(3, dtype=np.float32), 1, axis=0)))
+    def test_ckeck_box_ortho(self, box):
+        boxtype, checked_box = mda.lib.distances._check_box(box)
+        assert boxtype == 'ortho'
+        assert np.all(checked_box == self.ref_ortho)
+        assert checked_box.flags['C_CONTIGUOUS']
+
+    @pytest.mark.parametrize('box',
+         (np.array([1, 1, 2, 45, 90, 90], dtype=np.float32),
+         np.array([[1, 0, 0],
+                   [0, 1, 0],
+                   [0, 2**0.5, 2**0.5]], dtype=np.float32),
+         np.array([[0, 1, 0],
+                   [0, 0, 1],
+                   [2**0.5, 0, 2**0.5]], dtype=np.float32)))
+    def test_check_box_tri_vecs(self, box):
+        boxtype, checked_box = mda.lib.distances._check_box(box)
+        assert boxtype == 'tri_vecs'
+        assert_almost_equal(checked_box, self.ref_tri_vecs, self.prec)
+        assert checked_box.flags['C_CONTIGUOUS']
+
+    def test_check_box_wrong_dtype(self):
+        with pytest.raises(TypeError):
+            wrongbox = np.ones(3, dtype=np.float64)
+            boxtype, checked_box = mda.lib.distances._check_box(wrongbox)
+
+    def test_check_box_wrong_shape(self):
+        with pytest.raises(ValueError):
+            wrongbox = np.ones(5, dtype=np.float32)
+            boxtype, checked_box = mda.lib.distances._check_box(wrongbox)
+
+    def test_check_box_non_congiguous(self):
+        non_cont_box = np.ones(6, dtype=np.float32)[::2]
+        assert not non_cont_box.flags['C_CONTIGUOUS']
+        with pytest.raises(ValueError):
+            boxtype, checked_box = mda.lib.distances._check_box(non_cont_box)
+
 @pytest.mark.parametrize('coord_dtype', (np.float32, np.float64))
 def test_transform_StoR_pass(coord_dtype):
     box = np.array([10, 7, 3, 45, 60, 90], dtype=np.float32)

--- a/testsuite/MDAnalysisTests/lib/test_util.py
+++ b/testsuite/MDAnalysisTests/lib/test_util.py
@@ -970,8 +970,6 @@ class TestBlocksOf(object):
 
         view = util.blocks_of(arr, 1, 1)
 
-        # should return a (4, 1, 1) view
-        # ie 4 lots of 1x1
         assert view.shape == (4, 1, 1)
         assert_array_almost_equal(view,
                                   np.array([[[0]], [[5]], [[10]], [[15]]]))
@@ -990,7 +988,6 @@ class TestBlocksOf(object):
 
         view = util.blocks_of(arr, 2, 2)
 
-        # should return (2, 2, 2)
         assert view.shape == (2, 2, 2)
         assert_array_almost_equal(view, np.array([[[0, 1], [4, 5]],
                                                   [[10, 11], [14, 15]]]))
@@ -1012,10 +1009,20 @@ class TestBlocksOf(object):
 
         assert view.shape == (4, 2, 1)
 
+    def test_blocks_of_4(self):
+        # testing block exceeding array size results in empty view
+        arr = np.arange(4).reshape(2, 2)
+        view = util.blocks_of(arr, 3, 3)
+        assert view.shape == (0, 3, 3)
+        view[:] = 100
+        assert_array_equal(arr, np.arange(4).reshape(2, 2))
+
     def test_blocks_of_ValueError(self):
         arr = np.arange(16).reshape(4, 4)
         with pytest.raises(ValueError):
-            util.blocks_of(arr, 2, 1)
+            util.blocks_of(arr, 2, 1)  # blocks don't fit
+        with pytest.raises(ValueError):
+            util.blocks_of(arr[:, ::2], 2, 1)  # non-contiguous input
 
 
 class TestNamespace(object):

--- a/testsuite/MDAnalysisTests/lib/test_util.py
+++ b/testsuite/MDAnalysisTests/lib/test_util.py
@@ -1521,7 +1521,7 @@ class TestCheckCoords(object):
         # usage with posarg doubly defined:
         assert not func._invalid_call
         with pytest.raises(TypeError):
-            func(0, a=0)
+            func(0, a=0)  # pylint: disable=redundant-keyword-arg
         assert func._invalid_call
         func._invalid_call = False
 
@@ -1549,7 +1549,7 @@ class TestCheckCoords(object):
         # usage with unexpected kwarg:
         assert not func._invalid_call
         with pytest.raises(TypeError):
-            func(a=0, b=0, c=1, d=1)
+            func(a=0, b=0, c=1, d=1)  # pylint: disable=unexpected-keyword-arg
         assert func._invalid_call
         func._invalid_call = False
 

--- a/testsuite/MDAnalysisTests/lib/test_util.py
+++ b/testsuite/MDAnalysisTests/lib/test_util.py
@@ -36,7 +36,8 @@ from numpy.testing import (assert_equal, assert_almost_equal,
 import MDAnalysis as mda
 import MDAnalysis.lib.util as util
 import MDAnalysis.lib.mdamath as mdamath
-from MDAnalysis.lib.util import cached, static_variables, warn_if_not_unique
+from MDAnalysis.lib.util import (cached, static_variables, warn_if_not_unique,
+                                 check_coords)
 from MDAnalysis.core.topologyattrs import Bonds
 from MDAnalysis.exceptions import NoDataError, DuplicateWarning
 
@@ -1332,6 +1333,265 @@ class TestWarnIfNotUnique(object):
                 func(atoms)
                 assert not w.list
             assert len(record) == 0
+
+class TestCheckCoords(object):
+    """Tests concerning the decorator @check_coords
+    """
+
+    prec = 6
+
+    def test_default_options(self):
+        a_in = np.zeros(3, dtype=np.float32)
+        b_in = np.ones(3, dtype=np.float32)
+        b_in2 = np.ones((2, 3), dtype=np.float32)
+
+        @check_coords('a','b')
+        def func(a, b):
+            # check that enforce_copy is True by default:
+            assert a is not a_in
+            assert b is not b_in
+            # check that convert_single is True by default:
+            assert a.shape == (1, 3)
+            assert b.shape == (1, 3)
+            return a + b
+
+        # check that allow_single is True by default:
+        res = func(a_in, b_in)
+        # check that reduce_result_if_single is True by default:
+        assert res.shape == (3,)
+        # check correct function execution:
+        assert_array_equal(res, b_in)
+
+        # check that check_lenghts_match is True by default:
+        with pytest.raises(ValueError):
+            res = func(a_in, b_in2)
+
+    def test_enforce_copy(self):
+
+        a_2d = np.ones((1, 3), dtype=np.float32)
+        b_1d = np.zeros(3, dtype=np.float32)
+        c_2d = np.zeros((1, 6), dtype=np.float32)[:, ::2]
+        d_2d = np.zeros((1, 3), dtype=np.int64)
+
+        @check_coords('a', 'b', 'c', 'd', enforce_copy=False)
+        def func(a, b, c, d):
+            # Assert that if enforce_copy is False:
+            # no copy is made if input shape, order, and dtype are correct:
+            assert a is a_2d
+            # a copy is made if input shape has to be changed:
+            assert b is not b_1d
+            # a copy is made if input order has to be changed:
+            assert c is not c_2d
+            # a copy is made if input dtype has to be changed:
+            assert d is not d_2d
+            # Assert correct dtype conversion:
+            assert d.dtype == np.float32
+            assert_almost_equal(d, d_2d, self.prec)
+            # Assert all shapes are converted to (1, 3):
+            assert a.shape == b.shape == c.shape == d.shape == (1, 3)
+            return a + b + c + d
+
+        # Call func() to:
+        # - test the above assertions
+        # - ensure that input of single coordinates is simultaneously possible
+        #   with different shapes (3,) and (1, 3)
+        res = func(a_2d, b_1d, c_2d, d_2d)
+        # Since some inputs are not 1d, even though reduce_result_if_single is
+        # True, the result must have shape (1, 3):
+        assert res.shape == (1, 3)
+        # check correct function execution:
+        assert_array_equal(res, a_2d)
+
+    def test_no_allow_single(self):
+
+        @check_coords('a', allow_single=False)
+        def func(a):
+            pass
+
+        with pytest.raises(ValueError) as err:
+            func(np.zeros(3, dtype=np.float32))
+            assert err.msg == ("func(): a.shape must be (n, 3), got (3,).")
+
+    def test_no_convert_single(self):
+
+        a_1d = np.arange(-3, 0, dtype=np.float32)
+
+        @check_coords('a', enforce_copy=False, convert_single=False)
+        def func(a):
+            # assert no conversion and no copy were performed:
+            assert a is a_1d
+            return a
+
+        res = func(a_1d)
+        # Assert result has been reduced:
+        assert res == a_1d[0]
+        assert type(res) is np.float32
+
+    def test_no_reduce_result_if_single(self):
+
+        a_1d = np.zeros(3, dtype=np.float32)
+
+        # Test without shape conversion:
+        @check_coords('a', enforce_copy=False, convert_single=False,
+                      reduce_result_if_single=False)
+        def func(a):
+            return a
+
+        res = func(a_1d)
+        # make sure the input array is just passed through:
+        assert res is a_1d
+
+        # Test with shape conversion:
+        @check_coords('a', enforce_copy=False, reduce_result_if_single=False)
+        def func(a):
+            return a
+
+        res = func(a_1d)
+        assert res.shape == (1, 3)
+        assert_array_equal(res[0], a_1d)
+
+    def test_no_check_lengths_match(self):
+
+        a_2d = np.zeros((1, 3), dtype=np.float32)
+        b_2d = np.zeros((3, 3), dtype=np.float32)
+
+        @check_coords('a', 'b', enforce_copy=False, check_lengths_match=False)
+        def func(a, b):
+            return a, b
+
+        res_a, res_b = func(a_2d, b_2d)
+        # Assert arrays are just passed through:
+        assert res_a is a_2d
+        assert res_b is b_2d
+
+    def test_invalid_input(self):
+
+        a_inv_dtype = np.array([['hello', 'world', '!']])
+        a_inv_type = [[0., 0., 0.]]
+        a_inv_shape_1d = np.zeros(6, dtype=np.float32)
+        a_inv_shape_2d = np.zeros((3, 2), dtype=np.float32)
+
+        @check_coords('a')
+        def func(a):
+            pass
+
+        with pytest.raises(TypeError) as err:
+            func(a_inv_dtype)
+            assert err.msg.startswith("func(): a.dtype must be convertible to "
+                                      "float32, got ")
+
+        with pytest.raises(TypeError) as err:
+            func(a_inv_type)
+            assert err.msg == ("func(): Parameter 'a' must be a numpy.ndarray, "
+                               "got <class 'list'>.")
+
+        with pytest.raises(ValueError) as err:
+            func(a_inv_shape_1d)
+            assert err.msg == ("func(): a.shape must be (3,) or (n, 3), got "
+                               "(6,).")
+
+        with pytest.raises(ValueError) as err:
+            func(a_inv_shape_2d)
+            assert err.msg == ("func(): a.shape must be (3,) or (n, 3), got "
+                               "(3, 2).")
+
+    def test_usage_with_kwargs(self):
+
+        a_2d = np.zeros((1, 3), dtype=np.float32)
+
+        @check_coords('a', enforce_copy=False)
+        def func(a, b, c=0):
+            return a, b, c
+
+        # check correct functionality if passed as keyword argument:
+        a, b, c = func(a=a_2d, b=0, c=1)
+        assert a is a_2d
+        assert b == 0
+        assert c == 1
+
+    def test_wrong_func_call(self):
+
+        @check_coords('a', enforce_copy=False)
+        def func(a, b, c=0):
+            pass
+
+        # Make sure invalid call marker is present:
+        func._invalid_call = False
+
+        # usage with posarg doubly defined:
+        assert not func._invalid_call
+        with pytest.raises(TypeError):
+            func(0, a=0)
+        assert func._invalid_call
+        func._invalid_call = False
+
+        # usage with missing posargs:
+        assert not func._invalid_call
+        with pytest.raises(TypeError):
+            func(0)
+        assert func._invalid_call
+        func._invalid_call = False
+
+        # usage with missing posargs (supplied as kwargs):
+        assert not func._invalid_call
+        with pytest.raises(TypeError):
+            func(a=0, c=1)
+        assert func._invalid_call
+        func._invalid_call = False
+
+        # usage with too many posargs:
+        assert not func._invalid_call
+        with pytest.raises(TypeError):
+            func(0, 0, 0, 0)
+        assert func._invalid_call
+        func._invalid_call = False
+
+        # usage with unexpected kwarg:
+        assert not func._invalid_call
+        with pytest.raises(TypeError):
+            func(a=0, b=0, c=1, d=1)
+        assert func._invalid_call
+        func._invalid_call = False
+
+    def test_wrong_decorator_usage(self):
+
+        # usage without parantheses:
+        @check_coords
+        def func():
+            pass
+
+        with pytest.raises(TypeError):
+            func()
+
+        # usage without arguments:
+        with pytest.raises(ValueError) as err:
+            @check_coords()
+            def func():
+                pass
+
+            assert err.msg == ("Decorator check_coords() cannot be used "
+                               "without positional arguments.")
+
+        # usage with defaultarg:
+        with pytest.raises(ValueError) as err:
+            @check_coords('a')
+            def func(a=1):
+                pass
+
+            assert err.msg == ("In decorator check_coords(): Name 'a' doesn't "
+                               "correspond to any positional argument of the "
+                               "decorated function func().")
+
+        # usage with invalid parameter name:
+        with pytest.raises(ValueError) as err:
+            @check_coords('b')
+            def func(a):
+                pass
+
+            assert err.msg == ("In decorator check_coords(): Name 'b' doesn't "
+                               "correspond to any positional argument of the "
+                               "decorated function func().")
+
 
 @pytest.mark.parametrize("old_name", (None, "MDAnalysis.Universe"))
 @pytest.mark.parametrize("new_name", (None, "Multiverse"))

--- a/testsuite/MDAnalysisTests/utils/test_distances.py
+++ b/testsuite/MDAnalysisTests/utils/test_distances.py
@@ -233,6 +233,14 @@ class TestTriclinicDistances(object):
 
         return S_mol1, S_mol2
 
+    @staticmethod
+    @pytest.fixture()
+    def S_mol_single(TRIC):
+        S_mol1 = TRIC.atoms[383].position
+        S_mol2 = TRIC.atoms[390].position
+        return S_mol1, S_mol2
+
+    @pytest.mark.parametrize('S_mol', [S_mol, S_mol_single], indirect=True)
     def test_transforms(self, S_mol, box, boxV, backend):
         from MDAnalysis.lib.distances import transform_StoR, transform_RtoS
         # To check the cython coordinate transform, the same operation is done in numpy


### PR DESCRIPTION
Fixes (partially) #2046, this is just the beginning of a series of related PRs.

### Changes made in this Pull Request:
* Renamed `_box_check()` -> `_check_box()` to be consistent with naming of other helper functions.
* `_check_box()` now also returns the box in the format expected by low-level C functions in `lib.c_distances`, which reduces code duplications.
* Removed now obsolete box type `'tri_vecs_bad'` from `_check_box()`.
* Renamed `_check_array()` -> `_check_coord_array()` to better reflect its purpose.
* Renamed `_check_results_array()` -> `_check_result_array()` since the checked parameter is always named `result`.
* Moved coord array shape checks to separate functions.
* `_check_result_array()` now returns a numpy array of correct shape and dtype if `result` is `None`, which simplifies the code of several functions.
* Improved docstrings of `transform_RtoS()` and `transform_StoR()` and added input coordinate shape check. Adjusted `test_augment.py` accordingly.
* Added shape check for input coordinates of `calc_distance()`, `calc_angle()`, and `calc_dihedral()`.

### Question:
* Before I can continue to fix the rest of the docs, I'd like to hear further opinions on how to proceed with the requirements for the box arrays. Should the documented requirements for the box format be less strict or should we rather make the checks in `_check_box()` stricter? 

PR Checklist
------------
 - [ ] Tests? (~Do we need additional tests?~ Additional tests needed)
 - [x] Docs? (More to do)
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?
