### PR TITLE
Switch HydrogenBondAutoCorrel to use capped_distance

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -45,6 +45,8 @@ Enhancements
   * added more Van-der-Waals radii to improve guess_bonds (#2138, PR #2142)
   * added *Group.accumulate() (PR #2192)
   * added compound kwarg to total_mass and total_charge (PR #2192)
+  * updated HydrogenBondAutoCorrel to use capped_distance in place of
+    distance_array. (Issue #2103, PR #2209)
 
 Changes
   * added official support for Python 3.7 (PR #1963)

--- a/package/MDAnalysis/analysis/hbonds/hbond_autocorrel.py
+++ b/package/MDAnalysis/analysis/hbonds/hbond_autocorrel.py
@@ -423,10 +423,10 @@ class HydrogenBondAutoCorrel(object):
         pair, d = capped_distance(self.h.positions, self.a.positions, max_cutoff=self.d_crit, box=box)
         if self.exclusions:
             # set to above dist crit to exclude
-            exclude = [[a, b] for a, b in zip(self.exclusions[0], self.exclusions[1])]
+            exclude = np.column_stack((self.exclusions[0], self.exclusions[1]))
             pair = np.delete(pair, np.where(pair==exclude), 0)
         
-        hidx, aidx = [np.array(id_list)  for id_list in zip(*pair)]
+        hidx, aidx = np.transpose(pair)
 
 
         a = calc_angles(self.d.positions[hidx], self.h.positions[hidx],


### PR DESCRIPTION
Fixes #2103 

Changes made in this Pull Request:
 Update HydrogenBondAutoCorrel to use capped_distance in place of distance_array

PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
