### PR TITLE
New compounds 'molecules' and 'fragments' for COM and COG computations

### DIFF
--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -707,7 +707,7 @@ class GroupBase(_MutableBase):
 
 
         .. versionchanged:: 0.19.0 Added `compound` parameter
-        .. versionchanged:: 0.20.0 Added `'molecules'` and `'fragments'`
+        .. versionchanged:: 0.20.0 Added ``'molecules'`` and ``'fragments'``
             compounds
         """
 
@@ -788,12 +788,12 @@ class GroupBase(_MutableBase):
 
     @warn_if_not_unique
     def center_of_geometry(self, pbc=None, compound='group'):
-        """Center of geometry (also known as centroid) of the group.
+        """Center of geometry of (compounds of) the group.
 
         Computes the center of geometry (a.k.a. centroid) of
         :class:`Atoms<Atom>` in the group. Centers of geometry per
-        :class:`Residue` or per :class:`Segment` can be obtained by setting the
-        `compound` parameter accordingly.
+        :class:`Residue`, :class:`Segment`, molecule, or fragment can be
+        obtained by setting the `compound` parameter accordingly.
 
         Parameters
         ----------
@@ -1827,11 +1827,12 @@ class AtomGroup(GroupBase):
         # REMOVE in 1.0
         #
         # is this a known attribute failure?
-        if attr in ('fragments',):  # TODO: Generalise this to cover many attributes
+        if attr in ('fragments', 'fragnums'):  # TODO: Generalise this to cover many attributes
             # eg:
             # if attr in _ATTR_ERRORS:
             # raise NDE(_ATTR_ERRORS[attr])
-            raise NoDataError("AtomGroup has no fragments; this requires Bonds")
+            raise NoDataError("AtomGroup has no {}; this requires Bonds"
+                              "".format(attr))
         elif hasattr(self.universe._topology, 'names'):
             # Ugly hack to make multiple __getattr__s work
             try:
@@ -3123,8 +3124,9 @@ class Atom(ComponentBase):
     """
     def __getattr__(self, attr):
         """Try and catch known attributes and give better error message"""
-        if attr in ('fragment',):
-            raise NoDataError("Atom has no fragment data, this requires Bonds")
+        if attr in ('fragment', 'fragnum'):
+            raise NoDataError("Atom has no {} data, this requires Bonds"
+                              "".format(attr))
         else:
             raise AttributeError("{cls} has no attribute {attr}".format(
                 cls=self.__class__.__name__, attr=attr))

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -785,9 +785,10 @@ class Masses(AtomAttr):
     def center_of_mass(group, pbc=None, compound='group'):
         """Center of mass of (compounds of) the group.
 
-        Computes the center of mass of atoms in the group.
-        Centers of mass per residue or per segment can be obtained by setting
-        the `compound` parameter accordingly.
+        Computes the center of mass of :class:`Atoms<Atom>` in the group.
+        Centers of mass per :class:`Residue`, :class:`Segment`, molecule, or
+        fragment can be obtained by setting the `compound` parameter
+        accordingly.
 
         Parameters
         ----------
@@ -819,8 +820,10 @@ class Masses(AtomAttr):
 
         Note
         ----
-        The :class:`MDAnalysis.core.flags` flag *use_pbc* when set to
-        ``True`` allows the *pbc* flag to be used by default.
+        * This method can only be accessed if the underlying topology has
+          information about atomic masses.
+        * The :class:`MDAnalysis.core.flags` flag *use_pbc* when set to
+          ``True`` allows the *pbc* flag to be used by default.
 
 
         .. versionchanged:: 0.8 Added `pbc` parameter
@@ -1675,7 +1678,9 @@ class Bonds(_Connection):
     transplants = defaultdict(list)
 
     def bonded_atoms(self):
-        """An AtomGroup of all atoms bonded to this Atom"""
+        """An :class:`~MDAnalysis.core.groups.AtomGroup` of all
+        :class:`Atoms<MDAnalysis.core.groups.Atom>` bonded to this
+        :class:`~MDAnalysis.core.groups.Atom`."""
         idx = [b.partner(self).index for b in self.bonds]
         return self.universe.atoms[idx]
 
@@ -1684,37 +1689,88 @@ class Bonds(_Connection):
                                   bonded_atoms.__doc__)))
 
     def fragnum(self):
-        """The number (ID) of the fragment this Atom is part of
+        """The number (ID) of the
+        :class:`~MDAnalysis.core.topologyattrs.Bonds.fragment` this
+        :class:`~MDAnalysis.core.groups.Atom` is part of.
+
+        Note
+        ----
+        This property is only accessible if the underlying topology contains
+        bond information.
+
 
         .. versionadded:: 0.20.0
         """
         return self.universe._fragdict[self][0]
 
     def fragnums(self):
