### PR TITLE
Issue 2151 hoomdxmlbonds

### DIFF
--- a/package/MDAnalysis/topology/HoomdXMLParser.py
+++ b/package/MDAnalysis/topology/HoomdXMLParser.py
@@ -137,7 +137,7 @@ class HoomdXMLParser(TopologyReaderBase):
         ):
             try:
                 val = configuration.find(attrname)
-                vals = [(int(el) for el in line.split()[1:])
+                vals = [tuple(int(el) for el in line.split()[1:])
                         for line in val.text.strip().split('\n')
                         if line.strip()]
             except:

--- a/testsuite/MDAnalysisTests/topology/test_hoomdxml.py
+++ b/testsuite/MDAnalysisTests/topology/test_hoomdxml.py
@@ -45,9 +45,12 @@ class TestHoomdXMLParser(ParserBase):
 
     def test_bonds(self, top):
         assert len(top.bonds.values) == 704
+        assert isinstance(top.bonds.values[0], tuple)
 
     def test_angles(self, top):
         assert len(top.angles.values) == 640
+        assert isinstance(top.angles.values[0], tuple)
 
     def test_dihedrals(self, top):
         assert len(top.dihedrals.values) == 576
+        assert isinstance(top.dihedrals.values[0], tuple)


### PR DESCRIPTION
Fixes #2151 

Changes made in this Pull Request:
 - add tests to enforce that bonds, angles, dihedrals are read by the hoomdXML parser in as lists of tuples 
 - edit hoomdXML parser so reads in bonds, angles, dihedrals as lists of tuples, rather than lists of generators 


PR Checklist
------------
 - [x] Tests?
 - [ ] Docs? 
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?
