### PR TITLE
added experimental pickling support to Universe

### DIFF
--- a/package/MDAnalysis/auxiliary/base.py
+++ b/package/MDAnalysis/auxiliary/base.py
@@ -307,6 +307,10 @@ class AuxReader(six.with_metaclass(_AuxReaderMeta)):
             self.auxstep._dt = self.time - self.initial_time
             self.rewind()
 
+    def __getstate__(self):
+        # probably works fine, but someone needs to write tests to confirm
+        return NotImplementedError
+
     def copy(self):
         raise NotImplementedError("Copy not implemented for AuxReader")
 

--- a/package/MDAnalysis/coordinates/PDB.py
+++ b/package/MDAnalysis/coordinates/PDB.py
@@ -168,7 +168,7 @@ logger = logging.getLogger("MDAnalysis.coordinates.PBD")
 # Pairs of residue name / atom name in use to deduce PDB formatted atom names
 Pair = collections.namedtuple('Atom', 'resname name')
 
-class PDBReader(base.ReaderBase):
+class PDBReader(base.ReaderBase, base._BAsciiPickle):
     """PDBReader that reads a `PDB-formatted`_ file, no frills.
 
     The following *PDB records* are parsed (see `PDB coordinate section`_ for
@@ -277,7 +277,7 @@ class PDBReader(base.ReaderBase):
         if isinstance(filename, util.NamedStream) and isinstance(filename.stream, StringIO):
             filename.stream = BytesIO(filename.stream.getvalue().encode())
 
-        pdbfile = self._pdbfile = util.anyopen(filename, 'rb')
+        pdbfile = self._f = util.anyopen(filename, 'rb')
 
         line = "magical"
         while line:
@@ -345,7 +345,7 @@ class PDBReader(base.ReaderBase):
         # Pretend the current TS is -1 (in 0 based) so "next" is the
         # 0th frame
         self.close()
-        self._pdbfile = util.anyopen(self.filename, 'rb')
+        self._f = util.anyopen(self.filename, 'rb')
         self.ts.frame = -1
 
     def _read_next_timestep(self, ts=None):
@@ -371,8 +371,8 @@ class PDBReader(base.ReaderBase):
         occupancy = np.ones(self.n_atoms)
 
         # Seek to start and read until start of next frame
-        self._pdbfile.seek(start)
-        chunk = self._pdbfile.read(stop - start).decode()
+        self._f.seek(start)
+        chunk = self._f.read(stop - start).decode()
 
         tmp_buf = []
         for line in chunk.splitlines():
@@ -411,7 +411,7 @@ class PDBReader(base.ReaderBase):
         return self.ts
 
     def close(self):
-        self._pdbfile.close()
+        self._f.close()
 
 
 class PDBWriter(base.WriterBase):

--- a/package/MDAnalysis/coordinates/XYZ.py
+++ b/package/MDAnalysis/coordinates/XYZ.py
@@ -260,7 +260,7 @@ class XYZWriter(base.WriterBase):
                             "".format(atom, x, y, z))
 
 
-class XYZReader(base.ReaderBase):
+class XYZReader(base.ReaderBase, base._AsciiPickle):
     """Reads from an XYZ file
 
     :Data:
@@ -304,7 +304,7 @@ class XYZReader(base.ReaderBase):
         # coordinates::core.py so the last file extension will tell us if it is
         # bzipped or not
         root, ext = os.path.splitext(self.filename)
-        self.xyzfile = util.anyopen(self.filename)
+        self._f = util.anyopen(self.filename)
         self.compression = ext[1:] if ext[1:] != "xyz" else None
         self._cache = dict()
 
@@ -353,7 +353,7 @@ class XYZReader(base.ReaderBase):
         return n_frames
 
     def _read_frame(self, frame):
-        self.xyzfile.seek(self._offsets[frame])
+        self._f.seek(self._offsets[frame])
         self.ts.frame = frame - 1  # gets +1'd in next
         return self._read_next_timestep()
 
