### PR TITLE
Replaced kdtree in neighborsearch with capped distances

### DIFF
--- a/package/MDAnalysis/lib/NeighborSearch.py
+++ b/package/MDAnalysis/lib/NeighborSearch.py
@@ -82,6 +82,7 @@ class AtomNeighborSearch(object):
           char (A, R, S). Return atoms(A), residues(R) or segments(S) within
           *radius* of *atoms*.
         """
+        unique_idx = []
         if isinstance(atoms, Atom):
             positions = atoms.position.reshape(1, 3)
         else:
@@ -89,19 +90,9 @@ class AtomNeighborSearch(object):
         
         pairs = capped_distance(positions, self.atom_group.positions,
                                 radius, box=self._box, return_distances=False)
-        #cutoff = radius if self._box is not None else None
-        #self.kdtree.set_coords(self.atom_group.positions, cutoff=cutoff)
 
-        #indices = []
-        #for pos in positions:
-        #    self.kdtree.search(pos, radius)
-        #    indices.append(self.kdtree.get_indices())
-        #unique_idx = unique_int_1d(
-        #    np.array([i for l in indices for i in l], dtype=np.int64)
-        #)
-        unique_idx = []
         if pairs.size > 0:
-            unique_idx = unique_int_1d(pairs[:, 1])
+            unique_idx = unique_int_1d(np.asarray(pairs[:, 1], dtype=np.int64))
         return self._index2level(unique_idx, level)
 
     def _index2level(self, indices, level):

--- a/testsuite/MDAnalysisTests/lib/test_neighborsearch.py
+++ b/testsuite/MDAnalysisTests/lib/test_neighborsearch.py
@@ -41,8 +41,8 @@ def universe():
 
 
 def test_search(universe):
-    """simply check that for a centered protein in a large box pkdtree
-    and kdtree return the same result"""
+    """simply check that for a centered protein in a large box periodic
+    and non-periodic return the same result"""
     ns = NeighborSearch.AtomNeighborSearch(universe.atoms)
     pns = NeighborSearch.AtomNeighborSearch(universe.atoms,
                                             universe.atoms.dimensions)


### PR DESCRIPTION
Neighbor search uses KDTree as default search option for atomgroups. Replaced it with capped distances for  adjustable method selection.

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
