### PR TITLE
fixed Cython 0.26 not liking to call len inside nogil block

### DIFF
--- a/package/MDAnalysis/lib/nsgrid.pyx
+++ b/package/MDAnalysis/lib/nsgrid.pyx
@@ -417,7 +417,7 @@ cdef class NSResults(object):
         cdef ns_int idx, nsearch
         cdef real dist2, dist
 
-        nsearch = len(self.searchcoords)
+        nsearch = self.searchcoords.shape[0]
 
         self.indices_buffer = vector[intvec]()
         self.distances_buffer = vector[realvec]()


### PR DESCRIPTION
Fixes #2057

@jbarnoud can you check this works for you?

@ayushsuhane is `self.searchcoords.shape[0]` the same as `len` here?  (seems so)