-        """1d-numpy array of fragment numbers (IDs).
+        """The
+        :class:`fragment numbers<MDAnalysis.core.topologyattrs.Bonds.fragnum>`
+        of all :class:`Atoms<MDAnalysis.core.groups.Atom>` in this
+        :class:`~MDAnalysis.core.groups.AtomGroup`.
 
-        Contains all fragment numbers of all Atoms in this AtomGroup.
+        A :class:`numpy.ndarray` with
+        :attr:`~numpy.ndarray.shape`\ ``=(``\ :attr:`~AtomGroup.n_atoms`\ ``,)``
+        and :attr:`~numpy.ndarray.dtype`\ ``=numpy.int64``.
 
-        .. versionadded 0.20.0
+        Note
+        ----
+        This property is only accessible if the underlying topology contains
+        bond information.
+
+
+        .. versionadded:: 0.20.0
         """
         fragdict = self.universe._fragdict
         return np.array([fragdict[a][0] for a in self], dtype=np.int64)
 
     def fragment(self):
-        """The fragment that this Atom is part of
+        """An :class:`~MDAnalysis.core.groups.AtomGroup` representing the
+        fragment this :class:`~MDAnalysis.core.groups.Atom` is part of.
+
+        A fragment is a
+        :class:`group of atoms<MDAnalysis.core.groups.AtomGroup>` which are
+        interconnected by :class:`~MDAnalysis.core.topologyattrs.Bonds`, i.e.,
+        there exists a path along one
+        or more :class:`~MDAnalysis.core.topologyattrs.Bonds` between any pair
+        of :class:`Atoms<MDAnalysis.core.groups.Atom>`
+        within a fragment. Thus, a fragment typically corresponds to a molecule.
+
+        Note
+        ----
+        This property is only accessible if the underlying topology contains
+        bond information.
+
 
         .. versionadded:: 0.9.0
         """
         return self.universe._fragdict[self][1]
 
     def fragments(self):
-        """Read-only list of fragments.
+        """Read-only :class:`tuple` of
+        :class:`fragments<MDAnalysis.core.topologyattrs.Bonds.fragment>`.
 
-        Contains all fragments that any Atom in this AtomGroup is
-        part of, the contents of the fragments may extend beyond the
-        contents of this AtomGroup.
+        Contains all fragments that
+        any :class:`~MDAnalysis.core.groups.Atom` in this
+        :class:`~MDAnalysis.core.groups.AtomGroup` is part of.
 
-        .. versionadded 0.9.0
+        A fragment is a
+        :class:`group of atoms<MDAnalysis.core.groups.AtomGroup>` which are
+        interconnected by :class:`~MDAnalysis.core.topologyattrs.Bonds`, i.e.,
+        there exists a path along one
+        or more :class:`~MDAnalysis.core.topologyattrs.Bonds` between any pair
+        of :class:`Atoms<MDAnalysis.core.groups.Atom>`
+        within a fragment. Thus, a fragment typically corresponds to a molecule.
+
+        Note
+        ----
+        * This property is only accessible if the underlying topology contains
+          bond information.
+        * The contents of the fragments may extend beyond the contents of this
+          :class:`~MDAnalysis.core.groups.AtomGroup`.
+
+
+        .. versionadded:: 0.9.0
         """
         return tuple(sorted(
             set(a.fragment for a in self),

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -1012,9 +1012,9 @@ class Universe(object):
         frags = tuple([AtomGroup(np.sort(ix), self) for ix in frag_indices])
 
         fragdict = {}
-        for f in frags:
+        for i, f in enumerate(frags):
             for a in f:
-                fragdict[a] = f
+                fragdict[a] = (i, f)
 
         return fragdict
 

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -1004,6 +1004,8 @@ class Universe(object):
            by their first atom index so their order is predictable.
         .. versionchanged:: 0.19.0
            Uses faster C++ implementation
+        .. versionchanged:: 0.20.0
+           Added fragment number to fragdict items
         """
         atoms = self.atoms.ix
         bonds = self.atoms.bonds.to_indices()


### PR DESCRIPTION
Changes made in this Pull Request:
 - `*Group.center_of_mass()`, `*Group.center_of_geometry()`, and `*Group.center()` are now able to compute centers (of mass/geometry/whatever) per molecule or per fragment by setting the optional `compound` kwarg to `'molecules'` or `'fragments'`, respectively.
- In order to facilitate the per-fragment computation, the format of the items stored in `Universe._fragdict` now contain tuples of the form `(fragnum, fragment)` instead of just `fragment`.
- The fragnum(s) of an `Atom` /  `AtomGroup` can be accessed via the `Atom.fragnum` / `AtomGroup.fragnums` attribute (similar to `molnum` / `molnums`).

Tests and changelog entries are yet to come.

PR Checklist
------------
 - [ ] Tests?
 - [x] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
