### PR TITLE
Issue 2046 lib distances rework continued

### DIFF
--- a/package/MDAnalysis/lib/nsgrid.pyx
+++ b/package/MDAnalysis/lib/nsgrid.pyx
@@ -65,11 +65,12 @@ neighboring cells only. Care must be taken to ensure that `cellsize` is
 greater than the desired search distance, otherwise all of the neighbours might
 not reflect in the results.
 
-
 .. [#] a pair correspond to two particles that are considered as neighbors .
 
-
 .. versionadded:: 0.19.0
+
+Classes
+-------
 """
 
 # Used to handle memory allocation
@@ -314,10 +315,9 @@ cdef class _PBCBox(object):
 cdef class NSResults(object):
     """Class to store the results
 
-    All the required outputs from :class:`FastNS` is stored in the
-    instance of this class. All the methods of :class:`FastNS` returns
-    an instance of this class, which can be used to  generate the desired
-    results on demand.
+    All outputs from :class:`FastNS` are stored in an instance of this class.
+    All methods of :class:`FastNS` return an instance of this class, which can
+    be used to  generate the desired results on demand.
     """
 
     cdef readonly real cutoff
@@ -403,7 +403,7 @@ cdef class NSResults(object):
 
         See Also
         --------
-        MDAnalysis.lib.nsgrid.NSResults.get_pairs
+        :meth:`~NSResults.get_pairs`
 
         """
 
@@ -457,15 +457,15 @@ cdef class NSResults(object):
             size ``m`` where m is the number of neighbours of
             query atom[i].
 
-        .. code-block:: python
+            .. code-block:: python
 
                 results = NSResults()
                 indices = results.get_indices()
 
-        ``indices[i]`` will output a list of neighboring
-        atoms of ``atom[i]`` from query atoms ``atom``.
-        ``indices[i][j]`` will give the atom-id of initial coordinates
-        such that ``initial_atom[indices[i][j]]`` is a neighbor of ``atom[i]``
+            ``indices[i]`` will be a list of neighboring atoms of
+            ``atom[i]`` from query atoms ``atom``. ``indices[i][j]`` will give
+            the atom-id of initial coordinates such that
+            ``initial_atom[indices[i][j]]`` is a neighbor of ``atom[i]``.
 
         """
 
@@ -491,14 +491,14 @@ cdef class NSResults(object):
             shape ``m`` where m is the number of neighbours of
             query atom[i].
 
-        .. code-block:: python
+            .. code-block:: python
 
                 results = NSResults()
                 distances = results.get_distances()
 
         See Also
         --------
-        MDAnalysis.lib.nsgrid.NSResults.get_indices
+        :meth:`~NSResults.get_indices`
 
         """
 
@@ -757,7 +757,7 @@ cdef class FastNS(object):
           ``[10, 10, 10, 90, 90, 90]``
         * Following operations are advisable for non-PBC calculations
 
-        ..code-block:: python
+        .. code-block:: python
 
             lmax = all_coords.max(axis=0)
             lmin = all_coords.min(axis=0)
@@ -821,21 +821,17 @@ cdef class FastNS(object):
 
         Returns
         -------
-        results : NSResults object
-           The object from :class:NSResults
-           contains ``get_indices``, ``get_distances``.
-           ``get_pairs``, ``get_pair_distances``
+        results : NSResults
+           An :class:`NSResults` object holding neighbor search results, which
+           can be accessed by its methods :meth:`~NSResults.get_indices`,
+           :meth:`~NSResults.get_distances`, :meth:`~NSResults.get_pairs`, and
+           :meth:`~NSResults.get_pair_distances`.
 
         Note
         ----
         For non-PBC aware calculations, the current implementation doesn't work
-        if any of the query coordinates is beyond the range specified in
-        ``box`` in :func:`MDAnalysis.lib.nsgrid.FastNS`.
-
-        See Also
-        --------
-        MDAnalysis.lib.nsgrid.NSResults
-
+        if any of the query coordinates lies outside the `box` supplied to
+        :class:`~MDAnalysis.lib.nsgrid.FastNS`.
         """
 
         cdef ns_int i, j, size_search
@@ -926,15 +922,11 @@ cdef class FastNS(object):
 
         Returns
         -------
-        results : NSResults object
-           The object from :class:NSResults
-           contains ``get_indices``, ``get_distances``.
-           ``get_pairs``, ``get_pair_distances``
-
-        See Also
-        --------
-        MDAnalysis.lib.nsgrid.NSResults
-
+        results : NSResults
+           An :class:`NSResults` object holding neighbor search results, which
+           can be accessed by its methods :meth:`~NSResults.get_indices`,
+           :meth:`~NSResults.get_distances`, :meth:`~NSResults.get_pairs`, and
+           :meth:`~NSResults.get_pair_distances`.
         """
 
         cdef ns_int i, j, size_search

--- a/package/MDAnalysis/lib/nsgrid.pyx
+++ b/package/MDAnalysis/lib/nsgrid.pyx
@@ -88,21 +88,22 @@ DEF EPSILON = 1e-5
 
 ctypedef np.int_t ns_int
 ctypedef np.float32_t real
+ctypedef np.float64_t dreal
 ctypedef real rvec[DIM]
+ctypedef dreal drvec[DIM]
 ctypedef ns_int ivec[DIM]
 ctypedef real matrix[DIM][DIM]
 
 ctypedef vector[ns_int] intvec
 ctypedef vector[real] realvec
+ctypedef vector[dreal] drealvec
 
 # Useful Functions
 cdef real rvec_norm2(const rvec a) nogil:
     return a[XX]*a[XX] + a[YY]*a[YY] + a[ZZ]*a[ZZ]
 
-cdef void rvec_clear(rvec a) nogil:
-    a[XX] = 0.0
-    a[YY] = 0.0
-    a[ZZ] = 0.0
+cdef dreal drvec_norm2(const drvec a) nogil:
+    return a[XX]*a[XX] + a[YY]*a[YY] + a[ZZ]*a[ZZ]
 
 ###############################
 # Utility class to handle PBC #
@@ -112,16 +113,16 @@ cdef struct cPBCBox_t:
     rvec       fbox_diag
     rvec       hbox_diag
     rvec       mhbox_diag
-    real       max_cutoff2
+    dreal      max_cutoff2
 
 
 # Class to handle PBC calculations
-cdef class PBCBox(object):
+cdef class _PBCBox(object):
     """
     Cython implementation of
     `PBC-related <https://en.wikipedia.org/wiki/Periodic_boundary_conditions>`_
     operations. This class is used by classes :class:`FastNS`
-    and :class:`NSGrid` to put all particles inside a brick-shaped box
+    and :class:`_NSGrid` to put all particles inside a brick-shaped box
     and to compute PBC-aware distance. The class can also handle
     non-PBC aware distance evaluations through ``periodic`` argument.
 
@@ -165,7 +166,7 @@ cdef class PBCBox(object):
 
         """
         cdef ns_int i, j
-        cdef real min_hv2, min_ss, tmp
+        cdef dreal min_hv2, min_ss, tmp
 
         # Update matrix
         self.is_triclinic = False
@@ -174,7 +175,10 @@ cdef class PBCBox(object):
                 self.c_pbcbox.box[i][j] = box[i, j]
 
                 if i != j:
-                    if box[i, j] > EPSILON:
+                    # mdamath.triclinic_vectors explicitly sets the off-diagonal
+                    # elements to zero if the box is orthogonal, so we can
+                    # safely check floating point values for equality here
+                    if box[i, j] != 0.0:
                         self.is_triclinic = True
 
         # Update diagonals
@@ -228,7 +232,7 @@ cdef class PBCBox(object):
             raise ValueError("Box does not correspond to PBC=xyz")
         self.fast_update(box)
 
-    cdef void fast_pbc_dx(self, rvec ref, rvec other, rvec dx) nogil:
+    cdef void fast_pbc_dx(self, rvec ref, rvec other, drvec dx) nogil:
         """Dislacement between two points for both
         PBC and non-PBC conditions
 
@@ -254,20 +258,20 @@ cdef class PBCBox(object):
                     for j in range(i, -1, -1):
                         dx[j] += self.c_pbcbox.box[i][j]
 
-    cdef real fast_distance2(self, rvec a, rvec b) nogil:
+    cdef dreal fast_distance2(self, rvec a, rvec b) nogil:
         """Distance calculation between two points
         for both PBC and non-PBC aware calculations
 
         Returns the distance obeying minimum
         image convention if periodic is set to ``True`` while
-        instantiating the ``PBCBox`` object.
+        instantiating the :class:`_PBCBox` object.
         """
 
-        cdef rvec dx
+        cdef drvec dx
         self.fast_pbc_dx(a, b, dx)
-        return rvec_norm2(dx)
+        return drvec_norm2(dx)
 
-    cdef real[:, ::1]fast_put_atoms_in_bbox(self, real[:, ::1] coords) nogil:
+    cdef real[:, ::1] fast_put_atoms_in_bbox(self, real[:, ::1] coords) nogil:
         """Shifts all ``coords`` to an orthogonal brick shaped box
 
         All the coordinates are brought into an orthogonal
@@ -323,12 +327,12 @@ cdef class NSResults(object):
     cdef real[:, ::1] searchcoords
 
     cdef vector[intvec] indices_buffer
-    cdef vector[realvec] distances_buffer
+    cdef vector[drealvec] distances_buffer
     cdef vector[ns_int] pairs_buffer
-    cdef vector[real] pair_distances_buffer
-    cdef vector[real] pair_distances2_buffer
+    cdef vector[dreal] pair_distances_buffer
+    cdef vector[dreal] pair_distances2_buffer
 
-    def __init__(self, real cutoff, real[:, ::1]coords, real[:, ::1]searchcoords):
+    def __init__(self, dreal cutoff, real[:, ::1]coords, real[:, ::1]searchcoords):
         """
         Parameters
         ----------
@@ -348,7 +352,7 @@ cdef class NSResults(object):
 
         self.npairs = 0
 
-    cdef void add_neighbors(self, ns_int beadid_i, ns_int beadid_j, real distance2) nogil:
+    cdef void add_neighbors(self, ns_int beadid_i, ns_int beadid_j, dreal distance2) nogil:
         """Internal function to add pairs and distances to buffers
 
         The buffers populated using this method are used by
@@ -415,17 +419,17 @@ cdef class NSResults(object):
 
         cdef ns_int i, beadid_i, beadid_j
         cdef ns_int idx, nsearch
-        cdef real dist2, dist
+        cdef dreal dist2, dist
 
         nsearch = self.searchcoords.shape[0]
 
         self.indices_buffer = vector[intvec]()
-        self.distances_buffer = vector[realvec]()
+        self.distances_buffer = vector[drealvec]()
 
         # initialize rows corresponding to search
         for i in range(nsearch):
             self.indices_buffer.push_back(intvec())
-            self.distances_buffer.push_back(realvec())
+            self.distances_buffer.push_back(drealvec())
 
         for i in range(0, 2*self.npairs, 2):
             beadid_i = self.pairs_buffer[i]
@@ -482,7 +486,7 @@ cdef class NSResults(object):
 
         Returns
         -------
-        distances : np.ndarray
+        distances : list
             Every element i.e. ``distances[i]`` will be an array of
             shape ``m`` where m is the number of neighbours of
             query atom[i].
@@ -491,11 +495,6 @@ cdef class NSResults(object):
 
                 results = NSResults()
                 distances = results.get_distances()
-
-
-        atoms of ``atom[i]`` and query atoms ``atom``.
-        ``indices[i][j]`` will give the atom-id of initial coordinates
-        such that ``initial_atom[indices[i][j]]`` is a neighbor of ``atom[i]``
 
         See Also
         --------
@@ -507,11 +506,12 @@ cdef class NSResults(object):
             self.create_buffers()
         return list(self.distances_buffer)
 
-cdef class NSGrid(object):
+
+cdef class _NSGrid(object):
     """Constructs a uniform cuboidal grid for a brick-shaped box
 
-    This class uses :class:`PBCBox` to define the brick shaped box
-    It is essential to initialize the box with :class:`PBCBox`
+    This class uses :class:`_PBCBox` to define the brick shaped box
+    It is essential to initialize the box with :class:`_PBCBox`
     inorder to form the grid.
 
     The domain is subdivided into number of cells based on the desired search
@@ -526,15 +526,15 @@ cdef class NSGrid(object):
     This class assumes that all the coordinates are already
     inside the brick shaped box. Care must be taken to ensure
     all the particles are within the brick shaped box as
-    defined by :class:`PBCBox`. This can be ensured by using
-    :func:`~MDAnalysis.lib.nsgrid.PBCBox.fast_put_atoms_in_bbox`
+    defined by :class:`_PBCBox`. This can be ensured by using
+    :func:`~MDAnalysis.lib.nsgrid._PBCBox.fast_put_atoms_in_bbox`
 
     .. warning::
         This class is not meant to be used by end users.
 
     """
 
-    cdef readonly real cutoff  # cutoff
+    cdef readonly dreal cutoff  # cutoff
     cdef ns_int size  # total cells
     cdef ns_int ncoords  # number of coordinates
     cdef ns_int[DIM] ncells  # individual cells in every dimension
@@ -546,7 +546,7 @@ cdef class NSGrid(object):
     cdef ns_int *cellids  # ncoords (Cell occupation id for every atom)
     cdef bint force  # To negate the effects of optimized cutoff
 
-    def __init__(self, ncoords, cutoff, PBCBox box, max_size, force=False):
+    def __init__(self, ncoords, cutoff, _PBCBox box, max_size, force=False):
         """
         Parameters
         ----------
@@ -554,8 +554,8 @@ cdef class NSGrid(object):
             Number of coordinates to fill inside the brick shaped box
         cutoff : float
             Desired cutoff radius
-        box : PBCBox
-            Instance of :class:`PBCBox`
+        box : _PBCBox
+            Instance of :class:`_PBCBox`
         max_size : int
             Maximum total number of cells
         force : boolean
@@ -563,18 +563,24 @@ cdef class NSGrid(object):
         """
 
         cdef ns_int i
-        cdef ns_int ncellx, ncelly, ncellz, size, nbeadspercell
+        cdef ns_int ncellx, ncelly, ncellz
         cdef ns_int xi, yi, zi
         cdef real bbox_vol
+        cdef dreal relative_cutoff_margin
 
         self.ncoords = ncoords
 
         # Calculate best cutoff
         self.cutoff = cutoff
+        # First, we add a small margin to the cell size so that we can safely
+        # use the condition d <= cutoff (instead of d < cutoff) for neighbor
+        # search.
+        relative_cutoff_margin = 1.0e-8
+        while self.cutoff == cutoff:
+            self.cutoff = cutoff * (1.0 + relative_cutoff_margin)
+            relative_cutoff_margin *= 10.0
         if not force:
             bbox_vol = box.c_pbcbox.box[XX][XX] * box.c_pbcbox.box[YY][YY] * box.c_pbcbox.box[YY][YY]
-            size = bbox_vol/cutoff**3
-            nbeadspercell = ncoords/size
             while bbox_vol/self.cutoff**3 > max_size:
                 self.cutoff *= 1.2
 
@@ -591,12 +597,12 @@ cdef class NSGrid(object):
         # Number of beads in every cell
         self.nbeads = <ns_int *> PyMem_Malloc(sizeof(ns_int) * self.size)
         if not self.nbeads:
-            raise MemoryError("Could not allocate memory from NSGrid.nbeads ({} bits requested)".format(sizeof(ns_int) * self.size))
+            raise MemoryError("Could not allocate memory from _NSGrid.nbeads ({} bits requested)".format(sizeof(ns_int) * self.size))
         self.beadids = NULL
         # Cellindex of every bead
         self.cellids = <ns_int *> PyMem_Malloc(sizeof(ns_int) * self.ncoords)
         if not self.cellids:
-            raise MemoryError("Could not allocate memory from NSGrid.cellids ({} bits requested)".format(sizeof(ns_int) * self.ncoords))
+            raise MemoryError("Could not allocate memory from _NSGrid.cellids ({} bits requested)".format(sizeof(ns_int) * self.ncoords))
         self.nbeads_per_cell = 0
 
         for i in range(self.size):
@@ -671,7 +677,7 @@ cdef class NSGrid(object):
         # Allocate memory
         self.beadids = <ns_int *> PyMem_Malloc(sizeof(ns_int) * self.size * self.nbeads_per_cell)  # np.empty((self.size, nbeads_max), dtype=np.int)
         if not self.beadids:
-            raise MemoryError("Could not allocate memory for NSGrid.beadids ({} bits requested)".format(sizeof(ns_int) * self.size * self.nbeads_per_cell))
+            raise MemoryError("Could not allocate memory for _NSGrid.beadids ({} bits requested)".format(sizeof(ns_int) * self.size * self.nbeads_per_cell))
 
         with nogil:
             # Second loop: fill grid
@@ -686,18 +692,18 @@ cdef class NSGrid(object):
 cdef class FastNS(object):
     """Grid based search between two group of atoms
 
-    Instantiates a class object which uses :class:`PBCBox` and
-    :class:`NSGrid` to construct a cuboidal
+    Instantiates a class object which uses :class:`_PBCBox` and
+    :class:`_NSGrid` to construct a cuboidal
     grid in an orthogonal brick shaped box.
 
     Minimum image convention is used for distance evaluations
     if pbc is set to ``True``.
     """
-    cdef PBCBox box
+    cdef _PBCBox box
     cdef real[:, ::1] coords
     cdef real[:, ::1] coords_bbox
-    cdef readonly real cutoff
-    cdef NSGrid grid
+    cdef readonly dreal cutoff
+    cdef _NSGrid grid
     cdef ns_int max_gridsize
     cdef bint periodic
 
@@ -705,8 +711,8 @@ cdef class FastNS(object):
         """
         Initialize the grid and sort the coordinates in respective
         cells by shifting the coordinates in a brick shaped box.
-        The brick shaped box is defined by :class:`PBCBox`
-        and cuboidal grid is initialize by :class:`NSGrid`.
+        The brick shaped box is defined by :class:`_PBCBox`
+        and cuboidal grid is initialize by :class:`_NSGrid`.
         If box is supplied, periodic shifts along box vectors are used
         to contain all the coordinates inside the brick shaped box.
         If box is not supplied, the range of coordinates i.e.
@@ -778,7 +784,7 @@ cdef class FastNS(object):
         if box.shape != (3, 3):
             box = triclinic_vectors(box)
 
-        self.box = PBCBox(box, self.periodic)
+        self.box = _PBCBox(box, self.periodic)
 
         if cutoff < 0:
             raise ValueError("Cutoff must be positive!")
@@ -791,7 +797,7 @@ cdef class FastNS(object):
         self.max_gridsize = max_gridsize
         # Note that self.cutoff might be different from self.grid.cutoff
         # due to optimization
-        self.grid = NSGrid(self.coords_bbox.shape[0], self.cutoff, self.box, self.max_gridsize)
+        self.grid = _NSGrid(self.coords_bbox.shape[0], self.cutoff, self.box, self.max_gridsize)
 
         self.grid.fill_grid(self.coords_bbox)
 
@@ -840,15 +846,15 @@ cdef class FastNS(object):
 
         cdef NSResults results
 
-        cdef real d2
+        cdef dreal d2
         cdef rvec probe
 
         cdef real[:, ::1] searchcoords
         cdef real[:, ::1] searchcoords_bbox
-        cdef NSGrid searchgrid
+        cdef _NSGrid searchgrid
         cdef bint check
 
-        cdef real cutoff2 = self.cutoff * self.cutoff
+        cdef dreal cutoff2 = self.cutoff * self.cutoff
         cdef ns_int npairs = 0
 
         if (search_coords.ndim != 2 or search_coords.shape[1] != 3):
@@ -858,7 +864,7 @@ cdef class FastNS(object):
         # Generate another grid to search
         searchcoords = search_coords.astype(np.float32, order='C', copy=False)
         searchcoords_bbox = self.box.fast_put_atoms_in_bbox(searchcoords)
-        searchgrid = NSGrid(searchcoords_bbox.shape[0], self.grid.cutoff, self.box, self.max_gridsize, force=True)
+        searchgrid = _NSGrid(searchcoords_bbox.shape[0], self.grid.cutoff, self.box, self.max_gridsize, force=True)
         searchgrid.fill_grid(searchcoords_bbox)
 
         size_search = searchcoords.shape[0]
@@ -905,7 +911,7 @@ cdef class FastNS(object):
                                 bid = self.grid.beadids[cellindex_probe * self.grid.nbeads_per_cell + j]
                                 # find distance between search coords[i] and coords[bid]
                                 d2 = self.box.fast_distance2(&searchcoords_bbox[current_beadid, XX], &self.coords_bbox[bid, XX])
-                                if d2 < cutoff2:
+                                if d2 <= cutoff2:
                                     results.add_neighbors(current_beadid, bid, d2)
                                     npairs += 1
         return results
@@ -938,10 +944,10 @@ cdef class FastNS(object):
         cdef ns_int xi, yi, zi
 
         cdef NSResults results
-        cdef real d2
+        cdef dreal d2
         cdef rvec probe
 
-        cdef real cutoff2 = self.cutoff * self.cutoff
+        cdef dreal cutoff2 = self.cutoff * self.cutoff
         cdef ns_int npairs = 0
         cdef bint check
 
@@ -992,7 +998,7 @@ cdef class FastNS(object):
                                     continue
                                 # find distance between search coords[i] and coords[bid]
                                 d2 = self.box.fast_distance2(&self.coords_bbox[current_beadid, XX], &self.coords_bbox[bid, XX])
-                                if d2 < cutoff2 and d2 > EPSILON:
+                                if d2 <= cutoff2 and d2 > EPSILON:
                                     results.add_neighbors(current_beadid, bid, d2)
                                     results.add_neighbors(bid, current_beadid, d2)
                                     npairs += 2

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -38,6 +38,9 @@ Files and directories
 .. autofunction:: greedy_splitext
 .. autofunction:: which
 .. autofunction:: realpath
+.. autofunction:: get_ext
+.. autofunction:: check_compressed_format
+.. autofunction:: format_from_filename_extension
 .. autofunction:: guess_format
 
 Streams
@@ -108,7 +111,13 @@ Containers and lists
 .. autofunction:: asiterable
 .. autofunction:: hasmethod
 .. autoclass:: Namespace
+
+Arrays
+------
+
 .. autofunction:: unique_int_1d(values)
+.. autofunction:: unique_rows
+.. autofunction:: blocks_of
 
 File parsing
 ------------
@@ -122,6 +131,8 @@ Data manipulation and handling
 
 .. autofunction:: fixedwidth_bins
 .. autofunction:: get_weights
+.. autofunction:: ltruncate_int
+.. autofunction:: flatten_dict
 
 Strings
 -------
@@ -148,6 +159,11 @@ Code management
 .. autofunction:: deprecate
 .. autoclass:: _Deprecate
 .. autofunction:: dedent_docstring
+
+Data format checks
+------------------
+
+.. autofunction:: check_box
 
 .. Rubric:: Footnotes
 
@@ -1524,25 +1540,28 @@ def cached(key):
 
 
 def unique_rows(arr, return_index=False):
-    """Return the unique rows from an array
+    """Return the unique rows of an array.
 
     Arguments
     ---------
-    arr : np.array of shape (n1, m)
+    arr : numpy.ndarray
+        Array of shape ``(n1, m)``.
     return_index : bool, optional
       If ``True``, returns indices of array that formed answer (see
       :func:`numpy.unique`)
 
     Returns
     -------
-    unique_rows : numpy.array
-         shape (n2, m)
-    r_idx : numpy.array (optional)
-          index (if `return_index` was ``True``)
+    unique_rows : numpy.ndarray
+         Array of shape ``(n2, m)`` containing only the unique rows of `arr`.
+    r_idx : numpy.ndarray (optional)
+          Array containing the corresponding row indices (if `return_index`
+          is ``True``).
 
     Examples
     --------
     Remove dupicate rows from an array:
+    
     >>> a = np.array([[0, 1], [1, 2], [1, 2], [0, 1], [2, 3]])
     >>> b = unique_rows(a)
     >>> b
@@ -2271,18 +2290,16 @@ def check_box(box):
 
     Returns
     -------
-    boxtype : str
-        * ``'ortho'`` orthogonal box
-        * ``'tri_vecs'`` triclinic box vectors
-
-    checked_box : numpy.ndarray (``dtype=numpy.float32``)
-        Array containing box information:
-        * If `boxtype` is ``'ortho'``, `cecked_box` will have the shape ``(3,)``
-          containing the x-, y-, and z-dimensions of the orthogonal box.
-        * If  `boxtype` is ``'tri_vecs'``, `cecked_box` will have the shape
-          ``(3, 3)`` containing the triclinic box vectors in a lower triangular
-          matrix as returned by
-          :meth:`~MDAnalysis.lib.mdamath.triclinic_vectors`.
+    boxtype : {``'ortho'``, ``'tri_vecs'``}
+        String indicating the box type (orthogonal or triclinic).
+    checked_box : numpy.ndarray
+        Array of dtype ``numpy.float32`` containing box information:
+          * If `boxtype` is ``'ortho'``, `cecked_box` will have the shape ``(3,)``
+            containing the x-, y-, and z-dimensions of the orthogonal box.
+          * If  `boxtype` is ``'tri_vecs'``, `cecked_box` will have the shape
+            ``(3, 3)`` containing the triclinic box vectors in a lower triangular
+            matrix as returned by
+            :meth:`~MDAnalysis.lib.mdamath.triclinic_vectors`.
 
     Raises
     ------

--- a/testsuite/MDAnalysisTests/lib/test_distances.py
+++ b/testsuite/MDAnalysisTests/lib/test_distances.py
@@ -31,57 +31,6 @@ from MDAnalysis.lib import distances
 from MDAnalysis.lib import mdamath
 from MDAnalysis.tests.datafiles import PSF, DCD, TRIC
 
-class TestCheckBox(object):
-
-    prec = 6
-    ref_ortho = np.ones(3, dtype=np.float32)
-    ref_tri_vecs = np.array([[1, 0, 0], [0, 1, 0], [0, 2 ** 0.5, 2 ** 0.5]],
-                            dtype=np.float32)
-
-    @pytest.mark.parametrize('box',
-        ([1, 1, 1, 90, 90, 90],
-         (1, 1, 1, 90, 90, 90),
-         ['1', '1', 1, 90, '90', '90'],
-         ('1', '1', 1, 90, '90', '90'),
-         np.array(['1', '1', 1, 90, '90', '90']),
-         np.array([1, 1, 1, 90, 90, 90], dtype=np.float32),
-         np.array([1, 1, 1, 90, 90, 90], dtype=np.float64),
-         np.array([1, 1, 1, 1, 1, 1, 90, 90, 90, 90, 90, 90],
-                  dtype=np.float32)[::2]))
-    def test_ckeck_box_ortho(self, box):
-        boxtype, checked_box = distances._check_box(box)
-        assert boxtype == 'ortho'
-        assert_equal(checked_box, self.ref_ortho)
-        assert checked_box.dtype == np.float32
-        assert checked_box.flags['C_CONTIGUOUS']
-
-    @pytest.mark.parametrize('box',
-         ([1, 1, 2, 45, 90, 90],
-          (1, 1, 2, 45, 90, 90),
-          ['1', '1', 2, 45, '90', '90'],
-          ('1', '1', 2, 45, '90', '90'),
-          np.array(['1', '1', 2, 45, '90', '90']),
-          np.array([1, 1, 2, 45, 90, 90], dtype=np.float32),
-          np.array([1, 1, 2, 45, 90, 90], dtype=np.float64),
-          np.array([1, 1, 1, 1, 2, 2, 45, 45, 90, 90, 90, 90],
-                   dtype=np.float32)[::2]))
-    def test_check_box_tri_vecs(self, box):
-        boxtype, checked_box = distances._check_box(box)
-        assert boxtype == 'tri_vecs'
-        assert_almost_equal(checked_box, self.ref_tri_vecs, self.prec)
-        assert checked_box.dtype == np.float32
-        assert checked_box.flags['C_CONTIGUOUS']
-
-    def test_check_box_wrong_data(self):
-        with pytest.raises(ValueError):
-            wrongbox = ['invalid', 1, 1, 90, 90, 90]
-            boxtype, checked_box = distances._check_box(wrongbox)
-
-    def test_check_box_wrong_shape(self):
-        with pytest.raises(ValueError):
-            wrongbox = np.ones((3, 3), dtype=np.float32)
-            boxtype, checked_box = distances._check_box(wrongbox)
-
 
 class TestCheckResultArray(object):
 
@@ -179,7 +128,7 @@ def test_capped_distance_checkbrute(npoints, box, query, method, min_cutoff):
 
     if min_cutoff is None:
         min_cutoff = 0.
-    indices = np.where((dists < max_cutoff) & (dists > min_cutoff))
+    indices = np.where((dists <= max_cutoff) & (dists > min_cutoff))
 
     assert_equal(np.sort(found_pairs, axis=0), np.sort(indices[1], axis=0))
 
@@ -212,7 +161,7 @@ def test_capped_distance_return(npoints, box, query, method, min_cutoff):
 
     if min_cutoff is None:
         min_cutoff = 0.
-    indices = np.where((dists < max_cutoff) & (dists > min_cutoff))
+    indices = np.where((dists <= max_cutoff) & (dists > min_cutoff))
 
     assert_equal(np.sort(found_pairs, axis=0), np.sort(indices[1], axis=0))
 
@@ -233,7 +182,7 @@ def test_self_capped_distance(npoints, box, method, min_cutoff):
     for i, coord in enumerate(points):
         dist = distances.distance_array(coord, points[i+1:], box=box)
         if min_cutoff is not None:
-            idx = np.where((dist < max_cutoff) & (dist > min_cutoff))[1]
+            idx = np.where((dist <= max_cutoff) & (dist > min_cutoff))[1]
         else:
             idx = np.where((dist < max_cutoff))[1]
         for other_idx in idx:

--- a/testsuite/MDAnalysisTests/lib/test_nsgrid.py
+++ b/testsuite/MDAnalysisTests/lib/test_nsgrid.py
@@ -52,14 +52,14 @@ def test_pbc_box():
     """Check that PBC box accepts only well-formated boxes"""
     pbc = True
     with pytest.raises(TypeError):
-        nsgrid.PBCBox([])
+        nsgrid._PBCBox([])
 
     with pytest.raises(ValueError):
-        nsgrid.PBCBox(np.zeros((3)), pbc)  # Bad shape
-        nsgrid.PBCBox(np.zeros((3, 3)), pbc)  # Collapsed box
-        nsgrid.PBCBOX(np.array([[0, 0, 0], [0, 1, 0], [0, 0, 1]]), pbc)  # 2D box
-        nsgrid.PBCBOX(np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]), pbc)  # Box provided as array of integers
-        nsgrid.PBCBOX(np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=float), pbc)  # Box provided as array of double
+        nsgrid._PBCBox(np.zeros((3)), pbc)  # Bad shape
+        nsgrid._PBCBox(np.zeros((3, 3)), pbc)  # Collapsed box
+        nsgrid._PBCBox(np.array([[0, 0, 0], [0, 1, 0], [0, 0, 1]]), pbc)  # 2D box
+        nsgrid._PBCBox(np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]), pbc)  # Box provided as array of integers
+        nsgrid._PBCBox(np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=float), pbc)  # Box provided as array of double
 
 
 def test_nsgrid_badcutoff(universe):


### PR DESCRIPTION
Fixes (partially) #2046. This is the fifth of a series of related PRs following PRs #2048, #2062, #2070, and #2083.

Changes made in this Pull Request:
 - Moved `lib.distances._check_box()` to `lib.util.check_box()`
 - Ensured that all methods used in `capped_distance()` have the same cut-off criterion (`distances <= max_cutoff`). According to the `scipy.spatial.cKDTree.query_ball_tree` [docs](https://docs.scipy.org/doc/scipy-0.19.1/reference/generated/scipy.spatial.cKDTree.query_ball_tree.html) and according to some tests I ran, this should also be the case for the pKDTree method. In practice, this is rather pathological (comparing floating point values for equality, you know...) but should still be consistent.
- Ensured that none of the functions in `lib.distances` and `lib.nsgrid` make arbitrary assumptions about when a box is orthogonal. Since the number 90 has an exact float representation, we should refrain from defining arbitrary margins around that value. This is definitely a case where comparing floating point values for equality makes perfect sense (as it has always been done by `lib.mdamath.triclinic_vectors` and the box checks in `lib.distances` (now in `lib.utils`)).
 - Just like all other distance-related functions, `lib.nsgrid`now uses double precision for distance computation.
 - Prefixed all non-user-level classes in `lib.nsgrid` with an underscore.
 - Adjusted all affected tests accordingly.
 - Fixed up half-broken docs of `lib.nsgrid`.
 - Minor doc fix-ups in `lib.utils` I stumbled accross.

PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?
