### PR TITLE
Limit output of __repr__ for ChainReader class

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -19,6 +19,7 @@ mm/dd/18 orbeckst, PicoCentauri
 Enhancements
 
 Fixes
+   * limit output of Chainreader __repr__ (#2109)
    * added missing docs for lib.pkdtree (#2104)
 
 Changes

--- a/package/MDAnalysis/coordinates/chain.py
+++ b/package/MDAnalysis/coordinates/chain.py
@@ -189,6 +189,8 @@ class ChainReader(base.ProtoReader):
        frames and individual :attr:`dt`.
     .. versionchanged:: 0.19.0
        added ``continuous`` trajectory option
+    .. versionchanged:: 0.19.0
+       limit output of __repr__
 
     """
     format = 'CHAIN'
@@ -575,10 +577,16 @@ class ChainReader(base.ProtoReader):
             yield ts
 
     def __repr__(self):
-        return ("<{clsname} {fname} with {nframes} frames of {natoms} atoms>"
+        if len(self.filenames) > 3:
+            fnames = "{fname} and {nfanmes} more".format(
+                    fname=os.path.basename(self.filenames[0]), 
+                    nfanmes=len(self.filenames) - 1)
+        else:
+            fnames = ", ".join([os.path.basename(fn) for fn in self.filenames])
+        return ("<{clsname} containing {fname} with {nframes} frames of {natoms} atoms>"
                 "".format(
                     clsname=self.__class__.__name__,
-                    fname=[os.path.basename(fn) for fn in self.filenames],
+                    fname=fnames,
                     nframes=self.n_frames,
                     natoms=self.n_atoms))
 

--- a/testsuite/CHANGELOG
+++ b/testsuite/CHANGELOG
@@ -17,7 +17,8 @@ mm/dd/18 PicoCentauri
   * 0.19.1
 
 Enhancements
-
+   * Added tests for ChainReader __repr__
+   
 Fixes
    * Removed rmsfit_adk_dims.dcd file generation during test (Issue #2099).
 

--- a/testsuite/MDAnalysisTests/coordinates/test_chainreader.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_chainreader.py
@@ -49,6 +49,14 @@ class TestChainReader(object):
         return mda.Universe(PSF,
                             [DCD, CRD, DCD, CRD, DCD, CRD, CRD],
                             transformations=[translate([10,10,10])])
+                            
+    def test_regular_repr(self):
+        u = mda.Universe(PSF, [DCD, CRD, DCD])
+        assert_equal("<ChainReader containing adk_dims.dcd, adk_open.crd, adk_dims.dcd with 197 frames of 3341 atoms>", u.trajectory.__repr__())
+        
+                                
+    def test_truncated_repr(self, universe):
+        assert_equal("<ChainReader containing adk_dims.dcd and 6 more with 298 frames of 3341 atoms>", universe.trajectory.__repr__())
 
     def test_next_trajectory(self, universe):
         universe.trajectory.rewind()


### PR DESCRIPTION
Fixes #2109

Changes made in this Pull Request:

The output of __repr__ for the ChainReader class
is limited to 3 trajectories. For more only the first
one is printed.


PR Checklist
------------
 - [ ] Tests
 - [x] Docs
 - [x] CHANGELOG updated
 - [x] Issue raised/referenced