### PR TITLE
TST: add Azure Windows CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,42 @@
+trigger:
+  # start a new build for every push
+  batch: False
+  branches:
+    include:
+      - develop
+jobs:
+- job: Windows
+  pool:
+    vmIMage: 'VS2017-Win2016'
+  strategy:
+    maxParallel: 6
+    matrix:
+        Python35-64bit-full:
+          PYTHON_VERSION: '3.5'
+          PYTHON_ARCH: 'x64'
+        Python36-64bit-full:
+          PYTHON_VERSION: '3.6'
+          PYTHON_ARCH: 'x64'
+        Python37-64bit-full:
+          PYTHON_VERSION: '3.7'
+          PYTHON_ARCH: 'x64'
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: $(PYTHON_VERSION)
+      addToPath: true
+      architecture: $(PYTHON_ARCH)
+  - script: python -m pip install --upgrade pip setuptools wheel
+    displayName: 'Install tools'
+  - script: python -m pip install cython mock six biopython networkx joblib matplotlib scipy pytest mmtf-python GridDataFormats hypothesis pytest-cov codecov gsd==1.5.2 duecredit
+    displayName: 'Install dependencies'
+  - script: cd package && python setup.py develop --no-deps --user
+    displayName: 'Build MDAnalysis'
+  - script: cd testsuite && python setup.py develop --no-deps --user
+    displayName: 'Install MDAnalysis Test Suite'
+  - script: cd testsuite/MDAnalysisTests && pytest --cov=MDAnalysis -rsx --junitxml=junit/test-results.xml --disable-pytest-warnings
+    displayName: 'Run MDAnalysis Test Suite'
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFiles: '**/test-*.xml'
+      testRunTitle: 'Publish test results for Python $(python.version)'


### PR DESCRIPTION
Run 3 versions of Python in Windows tests in Azure CI.

10 free parallel jobs means this service is gaining popularity with NumPy / SciPy / Numba, etc. & can do Mac and Linux too.

I think there are a few Python 3.5 failures for MDA on Windows that need attention.

It may take a bit of effort to get the CI hooks working properly -- I went ahead and added the marketplace app for the repo, but there's also the online web config where I'll have to add some other devs etc. if we move forward with this.