### PR TITLE
Fixed error in segments, residues with 0 atoms

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -20,7 +20,7 @@ Fixes
    * limit output of Chainreader __repr__ (#2109)
    * added missing docs for lib.pkdtree (#2104)
    * Added sphinx markup for FrameIterator (#2106)
-
+   * fixed error for residues and segments containing 0 atoms (#1999)
 Changes
 
 Deprecations

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -2703,6 +2703,7 @@ class ResidueGroup(GroupBase):
         The :class:`Atoms<Atom>` are ordered locally by :class:`Residue` in the
         :class:`ResidueGroup`.  Duplicates are *not* removed.
         """
+        # If indices is an empty list np.concatenate will fail (Issue #1999).
         try:
             ag = self.universe.atoms[np.concatenate(self.indices)]
         except ValueError:
@@ -2865,6 +2866,7 @@ class SegmentGroup(GroupBase):
         are further ordered by :class:`Segment` in the :class:`SegmentGroup`.
         Duplicates are *not* removed.
         """
+        # If indices is an empty list np.concatenate will fail (Issue #1999).
         try:
             ag = self.universe.atoms[np.concatenate(self.indices)]
         except ValueError:

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -2703,7 +2703,10 @@ class ResidueGroup(GroupBase):
         The :class:`Atoms<Atom>` are ordered locally by :class:`Residue` in the
         :class:`ResidueGroup`.  Duplicates are *not* removed.
         """
-        ag = self.universe.atoms[np.concatenate(self.indices)]
+        try:
+            ag = self.universe.atoms[np.concatenate(self.indices)]
+        except ValueError:
+            ag = self.universe.atoms[self.indices]
         # If the ResidueGroup is known to be unique, this also holds for the
         # atoms therein, since atoms can only belong to one residue at a time.
         # On the contrary, if the ResidueGroup is not unique, this does not
@@ -2862,7 +2865,10 @@ class SegmentGroup(GroupBase):
         are further ordered by :class:`Segment` in the :class:`SegmentGroup`.
         Duplicates are *not* removed.
         """
-        ag = self.universe.atoms[np.concatenate(self.indices)]
+        try:
+            ag = self.universe.atoms[np.concatenate(self.indices)]
+        except ValueError:
+            ag = self.universe.atoms[self.indices]
         # If the SegmentGroup is known to be unique, this also holds for the
         # residues therein, and thus, also for the atoms in those residues.
         # On the contrary, if the SegmentGroup is not unique, this does not

--- a/testsuite/MDAnalysisTests/core/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/core/test_atomgroup.py
@@ -969,13 +969,19 @@ class TestAtomGroup(object):
         assert ag.n_residues == 214
         
     def test_zero_atoms_residues(self, ag):
-        ag[[]].residues.atoms
+        new_ag = ag[[]].residues.atoms
+
+        assert isinstance(new_ag, mda.AtomGroup)
+        assert len(new_ag) == 0
 
     def test_n_segments(self, ag):
         assert ag.n_segments == 1
         
     def test_zero_atoms_segments(self, ag):
-        ag[[]].segments.atoms
+        new_ag = ag[[]].segments.atoms
+
+        assert isinstance(new_ag, mda.AtomGroup)
+        assert len(new_ag) == 0
 
     def test_resids_dim(self, ag):
         assert len(ag.resids) == len(ag)

--- a/testsuite/MDAnalysisTests/core/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/core/test_atomgroup.py
@@ -967,9 +967,15 @@ class TestAtomGroup(object):
 
     def test_n_residues(self, ag):
         assert ag.n_residues == 214
+        
+    def test_zero_atoms_residues(self, ag):
+        ag[[]].residues.atoms
 
     def test_n_segments(self, ag):
         assert ag.n_segments == 1
+        
+    def test_zero_atoms_segments(self, ag):
+        ag[[]].segments.atoms
 
     def test_resids_dim(self, ag):
         assert len(ag.resids) == len(ag)


### PR DESCRIPTION
Fixes #1999 

Changes made in this Pull Request:
The value error of `np.concatenate` for residues and segments is catched.

PR Checklist
------------
 - [] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?