@@ -362,7 +362,7 @@ class XYZReader(base.ReaderBase):
         if ts is None:
             ts = self.ts
 
-        f = self.xyzfile
+        f = self._f
 
         try:
             # we assume that there are only two header lines per frame
@@ -383,17 +383,17 @@ class XYZReader(base.ReaderBase):
         self.open_trajectory()
 
     def open_trajectory(self):
-        if self.xyzfile is not None:
+        if self._f is not None:
             raise IOError(
                 errno.EALREADY, 'XYZ file already opened', self.filename)
 
-        self.xyzfile = util.anyopen(self.filename)
+        self._f = util.anyopen(self.filename)
 
         # reset ts
         ts = self.ts
         ts.frame = -1
 
-        return self.xyzfile
+        return self._f
 
     def Writer(self, filename, n_atoms=None, **kwargs):
         """Returns a XYZWriter for *filename* with the same parameters as this
@@ -423,7 +423,7 @@ class XYZReader(base.ReaderBase):
 
     def close(self):
         """Close xyz trajectory file if it was open."""
-        if self.xyzfile is None:
+        if self._f is None:
             return
-        self.xyzfile.close()
-        self.xyzfile = None
+        self._f.close()
+        self._f = None

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -2078,6 +2078,20 @@ class ReaderBase(ProtoReader):
 
         self._ts_kwargs = ts_kwargs
 
+    @classmethod
+    def _unpickle_Reader(cls, filename, timestep, auxs, trans):
+        new_R = cls(filename)
+        new_R.add_transformations(trans)
+        for auxname, auxdata in auxs.items():
+            new_R.add_aux(auxname, auxdata)
+
+    def __reduce__(self):
+        return (self._unpickle_Reader,
+                (self.filename, self.ts, self._auxs, self._transformations))
+
+    def __len__(self):
+        return self.n_frames
+
     def copy(self):
         """Return independent copy of this Reader.
 

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -2078,17 +2078,6 @@ class ReaderBase(ProtoReader):
 
         self._ts_kwargs = ts_kwargs
 
-    @classmethod
-    def _unpickle_Reader(cls, filename, timestep, auxs, trans):
-        new_R = cls(filename)
-        new_R.add_transformations(trans)
-        for auxname, auxdata in auxs.items():
-            new_R.add_aux(auxname, auxdata)
-
-    def __reduce__(self):
-        return (self._unpickle_Reader,
-                (self.filename, self.ts, self._auxs, self._transformations))
-
     def __len__(self):
         return self.n_frames
 

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -208,7 +208,7 @@ from .. import units
 from ..auxiliary.base import AuxReader
 from ..auxiliary.core import auxreader
 from ..core import flags
-from ..lib.util import asiterable, Namespace
+from ..lib.util import asiterable, Namespace, anyopen
 
 
 class Timestep(object):
@@ -374,6 +374,15 @@ class Timestep(object):
             ts.forces = forces
 
         return ts
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state.pop('_reader', None)
+
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
 
     def _init_unitcell(self):
         """Create custom datastructure for :attr:`_unitcell`."""
@@ -2029,6 +2038,33 @@ class ProtoReader(six.with_metaclass(_Readermeta, IOBase)):
         return ts
 
 
