### PR TITLE
WIP, TST: add Python 2.7 ARMv8 testing to MDA CI.

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -1,0 +1,64 @@
+branches:
+    only:
+       - mda_arm_ci_shippable
+
+language: python
+
+python:
+    # NOTE: Docker options in pre_ci_boot section 
+    # are not allowed on restricted shared node pools.
+    # so haven't had luck getting Python 3.6 working
+    # on ARM; try 2.7 for now
+    - 2.7
+    # NOTE: some pretty major issues with our test infrastructure
+    # / dependencies on 3.7 it seems, so hold off on that for now
+
+runtime:
+    # use the free open source pool of nodes
+    # only for ARM platform
+    nodePool: shippable_shared_aarch64
+
+build:
+    ci:
+    # install dependencies
+    - sudo apt-get install libfreetype6-dev pkg-config libpng12-dev build-essential
+    - sudo apt-get install gcc gfortran libblas-dev liblapack-dev
+
+    - pip install --upgrade pip pytest
+    - pip install cython --cache-dir=/root/.cache/pip/wheels/$SHIPPABLE_PYTHON_VERSION
+    - pip install numpy --cache-dir=/root/.cache/pip/wheels/$SHIPPABLE_PYTHON_VERSION
+    - pip install scipy --cache-dir=/root/.cache/pip/wheels/$SHIPPABLE_PYTHON_VERSION
+    - pip install matplotlib --cache-dir=/root/.cache/pip/wheels/$SHIPPABLE_PYTHON_VERSION
+    - pip install mmtf-python --cache-dir=/root/.cache/pip/wheels/$SHIPPABLE_PYTHON_VERSION
+    - pip install biopython --cache-dir=/root/.cache/pip/wheels/$SHIPPABLE_PYTHON_VERSION
+    - pip install GridDataFormats --cache-dir=/root/.cache/pip/wheels/$SHIPPABLE_PYTHON_VERSION
+    - pip install pytest-xdist --cache-dir=/root/.cache/pip/wheels/$SHIPPABLE_PYTHON_VERSION
+    - pip install gsd==1.5.2 --cache-dir=/root/.cache/pip/wheels/$SHIPPABLE_PYTHON_VERSION
+    - pip install duecredit --cache-dir=/root/.cache/pip/wheels/$SHIPPABLE_PYTHON_VERSION
+    - pip install joblib --cache-dir=/root/.cache/pip/wheels/$SHIPPABLE_PYTHON_VERSION
+    - pip install networkx --cache-dir=/root/.cache/pip/wheels/$SHIPPABLE_PYTHON_VERSION
+    - pip install hypothesis --cache-dir=/root/.cache/pip/wheels/$SHIPPABLE_PYTHON_VERSION
+
+    # build and test MDAnalysis
+    - cd package
+    - python setup.py develop --no-deps
+
+    - cd ../testsuite
+    - python setup.py develop --no-deps
+    # NOTE: lscpu suggests 96 cores available on ARMv8 nodes
+    - pytest --disable-pytest-warnings -n 96 --junit-xml=$SHIPPABLE_REPO_DIR/shippable/testresults/tests.xml -rsx
+
+    cache: true
+    cache_dir_list:
+        - /root/.cache/pip/wheels
+
+# disable email notification
+# of CI job result
+integrations:
+  notifications:
+    - integrationName: email
+      type: email
+      on_success: never
+      on_failure: never
+      on_cancel: never
+      on_pull_request: never

--- a/testsuite/MDAnalysisTests/analysis/test_encore.py
+++ b/testsuite/MDAnalysisTests/analysis/test_encore.py
@@ -437,6 +437,8 @@ class TestEncoreClustering(object):
                                                           "results: {0}".format(cluster_collection)
 
     
+    @pytest.mark.skipif(os.uname()[4] == 'aarch64',
+                        reason="currently fails on ARMv8 arch")
     def test_clustering_three_ensembles_two_identical(self, ens1, ens2):
         cluster_collection = encore.cluster([ens1, ens2, ens1])
         expected_value = 40

--- a/testsuite/MDAnalysisTests/analysis/test_rdf_s.py
+++ b/testsuite/MDAnalysisTests/analysis/test_rdf_s.py
@@ -21,6 +21,7 @@
 #
 from __future__ import absolute_import, division
 
+import os
 import pytest
 
 from numpy.testing import assert_almost_equal
@@ -98,6 +99,8 @@ def test_cdf(rdf):
     assert rdf.cdf[0][0][0][-1] == rdf.count[0][0][0].sum()/rdf.n_frames
 
 
+@pytest.mark.skipif(os.uname()[4] == 'aarch64',
+                    reason="test fails on ARMv8 arch")
 @pytest.mark.parametrize("density, value", [
     (True, 13275.775528444701),
     (False, 0.021915460340071267)])

--- a/testsuite/MDAnalysisTests/coordinates/test_xdr.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_xdr.py
@@ -767,6 +767,8 @@ class _GromacsReader_offsets(object):
         reader = self._reader(traj)
         reader[idx_frame]
 
+    @pytest.mark.skipif(os.uname()[4] == 'aarch64',
+                        reason="fails on ARMv8 arch")
     def test_persistent_offsets_readonly(self, tmpdir):
         shutil.copy(self.filename, str(tmpdir))
 

--- a/testsuite/MDAnalysisTests/core/test_universe.py
+++ b/testsuite/MDAnalysisTests/core/test_universe.py
@@ -163,6 +163,8 @@ class TestUniverseCreation(object):
         finally:
             temp_dir.dissolve()
 
+    @pytest.mark.skipif(os.uname()[4] == 'aarch64',
+                        reason="test fails on ARMv8 arch")
     def test_Universe_invalidpermissionfile_IE_msg(self):
         # check for file with invalid permissions (eg. no read access)
         temp_dir = TempDir()


### PR DESCRIPTION
Fixes #1989. Will probably need to adjust our repo settings to get the triggers working on this PR.

Python 2.7 only at the moment because of issues running our test suite with Python 3.7, and poor availability of 3.6 on shippable for the somewhat-exotic architecture (see related NumPy / Cython discussions for that..). Maybe when 3.7 is running on our x64 linux ci we can revisit for arm (works fine for other projects).

I think we'll need to set up a webhook somehow since I don't seem to have the option to do it for MDA through shippable itself, assuming we actually want to do this. Not sure why I couldn't just do it, since it worked for NumPy & I have lower privileges there unless we have some special block on auto-hook generation from services.

Results are [all green](https://app.shippable.com/github/tylerjereddy/mdanalysis/runs/37/1/console) on my fork with this feature branch. Good to double check that test skip counts match reasonably close to i.e., 2.7 on travis linux.

If the MDAnalysis project gets a separate S3 amazon cache with a different account, then we'll have to comment out subsections of the new `yml` file so that dependencies can be cached progressively before timeout. If we're lucky, the cache will be preserved and the build / test can run in about 20 minutes. Builds can be really slow on ARM for things like SciPy, so caching is really important.

There are 96 cores available on the nodes and we can use them all--helps for testing, but I'm not sure if our building mda itself has been optimized for parallel compile (tricky business usually with compile order / distutils constraints).