### PR TITLE
New default filename for align.AlignTraj

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,7 +13,7 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-mm/dd/18 orbeckst
+mm/dd/18 orbeckst, PicoCentauri
   * 0.19.1
 
 Enhancements
@@ -24,7 +24,8 @@ Fixes
 Changes
 
 Deprecations
-
+   * Default ``filename`` directory of align.AlignTraj is deprecated and 
+     will change in 1.0 to the current directory.
 
 10/09/18 tylerjereddy, richardjgowers, palnabarun, orbeckst, kain88-de, zemanj,
          VOD555, davidercruz, jbarnoud, ayushsuhane, hfmull, micaela-matta,

--- a/package/MDAnalysis/analysis/align.py
+++ b/package/MDAnalysis/analysis/align.py
@@ -600,6 +600,8 @@ class AlignTraj(AnalysisBase):
           already a :class:`MemoryReader` then it is *always* treated as if
           ``in_memory`` had been set to ``True``.
 
+        .. deprecated:: 0.19.1
+           Default ``filename`` directory will change in 1.0 to the current directory.
 
         .. versionchanged:: 0.16.0
            new general ``weights`` kwarg replace ``mass_weights``
@@ -620,6 +622,11 @@ class AlignTraj(AnalysisBase):
             logger.info("Moved mobile trajectory to in-memory representation")
         else:
             if filename is None:
+                # DEPRECATED in 0.19.1
+                # Change in 1.0
+                #
+                # fn = os.path.split(mobile.trajectory.filename)[1]
+                # filename = prefix + fn
                 path, fn = os.path.split(mobile.trajectory.filename)
                 filename = os.path.join(path, prefix + fn)
                 logger.info('filename of rms_align with no filename given'

--- a/testsuite/CHANGELOG
+++ b/testsuite/CHANGELOG
@@ -13,6 +13,18 @@ Also see https://github.com/MDAnalysis/mdanalysis/wiki/MDAnalysisTests
 and https://github.com/MDAnalysis/mdanalysis/wiki/UnitTests
 
 ------------------------------------------------------------------------------
+mm/dd/18 PicoCentauri
+  * 0.19.1
+
+Enhancements
+
+Fixes
+   * Removed rmsfit_adk_dims.dcd file generation during test (Issue #2099).
+
+Changes
+
+Deprecations
+     
 10/09/18 orbeckst, arm61
   * 0.19.0
     - skip tests for duecredit when duecredit is not installed (#1906)

--- a/testsuite/MDAnalysisTests/analysis/test_align.py
+++ b/testsuite/MDAnalysisTests/analysis/test_align.py
@@ -28,7 +28,7 @@ import os
 import numpy as np
 import pytest
 from MDAnalysis import SelectionError, SelectionWarning
-from MDAnalysisTests import executable_not_found
+from MDAnalysisTests import executable_not_found, tempdir
 from MDAnalysisTests.datafiles import PSF, DCD, FASTA, ALIGN_BOUND, ALIGN_UNBOUND
 from numpy.testing import (
     assert_almost_equal,
@@ -185,9 +185,13 @@ class TestAlign(object):
         assert_almost_equal(rmsd[1], rmsd_weights[1], 6)
 
     def test_AlignTraj_outfile_default(self, universe, reference):
-        reference.trajectory[-1]
-        x = align.AlignTraj(universe, reference)
-        assert os.path.basename(x.filename) == 'rmsfit_adk_dims.dcd'
+        # NOTE: Remove the line os.remove() with release 1.0,
+        #       when the default behavior of AlignTraj changes.
+        with tempdir.in_tempdir():
+            reference.trajectory[-1]
+            x = align.AlignTraj(universe, reference)
+            os.remove(x.filename)
+            assert os.path.basename(x.filename) == 'rmsfit_adk_dims.dcd'
 
     def test_AlignTraj_outfile_default_exists(self, universe, reference, tmpdir):
         reference.trajectory[-1]


### PR DESCRIPTION
Deprecate the default filename in align.AlignTraj and fixed
the file generation in the corresponding test.

Fixes #2099 