+class _AsciiPickle(object):
+    # mixin to allow ascii files to pickle it up with the pros
+    def __getstate__(self):
+        # Shallow copy of state of self
+        # shallow ie don't recursively copy all objects,
+        # just copy the references that __dict__ holds
+        stuff = self.__dict__.copy()
+        # don't pass the file handle over
+        del stuff['_f']
+        # instead pass enough metadata to reconstruct
+        stuff['_pickle_fn'] = self._f.name
+        # TODO: what other state does Reader hold?
+        # TODO: reconstruct file handle position
+        return stuff
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self._f = anyopen(self._pickle_fn)
+
+        del self._pickle_fn
+
+class _BAsciiPickle(_AsciiPickle):
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self._f = anyopen(self._pickle_fn, 'rb')
+
+        del self._pickle_fn
 
 class ReaderBase(ProtoReader):
     """Base class for trajectory readers that extends :class:`ProtoReader` with a

--- a/package/MDAnalysis/coordinates/chain.py
+++ b/package/MDAnalysis/coordinates/chain.py
@@ -353,6 +353,16 @@ class ChainReader(base.ProtoReader):
         self.ts = None
         self.rewind()
 
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state.pop('_ChainReader__chained_trajectories_iter', None)
+
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self.__chained_trajectories_iter = self._chained_iterator()
+
     def _get_local_frame(self, k):
         """Find trajectory index and trajectory frame for chained frame `k`.
 
@@ -415,8 +425,6 @@ class ChainReader(base.ProtoReader):
         # been modified since initial load
         new.ts = self.ts.copy()
         return new
-
-
 
     # attributes that can change with the current reader
     @property

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -768,11 +768,15 @@ class Universe(object):
         return "<Universe with {n_atoms} atoms>".format(
             n_atoms=len(self.atoms))
 
-    def __getstate__(self):
-        raise NotImplementedError
+    @classmethod
+    def _unpickle_U(cls, top, traj, anchor):
+        u = cls(top, anchor_name=anchor)
+        u.load_new(traj)
 
-    def __setstate__(self, state):
-        raise NotImplementedError
+        return u
+
+    def __reduce__(self):
+        return (self._unpickle_U, (self._topology, self.trajectory.filename, self.anchor_name))
 
     # Properties
     @property

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -738,7 +738,7 @@ class Universe(object):
                 return self._anchor_uuid
             except AttributeError:
                 # store this so we can later recall it if needed
-                self._anchor_uuid = uuid.uuid4()
+                self._anchor_uuid = str(uuid.uuid4())
                 return self._anchor_uuid
 
     @property
@@ -770,13 +770,20 @@ class Universe(object):
 
     @classmethod
     def _unpickle_U(cls, top, traj, anchor):
-        u = cls(top, anchor_name=anchor)
-        u.load_new(traj)
+        """Special method used by __reduce__ to deserialise a Universe"""
+        # top is a Topology object at this point, but Universe can handle that
+        u = cls(top)
+        u.anchor_name = anchor
+        # maybe this is None, but that's still cool
+        u.trajectory = traj
 
         return u
 
     def __reduce__(self):
-        return (self._unpickle_U, (self._topology, self.trajectory.filename, self.anchor_name))
+        # Can't quite use __setstate__/__getstate__ so go via __reduce__
+        # Universe's two "legs" of topology and traj both serialise themselves
+        # the only other state held in Universe is anchor name?
+        return (self._unpickle_U, (self._topology, self._trajectory, self.anchor_name))
 
     # Properties
     @property

--- a/testsuite/MDAnalysisTests/core/test_universe.py
+++ b/testsuite/MDAnalysisTests/core/test_universe.py
@@ -283,10 +283,14 @@ class TestUniverse(object):
         assert_equal(len(u.atoms), 3341, "Loading universe failed somehow")
         assert_equal(u.trajectory.n_frames, 2 * ref.trajectory.n_frames)
 
-    def test_pickle_raises_NotImplementedError(self):
+    def test_pickle(self):
         u = mda.Universe(PSF, DCD)
-        with pytest.raises(NotImplementedError):
-            cPickle.dumps(u, protocol = cPickle.HIGHEST_PROTOCOL)
+
+        s = cPickle.dumps(u, protocol = cPickle.HIGHEST_PROTOCOL)
+
+        new_u = cPickle.loads(s)
+
+        assert_equal(u.atoms.names, new_u.atoms.names)
 
     def test_set_dimensions(self):
         u = mda.Universe(PSF, DCD)

