### PR TITLE
sum method for atomgroups

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -43,6 +43,8 @@ Enhancements
     SegmentGroups via ResidueGroup.atoms or SegmentGroup.atoms, respectively.
     This speeds up all methods using these mechanisms. (Issue #2203, PR #2204)
   * added more Van-der-Waals radii to improve guess_bonds (#2138, PR #2142)
+  * added *Group.accumulate() (PR #2192)
+	* added compound kwarg to total_mass and total_charge (PR #2192)
 
 Changes
   * added official support for Python 3.7 (PR #1963)

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -44,7 +44,7 @@ Enhancements
     This speeds up all methods using these mechanisms. (Issue #2203, PR #2204)
   * added more Van-der-Waals radii to improve guess_bonds (#2138, PR #2142)
   * added *Group.accumulate() (PR #2192)
-	* added compound kwarg to total_mass and total_charge (PR #2192)
+  * added compound kwarg to total_mass and total_charge (PR #2192)
 
 Changes
   * added official support for Python 3.7 (PR #1963)

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -859,50 +859,50 @@ class GroupBase(_MutableBase):
         """Accumulates the attribute associated with (compounds of) the group.
 
         Accumulates the attribute of :class:`Atoms<Atom>` in the group.
-        The accumulation is done per :class:`Residue`, :class:`Segment`, molecule, 
+        The accumulation per :class:`Residue`, :class:`Segment`, molecule, 
         or fragment can be obtained by setting the `compound` parameter
-        accordingly. By default the method sums up all elements, but 
-        any numpy function that takes a multi-dimensional array of the same 
+        accordingly. By default, the method sums up all attributes per compound, but 
+        any function that takes a multi-dimensional array of the same 
         dtype and returns a scalar can be used. For multi-dimensional input 
-        arrays the accumulation is performed along the first axes.
+        arrays, the accumulation is performed along the first axes.
 
         Parameters
         ----------
-        attribute : str, numpy.ndarray
-            Attribute or :class:`numpy.ndarray` to accumulate.
-            If a :class:`numpy.ndarray` is provided which first dimensions 
+        attribute : str or array_like
+            Attribute or array of values to accumulate.
+            If a :class:`numpy.ndarray` is provided, its first dimension
             must have the same length as the total number of atoms in 
-            the :class:`AtomGroup`.
-        function : function, optional
+            the group.
+        function : callable, optional
             Numpy function to perform. It must take an array of the same dtype 
             and return a scalar.
         compound : {'group', 'segments', 'residues', 'molecules', 'fragments'}, optional
-            If ``'group'``, the sum over all elements associated
+            If ``'group'``, the sum over all attributes associated
             with atoms in the group will
-            be returned as a single value. Else, the sum for all elements
-            of each :class:`Segment`, :class:`Residue`, molecule, or fragment
-            will be returned as an 1d array.
-            Note that, in any case, *only* the positions of :class:`Atoms<Atom>`
+            be returned as a single value. Otherwise, the accumulation of the attributes
+            per :class:`Segment`, :class:`Residue`, molecule, or fragment
+            will be returned as a 1d array.
+            Note that, in any case, *only* the :class:`Atoms<Atom>`
             *belonging to the group* will be taken into account.
 
         Returns
         -------
         float or numpy.ndarray
-            Acuumulation of the attribute or provided numpy.ndarray.
-            If `compound` was set to ``'group'``, the first dimension 
-            of the input is contracted to a single value.
-            If `compound` was set to ``'segments'``, ``'residues'``, 
+            Acuumulation of the `attribute`.
+            If `compound` is set to ``'group'``, the first dimension 
+            of the `attribute` array will be contracted to a single value.
+            If `compound` is set to ``'segments'``, ``'residues'``, 
             ``'molecules'``, or ``'fragments'``, the length of 
-            the first dimension is the number of compounds. In all cases the
+            the length of the first dimension will correspond to the number of compounds. In all cases, the
             other dimensions of the return array are of the original shape.
 
         Raises
         ------
         ValueError
             If provided array does not have the same length 
-            as the number of atoms in the :class:`AtomGroup`:.
+            as the number of atoms in the group.
         ~MDAnalysis.exceptions.NoDataError
-            If :class:`AtomGroup`: does not have the given attribute.
+            If the given attribute is missing.
         ValueError
             If `compound` is not one of ``'group'``, ``'segments'``,
             ``'residues'``, ``'molecules'``, or ``'fragments'``.
@@ -924,7 +924,7 @@ class GroupBase(_MutableBase):
             >>> sel = u.select_atoms('name CA')
             >>> sel.accumulate('masses', compound='residues')
     
-        To find the maximal charge per fragment of a given :class:`AtomGroup`::
+        To find the maximum atomic charge per fragment of a given :class:`AtomGroup`::
         
             >>> sel.accumulate('charges', compound="fragments", function=np.max)
 
@@ -934,7 +934,7 @@ class GroupBase(_MutableBase):
 
         atoms = self.atoms
 
-        if type(attribute) in (np.ndarray, tuple, list):
+        if isinstance(attribute, (np.ndarray, tuple, list)):
             attribute_values = np.asarray(attribute)
             if len(attribute_values) != len(atoms):
                 raise ValueError("The input array length {} does not match "

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -861,10 +861,10 @@ class GroupBase(_MutableBase):
         Accumulates the attribute of :class:`Atoms<Atom>` in the group.
         The accumulation per :class:`Residue`, :class:`Segment`, molecule, 
         or fragment can be obtained by setting the `compound` parameter
-        accordingly. By default, the method sums up all attributes per compound, but 
-        any function that takes a multi-dimensional array of the same 
-        dtype and returns a scalar can be used. For multi-dimensional input 
-        arrays, the accumulation is performed along the first axes.
+        accordingly. By default, the method sums up all attributes per compound, 
+        but any function that takes a array and returns a acuumulation over a 
+        over a given axis can be used. For multi-dimensional input arrays, 
+        the accumulation is performed along the first axes.
 
         Parameters
         ----------
@@ -874,8 +874,10 @@ class GroupBase(_MutableBase):
             must have the same length as the total number of atoms in 
             the group.
         function : callable, optional
-            Numpy function to perform. It must take an array of the same dtype 
-            and return a scalar.
+            The function performing the accumulation. It must take the array of
+            attribute values to accumulate as its only positional argument and
+            accept an (optional) keyword argument ``axis`` allowing to specify
+            the axis along which the accumulation is performed.
         compound : {'group', 'segments', 'residues', 'molecules', 'fragments'}, optional
             If ``'group'``, the sum over all attributes associated
             with atoms in the group will
@@ -901,8 +903,6 @@ class GroupBase(_MutableBase):
         ValueError
             If provided array does not have the same length 
             as the number of atoms in the group.
-        ~MDAnalysis.exceptions.NoDataError
-            If the given attribute is missing.
         ValueError
             If `compound` is not one of ``'group'``, ``'segments'``,
             ``'residues'``, ``'molecules'``, or ``'fragments'``.
@@ -937,16 +937,11 @@ class GroupBase(_MutableBase):
         if isinstance(attribute, (np.ndarray, tuple, list)):
             attribute_values = np.asarray(attribute)
             if len(attribute_values) != len(atoms):
-                raise ValueError("The input array length {} does not match "
-                                 "the required length {} based on "
-                                 "the group size.".format(len(attribute_values),
-                                                          len(atoms)))
+                raise ValueError("The input array length ({}) does not match "
+                                 "the number of atoms ({}) in the group."
+                                 "".format(len(attribute_values), len(atoms)))
         else:
-            try:
-                attribute_values = getattr(atoms, attribute)
-            except AttributeError:
-                raise NoDataError("AtomGroup does not have '{}' "
-                                  "attribute.".format(attribute))
+            attribute_values = getattr(atoms, attribute)
 
         comp = compound.lower()
 

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -862,8 +862,9 @@ class GroupBase(_MutableBase):
         The accumulation is done per :class:`Residue`, :class:`Segment`, molecule, 
         or fragment can be obtained by setting the `compound` parameter
         accordingly. By default the method sums up all elements, but 
-        any numpy function that takes any multi-dimensional array of the same dtype and 
-        returns a scalar can be used.
+        any numpy function that takes a multi-dimensional array of the same 
+        dtype and returns a scalar can be used. For multi-dimensional input 
+        arrays the accumulation is performed along the first axes.
 
         Parameters
         ----------
@@ -886,13 +887,14 @@ class GroupBase(_MutableBase):
 
         Returns
         -------
-        numpy.ndarray
+        float or numpy.ndarray
             Acuumulation of the attribute or provided numpy.ndarray.
-            If `compound` was set to ``'group'``, the output will be a single
-            value.
+            If `compound` was set to ``'group'``, the first dimension 
+            of the input is contracted to a single value.
             If `compound` was set to ``'segments'``, ``'residues'``, 
-            ``'molecules'``, or ``'fragments'``, the output will be a 1d array
-            of shape ``(n,)`` where ``n`` is the number of compounds.
+            ``'molecules'``, or ``'fragments'``, the length of 
+            the first dimension is the number of compounds. In all cases the
+            other dimensions of the return array are of the original shape.
 
         Raises
         ------
@@ -933,7 +935,7 @@ class GroupBase(_MutableBase):
         atoms = self.atoms
 
         if type(attribute) in (np.ndarray, tuple, list):
-            attribute_values = np.array(attribute)
+            attribute_values = np.asarray(attribute)
             if len(attribute_values) != len(atoms):
                 raise ValueError("The input array length {} does not match "
                                  "the required length {} based on "

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -841,7 +841,7 @@ class Masses(AtomAttr):
             If 'group', the total mass of all atoms in the atomgroup will
             be returned as a single value. Else, the total masses
             of each :class:`Segment`, :class:`Residue`, molecule, or fragment
-            will be returned as an 1D array of values.
+            will be returned as a 1D array.
             Note that, in any case, *only* the masses of :class:`Atoms<Atom>`
             *belonging to the group* will be taken into account.
 
@@ -851,7 +851,7 @@ class Masses(AtomAttr):
             Total masses of the group.
             If `compound` was set to 'group', the output will be a single
             value.
-            If `compound` was set to 'segments' or 'residues', the output will
+            Otherwise, the output will
             be a 1d array of shape ``(n,)`` where ``n`` is the number
             compounds.
 
@@ -1202,7 +1202,7 @@ class Charges(AtomAttr):
             If 'group', the total charge of all atoms in the atomgroup will
             be returned as a single value. Else, the total charges
             of each :class:`Segment`, :class:`Residue`, molecule, or fragment
-            will be returned as an 1D array of values.
+            will be returned as a 1D array.
             Note that, in any case, *only* the masses of :class:`Atoms<Atom>`
             *belonging to the group* will be taken into account.
 
@@ -1212,7 +1212,7 @@ class Charges(AtomAttr):
             Total masses of the group.
             If `compound` was set to 'group', the output will be a single
             value.
-            If `compound` was set to 'segments' or 'residues', the output will
+            Otherwise, the output will
             be a 1d array of shape ``(n,)`` where ``n`` is the number
             compounds.
 

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -847,7 +847,7 @@ class Masses(AtomAttr):
 
         Returns
         -------
-        sum : numpy.ndarray
+        float or numpy.ndarray
             Total masses of the group.
             If `compound` was set to 'group', the output will be a single
             value.
@@ -1208,7 +1208,7 @@ class Charges(AtomAttr):
 
         Returns
         -------
-        sum : numpy.ndarray
+        float or numpy.ndarray
             Total masses of the group.
             If `compound` was set to 'group', the output will be a single
             value.

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -782,18 +782,20 @@ class Masses(AtomAttr):
         Parameters
         ----------
         pbc : bool, optional
-            If ``True`` and `compound` is 'group', move all atoms to the primary
-            unit cell before calculation.
-            If ``True`` and `compound` is 'segments' or 'residues', the centers
-            of mass of each compound will be calculated without moving any
-            atoms to keep the compounds intact. Instead, the resulting
+            If ``True`` and `compound` is ``'group'``, move all atoms to the
+            primary unit cell before calculation.
+            If ``True`` and `compound` is ``'segments'`` or ``'residues'``, the
+            centers of mass of each compound will be calculated without moving
+            any atoms to keep the compounds intact. Instead, the resulting
             center-of-mass position vectors will be moved to the primary unit
             cell after calculation.
-        compound : {'group', 'segments', 'residues', 'molecules', 'fragments'}, optional
-            If 'group', the center of mass of all atoms in the atomgroup will
-            be returned as a single position vector. Else, the centers of mass
-            of each :class:`Segment`, :class:`Residue`, molecule, or fragment
-            will be returned as an array of position vectors, i.e. a 2d array.
+        compound : {'group', 'segments', 'residues', 'molecules', 'fragments'},\
+                   optional
+            If ``'group'``, the center of mass of all atoms in the group will
+            be returned as a single position vector. Otherwise, the centers of
+            mass of each :class:`Segment`, :class:`Residue`, molecule, or
+            fragment will be returned as an array of position vectors, i.e. a 2d
+            array.
             Note that, in any case, *only* the positions of :class:`Atoms<Atom>`
             *belonging to the group* will be taken into account.
 
@@ -801,11 +803,11 @@ class Masses(AtomAttr):
         -------
         center : numpy.ndarray
             Position vector(s) of the center(s) of mass of the group.
-            If `compound` was set to 'group', the output will be a single
+            If `compound` was set to ``'group'``, the output will be a single
             position vector.
-            If `compound` was set to 'segments' or 'residues', the output will
-            be a 2d array of shape ``(n, 3)`` where ``n`` is the number
-            compounds.
+            If `compound` was set to ``'segments'`` or ``'residues'``, the
+            output will be a 2d coordinate array of shape ``(n, 3)`` where ``n``
+            is the number of compounds.
 
         Note
         ----
@@ -837,23 +839,22 @@ class Masses(AtomAttr):
 
         Parameters
         ----------
-        compound : {'group', 'segments', 'residues', 'molecules', 'fragments'}, optional
-            If 'group', the total mass of all atoms in the atomgroup will
-            be returned as a single value. Else, the total masses
-            of each :class:`Segment`, :class:`Residue`, molecule, or fragment
-            will be returned as a 1D array.
+        compound : {'group', 'segments', 'residues', 'molecules', 'fragments'},\
+                   optional
+            If ``'group'``, the total mass of all atoms in the group will be
+            returned as a single value. Otherwise, the total masses per
+            :class:`Segment`, :class:`Residue`, molecule, or fragment will be
+            returned as a 1d array.
             Note that, in any case, *only* the masses of :class:`Atoms<Atom>`
             *belonging to the group* will be taken into account.
 
         Returns
         -------
         float or numpy.ndarray
-            Total masses of the group.
-            If `compound` was set to 'group', the output will be a single
-            value.
-            Otherwise, the output will
-            be a 1d array of shape ``(n,)`` where ``n`` is the number
-            compounds.
+            Total mass of (compounds of) the group.
+            If `compound` was set to ``'group'``, the output will be a single
+            value. Otherwise, the output will be a 1d array of shape ``(n,)``
+            where ``n`` is the number of compounds.
 
 
         .. versionchanged:: 0.20.0 Added `compound` parameter
@@ -1197,23 +1198,22 @@ class Charges(AtomAttr):
 
         Parameters
         ----------
-        compound : {'group', 'segments', 'residues', 'molecules', 'fragments'}, optional
-            If 'group', the total charge of all atoms in the atomgroup will
-            be returned as a single value. Else, the total charges
-            of each :class:`Segment`, :class:`Residue`, molecule, or fragment
-            will be returned as a 1D array.
-            Note that, in any case, *only* the masses of :class:`Atoms<Atom>`
+        compound : {'group', 'segments', 'residues', 'molecules', 'fragments'},\
+                   optional
+            If 'group', the total charge of all atoms in the group will
+            be returned as a single value. Otherwise, the total charges per
+            :class:`Segment`, :class:`Residue`, molecule, or fragment
+            will be returned as a 1d array.
+            Note that, in any case, *only* the charges of :class:`Atoms<Atom>`
             *belonging to the group* will be taken into account.
 
         Returns
         -------
         float or numpy.ndarray
-            Total masses of the group.
-            If `compound` was set to 'group', the output will be a single
-            value.
-            Otherwise, the output will
-            be a 1d array of shape ``(n,)`` where ``n`` is the number
-            compounds.
+            Total charge of (compounds of) the group.
+            If `compound` was set to ``'group'``, the output will be a single
+            value. Otherwise, the output will be a 1d array of shape ``(n,)``
+            where ``n`` is the number of compounds.
 
 
         .. versionchanged:: 0.20.0 Added `compound` parameter

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -827,11 +827,39 @@ class Masses(AtomAttr):
         ('center_of_mass', center_of_mass))
 
     @warn_if_not_unique
-    def total_mass(group):
-        """Total mass of the Group.
+    def total_mass(group, compound='group'):
+        """Total mass of (compounds of) the group.
+        
+        Computes the total mass of :class:`Atoms<Atom>` in the group.
+        Total masses per :class:`Residue`, :class:`Segment`, molecule, or
+        fragment can be obtained by setting the `compound` parameter
+        accordingly.
 
+        Parameters
+        ----------
+        compound : {'group', 'segments', 'residues', 'molecules', 'fragments'}, optional
+            If 'group', the total mass of all atoms in the atomgroup will
+            be returned as a single value. Else, the total masses
+            of each :class:`Segment`, :class:`Residue`, molecule, or fragment
+            will be returned as an 1D array of values.
+            Note that, in any case, *only* the masses of :class:`Atoms<Atom>`
+            *belonging to the group* will be taken into account.
+
+        Returns
+        -------
+        sum : numpy.ndarray
+            Total masses of the group.
+            If `compound` was set to 'group', the output will be a single
+            value.
+            If `compound` was set to 'segments' or 'residues', the output will
+            be a 1d array of shape ``(n,)`` where ``n`` is the number
+            compounds.
+
+
+        .. versionchanged:: 0.20.0 Added `compound` parameter
         """
-        return group.masses.sum()
+        atoms = group.atoms
+        return atoms.sum(weights=atoms.masses, compound=compound)
 
     transplants[GroupBase].append(
         ('total_mass', total_mass))
@@ -1160,11 +1188,39 @@ class Charges(AtomAttr):
         return charges
 
     @warn_if_not_unique
-    def total_charge(group):
-        """Total charge of the Group.
+    def total_charge(group, compound='group'):
+        """Total charge of (compounds of) the group.
+        
+        Computes the total charge of :class:`Atoms<Atom>` in the group.
+        Total charges per :class:`Residue`, :class:`Segment`, molecule, or
+        fragment can be obtained by setting the `compound` parameter
+        accordingly.
 
+        Parameters
+        ----------
+        compound : {'group', 'segments', 'residues', 'molecules', 'fragments'}, optional
+            If 'group', the total charge of all atoms in the atomgroup will
+            be returned as a single value. Else, the total charges
+            of each :class:`Segment`, :class:`Residue`, molecule, or fragment
+            will be returned as an 1D array of values.
+            Note that, in any case, *only* the masses of :class:`Atoms<Atom>`
+            *belonging to the group* will be taken into account.
+
+        Returns
+        -------
+        sum : numpy.ndarray
+            Total masses of the group.
+            If `compound` was set to 'group', the output will be a single
+            value.
+            If `compound` was set to 'segments' or 'residues', the output will
+            be a 1d array of shape ``(n,)`` where ``n`` is the number
+            compounds.
+
+
+        .. versionchanged:: 0.20.0 Added `compound` parameter
         """
-        return group.charges.sum()
+        atoms = group.atoms
+        return atoms.sum(weights=atoms.charges, compound=compound)
 
     transplants[GroupBase].append(
         ('total_charge', total_charge))

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -859,7 +859,7 @@ class Masses(AtomAttr):
         .. versionchanged:: 0.20.0 Added `compound` parameter
         """
         atoms = group.atoms
-        return atoms.sum(weights=atoms.masses, compound=compound)
+        return atoms.accumulate("masses", compound=compound)
 
     transplants[GroupBase].append(
         ('total_mass', total_mass))
@@ -1220,7 +1220,7 @@ class Charges(AtomAttr):
         .. versionchanged:: 0.20.0 Added `compound` parameter
         """
         atoms = group.atoms
-        return atoms.sum(weights=atoms.charges, compound=compound)
+        return atoms.accumulate("charges", compound=compound)
 
     transplants[GroupBase].append(
         ('total_charge', total_charge))

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -820,8 +820,7 @@ class Masses(AtomAttr):
         .. versionchanged:: 0.20.0 Added ``'molecules'`` and ``'fragments'``
             compounds
         """
-        atoms = group.atoms
-        return atoms.center(weights=atoms.masses, pbc=pbc, compound=compound)
+        return group.atoms.center(weights=atoms.masses, pbc=pbc, compound=compound)
 
     transplants[GroupBase].append(
         ('center_of_mass', center_of_mass))
@@ -858,8 +857,7 @@ class Masses(AtomAttr):
 
         .. versionchanged:: 0.20.0 Added `compound` parameter
         """
-        atoms = group.atoms
-        return atoms.accumulate("masses", compound=compound)
+        return group.atoms.accumulate("masses", compound=compound)
 
     transplants[GroupBase].append(
         ('total_mass', total_mass))
@@ -1219,8 +1217,7 @@ class Charges(AtomAttr):
 
         .. versionchanged:: 0.20.0 Added `compound` parameter
         """
-        atoms = group.atoms
-        return atoms.accumulate("charges", compound=compound)
+        return group.atoms.accumulate("charges", compound=compound)
 
     transplants[GroupBase].append(
         ('total_charge', total_charge))

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -820,7 +820,8 @@ class Masses(AtomAttr):
         .. versionchanged:: 0.20.0 Added ``'molecules'`` and ``'fragments'``
             compounds
         """
-        return group.atoms.center(weights=atoms.masses, pbc=pbc, compound=compound)
+        atoms = group.atoms
+        return atoms.center(weights=atoms.masses, pbc=pbc, compound=compound)
 
     transplants[GroupBase].append(
         ('center_of_mass', center_of_mass))
@@ -857,7 +858,7 @@ class Masses(AtomAttr):
 
         .. versionchanged:: 0.20.0 Added `compound` parameter
         """
-        return group.atoms.accumulate("masses", compound=compound)
+        return group.accumulate("masses", compound=compound)
 
     transplants[GroupBase].append(
         ('total_mass', total_mass))
@@ -1217,7 +1218,7 @@ class Charges(AtomAttr):
 
         .. versionchanged:: 0.20.0 Added `compound` parameter
         """
-        return group.atoms.accumulate("charges", compound=compound)
+        return group.accumulate("charges", compound=compound)
 
     transplants[GroupBase].append(
         ('total_charge', total_charge))

--- a/testsuite/MDAnalysisTests/core/test_accumulate.py
+++ b/testsuite/MDAnalysisTests/core/test_accumulate.py
@@ -30,33 +30,29 @@ from MDAnalysis.exceptions import DuplicateWarning, NoDataError
 from MDAnalysisTests.datafiles import PSF, DCD, TPR_xvf, TRR_xvf, GRO
 import pytest
 
-universe = mda.Universe(PSF, DCD)
-universe_molfrag = mda.Universe(TPR_xvf, TRR_xvf)
-levellist = ('atoms', 'residues', 'segments')
-
-
+levelist=('atoms', 'residues', 'segments')
+        
 class TestAccumulate(object):
     """Tests the functionality of *Group.accumulate()."""
+    @pytest.fixture(params=levelist)
+    def group(self, request):
+        u = mda.Universe(PSF, DCD)
+        return getattr(u, request.param)
 
-    @pytest.mark.parametrize('level', levellist)
-    def test_accumulate_str_attribute(self, level):
-        group = getattr(universe, level)
-        assert_almost_equal(
-            group.accumulate("masses"), np.sum(group.atoms.masses))
+    def test_accumulate_str_attribute(self, group):
+        assert_almost_equal(group.accumulate("masses"), np.sum(group.atoms.masses))
 
-    @pytest.mark.parametrize('level', levellist)
-    def test_accumulate_different_func(self, level):
-        group = getattr(universe, level)
+    def test_accumulate_different_func(self, group):
         assert_almost_equal(
             group.accumulate("masses", function=np.prod),
             np.prod(group.atoms.masses))
 
     @pytest.mark.parametrize('universe, name, compound',
-                             ((universe, 'resids', 'residues'),
-                              (universe, 'segids', 'segments'),
-                              (universe_molfrag, 'molnums', 'molecules'),
-                              (universe_molfrag, 'fragindices', 'fragments')))
-    @pytest.mark.parametrize('level', levellist)
+                             ((mda.Universe(PSF, DCD), 'resids', 'residues'),
+                              (mda.Universe(PSF, DCD), 'segids', 'segments'),
+                              (mda.Universe(TPR_xvf, TRR_xvf), 'molnums', 'molecules'),
+                              (mda.Universe(TPR_xvf, TRR_xvf), 'fragindices', 'fragments')))
+    @pytest.mark.parametrize('level', levelist)
     def test_accumulate_str_attribute_compounds(self, universe, name, compound,
                                                 level):
         group = getattr(universe, level)
@@ -64,100 +60,83 @@ class TestAccumulate(object):
         vals = group.accumulate("masses", compound=compound)
         assert_almost_equal(vals, ref, decimal=5)
 
-    @pytest.mark.parametrize('level', levellist)
-    def test_accumulate_wrongname(self, level):
-        group = getattr(universe, level)
+    def test_accumulate_wrongname(self, group):
         with pytest.raises(AttributeError):
             group.accumulate("foo")
 
-    @pytest.mark.parametrize('level', levellist)
-    def test_accumulate_wrongcomponent(self, level):
-        group = getattr(universe, level)
+    def test_accumulate_wrongcomponent(self, group):
         with pytest.raises(ValueError):
             group.accumulate("masses", compound="foo")
 
-    @pytest.mark.parametrize('level', levellist)
+    @pytest.mark.parametrize('level', levelist)
     def test_accumulate_nobonds(self, level):
         group = getattr(mda.Universe(GRO), level)
         with pytest.raises(NoDataError):
             group.accumulate("masses", compound="fragments")
 
-    @pytest.mark.parametrize('level', levellist)
+    @pytest.mark.parametrize('level', levelist)
     def test_accumulate_nomolnums(self, level):
         group = getattr(mda.Universe(GRO), level)
         with pytest.raises(NoDataError):
             group.accumulate("masses", compound="molecules")
 
-    @pytest.mark.parametrize('level', levellist)
-    def test_accumulate_array_attribute(self, level):
-        group = getattr(universe, level)
+    def test_accumulate_array_attribute(self, group):
         a = np.ones((len(group.atoms), 10))
         assert_equal(group.accumulate(a), np.sum(a, axis=0))
 
-    @pytest.mark.parametrize('level', levellist)
-    def test_accumulate_array_attribute_wrongshape(self, level):
-        group = getattr(universe, level)
+    def test_accumulate_array_attribute_wrongshape(self, group):
         with pytest.raises(ValueError):
             group.accumulate(np.ones(len(group.atoms) - 1))
 
     @pytest.mark.parametrize('universe, name, compound',
-                             ((universe, 'resids', 'residues'),
-                              (universe, 'segids', 'segments'),
-                              (universe_molfrag, 'molnums', 'molecules'),
-                              (universe_molfrag, 'fragindices', 'fragments')))
-    @pytest.mark.parametrize('level', levellist)
+                             ((mda.Universe(PSF, DCD), 'resids', 'residues'),
+                              (mda.Universe(PSF, DCD), 'segids', 'segments'),
+                              (mda.Universe(TPR_xvf, TRR_xvf), 'molnums', 'molecules'),
+                              (mda.Universe(TPR_xvf, TRR_xvf), 'fragindices', 'fragments')))
+    @pytest.mark.parametrize('level', levelist)
     def test_accumulate_array_attribute_compounds(self, universe, name,
                                                   compound, level):
         group = getattr(universe, level)
         ref = [np.ones((len(a), 10)).sum(axis=0) for a in group.atoms.groupby(name).values()]
         assert_equal(group.accumulate(np.ones((len(group.atoms), 10)), compound=compound), ref)
 
-
 class TestTotals(object):
     """Tests the functionality of *Group.total*() like total_mass
     and total_charge.
     """
+    @pytest.fixture(params=levelist)
+    def group(self, request):
+        u = mda.Universe(PSF, DCD)
+        return getattr(u, request.param)
 
-    @pytest.mark.parametrize('level', levellist)
-    def test_total_charge(self, level):
-        group = getattr(universe, level)
+    def test_total_charge(self, group):
         assert_almost_equal(group.total_charge(), -4.0, decimal=4)
 
     @pytest.mark.parametrize('name, compound',
                              (('resids', 'residues'), ('segids', 'segments'),
                               ('fragindices', 'fragments')))
-    @pytest.mark.parametrize('level', levellist)
-    def test_total_charge_compounds(self, name, compound, level):
-        group = getattr(universe, level)
+    def test_total_charge_compounds(self, group, name, compound):
         ref = [sum(a.charges) for a in group.atoms.groupby(name).values()]
         assert_almost_equal(group.total_charge(compound=compound), ref)
 
-    @pytest.mark.parametrize('level', levellist)
-    def test_total_charge_duplicates(self, level):
-        group = getattr(universe, level)
+    def test_total_charge_duplicates(self, group):
         group2 = group + group[0]
         ref = group.total_charge() + group[0].charge
         with pytest.warns(DuplicateWarning) as w:
             assert_almost_equal(group2.total_charge(), ref)
             assert len(w) == 1
 
-    @pytest.mark.parametrize('level', levellist)
-    def test_total_mass(self, level):
-        group = getattr(universe, level)
+    def test_total_mass(self, group):
         assert_almost_equal(group.total_mass(), 23582.043)
 
     @pytest.mark.parametrize('name, compound',
                              (('resids', 'residues'), ('segids', 'segments'),
                               ('fragindices', 'fragments')))
-    @pytest.mark.parametrize('level', levellist)
-    def test_total_mass_compounds(self, name, compound, level):
-        group = getattr(universe, level)
+    def test_total_mass_compounds(self, group, name, compound):
         ref = [sum(a.masses) for a in group.atoms.groupby(name).values()]
         assert_almost_equal(group.total_mass(compound=compound), ref)
 
-    @pytest.mark.parametrize('level', levellist)
-    def test_total_mass_duplicates(self, level):
-        group = getattr(universe, level)
+    def test_total_mass_duplicates(self, group):
         group2 = group + group[0]
         ref = group.total_mass() + group2[0].mass
         with pytest.warns(DuplicateWarning) as w:

--- a/testsuite/MDAnalysisTests/core/test_accumulate.py
+++ b/testsuite/MDAnalysisTests/core/test_accumulate.py
@@ -1,0 +1,165 @@
+# -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 fileencoding=utf-8
+#
+# MDAnalysis --- https://www.mdanalysis.org
+# Copyright (c) 2006-2017 The MDAnalysis Development Team and contributors
+# (see the file AUTHORS for the full list of names)
+#
+# Released under the GNU Public Licence, v2 or any higher version
+#
+# Please cite your use of MDAnalysis in published work:
+#
+# R. J. Gowers, M. Linke, J. Barnoud, T. J. E. Reddy, M. N. Melo, S. L. Seyler,
+# D. L. Dotson, J. Domanski, S. Buchoux, I. M. Kenney, and O. Beckstein.
+# MDAnalysis: A Python package for the rapid analysis of molecular dynamics
+# simulations. In S. Benthall and S. Rostrup editors, Proceedings of the 15th
+# Python in Science Conference, pages 102-109, Austin, TX, 2016. SciPy.
+# doi: 10.25080/majora-629e541a-00e
+#
+# N. Michaud-Agrawal, E. J. Denning, T. B. Woolf, and O. Beckstein.
+# MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
+# J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
+#
+from __future__ import division, absolute_import
+
+import numpy as np
+from numpy.testing import assert_equal, assert_almost_equal
+
+import MDAnalysis as mda
+from MDAnalysis.exceptions import DuplicateWarning, NoDataError
+from MDAnalysisTests.datafiles import PSF, DCD, TPR_xvf, TRR_xvf, GRO
+import pytest
+
+universe = mda.Universe(PSF, DCD)
+universe_molfrag = mda.Universe(TPR_xvf, TRR_xvf)
+levellist = ('atoms', 'residues', 'segments')
+
+
+class TestAccumulate(object):
+    """Tests the functionality of *Group.accumulate()."""
+
+    @pytest.mark.parametrize('level', levellist)
+    def test_accumulate_str_attribute(self, level):
+        group = getattr(universe, level)
+        assert_almost_equal(
+            group.accumulate("masses"), np.sum(group.atoms.masses))
+
+    @pytest.mark.parametrize('level', levellist)
+    def test_accumulate_different_func(self, level):
+        group = getattr(universe, level)
+        assert_almost_equal(
+            group.accumulate("masses", function=np.prod),
+            np.prod(group.atoms.masses))
+
+    @pytest.mark.parametrize('universe, name, compound',
+                             ((universe, 'resids', 'residues'),
+                              (universe, 'segids', 'segments'),
+                              (universe_molfrag, 'molnums', 'molecules'),
+                              (universe_molfrag, 'fragindices', 'fragments')))
+    @pytest.mark.parametrize('level', levellist)
+    def test_accumulate_str_attribute_compounds(self, universe, name, compound,
+                                                level):
+        group = getattr(universe, level)
+        ref = [sum(a.masses) for a in group.atoms.groupby(name).values()]
+        vals = group.accumulate("masses", compound=compound)
+        assert_almost_equal(vals, ref, decimal=5)
+
+    @pytest.mark.parametrize('level', levellist)
+    def test_accumulate_wrongname(self, level):
+        group = getattr(universe, level)
+        with pytest.raises(AttributeError):
+            group.accumulate("foo")
+
+    @pytest.mark.parametrize('level', levellist)
+    def test_accumulate_wrongcomponent(self, level):
+        group = getattr(universe, level)
+        with pytest.raises(ValueError):
+            group.accumulate("masses", compound="foo")
+
+    @pytest.mark.parametrize('level', levellist)
+    def test_accumulate_nobonds(self, level):
+        group = getattr(mda.Universe(GRO), level)
+        with pytest.raises(NoDataError):
+            group.accumulate("masses", compound="fragments")
+
+    @pytest.mark.parametrize('level', levellist)
+    def test_accumulate_nomolnums(self, level):
+        group = getattr(mda.Universe(GRO), level)
+        with pytest.raises(NoDataError):
+            group.accumulate("masses", compound="molecules")
+
+    @pytest.mark.parametrize('level', levellist)
+    def test_accumulate_array_attribute(self, level):
+        group = getattr(universe, level)
+        a = np.ones((len(group.atoms), 10))
+        assert_equal(group.accumulate(a), np.sum(a, axis=0))
+
+    @pytest.mark.parametrize('level', levellist)
+    def test_accumulate_array_attribute_wrongshape(self, level):
+        group = getattr(universe, level)
+        with pytest.raises(ValueError):
+            group.accumulate(np.ones(len(group.atoms) - 1))
+
+    @pytest.mark.parametrize('universe, name, compound',
+                             ((universe, 'resids', 'residues'),
+                              (universe, 'segids', 'segments'),
+                              (universe_molfrag, 'molnums', 'molecules'),
+                              (universe_molfrag, 'fragindices', 'fragments')))
+    @pytest.mark.parametrize('level', levellist)
+    def test_accumulate_array_attribute_compounds(self, universe, name,
+                                                  compound, level):
+        group = getattr(universe, level)
+        ref = [np.ones((len(a), 10)).sum(axis=0) for a in group.atoms.groupby(name).values()]
+        assert_equal(group.accumulate(np.ones((len(group.atoms), 10)), compound=compound), ref)
+
+
+class TestTotals(object):
+    """Tests the functionality of *Group.total*() like total_mass
+    and total_charge.
+    """
+
+    @pytest.mark.parametrize('level', levellist)
+    def test_total_charge(self, level):
+        group = getattr(universe, level)
+        assert_almost_equal(group.total_charge(), -4.0, decimal=4)
+
+    @pytest.mark.parametrize('name, compound',
+                             (('resids', 'residues'), ('segids', 'segments'),
+                              ('fragindices', 'fragments')))
+    @pytest.mark.parametrize('level', levellist)
+    def test_total_charge_compounds(self, name, compound, level):
+        group = getattr(universe, level)
+        ref = [sum(a.charges) for a in group.atoms.groupby(name).values()]
+        assert_almost_equal(group.total_charge(compound=compound), ref)
+
+    @pytest.mark.parametrize('level', levellist)
+    def test_total_charge_duplicates(self, level):
+        group = getattr(universe, level)
+        group2 = group + group[0]
+        ref = group.total_charge() + group[0].charge
+        with pytest.warns(DuplicateWarning) as w:
+            assert_almost_equal(group2.total_charge(), ref)
+            assert len(w) == 1
+
+    @pytest.mark.parametrize('level', levellist)
+    def test_total_mass(self, level):
+        group = getattr(universe, level)
+        assert_almost_equal(group.total_mass(), 23582.043)
+
+    @pytest.mark.parametrize('name, compound',
+                             (('resids', 'residues'), ('segids', 'segments'),
+                              ('fragindices', 'fragments')))
+    @pytest.mark.parametrize('level', levellist)
+    def test_total_mass_compounds(self, name, compound, level):
+        group = getattr(universe, level)
+        ref = [sum(a.masses) for a in group.atoms.groupby(name).values()]
+        assert_almost_equal(group.total_mass(compound=compound), ref)
+
+    @pytest.mark.parametrize('level', levellist)
+    def test_total_mass_duplicates(self, level):
+        group = getattr(universe, level)
+        group2 = group + group[0]
+        ref = group.total_mass() + group2[0].mass
+        with pytest.warns(DuplicateWarning) as w:
+            assert_almost_equal(group2.total_mass(), ref)
+            assert len(w) == 1

--- a/testsuite/MDAnalysisTests/core/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/core/test_atomgroup.py
@@ -519,19 +519,20 @@ class TestAccumulate(object):
             ag.accumulate("masses", compound="foo")
         
     def test_accumulate_array_attribute(self, ag):
-        a = np.arange(len(ag))
-        assert_equal(ag.accumulate(a), np.sum(a))
+        a = np.ones((len(ag), 10))
+        assert_equal(ag.accumulate(a), np.sum(a, axis=0))
         
     def test_accumulate_array_attribute_wrongshape(self, ag):
         with pytest.raises(ValueError):
-            ag.accumulate(np.arange(len(ag) - 1))
+            ag.accumulate(np.ones(len(ag) - 1))
         
     @pytest.mark.parametrize('name, compound', (('resids', 'residues'),
                                                 ('segids', 'segments'),
                                                 ('fragindices', 'fragments')))
     def test_accumulate_array_attribute_compounds(self, ag, name, compound):
-        ref = [np.ones(len(a)).sum() for a in ag.groupby(name).values()]
-        assert_equal(ag.accumulate(np.ones(len(ag)), compound=compound), ref)
+        ref = [np.ones((len(a), 10)).sum(axis=0) for a in ag.groupby(name).values()]
+        assert_equal(ag.accumulate(np.ones((len(ag), 10)), compound=compound), 
+                     ref)
 
 
 class TestSplit(object):

--- a/testsuite/MDAnalysisTests/core/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/core/test_atomgroup.py
@@ -489,7 +489,6 @@ class TestCenter(object):
             ag.center(weights)
 
 
-
 class TestSplit(object):
 
     @pytest.fixture()

--- a/testsuite/MDAnalysisTests/core/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/core/test_atomgroup.py
@@ -512,10 +512,6 @@ class TestAccumulate(object):
         vals = ag.accumulate("masses", compound=compound)
         assert_almost_equal(vals, ref, decimal=5)
 
-    def test_accumulate_wrongname(self, ag):
-        with pytest.raises(NoDataError):
-            ag.accumulate("foo")
-
     def test_accumulate_wrongcomponent(self, ag):
         with pytest.raises(ValueError):
             ag.accumulate("masses", compound="foo")
@@ -536,7 +532,7 @@ class TestAccumulate(object):
         with pytest.raises(ValueError):
             ag.accumulate(np.ones(len(ag) - 1))
 
-    @pytest.mark.parametrize('ag, name, compound', 
+    @pytest.mark.parametrize('ag, name, compound',
                              ((mda.Universe(PSF, DCD).atoms, 'resids','residues'),
                               (mda.Universe(PSF, DCD).atoms, 'segids','segments'),
                               (mda.Universe(TPR_xvf, TRR_xvf).atoms, 'molnums','molecules'),

--- a/testsuite/MDAnalysisTests/core/util.py
+++ b/testsuite/MDAnalysisTests/core/util.py
@@ -127,6 +127,13 @@ class UnWrapUniverse(object):
     have_molnums : bool, optional
         If ``True``, the topology will have molecule information (molnums).
         If ``False``, that information will be missing.
+    have_charges : bool, optional
+        If ``False``, charges won't be present in the topology.
+        If ``True``, atoms will carry the following charges::
+        * atoms of molecule type A: 2 (total: 6)
+        * atoms of molecule type B: -0.5 (total: -6)
+        * atoms of molecule type C: -1.5 (total: -12)
+        * atoms of molecule type D: 0.5 (total: 12)
     is_triclinic : bool, optional
         If ``False``, the box will be a cube with an edge length of 10 Angstrom.
         If ``True``, the cubic box will be sheared by 1 Angstrom in the x and
@@ -134,7 +141,7 @@ class UnWrapUniverse(object):
     """
 
     def __new__(cls, have_bonds=True, have_masses=True, have_molnums=True,
-                is_triclinic=False):
+                have_charges=True, is_triclinic=False):
         # box:
         a = 10.0 # edge length
         tfac = 0.1  # factor for box vector shift of triclinic boxes (~84°)
@@ -305,6 +312,18 @@ class UnWrapUniverse(object):
             molnums += [7, 8]
             molnums += [9, 9, 10, 10, 11, 11]
             u.add_TopologyAttr(topologyattrs.Molnums(molnums))
+
+        # charges:
+        if have_charges:
+            # type A
+            charges = [2] * 3
+            # type B
+            charges += [-0.5] * 12
+            # type C
+            charges += [-1.5] * 8
+            # type C
+            charges += [0.5] * 24
+            u.add_TopologyAttr(topologyattrs.Charges(charges))
 
         # shamelessly monkey-patch some custom universe attributes:
         u._is_triclinic = is_triclinic


### PR DESCRIPTION
Changes made in this Pull Request:
 -  Added `*Group.sum()` method
 - Added compound parameter to `total_mass` and `total_charge`

Following the discussion of PR #2118 this PR adds a sum method to all groups. Furthermore a compound parameter to `*Group.total_charge()` and `*Group.total_mass()` was added similar to the `center_of_mass()`  method. 

I'm not sure if the name `sum`  is confusing but this was the best thing, which came to my mind.

PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
