### PR TITLE
allow import of WaterBridgeAnalysis from analysis.hbonds

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -105,6 +105,7 @@ Fixes
   * Added periodic boundary box support to the Tinker file reader (Issue #2001)
   * Modifying coordinates by assignation is consistently persistent when using
     the memory reader (Issue #2018)
+  * allow import of WaterBridgeAnalysis from analysis.hbonds (#2064)
 
 Changes
   * TopologyAttrs are now statically typed (Issue #1876)

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -52,10 +52,10 @@ Enhancements
   * Added a rotation coordinate transformation (PR #1937)
   * Added a box centering trajectory transformation (PR #1946)
   * Added a on-the-fly trajectory transformations API and a coordinate translation
-  	function (Issue #786)
+    function (Issue #786)
   * Added various duecredit stubs
   * Import time reduced by a factor two (PR #1881)
-  * added compound kwarg to center, centroid, center_of_geometry, center_of_mass (PR #1903)
+  * Added compound kwarg to center, centroid, center_of_geometry, center_of_mass (PR #1903)
   * Added rdf.InterRDF_s to calculate site-specific pair distribution
     functions (PR #1815)
   * Increased performance of (repeated) calls to AtomGroup.pack_into_box()
@@ -84,10 +84,10 @@ Enhancements
     arrays of coordinates now also accept single coordinates as input (PR #2048)
   * Performance improvements to make_whole (PR #1965)
   * Performance improvements to fragment finding (PR #2028)
-  * Added user defined boxes in density code (PR #2005)
+  * Added user-defined boxes in density code (PR #2005)
 
 Fixes
-  * rewind in the SingleFrameReader now reads the frame from the file (Issue #1929)
+  * Rewind in the SingleFrameReader now reads the frame from the file (Issue #1929)
   * Fixed order of indices in Angle/Dihedral/Improper repr
   * coordinates.memory.MemoryReader now takes np.ndarray only (Issue #1685)
   * Silenced warning when duecredit is not installed (Issue #1872)
@@ -105,7 +105,7 @@ Fixes
   * Added periodic boundary box support to the Tinker file reader (Issue #2001)
   * Modifying coordinates by assignation is consistently persistent when using
     the memory reader (Issue #2018)
-  * allow import of WaterBridgeAnalysis from analysis.hbonds (#2064)
+  * Allow import of WaterBridgeAnalysis from analysis.hbonds (#2064)
 
 Changes
   * TopologyAttrs are now statically typed (Issue #1876)
@@ -121,7 +121,7 @@ Changes
   * The TPR parser reads SETTLE constraints as bonds. (Issue #1949)
   * Indexing a trajectory with a slice or an array now returns an iterable
     (Issue #1894)
-  * removed unused function MDAnalysis.lb.mdamath.one_to_many_pointers()
+  * Removed unused function MDAnalysis.lb.mdamath.one_to_many_pointers()
     (issue #2010)
   * Box input for functions in `MDAnalysis.lib.distances` is now consistently
     enforced to be of the form ``[lx, ly, lz, alpha, beta, gamma]`` as required
@@ -129,10 +129,10 @@ Changes
   * Added periodic keyword to select_atoms (#759)
 
 Deprecations
-  * almost all "save()", "save_results()", "save_table()" methods in
+  * Almost all "save()", "save_results()", "save_table()" methods in
     analysis classes were deprecated and will be removed in 1.0 (Issue
     #1972 and #1745)
-  * deprecated use of core.flags.  For use_pbc, the pbc keyword should
+  * Deprecated use of core.flags. For use_pbc, the pbc keyword should
     be used, use_KDTree_routines is obsolete as all distance calculations
     select the fastest method, all other uses of flags are deprecated.
     (#782)

--- a/package/MDAnalysis/analysis/hbonds/__init__.py
+++ b/package/MDAnalysis/analysis/hbonds/__init__.py
@@ -1,5 +1,5 @@
 # -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
-# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
 #
 # MDAnalysis --- https://www.mdanalysis.org
 # Copyright (c) 2006-2017 The MDAnalysis Development Team and contributors
@@ -21,7 +21,9 @@
 #
 from __future__ import absolute_import
 
-__all__ = ['HydrogenBondAnalysis', 'HydrogenBondAutoCorrel']
+__all__ = ['HydrogenBondAnalysis', 'HydrogenBondAutoCorrel',
+           'WaterBridgeAnalysis']
 
 from .hbond_analysis import HydrogenBondAnalysis
 from .hbond_autocorrel import HydrogenBondAutoCorrel
+from .wbridge_analysis import WaterBridgeAnalysis

--- a/testsuite/MDAnalysisTests/analysis/test_wbridge.py
+++ b/testsuite/MDAnalysisTests/analysis/test_wbridge.py
@@ -6,6 +6,14 @@ from numpy.testing import assert_equal
 import MDAnalysis
 from MDAnalysis.analysis.hbonds.wbridge_analysis import WaterBridgeAnalysis
 
+def test_import_from_hbonds():
+    try:
+        from MDAnalysis.analysis.hbonds import WaterBridgeAnalysis
+    except ImportError:
+        raise AssertionError("Issue #2064 not fixed: "
+                             "importing WaterBridgeAnalysis from "
+                             "MDAnalysis.analysis.hbonds failed.'")
+
 class TestWaterBridgeAnalysis(object):
     def test_acceptor_water_accepter(self):
         '''Test case where the hydrogen bond acceptor from selection 1 form


### PR DESCRIPTION
Fixes #2064

Changes made in this Pull Request:
 - add WaterBridgeAnalysis to analysis.hbonds


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