--- a/testsuite/MDAnalysisTests/parallelism/test_multiprocessing.py
+++ b/testsuite/MDAnalysisTests/parallelism/test_multiprocessing.py
@@ -7,32 +7,62 @@ import pytest
 
 import MDAnalysis as mda
 from MDAnalysisTests.datafiles import (
-    PSF, DCD
+    PSF, DCD,
+    GRO, XTC,
+    PDB,
+    XYZ,
 )
 
 from numpy.testing import assert_equal
 
 
-@pytest.fixture
-def u():
-    return mda.Universe(PSF, DCD)
+@pytest.fixture(params=[
+    (PSF, DCD),
+    (GRO, XTC),
+    (PDB,),
+    (XYZ,),
+])
+def u(request):
+    if len(request.param) == 1:
+        f = request.param
+        return mda.Universe(f)
+    else:
+        top, trj = request.param
+        return mda.Universe(top, trj)
 
-
+# Define target functions here
+# inside test functions doesn't work
 def cog(u, ag, frame_id):
     u.trajectory[frame_id]
 
     return ag.center_of_geometry()
 
 
-def test_multiprocess_COM(u):
+def getnames(u, ix):
+    # Check topology stuff works
+    return u.atoms[ix].name
+
+
+def test_multiprocess_COG(u):
     ag = u.atoms[10:20]
 
     ref = np.array([cog(u, ag, i)
                     for i in range(4)])
 
     p = multiprocessing.Pool(2)
-
     res = np.array([p.apply(cog, args=(u, ag, i))
                     for i in range(4)])
+    p.close()
+    assert_equal(ref, res)
+
+
+def test_multiprocess_names(u):
+    ref = [getnames(u, i)
+           for i in range(10)]
+
+    p = multiprocessing.Pool(2)
+    res = [p.apply(getnames, args=(u, i))
+                   for i in range(10)]
+    p.close()
 
     assert_equal(ref, res)

--- a/testsuite/MDAnalysisTests/parallelism/test_multiprocessing.py
+++ b/testsuite/MDAnalysisTests/parallelism/test_multiprocessing.py
@@ -1,0 +1,38 @@
+"""Test that MDAnalysis plays nicely with multiprocessing
+
+"""
+import multiprocessing
+import numpy as np
+import pytest
+
+import MDAnalysis as mda
+from MDAnalysisTests.datafiles import (
+    PSF, DCD
+)
+
+from numpy.testing import assert_equal
+
+
+@pytest.fixture
+def u():
+    return mda.Universe(PSF, DCD)
+
+
+def cog(u, ag, frame_id):
+    u.trajectory[frame_id]
+
+    return ag.center_of_geometry()
+
+
+def test_multiprocess_COM(u):
+    ag = u.atoms[10:20]
+
+    ref = np.array([cog(u, ag, i)
+                    for i in range(4)])
+
+    p = multiprocessing.Pool(2)
+
+    res = np.array([p.apply(cog, args=(u, ag, i))
+                    for i in range(4)])
+
+    assert_equal(ref, res)


### PR DESCRIPTION
This adds a basic form of pickling for a Universe, everything seems to work in the snippet below

```python
import dask
from dask import distributed

import MDAnalysis as mda
from MDAnalysisTests.datafiles import GRO, XTC

c = distributed.Client()

u = mda.Universe(GRO, XTC)

ag = u.atoms[:5]

def get_pos(u, ag, frame):    
    u.trajectory[frame]
    
    return ag.center_of_mass()

futures = []
for i in range(10):
    futures.append(dask.delayed(get_pos)(u, ag, i))

L = c.compute(dask.delayed(futures))

ref = [get_pos(u, ag, i) for i in range(10)]
```

WRT what sort of schedulers this should work for, I think this is only safe for distributed or multiprocessing, but not thread (as you can't share a Universe **and** play with frames)

@VOD555 I think this means you can send AtomGroups directly (no more remembering `.ix` tricks), and you don't reread the topology file (ie faster) because that half of the Universe is pickled.