### PR TITLE
 Fix SETTLE in TPR parser 

### DIFF
--- a/package/MDAnalysis/topology/tpr/utils.py
+++ b/package/MDAnalysis/topology/tpr/utils.py
@@ -638,14 +638,24 @@ def do_moltype(data, symtab, fver):
             elif ik_obj.name == 'SETTLE':
                 # SETTLE interactions are optimized triangular constraints for
                 # water molecules. They should be counted as a pair of bonds
-                # between the oxigen and the hydrogens. The format only
-                # specifies the index of the oxygen and assumes that the next
-                # two atoms are the hydrogens.
-                base_atom = ilist.iatoms[-1]
-                bonds += [
-                    [base_atom, base_atom + 1],
-                    [base_atom, base_atom + 2]
-                ]
+                # between the oxigen and the hydrogens. In older versions of
+                # the TPR format only specifies the index of the oxygen and
+                # assumes that the next two atoms are the hydrogens.
+                if len(ias) == 2:
+                    # Old format. Only the first atom is specified.
+                    base_atom = ias[1]
+                    bonds += [
+                        [base_atom, base_atom + 1],
+                        [base_atom, base_atom + 2],
+                    ]
+                else:
+                    all_settle = ik_obj.process(ias)
+                    for settle in all_settle:
+                        base_atom = settle[0]
+                        bonds += [
+                            [settle[0], settle[1]],
+                            [settle[0], settle[2]],
+                        ]
             else:
                 # other interaction types are not interested at the moment
                 pass

--- a/testsuite/MDAnalysisTests/topology/test_tprparser.py
+++ b/testsuite/MDAnalysisTests/topology/test_tprparser.py
@@ -233,3 +233,5 @@ def bonds_water(request):
 def test_settle(bonds_water):
     # There are 101 water molecule with 2 bonds each
     assert len(bonds_water) == 202
+    # The last index corresponds to the last water atom
+    assert bonds_water[-1][1] == 2262


### PR DESCRIPTION
Support for SETTLE interactions in the TPR parser was added in #1953.
Though, the support was only added for the older versions of the TPR
format, causing errors with the newest files. In practice, when reading
the bonds on a recent TPR file containing SETTLE constraints, the
indices to the atoms involved in the bonds would be shifted. This is
because, the older TPR files use a different format to describe SETTLE
constraints.

This commit should fix the issue by supporting both the old and the new
format for SETTLE.

PR Checklist
------------
 - [X] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
