### PR TITLE
bug fixes in lib.distances

### DIFF
--- a/package/MDAnalysis/lib/distances.py
+++ b/package/MDAnalysis/lib/distances.py
@@ -592,16 +592,16 @@ def _bruteforce_capped(reference, configuration, max_cutoff, min_cutoff=None,
     distances = np.empty((0,), dtype=np.float64)
 
     if len(reference) > 0 and len(configuration) > 0:
-        distances = distance_array(reference, configuration, box=box)
+        _distances = distance_array(reference, configuration, box=box)
         if min_cutoff is not None:
-            mask = np.where((distances <= max_cutoff) & \
-                            (distances > min_cutoff))
+            mask = np.where((_distances <= max_cutoff) & \
+                            (_distances > min_cutoff))
         else:
-            mask = np.where((distances < max_cutoff))
+            mask = np.where((_distances < max_cutoff))
         if mask[0].size > 0:
             pairs = np.c_[mask[0], mask[1]]
             if return_distances:
-                distances = distances[mask]
+                distances = _distances[mask]
 
     if return_distances:
         return pairs, distances
@@ -760,14 +760,10 @@ def _nsgrid_capped(reference, configuration, max_cutoff, min_cutoff=None,
             lmin = all_coords.min(axis=0)
             # Using maximum dimension as the box size
             boxsize = (lmax-lmin).max()
-            # to avoid failures of very close particles
-            # but with larger cutoff
-            if boxsize < 2*max_cutoff:
-                # just enough box size so that NSGrid doesnot fails
-                sizefactor = 2.2*max_cutoff/boxsize
-            else:
-                sizefactor = 1.2
-            pseudobox[:3] = sizefactor*boxsize
+            # to avoid failures for very close particles but with
+            # larger cutoff
+            boxsize = np.maximum(boxsize, 2 * max_cutoff)
+            pseudobox[:3] = 1.2 * boxsize
             pseudobox[3:] = 90.
             shiftref, shiftconf = reference.copy(), configuration.copy()
             # Extra padding near the origin

--- a/package/MDAnalysis/lib/distances.py
+++ b/package/MDAnalysis/lib/distances.py
@@ -144,8 +144,8 @@ def _check_box(box):
         * ``'ortho'`` orthogonal box
         * ``'tri_vecs'`` triclinic box vectors
 
-    checked_box : numpy.ndarray
-        Array of dtype ``numpy.float32`` containing box information:
+    checked_box : numpy.ndarray (``dtype=numpy.float32``)
+        Array containing box information:
         * If `boxtype` is ``'ortho'``, `cecked_box` will have the shape ``(3,)``
           containing the x-, y-, and z-dimensions of the orthogonal box.
         * If  `boxtype` is ``'tri_vecs'``, `cecked_box` will have the shape
@@ -198,7 +198,7 @@ def _check_result_array(result, shape):
 
     Returns
     -------
-    result : numpy.ndarray
+    result : numpy.ndarray (``dtype=numpy.float64``, ``shape=shape``)
         The input array or a newly created array if the input was ``None``.
 
     Raises
@@ -263,9 +263,9 @@ def distance_array(reference, configuration, box=None, result=None,
 
     Returns
     -------
-    d : numpy.ndarray
-        Array with shape ``(n, m)`` containing the distances ``d[i,j]`` between
-        reference coordinates ``i`` and configuration coordinates ``j``.
+    d : numpy.ndarray (``dtype=numpy.float64``, ``shape=(n, m)``)
+        Array containing the distances ``d[i,j]`` between reference coordinates
+        ``i`` and configuration coordinates ``j``.
 
 
     .. versionchanged:: 0.13.0
@@ -330,10 +330,9 @@ def self_distance_array(reference, box=None, result=None, backend="serial"):
 
     Returns
     -------
-    d : numpy.ndarray
-        Array with shape ``(n*(n-1)/2,)`` containing the distances ``dist[i,j]``
-        between reference coordinates ``i`` and ``j`` at position ``d[k]``. Loop
-        through ``d``:
+    d : numpy.ndarray (``dtype=numpy.float64``, ``shape=(n*(n-1)/2,)``)
+        Array containing the distances ``dist[i,j]`` between reference
+        coordinates ``i`` and ``j`` at position ``d[k]``. Loop through ``d``:
 
         .. code-block:: python
 
@@ -413,14 +412,14 @@ def capped_distance(reference, configuration, max_cutoff, min_cutoff=None,
 
     Returns
     -------
-    pairs : numpy.ndarray
+    pairs : numpy.ndarray (``dtype=numpy.int64``, ``shape=(n_pairs, 2)``)
         Pairs of indices, corresponding to coordinates in the `reference` and
         `configuration` arrays such that the distance between them lies within
         the interval (`min_cutoff`, `max_cutoff`].
         Each row in `pairs` is an index pair ``[i, j]`` corresponding to the
         ``i``-th coordinate in `reference` and the ``j``-th coordinate in
         `configuration`.
-    distances : numpy.ndarray, optional
+    distances : numpy.ndarray (``dtype=numpy.float64``, ``shape=(n_pairs,)``), optional
         Distances corresponding to each pair of indices. Only returned if
         `return_distances` is ``True``. ``distances[k]`` corresponds to the
         ``k``-th pair returned in `pairs` and gives the distance between the
@@ -574,14 +573,14 @@ def _bruteforce_capped(reference, configuration, max_cutoff, min_cutoff=None,
 
     Returns
     -------
-    pairs : numpy.ndarray
+    pairs : numpy.ndarray (``dtype=numpy.int64``, ``shape=(n_pairs, 2)``)
         Pairs of indices, corresponding to coordinates in the `reference` and
         `configuration` arrays such that the distance between them lies within
         the interval (`min_cutoff`, `max_cutoff`].
         Each row in `pairs` is an index pair ``[i, j]`` corresponding to the
         ``i``-th coordinate in `reference` and the ``j``-th coordinate in
         `configuration`.
-    distances : numpy.ndarray, optional
+    distances : numpy.ndarray (``dtype=numpy.float64``, ``shape=(n_pairs,)``), optional
         Distances corresponding to each pair of indices. Only returned if
         `return_distances` is ``True``. ``distances[k]`` corresponds to the
         ``k``-th pair returned in `pairs` and gives the distance between the
@@ -650,14 +649,14 @@ def _pkdtree_capped(reference, configuration, max_cutoff, min_cutoff=None,
 
     Returns
     -------
-    pairs : numpy.ndarray
+    pairs : numpy.ndarray (``dtype=numpy.int64``, ``shape=(n_pairs, 2)``)
         Pairs of indices, corresponding to coordinates in the `reference` and
         `configuration` arrays such that the distance between them lies within
         the interval (`min_cutoff`, `max_cutoff`].
         Each row in `pairs` is an index pair ``[i, j]`` corresponding to the
         ``i``-th coordinate in `reference` and the ``j``-th coordinate in
         `configuration`.
-    distances : numpy.ndarray, optional
+    distances : numpy.ndarray (``dtype=numpy.float64``, ``shape=(n_pairs,)``), optional
         Distances corresponding to each pair of indices. Only returned if
         `return_distances` is ``True``. ``distances[k]`` corresponds to the
         ``k``-th pair returned in `pairs` and gives the distance between the
@@ -721,7 +720,7 @@ def _nsgrid_capped(reference, configuration, max_cutoff, min_cutoff=None,
     min_cutoff : float, optional
         Minimum cutoff distance between `reference` and `configuration`
         coordinates.
-    box : numpy.ndarray, optional
+    box : numpy.ndarray (``dtype=numpy.float64``, ``shape=(n_pairs,)``), optional
         The unitcell dimensions of the system, which can be orthogonal or
         triclinic and must be provided in the same format as returned by
         :attr:`MDAnalysis.coordinates.base.Timestep.dimensions`:\n
@@ -731,7 +730,7 @@ def _nsgrid_capped(reference, configuration, max_cutoff, min_cutoff=None,
 
     Returns
     -------
-    pairs : numpy.ndarray
+    pairs : numpy.ndarray (``dtype=numpy.int64``, ``shape=(n_pairs, 2)``)
         Pairs of indices, corresponding to coordinates in the `reference` and
         `configuration` arrays such that the distance between them lies within
         the interval (`min_cutoff`, `max_cutoff`].
@@ -823,13 +822,13 @@ def self_capped_distance(reference, max_cutoff, min_cutoff=None, box=None,
 
     Returns
     -------
-    pairs : numpy.ndarray
+    pairs : numpy.ndarray (``dtype=numpy.int64``, ``shape=(n_pairs, 2)``)
         Pairs of indices, corresponding to coordinates in the `reference` array
         such that the distance between them lies within the interval
         (`min_cutoff`, `max_cutoff`].
         Each row in `pairs` is an index pair ``[i, j]`` corresponding to the
         ``i``-th and the ``j``-th coordinate in `reference`.
-    distances : numpy.ndarray
+    distances : numpy.ndarray (``dtype=numpy.float64``, ``shape=(n_pairs,)``)
         Distances corresponding to each pair of indices. ``distances[k]``
         corresponds to the ``k``-th pair returned in `pairs` and gives the
         distance between the coordinates ``reference[pairs[k, 0]]`` and
@@ -954,13 +953,13 @@ def _bruteforce_capped_self(reference, max_cutoff, min_cutoff=None, box=None):
 
     Returns
     -------
-    pairs : numpy.ndarray
+    pairs : numpy.ndarray (``dtype=numpy.int64``, ``shape=(n_pairs, 2)``)
         Pairs of indices, corresponding to coordinates in the `reference` array
         such that the distance between them lies within the interval
         (`min_cutoff`, `max_cutoff`].
         Each row in `pairs` is an index pair ``[i, j]`` corresponding to the
         ``i``-th and the ``j``-th coordinate in `reference`.
-    distances : numpy.ndarray
+    distances : numpy.ndarray (``dtype=numpy.float64``, ``shape=(n_pairs,)``)
         Distances corresponding to each pair of indices. ``distances[k]``
         corresponds to the ``k``-th pair returned in `pairs` and gives the
         distance between the coordinates ``reference[pairs[k, 0]]`` and
@@ -1016,13 +1015,13 @@ def _pkdtree_capped_self(reference, max_cutoff, min_cutoff=None, box=None):
 
     Returns
     -------
-    pairs : numpy.ndarray
+    pairs : numpy.ndarray (``dtype=numpy.int64``, ``shape=(n_pairs, 2)``)
         Pairs of indices, corresponding to coordinates in the `reference` array
         such that the distance between them lies within the interval
         (`min_cutoff`, `max_cutoff`].
         Each row in `pairs` is an index pair ``[i, j]`` corresponding to the
         ``i``-th and the ``j``-th coordinate in `reference`.
-    distances : numpy.ndarray
+    distances : numpy.ndarray (``dtype=numpy.float64``, ``shape=(n_pairs,)``)
         Distances corresponding to each pair of indices. ``distances[k]``
         corresponds to the ``k``-th pair returned in `pairs` and gives the
         distance between the coordinates ``reference[pairs[k, 0]]`` and
@@ -1077,13 +1076,13 @@ def _nsgrid_capped_self(reference, max_cutoff, min_cutoff=None, box=None):
 
     Returns
     -------
-    pairs : numpy.ndarray
+    pairs : numpy.ndarray (``dtype=numpy.int64``, ``shape=(n_pairs, 2)``)
         Pairs of indices, corresponding to coordinates in the `reference` array
         such that the distance between them lies within the interval
         (`min_cutoff`, `max_cutoff`].
         Each row in `pairs` is an index pair ``[i, j]`` corresponding to the
         ``i``-th and the ``j``-th coordinate in `reference`.
-    distances : numpy.ndarray
+    distances : numpy.ndarray (``dtype=numpy.float64``, ``shape=(n_pairs,)``)
         Distances corresponding to each pair of indices. ``distances[k]``
         corresponds to the ``k``-th pair returned in `pairs` and gives the
         distance between the coordinates ``reference[pairs[k, 0]]`` and
@@ -1153,9 +1152,8 @@ def transform_RtoS(coords, box, backend="serial"):
 
     Returns
     -------
-    newcoords : numpy.ndarray
-        An array of dtype ``numpy.float32`` with the same shape as `coords`
-        containing fractional coordiantes.
+    newcoords : numpy.ndarray (``dtype=numpy.float32``, ``shape=coords.shape``)
+        An array containing fractional coordiantes.
 
 
     .. versionchanged:: 0.13.0
@@ -1202,9 +1200,8 @@ def transform_StoR(coords, box, backend="serial"):
 
     Returns
     -------
-    newcoords : numpy.ndarray
-        An array of dtype ``numpy.float32`` with the same shape as `coords`
-        containing real space coordiantes.
+    newcoords : numpy.ndarray (``dtype=numpy.float32``, ``shape=coords.shape``)
+        An array containing real space coordiantes.
 
 
     .. versionchanged:: 0.13.0
@@ -1270,10 +1267,10 @@ def calc_bonds(coords1, coords2, box=None, result=None, backend="serial"):
 
     Returns
     -------
-    bondlengths : numpy.ndarray or float
-        Array of dtype ``numpy.float64`` containing the bond lengths between
-        each pair of coordinates. If two single coordinates were supplied, their
-        distance is returned as a single number instead of an array.
+    bondlengths : numpy.ndarray (``dtype=numpy.float64``, ``shape=(n,)``) or numpy.float64
+        Array containing the bond lengths between each pair of coordinates. If
+        two single coordinates were supplied, their distance is returned as a
+        single number instead of an array.
 
 
     .. versionadded:: 0.8
@@ -1359,11 +1356,10 @@ def calc_angles(coords1, coords2, coords3, box=None, result=None,
 
     Returns
     -------
-    angles : numpy.ndarray or float
-        Array of dtype ``numpy.float64`` containing the angles between each
-        triplet of coordinates. Values are returned in radians (rad). If three
-        single coordinates were supplied, the angle is returned as a single
-        number instead of an array.
+    angles : numpy.ndarray (``dtype=numpy.float64``, ``shape=(n,)``) or numpy.float64
+        Array containing the angles between each triplet of coordinates. Values
+        are returned in radians (rad). If three single coordinates were
+        supplied, the angle is returned as a single number instead of an array.
 
 
     .. versionadded:: 0.8
@@ -1462,11 +1458,11 @@ def calc_dihedrals(coords1, coords2, coords3, coords4, box=None, result=None,
 
     Returns
     -------
-    dihedrals : numpy.ndarray or float
-        Array of dtype ``numpy.float64`` containing the dihedral angles formed
-        by each quadruplet of coordinates. Values are returned in radians (rad).
-        If four single coordinates were supplied, the dihedral angle is returned
-        as a single number instead of an array.
+    dihedrals : numpy.ndarray (``dtype=numpy.float64``, ``shape=(n,)``) or numpy.float64
+        Array containing the dihedral angles formed by each quadruplet of
+        coordinates. Values are returned in radians (rad). If four single
+        coordinates were supplied, the dihedral angle is returned as a single
+        number instead of an array.
 
 
     .. versionadded:: 0.8
@@ -1522,9 +1518,9 @@ def apply_PBC(coords, box, backend="serial"):
 
     Returns
     -------
-    newcoords : numpy.ndarray
-        Array of dtype ``numpy.float32`` containing coordinates that all lie
-        within the primary unit cell as defined by `box`.
+    newcoords : numpy.ndarray  (``dtype=numpy.float32``, ``shape=coords.shape``)
+        Array containing coordinates that all lie within the primary unit cell
+        as defined by `box`.
 
 
     .. versionadded:: 0.8

--- a/package/MDAnalysis/lib/distances.py
+++ b/package/MDAnalysis/lib/distances.py
@@ -452,22 +452,10 @@ def capped_distance(reference, configuration, max_cutoff, min_cutoff=None,
             raise ValueError("Box Argument is of incompatible type. The "
                              "dimension should be either None or of the form "
                              "[lx, ly, lz, alpha, beta, gamma]")
-    method = _determine_method(reference, configuration,
-                               max_cutoff, min_cutoff=min_cutoff,
-                               box=box, method=method)
-
-    if return_distances:
-        pairs, dist = method(reference, configuration, max_cutoff,
-                         min_cutoff=min_cutoff, box=box,
-                         return_distances=return_distances)
-        return (np.asarray(pairs, dtype=np.int64),
-                np.asarray(dist, dtype=np.float64))
-    else:
-        pairs = method(reference, configuration, max_cutoff,
-                         min_cutoff=min_cutoff, box=box,
-                         return_distances=return_distances)
-
-        return np.asarray(pairs, dtype=np.int64)
+    method = _determine_method(reference, configuration, max_cutoff,
+                               min_cutoff=min_cutoff, box=box, method=method)
+    return method(reference, configuration, max_cutoff, min_cutoff=min_cutoff,
+                  box=box, return_distances=return_distances)
 
 
 def _determine_method(reference, configuration, max_cutoff, min_cutoff=None,
@@ -587,6 +575,7 @@ def _bruteforce_capped(reference, configuration, max_cutoff, min_cutoff=None,
         coordinates ``reference[pairs[k, 0]]`` and
         ``configuration[pairs[k, 1]]``.
     """
+    # Default return values (will be overwritten only if pairs are found):
     pairs = np.empty((0, 2), dtype=np.int64)
     distances = np.empty((0,), dtype=np.float64)
 
@@ -665,6 +654,7 @@ def _pkdtree_capped(reference, configuration, max_cutoff, min_cutoff=None,
     """
     from .pkdtree import PeriodicKDTree  # must be here to avoid circular import
 
+    # Default return values (will be overwritten only if pairs are found):
     pairs = np.empty((0, 2), dtype=np.int64)
     distances = np.empty((0,), dtype=np.float64)
 
@@ -744,6 +734,7 @@ def _nsgrid_capped(reference, configuration, max_cutoff, min_cutoff=None,
         coordinates ``reference[pairs[k, 0]]`` and
         ``configuration[pairs[k, 1]]``.
     """
+    # Default return values (will be overwritten only if pairs are found):
     pairs = np.empty((0, 2), dtype=np.int64)
     distances = np.empty((0,), dtype=np.float64)
 
@@ -863,10 +854,7 @@ def self_capped_distance(reference, max_cutoff, min_cutoff=None, box=None,
     method = _determine_method_self(reference, max_cutoff,
                                     min_cutoff=min_cutoff,
                                     box=box, method=method)
-    pairs, dist = method(reference,  max_cutoff, min_cutoff=min_cutoff, box=box)
-
-    return (np.asarray(pairs, dtype=np.int64),
-            np.asarray(dist, dtype=np.float64))
+    return method(reference,  max_cutoff, min_cutoff=min_cutoff, box=box)
 
 
 def _determine_method_self(reference, max_cutoff, min_cutoff=None, box=None,
@@ -965,10 +953,13 @@ def _bruteforce_capped_self(reference, max_cutoff, min_cutoff=None, box=None):
         distance between the coordinates ``reference[pairs[k, 0]]`` and
         ``reference[pairs[k, 1]]``.
     """
+    # Default return values (will be overwritten only if pairs are found):
     pairs = np.empty((0, 2), dtype=np.int64)
     distances = np.empty((0,), dtype=np.float64)
 
     N = len(reference)
+    # We're searching within a single coordinate set, so we need at least two
+    # coordinates to find distances between them.
     if N > 1:
         distvec = self_distance_array(reference, box=box)
         dist = np.full((N, N), max_cutoff, dtype=np.float64)
@@ -1029,9 +1020,12 @@ def _pkdtree_capped_self(reference, max_cutoff, min_cutoff=None, box=None):
     """
     from .pkdtree import PeriodicKDTree  # must be here to avoid circular import
 
+    # Default return values (will be overwritten only if pairs are found):
     pairs = np.empty((0, 2), dtype=np.int64)
     distances = np.empty((0,), dtype=np.float64)
 
+    # We're searching within a single coordinate set, so we need at least two
+    # coordinates to find distances between them.
     if len(reference) > 1:
         kdtree = PeriodicKDTree(box=box)
         cut = max_cutoff if box is not None else None
@@ -1088,8 +1082,12 @@ def _nsgrid_capped_self(reference, max_cutoff, min_cutoff=None, box=None):
         distance between the coordinates ``reference[pairs[k, 0]]`` and
         ``reference[pairs[k, 1]]``.
     """
+    # Default return values (will be overwritten only if pairs are found):
     pairs = np.empty((0, 2), dtype=np.int64)
     distances = np.empty((0,), dtype=np.float64)
+
+    # We're searching within a single coordinate set, so we need at least two
+    # coordinates to find distances between them.
     if len(reference) > 1:
         if box is None:
             # create a pseudobox

--- a/package/MDAnalysis/lib/distances.py
+++ b/package/MDAnalysis/lib/distances.py
@@ -222,8 +222,8 @@ def _check_result_array(result, shape):
     return result
 
 
-@check_coords('reference', 'configuration', enforce_copy=False,
-              reduce_result_if_single=False, check_lengths_match=False)
+@check_coords('reference', 'configuration', reduce_result_if_single=False,
+              check_lengths_match=False)
 def distance_array(reference, configuration, box=None, result=None,
                    backend="serial"):
     """Calculate all possible distances between a reference set and another
@@ -278,6 +278,8 @@ def distance_array(reference, configuration, box=None, result=None,
     refnum = reference.shape[0]
 
     distances = _check_result_array(result, (refnum, confnum))
+    if len(distances) == 0:
+        return distances
 
     if box is not None:
         boxtype, box = _check_box(box)
@@ -297,7 +299,7 @@ def distance_array(reference, configuration, box=None, result=None,
     return distances
 
 
-@check_coords('reference', enforce_copy=False, reduce_result_if_single=False)
+@check_coords('reference', reduce_result_if_single=False)
 def self_distance_array(reference, box=None, result=None, backend="serial"):
     """Calculate all possible distances within a configuration `reference`.
 
@@ -1031,6 +1033,7 @@ def _pkdtree_capped_self(reference, max_cutoff, min_cutoff=None, box=None):
     return np.asarray(pairs), np.asarray(distance)
 
 
+@check_coords('reference', enforce_copy=False, reduce_result_if_single=False)
 def _nsgrid_capped_self(reference, max_cutoff, min_cutoff=None, box=None):
     """Capped distance evaluations using a grid-based search method.
 
@@ -1203,7 +1206,7 @@ def transform_StoR(coords, box, backend="serial"):
     return coords
 
 
-@check_coords('coords1', 'coords2', enforce_copy=False)
+@check_coords('coords1', 'coords2')
 def calc_bonds(coords1, coords2, box=None, result=None, backend="serial"):
     """Calculates the bond lengths between pairs of atom positions from the two
     coordinate arrays `coords1` and `coords2`, which must contain the same
@@ -1284,7 +1287,7 @@ def calc_bonds(coords1, coords2, box=None, result=None, backend="serial"):
     return bondlengths
 
 
-@check_coords('coords1', 'coords2', 'coords3', enforce_copy=False)
+@check_coords('coords1', 'coords2', 'coords3')
 def calc_angles(coords1, coords2, coords3, box=None, result=None,
                 backend="serial"):
     """Calculates the angles formed between triplets of atom positions from the
@@ -1376,7 +1379,7 @@ def calc_angles(coords1, coords2, coords3, box=None, result=None,
     return angles
 
 
-@check_coords('coords1', 'coords2', 'coords3', 'coords4', enforce_copy=False)
+@check_coords('coords1', 'coords2', 'coords3', 'coords4')
 def calc_dihedrals(coords1, coords2, coords3, coords4, box=None, result=None,
                    backend="serial"):
     """Calculates the dihedral angles formed between quadruplets of positions

--- a/package/MDAnalysis/lib/nsgrid.pyx
+++ b/package/MDAnalysis/lib/nsgrid.pyx
@@ -380,7 +380,7 @@ cdef class NSResults(object):
             and initial atom coordinates of shape ``(N, 2)``
         """
 
-        return np.asarray(self.pairs_buffer).reshape(self.npairs, 2)
+        return np.asarray(self.pairs_buffer, dtype=np.int64).reshape(self.npairs, 2)
 
     def get_pair_distances(self):
         """Returns all the distances corresponding to each pair of neighbors

--- a/testsuite/MDAnalysisTests/lib/test_distances.py
+++ b/testsuite/MDAnalysisTests/lib/test_distances.py
@@ -24,6 +24,7 @@ from __future__ import division, absolute_import
 import pytest
 import numpy as np
 from numpy.testing import assert_equal, assert_almost_equal
+from itertools import combinations_with_replacement as comb
 
 import MDAnalysis
 from MDAnalysis.lib import distances
@@ -1052,6 +1053,9 @@ class TestEmptyInputCoordinates(object):
       * apply_PBC
     """
 
+    max_cut = 0.25  # max_cutoff parameter for *capped_distance()
+    min_cut = 0.0  # optional min_cutoff parameter for *capped_distance()
+
     boxes = ([1.0, 1.0, 1.0, 90.0, 90.0, 90.0],  # orthorhombic
              [1.0, 1.0, 1.0, 80.0, 80.0, 80.0],  # triclinic
              None)  # no PBC
@@ -1077,12 +1081,14 @@ class TestEmptyInputCoordinates(object):
         assert_equal(res, np.empty((0,), dtype=np.float64))
 
     @pytest.mark.parametrize('box', boxes)
-    @pytest.mark.parametrize('met', ["bruteforce", "pkdtree", "nsgrid", None])
+    @pytest.mark.parametrize('min_cut', [min_cut, None])
     @pytest.mark.parametrize('ret_dist', [False, True])
-    def test_empty_input_capped_distance(self, empty_coord, box, met, ret_dist):
-        r_cut = 0.25
+    @pytest.mark.parametrize('met', ["bruteforce", "pkdtree", "nsgrid", None])
+    def test_empty_input_capped_distance(self, empty_coord, min_cut, box, met,
+                                         ret_dist):
         res = distances.capped_distance(empty_coord, empty_coord,
-                                        max_cutoff=r_cut, box=box, method=met,
+                                        max_cutoff=self.max_cut,
+                                        min_cutoff=min_cut, box=box, method=met,
                                         return_distances=ret_dist)
         if ret_dist:
             assert_equal(res[0], np.empty((0, 2), dtype=np.int64))
@@ -1091,11 +1097,14 @@ class TestEmptyInputCoordinates(object):
             assert_equal(res, np.empty((0, 2), dtype=np.int64))
 
     @pytest.mark.parametrize('box', boxes)
+    @pytest.mark.parametrize('min_cut', [min_cut, None])
     @pytest.mark.parametrize('met', ["bruteforce", "pkdtree", "nsgrid", None])
-    def test_empty_input_self_capped_distance(self, empty_coord, box, met):
-        r_cut = 0.25
-        res = distances.self_capped_distance(empty_coord, max_cutoff=r_cut,
-                                             box=box, method=met)
+    def test_empty_input_self_capped_distance(self, empty_coord, min_cut, box,
+                                              met):
+        res = distances.self_capped_distance(empty_coord,
+                                             max_cutoff=self.max_cut,
+                                             min_cutoff=min_cut, box=box,
+                                             method=met)
         assert_equal(res[0], np.empty((0, 2), dtype=np.int64))
         assert_equal(res[1], np.empty((0,), dtype=np.float64))
     
@@ -1137,6 +1146,179 @@ class TestEmptyInputCoordinates(object):
     def test_empty_input_apply_PBC(self, empty_coord, box, backend):
         res = distances.apply_PBC(empty_coord, box, backend=backend)
         assert_equal(res, empty_coord)
+
+
+class TestOutputTypes(object):
+    """Tests ensuring that the following functions in MDAnalysis.lib.distances
+    return results of the types stated in the docs:
+      * distance_array:
+        - numpy.ndarray (shape=(n, m), dtype=numpy.float64)
+      * self_distance_array:
+        - numpy.ndarray (shape=(n*(n-1)//2,), dtype=numpy.float64)
+      * capped_distance:
+        - numpy.ndarray (shape=(n, 2), dtype=numpy.int64)
+        - numpy.ndarray (shape=(n,), dtype=numpy.float64) (optional)
+      * self_capped_distance:
+        - numpy.ndarray (shape=(n, 2), dtype=numpy.int64)
+        - numpy.ndarray (shape=(n,), dtype=numpy.float64)
+      * transform_RtoS:
+        - numpy.ndarray (shape=input.shape, dtype=numpy.float32)
+      * transform_StoR:
+        - numpy.ndarray (shape=input.shape, dtype=numpy.float32)
+      * calc_bonds:
+        - numpy.ndarray (shape=(n,), dtype=numpy.float64) for at least one
+          shape (n,3) input, or numpy.float64 if all inputs are of shape (3,)
+      * calc_angles:
+        - numpy.ndarray (shape=(n,), dtype=numpy.float64) for at least one
+          shape (n,3) input, or numpy.float64 if all inputs are of shape (3,)
+      * calc_dihedrals:
+        - numpy.ndarray (shape=(n,), dtype=numpy.float64) for at least one
+          shape (n,3) input, or numpy.float64 for if all inputs are of
+          shape (3,)
+      * apply_PBC:
+        - numpy.ndarray (shape=input.shape, dtype=numpy.float32)
+    """
+    max_cut = 0.25  # max_cutoff parameter for *capped_distance()
+    min_cut = 0.0  # optional min_cutoff parameter for *capped_distance()
+
+    boxes = ([1.0, 1.0, 1.0, 90.0, 90.0, 90.0],  # orthorhombic
+             [1.0, 1.0, 1.0, 80.0, 80.0, 80.0],  # triclinic
+             None)  # no PBC
+
+    coords = [np.empty((0, 3), dtype=np.float32),  # empty coord array
+              np.array([[0.1, 0.1, 0.1]], dtype=np.float32),  # coord array
+              np.array([0.1, 0.1, 0.1], dtype=np.float32)]  # single coord
+
+    @pytest.mark.parametrize('box', boxes)
+    @pytest.mark.parametrize('incoords', list(comb(coords, 2)))
+    @pytest.mark.parametrize('backend', ['serial', 'openmp'])
+    def test_output_type_distance_array(self, incoords, box, backend):
+        res = distances.distance_array(*incoords, box=box, backend=backend)
+        assert type(res) == np.ndarray
+        assert res.shape == (incoords[0].shape[0] % 2, incoords[1].shape[0] % 2)
+        assert res.dtype.type == np.float64
+
+    @pytest.mark.parametrize('box', boxes)
+    @pytest.mark.parametrize('incoords', coords)
+    @pytest.mark.parametrize('backend', ['serial', 'openmp'])
+    def test_output_type_self_distance_array(self, incoords, box, backend):
+        res = distances.self_distance_array(incoords, box=box, backend=backend)
+        assert type(res) == np.ndarray
+        assert res.shape == (0,)
+        assert res.dtype.type == np.float64
+
+    @pytest.mark.parametrize('box', boxes)
+    @pytest.mark.parametrize('min_cut', [min_cut, None])
+    @pytest.mark.parametrize('ret_dist', [False, True])
+    @pytest.mark.parametrize('incoords', list(comb(coords, 2)))
+    @pytest.mark.parametrize('met', ["bruteforce", "pkdtree", "nsgrid", None])
+    def test_output_type_capped_distance(self, incoords, min_cut, box, met,
+                                         ret_dist):
+        res = distances.capped_distance(*incoords, max_cutoff=self.max_cut,
+                                        min_cutoff=min_cut, box=box, method=met,
+                                        return_distances=ret_dist)
+        if ret_dist:
+            pairs, dist = res
+        else:
+            pairs = res
+        assert type(pairs) == np.ndarray
+        assert pairs.dtype.type == np.int64
+        assert pairs.ndim == 2
+        assert pairs.shape[1] == 2
+        if ret_dist:
+            assert type(dist) == np.ndarray
+            assert dist.dtype.type == np.float64
+            assert dist.shape == (pairs.shape[0],)
+
+    @pytest.mark.parametrize('box', boxes)
+    @pytest.mark.parametrize('min_cut', [min_cut, None])
+    @pytest.mark.parametrize('incoords', coords)
+    @pytest.mark.parametrize('met', ["bruteforce", "pkdtree", "nsgrid", None])
+    def test_output_type_self_capped_distance(self, incoords, min_cut, box,
+                                              met):
+        pairs, dist = distances.self_capped_distance(incoords,
+                                                     max_cutoff=self.max_cut,
+                                                     min_cutoff=min_cut,
+                                                     box=box, method=met)
+        assert type(pairs) == np.ndarray
+        assert type(dist) == np.ndarray
+        assert pairs.dtype.type == np.int64
+        assert dist.dtype.type == np.float64
+        assert pairs.ndim == 2
+        assert pairs.shape[1] == 2
+        assert dist.shape == (pairs.shape[0],)
+
+    @pytest.mark.parametrize('box', boxes[:2])
+    @pytest.mark.parametrize('incoords', coords)
+    @pytest.mark.parametrize('backend', ['serial', 'openmp'])
+    def test_output_dtype_transform_RtoS(self, incoords, box, backend):
+        res = distances.transform_RtoS(incoords, box, backend=backend)
+        assert type(res) == np.ndarray
+        assert res.dtype.type == np.float32
+        assert res.shape == incoords.shape
+
+    @pytest.mark.parametrize('box', boxes[:2])
+    @pytest.mark.parametrize('incoords', coords)
+    @pytest.mark.parametrize('backend', ['serial', 'openmp'])
+    def test_output_dtype_transform_RtoS(self, incoords, box, backend):
+        res = distances.transform_RtoS(incoords, box, backend=backend)
+        assert type(res) == np.ndarray
+        assert res.dtype.type == np.float32
+        assert res.shape == incoords.shape
+
+    @pytest.mark.parametrize('box', boxes)
+    @pytest.mark.parametrize('incoords',
+                             [2 * [coords[0]]] + list(comb(coords[1:], 2)))
+    @pytest.mark.parametrize('backend', ['serial', 'openmp'])
+    def test_output_type_calc_bonds(self, incoords, box, backend):
+        res = distances.calc_bonds(*incoords, box=box, backend=backend)
+        maxdim = max([crd.ndim for crd in incoords])
+        if maxdim == 1:
+            assert type(res) == np.float64
+        else:
+            assert type(res) == np.ndarray
+            assert res.dtype.type == np.float64
+            coord = [crd for crd in incoords if crd.ndim == maxdim][0]
+            assert res.shape == (coord.shape[0],)
+
+    @pytest.mark.parametrize('box', boxes)
+    @pytest.mark.parametrize('incoords',
+                             [3 * [coords[0]]] + list(comb(coords[1:], 3)))
+    @pytest.mark.parametrize('backend', ['serial', 'openmp'])
+    def test_output_type_calc_angles(self, incoords, box, backend):
+        res = distances.calc_angles(*incoords, box=box, backend=backend)
+        maxdim = max([crd.ndim for crd in incoords])
+        if maxdim == 1:
+            assert type(res) == np.float64
+        else:
+            assert type(res) == np.ndarray
+            assert res.dtype.type == np.float64
+            coord = [crd for crd in incoords if crd.ndim == maxdim][0]
+            assert res.shape == (coord.shape[0],)
+
+    @pytest.mark.parametrize('box', boxes)
+    @pytest.mark.parametrize('incoords',
+                             [4 * [coords[0]]] + list(comb(coords[1:], 4)))
+    @pytest.mark.parametrize('backend', ['serial', 'openmp'])
+    def test_output_type_calc_dihedrals(self, incoords, box, backend):
+        res = distances.calc_dihedrals(*incoords, box=box, backend=backend)
+        maxdim = max([crd.ndim for crd in incoords])
+        if maxdim == 1:
+            assert type(res) == np.float64
+        else:
+            assert type(res) == np.ndarray
+            assert res.dtype.type == np.float64
+            coord = [crd for crd in incoords if crd.ndim == maxdim][0]
+            assert res.shape == (coord.shape[0],)
+
+    @pytest.mark.parametrize('box', boxes[:2])
+    @pytest.mark.parametrize('incoords', coords)
+    @pytest.mark.parametrize('backend', ['serial', 'openmp'])
+    def test_output_type_apply_PBC(self, incoords, box, backend):
+        res = distances.apply_PBC(incoords, box, backend=backend)
+        assert type(res) == np.ndarray
+        assert res.dtype.type == np.float32
+        assert res.shape == incoords.shape
 
 
 class TestDistanceBackendSelection(object):

--- a/testsuite/MDAnalysisTests/lib/test_distances.py
+++ b/testsuite/MDAnalysisTests/lib/test_distances.py
@@ -1187,7 +1187,8 @@ class TestOutputTypes(object):
 
     coords = [np.empty((0, 3), dtype=np.float32),  # empty coord array
               np.array([[0.1, 0.1, 0.1]], dtype=np.float32),  # coord array
-              np.array([0.1, 0.1, 0.1], dtype=np.float32)]  # single coord
+              np.array([0.1, 0.1, 0.1], dtype=np.float32),  # single coord
+              np.array([[-1.1, -1.1, -1.1]], dtype=np.float32)]  # outside box
 
     @pytest.mark.parametrize('box', boxes)
     @pytest.mark.parametrize('incoords', list(comb(coords, 2)))


### PR DESCRIPTION
Fixes (partially) #2046. This is the fourth of a series of related PRs following PRs #2048, #2062, and #2070.

Changes made in this Pull Request:
- Ensured that none of the functions in `MDAnalysis.lib.distances` modifies its input coordinate arrays in-place. This fixes a bug I introduced in PR #2048 (see updated issue #2046).
- Allowed for empty coordinate array input (`shape=(0,3)`) in all `lib.distances` functions.
- Fixed failures / wrong distance output of `*capped_distance()` in several corner cases.
- Added corresponding tests ensuring non-modified input, correct functionality with empty input, and correct return types.
- Improved return type specifications in the docs.

PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?
