### PR TITLE
Restores support for gcc on MacOS (closes #2162)

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -15,14 +15,15 @@ The rules for this file:
 ------------------------------------------------------------------------------
 
 mm/dd/yy micaela-matta, xiki-tempula, zemanj, mattwthompson, orbeckst, aliehlen,
-         dpadula85, jbarnoud
+         dpadula85, jbarnoud, manuel.nuno.melo
   * 0.19.3
 
 Fixes
+  * fixed gcc support in MacOS (Issue #2162, PR #2163)
   * fixed error when reading bonds/angles/dihedrals from gsd file (Issue #2152,
-    PR #2154))
+    PR #2154)
   * fixed error when reading bonds/angles/dihedrals from hoomdxml file 
-    (Issue #2151, PR #2153))
+    (Issue #2151, PR #2153)
   * fixed MacOS (XCode) library compatibility 
     (Issue #2144)
   * fixed lib.nsgrid segfault for coordinates very close to the box boundary


### PR DESCRIPTION
Fixes #2162 

MacOS/clang-specific build flags are now only added if the compiler really is clang.

**Important:**
The actual compiler that'll be used is found via a combination of `distutils`' `new_compiler()` and `customize_compiler()`. This felt like the right thing to do also for the OpenMP detection routine, which only used `new_compiler()` (thus ignoring `$CC` et al.). It may very well be a don't-fix-it-if-it-ain't-broken situation, in which case I'll be glad to roll that back.

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
