### PR TITLE
WIP, TST: remove gsd & add Python 2.7 to appveyor config

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,6 +31,7 @@ environment:
 
         - PYTHON_VERSION: 2.7
           PYTHON_ARCH: 64
+          MSVC_VERSION: "Visual Studio 10 Win64"
 
 init:
     - ps: Write-Host ${env:PYTHON} ${env:PYTHON_VERSION} ${env:PYTHON_ARCH}

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,7 +14,7 @@ environment:
     global:
         CONDA_CHANNELS: conda-forge
         CONDA_DEPENDENCIES: pip setuptools wheel cython mock six biopython networkx joblib matplotlib scipy vs2015_runtime pytest mmtf-python GridDataFormats hypothesis pytest-cov codecov
-        PIP_DEPENDENCIES: gsd==1.5.2 duecredit
+        PIP_DEPENDENCIES: duecredit
         DEBUG: "False"
         MINGW_64: C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin
         OPENBLAS_64: https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-5f998ef_gcc7_1_0_win64.zip
@@ -28,6 +28,9 @@ environment:
         - PYTHON_VERSION: 3.6
           PYTHON_ARCH: 64
           MSVC_VERSION: "Visual Studio 10 Win64"
+
+        - PYTHON_VERSION: 2.7
+          PYTHON_ARCH: 64
 
 init:
     - ps: Write-Host ${env:PYTHON} ${env:PYTHON_VERSION} ${env:PYTHON_ARCH}


### PR DESCRIPTION
IIRC the need to "mock import" `gsd` was preventing us from building & testing MDAnalysis with Python 2.7 on Windows (`gsd` could be built but not actually used in 3.6, but not even built in 2.7 I think).

This follows up on #2090 to see if Appveyor is happy with Python 2.7 builds now.
