### PR TITLE
Improved docstrings in lib/_augment.pyx

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -80,6 +80,8 @@ Enhancements
   * Added dihedrals.py with Dihedral, Ramachandran, and Janin classes to
     analysis module (PR #1997, PR #2033)
   * Added the analysis.data module for reference data used in analysis (PR #2033)
+  * Most functions in `MDanalysis.lib.distances` previously only accepting
+    arrays of coordinates now also accept single coordinates as input (PR #2048)
 
 Fixes
   * rewind in the SingleFrameReader now reads the frame from the file (Issue #1929)
@@ -117,6 +119,9 @@ Changes
     (Issue #1894)
   * removed unused function MDAnalysis.lb.mdamath.one_to_many_pointers()
     (issue #2010)
+  * Box input for functions in `MDAnalysis.lib.distances` is now consistently
+    enforced to be of the form ``[lx, ly, lz, alpha, beta, gamma]`` as required
+    by the docs (Issue #2046, PR #2048)
 
 Deprecations
   * almost all "save()", "save_results()", "save_table()" methods in

--- a/package/MDAnalysis/lib/_augment.pyx
+++ b/package/MDAnalysis/lib/_augment.pyx
@@ -37,43 +37,44 @@ __all__ = ['augment_coordinates', 'undo_augment']
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def augment_coordinates(float[:, ::1] coordinates, float[:] box, float r):
-    r"""Calculates the relevant images of particles which are within a
-    distance 'r' from the box walls
+    r"""Calculates the periodic images of particles which are within a distance
+    `r` from the box walls.
 
-    The algorithm works by generating explicit periodic images of
-    interior atoms residing close to any of the six box walls.
-    The steps involved in generating images involves
-    evaluation of reciprocal vectors for the given box vectors
-    followed by calculation of projection distance of atom along the
-    reciprocal vectors. If the distance is less than a
-    specified cutoff distance, relevant periodic images are generated
-    using box translation vectors i.e. ``l[a] + m[b] + n[c]``, where
-    ``[l, m, n]`` are the neighbouring cell indices relative to the central cell,
-    and ``[a, b, c]`` are the box vectors. For instance, an atom close to
-    ``XY`` plane containing origin will generate a periodic image
-    outside the central cell and close to the opposite `XY` plane
-    of the box i.e. at ``0[a] + 0[b] + 1[c]``.
-    Similarly, if the particle is close to more than
-    one box walls, images along the diagonals are also generated ::
+    The algorithm works by generating explicit periodic images of atoms residing
+    close to any of the six box walls. The steps involved in generating images
+    involves the evaluation of reciprocal box vectors followed by the
+    calculation of distances of atoms from the walls by means of projection onto
+    the reciprocal vectors. If the distance is less than a specified cutoff
+    distance, relevant periodic images are generated using box translation
+    vectors :math:`\vec{t}` with
 
+    .. math:: \vec{t}=l\cdot\vec{a}+m\cdot\vec{b}+n\cdot \vec{c}\,,
 
-                           |  x               x
-        +---------------+  |    +---------------+
-        |               |  |    |               |
-        |               |  |    |               |
-        |               |  |    |               |
-        |             o |  |  x |             o |
-        +---------------+  |    +---------------+
-                           |
+    where :math:`l,\,m,\,n \in \{-1,\,0,\,1\}` are the neighboring cell indices
+    in :math:`x`-, :math:`y`-, and :math:`z`-direction relative to the central
+    cell with box vectors :math:`\vec{a},\,\vec{b},\,\vec{c}`.
 
+    For instance, an atom close to the :math:`xy`-plane containing the origin
+    will generate a periodic image outside the central cell and close to the
+    opposite :math:`xy`-plane of the box, i.e., shifted by
+    :math:`\vec{t} = 0\cdot\vec{a}+0\cdot\vec{b}+1\cdot\vec{c}=\vec{c}`.
 
+    Likewise, if the particle is close to more than one box walls, images along
+    the diagonals are also generated::
+
+                                    x            x
+        +------------+                +------------+
+        |            |   augment      |            |
+        |            |   ------->     |            |
+        |          o |              x |          o |
+        +------------+                +------------+
 
     Parameters
     ----------
     coordinates : numpy.ndarray
-      Input coordinate array of dtype ``numpy.float32`` used to generate
-      duplicate images in the vicinity of the central cell. All coordinates
-      must be within the primary unit cell.
+      Input coordinate array of shape ``(n, 3)`` and dtype ``numpy.float32``
+      used to generate duplicate images in the vicinity of the central cell. All
+      coordinates must be within the primary unit cell.
     box : numpy.ndarray
       Box dimensions of shape ``(6,)`` and dtype ``numpy.float32``. The
       dimensions must be provided in the same format as returned
@@ -100,7 +101,7 @@ def augment_coordinates(float[:, ::1] coordinates, float[:] box, float r):
     .. code-block:: python
 
         images, mapping = augment_coordinates(coordinates, box, max_cutoff)
-        all_coords = np.concatenate([coordinates, images])
+        all_coords = numpy.concatenate([coordinates, images])
 
 
     See Also
@@ -303,16 +304,15 @@ def undo_augment(np.int64_t[:] results, np.int64_t[:] translation, int nreal):
     Parameters
     ----------
     results : numpy.ndarray
-      Array of coordinate indices (dtype ``numpy.int64``), including "augmented"
-      indices.
+      Array of coordinate indices with dtype ``numpy.int64``, including
+      "augmented" indices.
     translation : numpy.ndarray
-      Map to link the augmented indices to the original particle indices
-      such that ``translation[augmentedindex] = originalindex``
-      (dtype = numpy.int64)
+      Index map (dtype ``numpy.int64``) linking the augmented indices to the
+      original particle indices such that
+      ``translation[augmented_index] = real_index``
     nreal : int
-      number of real coordinates, i.e. values in results equal or larger
+      Number of real coordinates, i.e., values in results equal or larger
       than this need to be translated to their real counterpart
-
 
     Returns
     -------

--- a/package/MDAnalysis/lib/_augment.pyx
+++ b/package/MDAnalysis/lib/_augment.pyx
@@ -299,26 +299,26 @@ def augment_coordinates(float[:, ::1] coordinates, float[:] box, float r):
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def undo_augment(np.int64_t[:] results, np.int64_t[:] translation, int nreal):
-    """Translate augmented indices back to original indices
+    """Translate augmented indices back to original indices.
 
     Parameters
     ----------
     results : numpy.ndarray
-      Array of coordinate indices with dtype ``numpy.int64``, including
+      Array of dtype ``numpy.int64`` containing coordinate indices, including
       "augmented" indices.
     translation : numpy.ndarray
-      Index map (dtype ``numpy.int64``) linking the augmented indices to the
+      Index map of dtype ``numpy.int64`` linking the augmented indices to the
       original particle indices such that
-      ``translation[augmented_index] = real_index``
+      ``translation[augmented_index] = original_index``.
     nreal : int
-      Number of real coordinates, i.e., values in results equal or larger
-      than this need to be translated to their real counterpart
+      Number of real coordinates, i.e., indices in `results` equal or larger
+      than this need to be mapped to their real counterpart.
 
     Returns
     -------
     results : numpy.ndarray
       Modified input `results` with all the augmented indices translated to
-      their corresponding initial original indices (dtype ``numpy.int64``)
+      their corresponding initial original indices.
 
     Note
     ----

--- a/package/MDAnalysis/lib/_augment.pyx
+++ b/package/MDAnalysis/lib/_augment.pyx
@@ -41,18 +41,18 @@ def augment_coordinates(float[:, ::1] coordinates, float[:] box, float r):
     distance 'r' from the box walls
 
     The algorithm works by generating explicit periodic images of
-    interior atoms residing close to any of the six box walls. 
+    interior atoms residing close to any of the six box walls.
     The steps involved in generating images involves
-    evaluation of reciprocal vectors for the given box vectors 
-    followed by calculation of projection distance of atom along the 
+    evaluation of reciprocal vectors for the given box vectors
+    followed by calculation of projection distance of atom along the
     reciprocal vectors. If the distance is less than a
     specified cutoff distance, relevant periodic images are generated
-    using box translation vectors i.e. ``l[a] + m[b] + n[c]``, where 
-    ``[l, m, n]`` are the neighbouring cell indices relative to the central cell, 
+    using box translation vectors i.e. ``l[a] + m[b] + n[c]``, where
+    ``[l, m, n]`` are the neighbouring cell indices relative to the central cell,
     and ``[a, b, c]`` are the box vectors. For instance, an atom close to
     ``XY`` plane containing origin will generate a periodic image
     outside the central cell and close to the opposite `XY` plane
-    of the box i.e. at ``0[a] + 0[b] + 1[c]``. 
+    of the box i.e. at ``0[a] + 0[b] + 1[c]``.
     Similarly, if the particle is close to more than
     one box walls, images along the diagonals are also generated ::
 
@@ -70,43 +70,42 @@ def augment_coordinates(float[:, ::1] coordinates, float[:] box, float r):
 
     Parameters
     ----------
-    coordinates : array
-      Input coordinate array to generate duplicate images
-      in the vicinity of the central cell. All the coordinates
-      must be within the primary unit cell. (dtype = numpy.float32)
-    box : array
-      Box dimension of shape (6, ). The dimensions must be
-      provided in the same format as returned
+    coordinates : numpy.ndarray
+      Input coordinate array of dtype ``numpy.float32`` used to generate
+      duplicate images in the vicinity of the central cell. All coordinates
+      must be within the primary unit cell.
+    box : numpy.ndarray
+      Box dimensions of shape ``(6,)`` and dtype ``numpy.float32``. The
+      dimensions must be provided in the same format as returned
       by :attr:`MDAnalysis.coordinates.base.Timestep.dimensions`:
-      ``[lx, ly, lz, alpha, beta, gamma]`` (dtype = numpy.float32)
+      ``[lx, ly, lz, alpha, beta, gamma]``
     r : float
-      thickness of cutoff region for duplicate image generation
+      Thickness of cutoff region for duplicate image generation.
 
     Returns
     -------
-    output : array
-      coordinates of duplicate(augmented) particles (dtype = numpy.float32)
-    indices : array
-      original indices of the augmented coordinates (dtype = numpy.int64)
-      A map which translates the indices of augmented particles
-      to their original particle index such that
-      ``indices[augmentedindex] = originalindex``
+    output : numpy.ndarray
+      Coordinates of duplicate (augmented) particles (dtype ``numpy.float32``).
+    indices : numpy.ndarray
+      Original indices of the augmented coordinates (dtype ``numpy.int64``).
+      Maps the indices of augmented particles to their original particle index
+      such that ``indices[augmented_index] = original_index``.
 
     Note
     ----
-    Output doesnot return coordinates from the initial array.
-    To merge the particles with their respective images, following operation
-    needs to be superseded after generating the images:
-    
+    Output does not return coordinates from the initial array.
+    To merge the particles with their respective images, the following operation
+    is necessary when generating the images:
+
     .. code-block:: python
 
-            images, mapping = augment_coordinates(coordinates, box, max_cutoff)
-            all_coords = np.concatenate([coordinates, images])
+        images, mapping = augment_coordinates(coordinates, box, max_cutoff)
+        all_coords = np.concatenate([coordinates, images])
 
 
     See Also
     --------
-    MDAnalysis.lib._augment.undo_augment
+    :meth:`undo_augment`
 
 
     .. versionadded:: 0.19.0
@@ -304,7 +303,8 @@ def undo_augment(np.int64_t[:] results, np.int64_t[:] translation, int nreal):
     Parameters
     ----------
     results : numpy.ndarray
-      indices of coordinates, including "augmented" indices (dtype = numpy.int64)
+      Array of coordinate indices (dtype ``numpy.int64``), including "augmented"
+      indices.
     translation : numpy.ndarray
       Map to link the augmented indices to the original particle indices
       such that ``translation[augmentedindex] = originalindex``
@@ -317,17 +317,16 @@ def undo_augment(np.int64_t[:] results, np.int64_t[:] translation, int nreal):
     Returns
     -------
     results : numpy.ndarray
-      modified input results with all the augmented indices
-      translated to their corresponding initial original indices
-      (dtype = numpy.int64)
+      Modified input `results` with all the augmented indices translated to
+      their corresponding initial original indices (dtype ``numpy.int64``)
 
     Note
     ----
-    Modifies the results array in place
+    Modifies the results array in place.
 
     See Also
     --------
-    'MDAnalysis.lib._augment.augment_coordinates'
+    :meth:`augment_coordinates`
 
 
     .. versionadded:: 0.19.0

--- a/package/MDAnalysis/lib/distances.py
+++ b/package/MDAnalysis/lib/distances.py
@@ -221,7 +221,7 @@ def _check_result_array(result, shape):
     return result
 
 @check_coords('reference', 'configuration', enforce_copy=False,
-              check_lengths_match=False)
+              reduce_result_if_single=False, check_lengths_match=False)
 def distance_array(reference, configuration, box=None, result=None,
                    backend="serial"):
     """Calculate all distances between a reference set and another configuration.


### PR DESCRIPTION
Fixes (partially) #2046, this is the second of a series of related PRs, following PR #2048.

Changes made in this Pull Request:
 - Improved documentation of `MDAnalysis.lib.distances.augment_coordinates()` and `MDAnalysis.lib.distances.undo_augment()` to better explain what the methods are actually doing.
- Added corresponding `.. autofunction` in `lib/distances.py` so that the signatures of both functions are now properly displayed in the html docs.
- Corrected a mistake from PR #2048 so that `distance_array()` now also returns an array for single coordinate input.
- Added missing CHANGELOG entries for PR #2048.

Apparently, there is a problem with Windows/Linux (i.e., CRLF vs. LF) line endings resulting in an incorrect `git diff` output for `lib/_augment.pyx`, which now looks as if I changed every line in the file, even though I only changed the docstrings. With `git diff -b` the changes are displayed correctly, though. On github, just change the diff settings to ignore whitespace.

PR Checklist
------------
 - [ ] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
