### PR TITLE
Change positions order from 'F' to 'C' == faster wrapping

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -49,6 +49,17 @@ Enhancements
     distance_array. (Issue #2103, PR #2209)
   * updated analysis.distances.contact_matrix to use capped_distance. (Issue #2102,
     PR #2215)
+  * improved performance of *Group.center(), especially for per-compound
+    computations and contiguous AtomGroups (PR #2211)
+  * improved performance of *Group.wrap(), especially for per-compound
+    computations and  contiguous AtomGroups (PR #2211)
+  * Added boolean *Group.iscontiguous property stating whether a group's indices
+    (*Group.ix property) is a contiguous, increasing range of numbers (PR #2211)
+  * Added optional keywords return_counts, return_masks, and assume_unsorted
+    to lib.util.unique_int_1d() and improved its performance (PR #2211)
+  * Added several helper functions to lib.util: iscontiguous_int_1d(),
+    indices_to_slice_1d(), argwhere_int_1d(), unique_masks_int_1d(),
+    check_compound(), coords_add_vector() (PR #2211)
 
 Changes
   * added official support for Python 3.7 (PR #1963)
@@ -58,6 +69,8 @@ Changes
     invalid, an all-zero array or zero is returned, respectively. (Issue #2200,
     PR #2201)
   * changed fudge_factor in guess_bonds to deal with new vdw radii (#2138, PR #2142)
+  * changed memory layout of Timestep.positions from FORTRAN- to C-contiguous
+    (Issue #2210, PR #2211)
 
 Fixes
   * fixed the segmentation fault in capped_distances (Issue #2164, PR #2169)

--- a/package/MDAnalysis/analysis/rms.py
+++ b/package/MDAnalysis/analysis/rms.py
@@ -148,7 +148,7 @@ from MDAnalysis.analysis.base import AnalysisBase
 from MDAnalysis.exceptions import SelectionError, NoDataError
 from MDAnalysis.lib.log import ProgressMeter
 from MDAnalysis.lib.util import (asiterable, iterable, get_weights, deprecate,
-                                 coords_add_vec)
+                                 coords_add_vector)
 
 logger = logging.getLogger('MDAnalysis.analysis.rmsd')
 
@@ -621,11 +621,11 @@ class RMSD(AnalysisBase):
             # Transform each atom in the trajectory (use inplace ops to
             # avoid copying arrays) (Marginally (~3%) faster than
             # "ts.positions[:] = (ts.positions - x_com) * R + ref_com".)
-            coords_add_vec(self._ts.positions, -mobile_com)
+            coords_add_vector(self._ts.positions, -mobile_com)
 
             # R acts to the left & is broadcasted N times.
             self._ts.positions[:] = np.dot(self._ts.positions, self._R)
-            coords_add_vec(self._ts.positions, self._ref_com)
+            coords_add_vector(self._ts.positions, self._ref_com)
 
             # 2) calculate secondary RMSDs (without any further
             #    superposition)

--- a/package/MDAnalysis/analysis/rms.py
+++ b/package/MDAnalysis/analysis/rms.py
@@ -147,8 +147,8 @@ import MDAnalysis.lib.qcprot as qcp
 from MDAnalysis.analysis.base import AnalysisBase
 from MDAnalysis.exceptions import SelectionError, NoDataError
 from MDAnalysis.lib.log import ProgressMeter
-from MDAnalysis.lib.util import asiterable, iterable, get_weights, deprecate
-
+from MDAnalysis.lib.util import (asiterable, iterable, get_weights, deprecate,
+                                 coords_add_vec)
 
 logger = logging.getLogger('MDAnalysis.analysis.rmsd')
 
@@ -621,11 +621,11 @@ class RMSD(AnalysisBase):
             # Transform each atom in the trajectory (use inplace ops to
             # avoid copying arrays) (Marginally (~3%) faster than
             # "ts.positions[:] = (ts.positions - x_com) * R + ref_com".)
-            self._ts.positions[:] -= mobile_com
+            coords_add_vec(self._ts.positions, -mobile_com)
 
             # R acts to the left & is broadcasted N times.
             self._ts.positions[:] = np.dot(self._ts.positions, self._R)
-            self._ts.positions += self._ref_com
+            coords_add_vec(self._ts.positions, self._ref_com)
 
             # 2) calculate secondary RMSDs (without any further
             #    superposition)

--- a/package/MDAnalysis/coordinates/DLPoly.py
+++ b/package/MDAnalysis/coordinates/DLPoly.py
@@ -108,11 +108,11 @@ class ConfigReader(base.SingleFrameReaderBase):
 
                 line = inf.readline().strip()
 
-        coords = np.array(coords, dtype=np.float32, order='F')
+        coords = np.array(coords, dtype=np.float32, order='C')
         if has_vels:
-            velocities = np.array(velocities, dtype=np.float32, order='F')
+            velocities = np.array(velocities, dtype=np.float32, order='C')
         if has_forces:
-            forces = np.array(forces, dtype=np.float32, order='F')
+            forces = np.array(forces, dtype=np.float32, order='C')
         self.n_atoms = len(coords)
 
         if ids:

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -227,6 +227,8 @@ class Timestep(object):
        :attr:`n_atoms` now a read only property.
        :attr:`frame` now 0-based instead of 1-based.
        Attributes `status` and `step` removed.
+    .. versionchanged:: 0.20.0
+       Changed order of positions, velocities, and forces arrays from 'F' to 'C'
     """
     order = 'C'
 

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -228,7 +228,7 @@ class Timestep(object):
        :attr:`frame` now 0-based instead of 1-based.
        Attributes `status` and `step` removed.
     """
-    order = 'F'
+    order = 'C'
 
     def __init__(self, n_atoms, **kwargs):
         """Create a Timestep, representing a frame of a trajectory

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -692,12 +692,8 @@ class GroupBase(_MutableBase):
 
         .. versionadded:: 0.20.0
         """
-        ix = self._ix
-        if util.iscontiguous_int_1d(ix):
-            self._cache['ix_or_slice'] = slice(ix[0], ix[-1] + 1, 1)
-            return True
-        self._cache['ix_or_slice'] = ix
-        return False
+        ix_or_slice = self._ix_or_slice
+        return isinstance(ix_or_slice, slice) and ix_or_slice.step == 1
 
     @warn_if_not_unique
     def center(self, weights, pbc=None, compound='group', check_weights=False):

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -105,7 +105,7 @@ from numpy.lib.utils import deprecate
 from .. import _ANCHOR_UNIVERSES
 from ..lib import util
 from ..lib.util import (cached, warn_if_not_unique, unique_int_1d,
-                        isrange_int_1d, argwhere_int_1d)
+                        iscontiguous_int_1d, argwhere_int_1d)
 from ..lib import distances
 from ..lib import c_distances
 from ..lib import transformations
@@ -676,7 +676,7 @@ class GroupBase(_MutableBase):
 
         .. versionadded:: 0.20.0
         """
-        return isrange_int_1d(self._ix)
+        return iscontiguous_int_1d(self._ix)
 
     def _compound_indices(self, compound):
         """Return compound indices of the AtomGroup's atoms.

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -692,8 +692,8 @@ class GroupBase(_MutableBase):
 
         .. versionadded:: 0.20.0
         """
-        ix_or_slice = self._ix_or_slice
-        return isinstance(ix_or_slice, slice) and ix_or_slice.step == 1
+        self._ix_or_slice  # This already populates the cache
+        return self._cache['iscontiguous']
 
     @warn_if_not_unique
     def center(self, weights, pbc=None, compound='group', check_weights=False):

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -735,6 +735,33 @@ class GroupBase(_MutableBase):
         return np.ascontiguousarray(compound_indices, dtype=np.intp)
 
     def _check_compound(self, compound, atoms=False):
+        """Checks if `compound` is a known compound.
+
+        `compound` is case-insensitive.
+
+        Parameters
+        ----------
+        compound: str
+            The `compound` keyword to check. Must be one of ``'group'``,
+            ``'segments'``, ``'residues'``, ``'molecules'``, or ``'fragments'``.
+        atoms: bool
+            If ``True``, ``'atoms'`` is also allowed as a `compound`.
+
+        Returns
+        -------
+        str
+            `compound` converted to lowercase.
+
+        Raises
+        ------
+        ValueError
+            If ``compound.lower()`` is none of ``'group'``, ``'segments'``,
+            ``'residues'``, ``'molecules'``, or ``'fragments'`` (or, if `atoms`
+            is ``True``, also ``'atoms'``).
+
+        
+        .. versionadded:: 0.20.0
+        """
         valid = ['group', 'segments', 'residues', 'molecules', 'fragments']
         if atoms:
             valid.append('atoms')

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -1744,7 +1744,7 @@ class Bonds(_Connection):
 
         .. versionadded:: 0.20.0
         """
-        return self.universe._fragdict[self.ix].ix
+        return self.universe._fraginfo.fragindices[self.ix]
 
     def fragindices(self):
         """The
@@ -1764,8 +1764,7 @@ class Bonds(_Connection):
 
         .. versionadded:: 0.20.0
         """
-        fragdict = self.universe._fragdict
-        return np.array([fragdict[aix].ix for aix in self.ix], dtype=np.int64)
+        return self.universe._fraginfo.fragindices[self.ix]
 
     def fragment(self):
         """An :class:`~MDAnalysis.core.groups.AtomGroup` representing the
@@ -1787,7 +1786,7 @@ class Bonds(_Connection):
 
         .. versionadded:: 0.9.0
         """
-        return self.universe._fragdict[self.ix].fragment
+        return self.universe._fraginfo.fragments[self.fragindex]
 
     def fragments(self):
         """Read-only :class:`tuple` of
@@ -1815,9 +1814,8 @@ class Bonds(_Connection):
 
         .. versionadded:: 0.9.0
         """
-        fragdict = self.universe._fragdict
-        return tuple(sorted(set(fragdict[aix].fragment for aix in self.ix),
-                            key=lambda x: x[0].ix))
+        unique_fragindices = unique_int_1d(self.fragindices)
+        return tuple(self.universe._fraginfo.fragments[unique_fragindices])
 
     def n_fragments(self):
         """The number of unique

--- a/package/MDAnalysis/lib/_cutil.pyx
+++ b/package/MDAnalysis/lib/_cutil.pyx
@@ -41,7 +41,7 @@ from libcpp.vector cimport vector
 from cython.operator cimport dereference as deref
 
 
-__all__ = ['unique_int_1d', 'isrange_int_1d', 'argwhere_int_1d',
+__all__ = ['unique_int_1d', 'iscontiguous_int_1d', 'argwhere_int_1d',
            'make_whole', 'find_fragments']
 
 
@@ -193,7 +193,7 @@ cdef inline np.intp_t[::1] _unique_int_1d_with_counts(np.intp_t[:] values,
     return result
 
 
-def isrange_int_1d(np.intp_t[:] values):
+def iscontiguous_int_1d(np.intp_t[:] values):
     """Checks if an integer array is a contiguous range.
 
     Checks if ``values[i+1] == values[i] + 1`` holds for all elements of
@@ -222,19 +222,19 @@ def isrange_int_1d(np.intp_t[:] values):
     """
     cdef np.intp_t n_values = values.shape[0]
     cdef np.intp_t i
-    cdef bint isrange = True
+    cdef bint iscontiguous = True
     with nogil:
         if n_values > 1:
             if (values[n_values - 1] - values[0] + 1) == n_values:
                 for i in range(n_values - 1):
                     if values[i] + 1 != values[i + 1]:
-                        isrange = False
+                        iscontiguous = False
                         break
             else:
-                isrange = False
+                iscontiguous = False
         elif n_values == 0:
-            isrange = False
-    return isrange
+            iscontiguous = False
+    return iscontiguous
 
 
 def argwhere_int_1d(np.intp_t[:] arr, np.intp_t value):

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -116,13 +116,14 @@ Containers and lists
 Arrays
 ------
 
-.. autofunction:: unique_int_1d(values, return_counts=False, return_masks=False)
-.. autofunction:: unique_masks_int_1d(values)
+.. autofunction:: unique_int_1d(values, return_counts=False, \
+                                return_masks=False, assume_unsorted=False)
+.. autofunction:: unique_masks_int_1d(values, assume_unsorted=False)
 .. autofunction:: iscontiguous_int_1d(values)
 .. autofunction:: argwhere_int_1d(arr, value)
 .. autofunction:: unique_rows
 .. autofunction:: blocks_of
-.. autofunction:: coords_add_vec(coordinates, vector)
+.. autofunction:: coords_add_vector(coordinates, vector)
 
 File parsing
 ------------
@@ -213,7 +214,7 @@ from numpy.testing import assert_equal
 import inspect
 
 from ..exceptions import StreamWarning, DuplicateWarning
-from ._cutil import (coords_add_vec, unique_int_1d, unique_masks_int_1d,
+from ._cutil import (coords_add_vector, unique_int_1d, unique_masks_int_1d,
                      iscontiguous_int_1d, argwhere_int_1d, indices_to_slice_1d)
 
 

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -117,7 +117,7 @@ Arrays
 ------
 
 .. autofunction:: unique_int_1d(values, return_counts=False)
-.. autofunction:: isrange_int_1d(values)
+.. autofunction:: iscontiguous_int_1d(values)
 .. autofunction:: argwhere_int_1d(arr, value)
 .. autofunction:: unique_rows
 .. autofunction:: blocks_of
@@ -210,7 +210,7 @@ from numpy.testing import assert_equal
 import inspect
 
 from ..exceptions import StreamWarning, DuplicateWarning
-from ._cutil import unique_int_1d, isrange_int_1d, argwhere_int_1d
+from ._cutil import unique_int_1d, iscontiguous_int_1d, argwhere_int_1d
 
 
 # Python 3.0, 3.1 do not have the builtin callable()

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -116,8 +116,9 @@ Containers and lists
 Arrays
 ------
 
-.. autofunction:: unique_int_1d(values)
+.. autofunction:: unique_int_1d(values, return_counts=False)
 .. autofunction:: isrange_int_1d(values)
+.. autofunction:: argwhere_int_1d(arr, value)
 .. autofunction:: unique_rows
 .. autofunction:: blocks_of
 
@@ -209,7 +210,7 @@ from numpy.testing import assert_equal
 import inspect
 
 from ..exceptions import StreamWarning, DuplicateWarning
-from ._cutil import unique_int_1d, isrange_int_1d
+from ._cutil import unique_int_1d, isrange_int_1d, argwhere_int_1d
 
 
 # Python 3.0, 3.1 do not have the builtin callable()

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -214,7 +214,7 @@ import inspect
 
 from ..exceptions import StreamWarning, DuplicateWarning
 from ._cutil import (coords_add_vec, unique_int_1d, unique_masks_int_1d,
-                     iscontiguous_int_1d, argwhere_int_1d)
+                     iscontiguous_int_1d, argwhere_int_1d, indices_to_slice_1d)
 
 
 # Python 3.0, 3.1 do not have the builtin callable()

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -124,6 +124,9 @@ Arrays
 .. autofunction:: unique_rows
 .. autofunction:: blocks_of
 .. autofunction:: coords_add_vector(coordinates, vector)
+.. autofunction:: coords_center(coordinates, weights=None, \
+                                compound_indices=None, check_weights=False, \
+                                return_compound_masks=False)
 
 File parsing
 ------------
@@ -214,8 +217,9 @@ from numpy.testing import assert_equal
 import inspect
 
 from ..exceptions import StreamWarning, DuplicateWarning
-from ._cutil import (coords_add_vector, unique_int_1d, unique_masks_int_1d,
-                     iscontiguous_int_1d, argwhere_int_1d, indices_to_slice_1d)
+from ._cutil import (coords_add_vector, _coords_add_vectors, coords_center,
+                     unique_int_1d, unique_masks_int_1d, iscontiguous_int_1d,
+                     argwhere_int_1d, indices_to_slice_1d)
 
 
 # Python 3.0, 3.1 do not have the builtin callable()

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -116,7 +116,8 @@ Containers and lists
 Arrays
 ------
 
-.. autofunction:: unique_int_1d(values, return_counts=False)
+.. autofunction:: unique_int_1d(values, return_counts=False, return_masks=False)
+.. autofunction:: unique_masks_int_1d(values)
 .. autofunction:: iscontiguous_int_1d(values)
 .. autofunction:: argwhere_int_1d(arr, value)
 .. autofunction:: unique_rows
@@ -210,7 +211,8 @@ from numpy.testing import assert_equal
 import inspect
 
 from ..exceptions import StreamWarning, DuplicateWarning
-from ._cutil import unique_int_1d, iscontiguous_int_1d, argwhere_int_1d
+from ._cutil import (unique_int_1d, unique_masks_int_1d, iscontiguous_int_1d,
+                     argwhere_int_1d)
 
 
 # Python 3.0, 3.1 do not have the builtin callable()

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -117,6 +117,7 @@ Arrays
 ------
 
 .. autofunction:: unique_int_1d(values)
+.. autofunction:: isrange_int_1d(values)
 .. autofunction:: unique_rows
 .. autofunction:: blocks_of
 
@@ -208,7 +209,7 @@ from numpy.testing import assert_equal
 import inspect
 
 from ..exceptions import StreamWarning, DuplicateWarning
-from ._cutil import unique_int_1d
+from ._cutil import unique_int_1d, isrange_int_1d
 
 
 # Python 3.0, 3.1 do not have the builtin callable()

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -122,6 +122,7 @@ Arrays
 .. autofunction:: argwhere_int_1d(arr, value)
 .. autofunction:: unique_rows
 .. autofunction:: blocks_of
+.. autofunction:: coords_add_vec(coordinates, vector)
 
 File parsing
 ------------
@@ -211,8 +212,8 @@ from numpy.testing import assert_equal
 import inspect
 
 from ..exceptions import StreamWarning, DuplicateWarning
-from ._cutil import (unique_int_1d, unique_masks_int_1d, iscontiguous_int_1d,
-                     argwhere_int_1d)
+from ._cutil import (coords_add_vec, unique_int_1d, unique_masks_int_1d,
+                     iscontiguous_int_1d, argwhere_int_1d)
 
 
 # Python 3.0, 3.1 do not have the builtin callable()

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -169,6 +169,7 @@ Data format checks
 ------------------
 
 .. autofunction:: check_box
+.. autofunction:: check_compound
 
 .. Rubric:: Footnotes
 
@@ -2334,3 +2335,41 @@ def check_box(box):
     if np.all(box[3:] == 90.):
         return 'ortho', box[:3]
     return 'tri_vecs', triclinic_vectors(box)
+
+
+def check_compound(compound, atoms=False):
+        """Checks if `compound` is a known compound.
+
+        `compound` is case-insensitive.
+
+        Parameters
+        ----------
+        compound: str
+            The `compound` keyword to check. Must be one of ``'group'``,
+            ``'segments'``, ``'residues'``, ``'molecules'``, or ``'fragments'``.
+        atoms: bool
+            If ``True``, ``'atoms'`` is also allowed as a `compound`.
+
+        Returns
+        -------
+        str
+            `compound` converted to lowercase.
+
+        Raises
+        ------
+        ValueError
+            If ``compound.lower()`` is none of ``'group'``, ``'segments'``,
+            ``'residues'``, ``'molecules'``, or ``'fragments'`` (or, if `atoms`
+            is ``True``, also ``'atoms'``).
+
+
+        .. versionadded:: 0.20.0
+        """
+        valid = ['group', 'segments', 'residues', 'molecules', 'fragments']
+        if atoms:
+            valid.append('atoms')
+        comp = compound.lower()
+        if comp not in valid:
+            raise ValueError("Unrecognized compound definition '{}'. "
+                             "Please use one of {}.".format(compound, valid))
+        return comp

--- a/package/MDAnalysis/transformations/rotate.py
+++ b/package/MDAnalysis/transformations/rotate.py
@@ -39,6 +39,7 @@ from functools import partial
 
 from ..lib.transformations import rotation_matrix
 from ..lib.util import get_weights
+from ..lib.util import coords_add_vec
 
 def rotateby(angle, direction, point=None, ag=None, weights=None, wrap=False):
     '''
@@ -143,7 +144,7 @@ def rotateby(angle, direction, point=None, ag=None, weights=None, wrap=False):
         rotation = matrix[:3, :3].T
         translation = matrix[:3, 3]
         ts.positions= np.dot(ts.positions, rotation)
-        ts.positions += translation
+        coords_add_vec(ts.positions, translation)
         
         return ts
     

--- a/package/MDAnalysis/transformations/rotate.py
+++ b/package/MDAnalysis/transformations/rotate.py
@@ -39,7 +39,7 @@ from functools import partial
 
 from ..lib.transformations import rotation_matrix
 from ..lib.util import get_weights
-from ..lib.util import coords_add_vec
+from ..lib.util import coords_add_vector
 
 def rotateby(angle, direction, point=None, ag=None, weights=None, wrap=False):
     '''
@@ -144,7 +144,7 @@ def rotateby(angle, direction, point=None, ag=None, weights=None, wrap=False):
         rotation = matrix[:3, :3].T
         translation = matrix[:3, 3]
         ts.positions= np.dot(ts.positions, rotation)
-        coords_add_vec(ts.positions, translation)
+        coords_add_vector(ts.positions, translation)
         
         return ts
     

--- a/package/MDAnalysis/transformations/translate.py
+++ b/package/MDAnalysis/transformations/translate.py
@@ -42,6 +42,7 @@ import numpy as np
 from functools import partial
 
 from ..lib.mdamath import triclinic_vectors
+from ..lib.util import coords_add_vec
 
 def translate(vector):
     """
@@ -68,7 +69,7 @@ def translate(vector):
         raise ValueError("{} vector is too short".format(vector))
 
     def wrapped(ts):
-        ts.positions += vector
+        coords_add_vec(ts.positions, vector)
 
         return ts
 
@@ -139,7 +140,7 @@ def center_in_box(ag, center='geometry', point=None, wrap=False):
         ag_center = center_method()
 
         vector = boxcenter - ag_center
-        ts.positions += vector
+        coords_add_vec(ts.positions, vector)
 
         return ts
 

--- a/package/MDAnalysis/transformations/translate.py
+++ b/package/MDAnalysis/transformations/translate.py
@@ -42,7 +42,7 @@ import numpy as np
 from functools import partial
 
 from ..lib.mdamath import triclinic_vectors
-from ..lib.util import coords_add_vec
+from ..lib.util import coords_add_vector
 
 def translate(vector):
     """
@@ -69,7 +69,7 @@ def translate(vector):
         raise ValueError("{} vector is too short".format(vector))
 
     def wrapped(ts):
-        coords_add_vec(ts.positions, vector)
+        coords_add_vector(ts.positions, vector)
 
         return ts
 
@@ -140,7 +140,7 @@ def center_in_box(ag, center='geometry', point=None, wrap=False):
         ag_center = center_method()
 
         vector = boxcenter - ag_center
-        coords_add_vec(ts.positions, vector)
+        coords_add_vector(ts.positions, vector)
 
         return ts
 

--- a/testsuite/MDAnalysisTests/core/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/core/test_atomgroup.py
@@ -1074,6 +1074,10 @@ class TestAtomGroup(object):
         with pytest.raises(NoDataError):
             ag_no_molfrg._compound_indices(compound)
 
+    def test_compound_indices_wrongname(self, ag):
+        with pytest.raises(ValueError):
+            ag._compound_indices('boogie-woogie')
+
     def test_center_of_geometry(self, ag):
         assert_almost_equal(ag.center_of_geometry(),
                             [-0.04223963, 0.0141824, -0.03505163], decimal=5)

--- a/testsuite/MDAnalysisTests/core/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/core/test_atomgroup.py
@@ -730,12 +730,11 @@ class TestAtomGroupProperties(object):
         # make sure both are equal:
         assert_equal(pos, _pos)
         # for contiguous atomgroups, _pos must be a view (a copy otherwise):
-        _isview = not _pos.flags['OWNDATA']
-        assert _isview == isview
+        assert _pos.flags['OWNDATA'] == (not isview)
         assert atomgroup.iscontiguous == isview
         # in any case, _pos must be C-contiguous:
         assert _pos.flags['CARRAY']
-        # change an entry in _pos:
+        # change _pos:
         if len(atomgroup) > 0:
             _pos -= 1.0
             if isview:

--- a/testsuite/MDAnalysisTests/core/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/core/test_atomgroup.py
@@ -1002,6 +1002,49 @@ class TestAtomGroup(object):
         """testing that len(atomgroup) == atomgroup.n_atoms"""
         assert len(ag) == ag.n_atoms, "len and n_atoms disagree"
 
+    @pytest.mark.parametrize('compound, ref', (
+        ('aToMs', 'atoms'),
+        ('gRoUp', 'group'),
+        ('rEsIdUeS', 'residues'),
+        ('sEgMeNtS', 'segments'),
+        ('mOlEcUlEs', 'molecules'),
+        ('fRaGmEnTs', 'fragments')
+    ))
+    @pytest.mark.parametrize('atoms', (True, False))
+    def test_check_compound(self, ag, compound, ref, atoms):
+        if (not atoms) and (ref == 'atoms'):
+            with pytest.raises(ValueError):
+               ag._check_compound(compound, atoms=atoms)
+        else: 
+            assert ag._check_compound(compound, atoms=atoms) == ref
+
+    @pytest.mark.parametrize('atoms', (True, False))
+    def test_check_compound_wrongname(self, ag, atoms):
+        with pytest.raises(ValueError):
+            ag._check_compound('random_bs', atoms=atoms)
+
+    @pytest.mark.parametrize('compound, indexname', (
+        ('atoms', 'ix'),
+        ('group', None),
+        ('residues', 'resindices'),
+        ('segments', 'segindices'),
+        ('molecules', 'molnums'),
+        ('fragments', 'fragindices')
+    ))
+    def test_compound_indices(self, ag_molfrg, compound, indexname):
+        if compound == 'group':
+            ref = np.zeros(len(ag_molfrg), dtype=np.intp)
+        else:
+            ref = getattr(ag_molfrg, indexname)
+        res = ag_molfrg._compound_indices(compound)
+        assert_equal(res, ref)
+        assert res.dtype == ref.dtype
+
+    @pytest.mark.parametrize('compound', ('molecules', 'fragments'))
+    def test_compound_indices_nomols_nofrags(self, ag_no_molfrg, compound):
+        with pytest.raises(NoDataError):
+            ag_no_molfrg._compound_indices(compound)
+
     def test_center_of_geometry(self, ag):
         assert_almost_equal(ag.center_of_geometry(),
                             [-0.04223963, 0.0141824, -0.03505163], decimal=5)

--- a/testsuite/MDAnalysisTests/core/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/core/test_atomgroup.py
@@ -1033,27 +1033,6 @@ class TestAtomGroup(object):
         """testing that len(atomgroup) == atomgroup.n_atoms"""
         assert len(ag) == ag.n_atoms, "len and n_atoms disagree"
 
-    @pytest.mark.parametrize('compound, ref', (
-        ('aToMs', 'atoms'),
-        ('gRoUp', 'group'),
-        ('rEsIdUeS', 'residues'),
-        ('sEgMeNtS', 'segments'),
-        ('mOlEcUlEs', 'molecules'),
-        ('fRaGmEnTs', 'fragments')
-    ))
-    @pytest.mark.parametrize('atoms', (True, False))
-    def test_check_compound(self, ag, compound, ref, atoms):
-        if (not atoms) and (ref == 'atoms'):
-            with pytest.raises(ValueError):
-               ag._check_compound(compound, atoms=atoms)
-        else: 
-            assert ag._check_compound(compound, atoms=atoms) == ref
-
-    @pytest.mark.parametrize('atoms', (True, False))
-    def test_check_compound_wrongname(self, ag, atoms):
-        with pytest.raises(ValueError):
-            ag._check_compound('random_bs', atoms=atoms)
-
     @pytest.mark.parametrize('compound, indexname', (
         ('atoms', 'ix'),
         ('group', None),
@@ -1067,18 +1046,18 @@ class TestAtomGroup(object):
             ref = np.zeros(len(ag_molfrg), dtype=np.intp)
         else:
             ref = getattr(ag_molfrg, indexname)
-        res = ag_molfrg._compound_indices(compound)
+        res = ag_molfrg.compound_indices(compound)
         assert_equal(res, ref)
         assert res.dtype == ref.dtype
 
     @pytest.mark.parametrize('compound', ('molecules', 'fragments'))
     def test_compound_indices_nomols_nofrags(self, ag_no_molfrg, compound):
         with pytest.raises(NoDataError):
-            ag_no_molfrg._compound_indices(compound)
+            ag_no_molfrg.compound_indices(compound)
 
     def test_compound_indices_wrongname(self, ag):
         with pytest.raises(ValueError):
-            ag._compound_indices('boogie-woogie')
+            ag.compound_indices('boogie-woogie')
 
     def test_center_of_geometry(self, ag):
         assert_almost_equal(ag.center_of_geometry(),

--- a/testsuite/MDAnalysisTests/core/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/core/test_atomgroup.py
@@ -692,6 +692,8 @@ class TestAtomGroupProperties(object):
         _isview = not _pos.flags['OWNDATA']
         assert _isview == isview
         assert atomgroup.iscontiguous == isview
+        # in any case, _pos must be C-contiguous:
+        assert _pos.flags['CARRAY']
         # change an entry in _pos:
         if len(atomgroup) > 0:
             _pos -= 1.0

--- a/testsuite/MDAnalysisTests/core/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/core/test_atomgroup.py
@@ -460,33 +460,41 @@ class TestCenter(object):
     def test_center_1(self, ag):
         weights = np.zeros(ag.n_atoms)
         weights[0] = 1
-        assert_almost_equal(ag.center(weights),
-                                  ag.positions[0])
+        pos = ag.positions
+        assert_almost_equal(ag.center(weights), ag.positions[0])
+        assert_equal(ag.positions, pos)
 
     def test_center_2(self, ag):
         weights = np.zeros(ag.n_atoms)
         weights[:4] = 1. / 4.
-        assert_almost_equal(ag.center(weights),
-                                  ag.positions[:4].mean(axis=0))
+        pos = ag.positions
+        assert_almost_equal(ag.center(weights), ag.positions[:4].mean(axis=0))
+        assert_equal(ag.positions, pos)
 
     def test_center_duplicates(self, ag):
         weights = np.ones(ag.n_atoms)
         weights[0] = 2.
         ref = ag.center(weights)
         ag2 = ag + ag[0]
+        pos = ag2.positions
         with pytest.warns(DuplicateWarning):
             ctr = ag2.center(None)
         assert_almost_equal(ctr, ref, decimal=6)
+        assert_equal(ag2.positions, pos)
 
     def test_center_wrong_length(self, ag):
         weights = np.ones(ag.n_atoms + 4)
+        pos = ag.positions
         with pytest.raises(ValueError):
             ag.center(weights)
+        assert_equal(ag.positions, pos)
 
     def test_center_wrong_shape(self, ag):
         weights = np.ones((ag.n_atoms, 2))
+        pos = ag.positions
         with pytest.raises(ValueError):
             ag.center(weights)
+        assert_equal(ag.positions, pos)
 
     def test_center_emty_ag(self, ag):
         eag = ag[[]]
@@ -505,8 +513,10 @@ class TestCenter(object):
 
     def test_center_invalid_box(self, ag):
         ag.universe.dimensions = [0, 0, 0, 0, 0, 0]
+        pos = ag.positions
         with pytest.raises(ValueError):
             ag.center(None, pbc=True)
+        assert_equal(ag.positions, pos)
 
 
 class TestSplit(object):
@@ -1159,13 +1169,17 @@ class TestAtomGroup(object):
         assert_almost_equal(com, ref, decimal=5)
 
     def test_center_wrong_compound(self, ag):
+        pos = ag.positions
         with pytest.raises(ValueError):
             ag.center(weights=None, compound="foo")
+        assert_equal(ag.positions, pos)
 
     @pytest.mark.parametrize('compound', ('molecules', 'fragments'))
     def test_center_compounds_special_fail(self, ag_no_molfrg, compound):
+        pos = ag_no_molfrg.positions
         with pytest.raises(NoDataError):
             ag_no_molfrg.center(weights=None, compound=compound)
+        assert_equal(ag_no_molfrg.positions, pos)
 
     @pytest.mark.parametrize('weights', (None, np.array([0.0]),
                                          np.array([2.0])))
@@ -1180,7 +1194,9 @@ class TestAtomGroup(object):
         if compound != 'group':
             ref = ref.reshape((1, 3))
         ag_s = mda.AtomGroup([at])
+        pos = ag_s.positions
         assert_equal(ref, ag_s.center(weights, pbc=False, compound=compound))
+        assert_equal(ag_s.positions, pos)
 
     @pytest.mark.parametrize('pbc', (False, True))
     @pytest.mark.parametrize('weights', (None, np.array([])))
@@ -1205,7 +1221,9 @@ class TestAtomGroup(object):
         if compound != 'group':
             ref = ref.reshape((1, 3))
         ag_s = mda.AtomGroup([at])
+        pos = ag_s.positions
         assert_equal(ref, ag_s.center(weights, pbc=True, compound=compound))
+        assert_equal(ag_s.positions, pos)
 
     @pytest.mark.parametrize('pbc', (False, True))
     @pytest.mark.parametrize('weights', (None, np.array([])))
@@ -1213,7 +1231,7 @@ class TestAtomGroup(object):
                                           'molecules', 'fragments'))
     def test_center_compounds_empty(self, ag_molfrg, pbc, weights, compound):
         ref = np.empty((0, 3), dtype=np.float64)
-        ag_e = mda.AtomGroup([], ag_molfrg.universe)
+        ag_e = ag_molfrg[[]]
         assert_equal(ref, ag_e.center(weights, pbc=pbc, compound=compound))
 
     @pytest.mark.parametrize('pbc', (False, True))
@@ -1230,7 +1248,9 @@ class TestAtomGroup(object):
             n_compounds = len(ag_molfrg.groupby(name))
             ref = np.full((n_compounds, 3), np.nan, dtype=np.float64)
         weights = np.zeros(len(ag_molfrg))
+        pos = ag_molfrg.positions
         assert_equal(ref, ag_molfrg.center(weights, pbc=pbc, compound=compound))
+        assert_equal(ag_molfrg.positions, pos)
 
     def test_coordinates(self, ag):
         assert_almost_equal(

--- a/testsuite/MDAnalysisTests/core/test_fragments.py
+++ b/testsuite/MDAnalysisTests/core/test_fragments.py
@@ -166,7 +166,7 @@ class TestFragments(object):
             assert len(frag) == 25
             assert at in frag
             fragindex = at.fragindex
-            assert isinstance(fragindex, int)
+            assert isinstance(fragindex, np.intp)
             with pytest.raises(AttributeError):
                 x = at.n_fragments
 

--- a/testsuite/MDAnalysisTests/core/test_groups.py
+++ b/testsuite/MDAnalysisTests/core/test_groups.py
@@ -138,6 +138,58 @@ class TestGroupProperties(object):
         unique_group = group.unique
         assert unique_group is group.unique
 
+    @pytest.mark.parametrize('group, ref', (
+        (uni.atoms, True),
+        (uni.atoms[[1]], True),
+        (uni.atoms[[-1]], True),
+        (uni.atoms[[1, 2, 3, 4]], True),
+        (uni.atoms[-3:-1], True),
+        (uni.atoms[31:100], True),
+        (uni.atoms[1:-20], True),
+        (uni.residues, True),
+        (uni.residues[[1]], True),
+        (uni.residues[[-1]], True),
+        (uni.residues[[1, 2, 3, 4]], True),
+        (uni.residues[-3:-1], True),
+        (uni.residues[2:5], True),
+        (uni.residues[1:-1], True),
+        (uni.segments, True),
+        (uni.segments[[1]], True),
+        (uni.segments[[-1]], True),
+        (uni.segments[[1, 2, 3, 4]], True),
+        (uni.segments[-3:-1], True),
+        (uni.segments[2:5], True),
+        (uni.segments[1:-1], True),
+        (uni.atoms[[]], False),
+        (uni.atoms + uni.atoms[[0]], False),
+        (uni.atoms[[0]] + uni.atoms, False),
+        (uni.atoms[[2, 1]], False),
+        (uni.atoms[[2, 1, 7, 50]], False),
+        (uni.atoms[::2], False),
+        (uni.atoms[::-1], False),
+        (uni.atoms[-1:-4:-1], False),
+        (uni.residues[[]], False),
+        (uni.residues + uni.residues[[0]], False),
+        (uni.residues[[0]] + uni.residues, False),
+        (uni.residues[[2, 1]], False),
+        (uni.residues[[2, 1, 4, 3]], False),
+        (uni.residues[::2], False),
+        (uni.residues[::-1], False),
+        (uni.residues[-1:-4:-1], False),
+        (uni.segments[[]], False),
+        (uni.segments + uni.segments[[0]], False),
+        (uni.segments[[0]] + uni.segments, False),
+        (uni.segments[[2, 1]], False),
+        (uni.segments[[2, 1, 4, 3]], False),
+        (uni.segments[::2], False),
+        (uni.segments[::-1], False),
+        (uni.segments[-1:-4:-1], False)
+        ))
+    def test_group_iscontiguous(self, group, ref):
+        res = group.iscontiguous
+        assert res == ref
+        assert type(res) == bool
+
 
 class TestGroupSlicing(object):
     """All Groups (Atom, Residue, Segment) should slice like a numpy array

--- a/testsuite/MDAnalysisTests/core/test_wrap.py
+++ b/testsuite/MDAnalysisTests/core/test_wrap.py
@@ -63,6 +63,8 @@ class TestWrap(object):
         # check for correct result:
         assert_almost_equal(wrapped_pos, ref_wrapped_pos,
                             decimal=self.precision)
+        # check that the returned positions are a copy:
+        assert wrapped_pos.flags['OWNDATA']
         # make sure atom positions are unchanged:
         assert_array_equal(group.atoms.positions, orig_pos)
         # now, do the wrapping inplace:
@@ -70,6 +72,8 @@ class TestWrap(object):
                                   inplace=True)
         # check that result is the same as for out-of-place computation:
         assert_array_equal(wrapped_pos, wrapped_pos2)
+        # check that the returned positions are a copy:
+        assert wrapped_pos2.flags['OWNDATA']
         # check that wrapped positions are applied:
         assert_array_equal(group.atoms.positions, wrapped_pos)
         # check that nobody messed with the reference positions,

--- a/testsuite/MDAnalysisTests/lib/test_cutil.py
+++ b/testsuite/MDAnalysisTests/lib/test_cutil.py
@@ -26,24 +26,50 @@ import pytest
 import numpy as np
 from numpy.testing import assert_equal
 
-from MDAnalysis.lib._cutil import unique_int_1d, isrange_int_1d, find_fragments
+from MDAnalysis.lib._cutil import (unique_int_1d, isrange_int_1d,
+                                   argwhere_int_1d, find_fragments)
 
 
 @pytest.mark.parametrize('values', (
-    [],  # empty array
-    [1, 1, 1, 1, ],  # all identical
-    [2, 3, 5, 7, ],  # all different, monotonic
-    [5, 2, 7, 3, ],  # all different, non-monotonic
-    [1, 2, 2, 4, 4, 6, ],  # duplicates, monotonic
-    [1, 2, 2, 6, 4, 4, ],  # duplicates, non-monotonic
+    [],                  # empty array
+    [-999],              # single value array
+    [1, 1, 1, 1],        # all identical
+    [2, 3, 5, 7],        # all different, monotonic
+    [5, 2, 7, 3],        # all different, non-monotonic
+    [1, 2, 2, 4, 4, 6],  # duplicates, monotonic
+    [1, 2, 2, 6, 4, 4],  # duplicates, non-monotonic
+    [4, 2, 6, 1, 4, 2]   # duplicates, scrambled
 ))
 def test_unique_int_1d(values):
-    array = np.array(values, dtype=np.int64)
+    array = np.array(values, dtype=np.intp)
     ref = np.unique(array)
     res = unique_int_1d(array)
     assert_equal(res, ref)
     assert type(res) == type(ref)
     assert res.dtype == ref.dtype
+
+
+@pytest.mark.parametrize('values', (
+    [],                  # empty array
+    [-999],              # single value array
+    [1, 1, 1, 1],        # all identical
+    [2, 3, 5, 7],        # all different, monotonic
+    [5, 2, 7, 3],        # all different, non-monotonic
+    [1, 2, 2, 4, 4, 6],  # duplicates, monotonic
+    [1, 2, 2, 6, 4, 4],  # duplicates, non-monotonic
+    [4, 2, 6, 1, 4, 2]   # duplicates, scrambled
+))
+def test_unique_int_1d_return_counts(values):
+    array = np.array(values, dtype=np.intp)
+    ref_unique, ref_counts = np.unique(array, return_counts=True)
+    unique, counts = unique_int_1d(array, return_counts=True)
+    assert_equal(unique, ref_unique)
+    assert_equal(counts, ref_counts)
+    assert type(unique) == type(ref_unique)
+    assert type(counts) == type(ref_counts)
+    assert unique.dtype == ref_unique.dtype
+    assert counts.dtype == ref_counts.dtype
+
 
 @pytest.mark.parametrize('values, ref', (
     ([-3], True),                   # length-1 array, negative
@@ -76,6 +102,26 @@ def test_isrange_int_1d(values, ref):
     res = isrange_int_1d(array)
     assert_equal(res, ref)
     assert type(res) == bool
+
+
+@pytest.mark.parametrize('arr', (
+    [],                       # empty array
+    [1],                      # single value array
+    [1, 1, 1, 1],             # all identical
+    [0, 3, 5, 7],             # all different, monotonic
+    [5, 2, 7, 3],             # all different, non-monotonic
+    [-1, -1, 2, 2, 4, 4, 6],  # duplicates, monotonic
+    [1, 2, 2, 6, 4, 4, -1],   # duplicates, non-monotonic
+    [4, 2, 6, 1, 4, 2, -1]    # duplicates, scrambled
+))
+@pytest.mark.parametrize('value', (-1, 0, 1, 2, 3, 4, 5, 6, 7))
+def test_argwhere_int_1d(arr, value):
+    arr = np.array(arr, dtype=np.intp)
+    ref = np.argwhere(arr == value).ravel()
+    res = argwhere_int_1d(arr, value)
+    assert_equal(res, ref)
+    assert type(res) == type(ref)
+    assert res.dtype == ref.dtype
 
 
 @pytest.mark.parametrize('edges,ref', [

--- a/testsuite/MDAnalysisTests/lib/test_cutil.py
+++ b/testsuite/MDAnalysisTests/lib/test_cutil.py
@@ -26,7 +26,7 @@ import pytest
 import numpy as np
 from numpy.testing import assert_equal
 
-from MDAnalysis.lib._cutil import (unique_int_1d, isrange_int_1d,
+from MDAnalysis.lib._cutil import (unique_int_1d, iscontiguous_int_1d,
                                    argwhere_int_1d, find_fragments)
 
 
@@ -97,9 +97,9 @@ def test_unique_int_1d_return_counts(values):
     ([1, 1, 2, 3, 4], False),       # range with start duplicates
     ([-1, 2, 2, 4, 3], False)       # duplicates, non-monotonic
 ))
-def test_isrange_int_1d(values, ref):
+def test_iscontiguous_int_1d(values, ref):
     array = np.array(values, dtype=np.intp)
-    res = isrange_int_1d(array)
+    res = iscontiguous_int_1d(array)
     assert_equal(res, ref)
     assert type(res) == bool
 

--- a/testsuite/MDAnalysisTests/lib/test_cutil.py
+++ b/testsuite/MDAnalysisTests/lib/test_cutil.py
@@ -26,7 +26,7 @@ import pytest
 import numpy as np
 from numpy.testing import assert_equal
 
-from MDAnalysis.lib._cutil import unique_int_1d, find_fragments
+from MDAnalysis.lib._cutil import unique_int_1d, isrange_int_1d, find_fragments
 
 
 @pytest.mark.parametrize('values', (
@@ -44,6 +44,38 @@ def test_unique_int_1d(values):
     assert_equal(res, ref)
     assert type(res) == type(ref)
     assert res.dtype == ref.dtype
+
+@pytest.mark.parametrize('values, ref', (
+    ([-3], True),                   # length-1 array, negative
+    ([3], True),                    # length-1 array, positive
+    ([0], True),                    # length-1 array, zero
+    ([-5, -4], True),               # length-2 contiguous range
+    ([1, 2, 3, 4, 5], True),        # contiguous range, positive
+    ([-5, -4, -3, -2, -1], True),   # contiguous range, negative
+    ([-2, -1, 0, 1, 2], True),      # contiguous range, neg to pos
+    ([], False),                    # empty array
+    ([0, 0], False),                # length-2 array, zeros
+    ([-3, -4], False),              # length-2 inverted range
+    ([5, 4, 3, 2, 1], False),       # inverted range, positive
+    ([-1, -2, -3, -4, -5], False),  # inverted range, negative
+    ([2, 1, 0, -1, -2], False),     # inverted range, pos to neg
+    ([1, 3, 5, 7, 9], False),       # strided range, positive
+    ([-9, -7, -5, -3, -1], False),  # strided range, negative
+    ([-5, -3, -1, 1, 3], False),    # strided range, neg to pos
+    ([3, 1, -1, -3, -5], False),    # inverted strided range, pos to neg
+    ([1, 1, 1, 1], False),          # all identical
+    ([2, 3, 5, 7], False),          # monotonic
+    ([5, 2, 7, 3], False),          # non-monotonic
+    ([1, 2, 2, 3, 4], False),       # range with middle duplicates
+    ([1, 2, 3, 4, 4], False),       # range with end duplicates
+    ([1, 1, 2, 3, 4], False),       # range with start duplicates
+    ([-1, 2, 2, 4, 3], False)       # duplicates, non-monotonic
+))
+def test_isrange_int_1d(values, ref):
+    array = np.array(values, dtype=np.intp)
+    res = isrange_int_1d(array)
+    assert_equal(res, ref)
+    assert type(res) == bool
 
 
 @pytest.mark.parametrize('edges,ref', [

--- a/testsuite/MDAnalysisTests/lib/test_cutil.py
+++ b/testsuite/MDAnalysisTests/lib/test_cutil.py
@@ -24,297 +24,696 @@ from __future__ import absolute_import
 
 import pytest
 import numpy as np
-from numpy.testing import assert_equal
+from numpy.testing import assert_equal, assert_almost_equal
 
-from MDAnalysis.lib._cutil import (coords_add_vec, unique_int_1d,
+from MDAnalysis.lib._cutil import (coords_add_vector, _coords_add_vectors,
+                                   coords_center, unique_int_1d,
                                    unique_masks_int_1d, iscontiguous_int_1d,
                                    argwhere_int_1d, indices_to_slice_1d,
                                    find_fragments)
 
 
-@pytest.mark.parametrize('positions', (
-    np.zeros((0, 3), dtype=np.float32),
-    np.array([[1.0000001, -1.0000001, 0.0000001]], dtype=np.float32),
-    np.zeros((10, 3), dtype=np.float32),
-    np.ones((10, 3), dtype=np.float32),
-    np.reshape(np.arange(-30, 30, dtype=np.float32), (-1, 3))
-))
-@pytest.mark.parametrize('vector', (
-    np.array([-1, 2, 3], dtype=np.float32),
-    np.array([-1, 2, 3], dtype=np.float64),
-    np.array([-1, 2, 3], dtype=int),
-    np.array([-1, 0, 3], dtype=bool),
-    np.zeros(3, dtype=np.float32),
-    np.zeros(3, dtype=np.float64),
-    np.zeros(3, dtype=int),
-    np.zeros(3, dtype=bool),
-    np.array([1.000000051, 0.000000051, -1.000000051], dtype=np.float32),
-    np.array([1.000000051, 0.000000051, -1.000000051], dtype=np.float64),
-    np.array([np.nan, np.nan, np.nan], dtype=np.float32),
-    np.array([np.nan, np.nan, np.nan], dtype=np.float64),
-    np.array([np.inf, -np.inf, np.nan], dtype=np.float32),
-    np.array([np.inf, -np.inf, np.nan], dtype=np.float64),
-    np.array([1, 2, 3, 4, 5, 6], dtype=np.float32)[::2],
-    np.array([1, 2, 3, 4, 5, 6], dtype=np.float64)[::2],
-    np.array([1, 2, 3, 4, 5, 6], dtype=np.float32)[::-2],
-    np.array([1, 2, 3, 4, 5, 6], dtype=np.float64)[::-2],
-))
-def test_coords_add_vec(positions, vector):
-    ref = positions.copy()
-    ref += vector
-    coords_add_vec(positions, vector)
-    assert_equal(positions, ref)
+
+class TestCoordFunctions(object):
+
+    precision = 14
+    seed = 1337
+    rng = None
+
+    @classmethod
+    def setup_class(self):
+        """Setup class-local PRNG"""
+        self.rng = np.random.RandomState(seed=self.seed)
+
+    def gen_masks(self, n_coords, duplicates=False, random=False):
+        ix = np.arange(n_coords, dtype=np.intp)
+        if n_coords > 1 and duplicates:
+            ix[:-1:2] = ix[1::2]
+        if random:
+            self.rng.shuffle(ix)
+        print(ix)
+        masks = unique_masks_int_1d(ix)
+        return masks
 
 
-def test_coords_add_vec_wrong_types():
-    # wrong pos dtypes:
-    with pytest.raises(ValueError):
-        coords_add_vec(np.zeros((1, 3), dtype=np.float64),
-                       np.zeros(3, dtype=np.float32))
-    with pytest.raises(ValueError):
-        coords_add_vec(np.zeros((1, 3), dtype=np.int32),
-                       np.zeros(3, dtype=np.float64))
-    # wrong pos type:
-    with pytest.raises(TypeError):
-        coords_add_vec([[1, 2, 3]], np.zeros(3, dtype=np.float64))
-    # wrong vec dtype:
-    with pytest.raises(ValueError):
-        coords_add_vec(np.zeros((1, 3), dtype=np.float32),
-                       np.array(["x", "y", "z"], dtype='S8'))
-    # wrong vec type:
-    with pytest.raises(TypeError):
-        coords_add_vec(np.zeros((1, 3), dtype=np.float32), [0, 0, 0])
+    @pytest.mark.parametrize('positions', (
+        np.zeros((0, 3), dtype=np.float32),
+        np.array([[1.0000001, -1.0000001, 0.0000001]], dtype=np.float32),
+        np.zeros((10, 3), dtype=np.float32),
+        np.ones((10, 3), dtype=np.float32),
+        np.reshape(np.arange(-30, 30, dtype=np.float32), (-1, 3))
+    ))
+    @pytest.mark.parametrize('vector', (
+        np.array([-1, 2, 3], dtype=np.float32),
+        np.array([-1, 2, 3], dtype=np.float64),
+        np.array([-1, 2, 3], dtype=int),
+        np.array([-1, 0, 3], dtype=bool),
+        np.zeros(3, dtype=np.float32),
+        np.zeros(3, dtype=np.float64),
+        np.zeros(3, dtype=int),
+        np.zeros(3, dtype=bool),
+        np.array([1.000000051, 0.000000051, -1.000000051], dtype=np.float32),
+        np.array([1.000000051, 0.000000051, -1.000000051], dtype=np.float64),
+        np.array([np.nan, np.nan, np.nan], dtype=np.float32),
+        np.array([np.nan, np.nan, np.nan], dtype=np.float64),
+        np.array([np.inf, -np.inf, np.nan], dtype=np.float32),
+        np.array([np.inf, -np.inf, np.nan], dtype=np.float64),
+        np.array([1, 2, 3, 4, 5, 6], dtype=np.float32)[::2],
+        np.array([1, 2, 3, 4, 5, 6], dtype=np.float64)[::2],
+        np.array([1, 2, 3, 4, 5, 6], dtype=np.float32)[::-2],
+        np.array([1, 2, 3, 4, 5, 6], dtype=np.float64)[::-2],
+    ))
+    def test_coords_add_vector(self, positions, vector):
+        ref = positions.copy()
+        ref += vector
+        coords_add_vector(positions, vector)
+        assert_equal(positions, ref)
 
 
-@pytest.mark.parametrize('positions', (
-    np.array([[]], dtype=np.float32),
-    np.zeros(3, dtype=np.float32),
-    np.zeros((2, 2), dtype=np.float32),
-    np.zeros((1, 1, 3), dtype=np.float32),
-    np.zeros((1, 4), dtype=np.float32)
-))
-def test_coords_add_vec_wrong_pos_shape(positions):
-    with pytest.raises(ValueError):
-        coords_add_vec(positions, np.zeros(3, dtype=np.float32))
+    def test_coords_add_vector_wrong_types(self):
+        # wrong pos dtypes:
+        with pytest.raises(ValueError):
+            coords_add_vector(np.zeros((1, 3), dtype=np.float64),
+                              np.zeros(3, dtype=np.float32))
+        with pytest.raises(ValueError):
+            coords_add_vector(np.zeros((1, 3), dtype=np.int32),
+                              np.zeros(3, dtype=np.float64))
+        # wrong pos type:
+        with pytest.raises(TypeError):
+            coords_add_vector([[1, 2, 3]], np.zeros(3, dtype=np.float64))
+        # wrong vec dtype:
+        with pytest.raises(ValueError):
+            coords_add_vector(np.zeros((1, 3), dtype=np.float32),
+                              np.array(["x", "y", "z"], dtype='S8'))
+        # wrong vec type:
+        with pytest.raises(TypeError):
+            coords_add_vector(np.zeros((1, 3), dtype=np.float32), [0, 0, 0])
 
 
-@pytest.mark.parametrize('vector', (
-    np.array([], dtype=np.float32),
-    np.zeros((1, 3), dtype=np.float32),
-    np.zeros((1, 2, 3), dtype=np.float32),
-    np.zeros(1, dtype=np.float32),
-    np.zeros(4, dtype=np.float32)
-))
-def test_coords_add_vec_wrong_vec_shape(vector):
-    positions = np.zeros((1, 3), dtype=np.float32)
-    with pytest.raises(ValueError):
-        coords_add_vec(positions, vector)
-    with pytest.raises(ValueError):
-        coords_add_vec(positions, vector.astype(np.float64))
+    @pytest.mark.parametrize('positions', (
+        np.array([[]], dtype=np.float32),
+        np.zeros(3, dtype=np.float32),
+        np.zeros((2, 2), dtype=np.float32),
+        np.zeros((1, 1, 3), dtype=np.float32),
+        np.zeros((1, 4), dtype=np.float32)
+    ))
+    def test_coords_add_vector_wrong_pos_shape(self, positions):
+        with pytest.raises(ValueError):
+            coords_add_vector(positions, np.zeros(3, dtype=np.float32))
 
 
-@pytest.mark.parametrize('values', (
-    [],                  # empty array
-    [-999],              # single value array
-    [1, 1, 1, 1],        # all identical
-    [2, 3, 5, 7],        # all different, monotonic
-    [5, 2, 7, 3],        # all different, non-monotonic
-    [1, 2, 2, 4, 4, 6],  # duplicates, monotonic
-    [1, 2, 2, 6, 4, 4],  # duplicates, non-monotonic
-    [4, 2, 6, 1, 4, 2]   # duplicates, scrambled
-))
-@pytest.mark.parametrize('counts', (True, False))
-@pytest.mark.parametrize('masks', (True, False))
-def test_unique_int_1d(values, counts, masks):
-    array = np.array(values, dtype=np.intp)
-    ref = np.unique(array)
-    res = unique_int_1d(array, return_counts=counts, return_masks=masks)
-    if counts or masks:
-        res = res[0]
-    assert_equal(res, ref)
-    assert type(res) == type(ref)
-    assert res.dtype == ref.dtype
+    @pytest.mark.parametrize('vector', (
+        np.array([], dtype=np.float32),
+        np.zeros((1, 3), dtype=np.float32),
+        np.zeros((1, 2, 3), dtype=np.float32),
+        np.zeros(1, dtype=np.float32),
+        np.zeros(4, dtype=np.float32)
+    ))
+    def test_coords_add_vector_wrong_vec_shape(self, vector):
+        positions = np.zeros((1, 3), dtype=np.float32)
+        with pytest.raises(ValueError):
+            coords_add_vector(positions, vector)
+        with pytest.raises(ValueError):
+            coords_add_vector(positions, vector.astype(np.float64))
 
 
-@pytest.mark.parametrize('values', (
-    [],                  # empty array
-    [-999],              # single value array
-    [1, 1, 1, 1],        # all identical
-    [2, 3, 5, 7],        # all different, monotonic
-    [5, 2, 7, 3],        # all different, non-monotonic
-    [1, 2, 2, 4, 4, 6],  # duplicates, monotonic
-    [1, 2, 2, 6, 4, 4],  # duplicates, non-monotonic
-    [4, 2, 6, 1, 4, 2]   # duplicates, scrambled
-))
-@pytest.mark.parametrize('masks', (True, False))
-def test_unique_int_1d_return_counts(values, masks):
-    array = np.array(values, dtype=np.intp)
-    _, ref_counts = np.unique(array, return_counts=True)
-    res = unique_int_1d(array, return_counts=True, return_masks=masks)
-    counts = res[1]
-    assert_equal(counts, ref_counts)
-    assert type(counts) == type(ref_counts)
-    assert counts.dtype == ref_counts.dtype
+    @pytest.mark.parametrize('positions', (
+        np.zeros((0, 3), dtype=np.float32),
+        np.array([[1.0000001, -1.0000001, 0.0000001]], dtype=np.float32),
+        np.zeros((10, 3), dtype=np.float32),
+        np.ones((10, 3), dtype=np.float32),
+        np.reshape(np.arange(-30, 30, dtype=np.float32), (-1, 3))
+    ))
+    @pytest.mark.parametrize('vector', (
+        np.array([-1, 2, 3], dtype=np.float32),
+        np.array([-1, 2, 3], dtype=np.float64),
+        np.array([-1, 2, 3], dtype=int),
+        np.array([-1, 0, 3], dtype=bool),
+        np.zeros(3, dtype=np.float32),
+        np.zeros(3, dtype=np.float64),
+        np.zeros(3, dtype=int),
+        np.zeros(3, dtype=bool),
+        np.array([1.000000051, 0.000000051, -1.000000051], dtype=np.float32),
+        np.array([1.000000051, 0.000000051, -1.000000051], dtype=np.float64),
+        np.array([np.nan, np.nan, np.nan], dtype=np.float32),
+        np.array([np.nan, np.nan, np.nan], dtype=np.float64),
+        np.array([np.inf, -np.inf, np.nan], dtype=np.float32),
+        np.array([np.inf, -np.inf, np.nan], dtype=np.float64),
+        np.array([1, 2, 3, 4, 5, 6], dtype=np.float32)[::2],
+        np.array([1, 2, 3, 4, 5, 6], dtype=np.float64)[::2],
+        np.array([1, 2, 3, 4, 5, 6], dtype=np.float32)[::-2],
+        np.array([1, 2, 3, 4, 5, 6], dtype=np.float64)[::-2],
+    ))
+    def test_coords_add_vectors_nomasks(self, positions, vector):
+        vectors = np.repeat(vector[None, :], len(positions), axis=0)
+        ref = positions.copy()
+        ref += vectors
+        _coords_add_vectors(positions, vectors, compound_masks=None)
+        assert_equal(positions, ref)
 
 
-@pytest.mark.parametrize('values', (
-    [],                  # empty array
-    [-999],              # single value array
-    [1, 1, 1, 1],        # all identical
-    [2, 3, 5, 7],        # all different, monotonic
-    [5, 2, 7, 3],        # all different, non-monotonic
-    [1, 2, 2, 4, 4, 6],  # duplicates, monotonic
-    [1, 2, 2, 6, 4, 4],  # duplicates, non-monotonic
-    [4, 2, 6, 1, 4, 2]   # duplicates, scrambled
-))
-@pytest.mark.parametrize('counts', (True, False))
-def test_unique_int_1d_return_masks(values, counts):
-    array = np.array(values, dtype=np.intp)
-    ref_masks = unique_masks_int_1d(array)
-    res = unique_int_1d(array, return_counts=counts, return_masks=True)
-    if counts:
-        masks = res[2]
-    else:
-        masks = res[1]
-    assert type(masks) == type(ref_masks)
-    assert masks.dtype == ref_masks.dtype
-    assert len(masks) == len(ref_masks)
-    for i in range(len(masks)):
-        assert isinstance(masks[i], (tuple, slice))
-        assert_equal(masks[i], ref_masks[i])
+    @pytest.mark.parametrize('positions', (
+        np.zeros((0, 3), dtype=np.float32),
+        np.array([[1.0000001, -1.0000001, 0.0000001]], dtype=np.float32),
+        np.zeros((10, 3), dtype=np.float32),
+        np.ones((10, 3), dtype=np.float32),
+        np.reshape(np.arange(-30, 30, dtype=np.float32), (-1, 3))
+    ))
+    @pytest.mark.parametrize('vector', (
+        np.array([-1, 2, 3], dtype=np.float32),
+        np.array([-1, 2, 3], dtype=np.float64),
+        np.array([-1, 2, 3], dtype=int),
+        np.array([-1, 0, 3], dtype=bool),
+        np.zeros(3, dtype=np.float32),
+        np.zeros(3, dtype=np.float64),
+        np.zeros(3, dtype=int),
+        np.zeros(3, dtype=bool),
+        np.array([1.000000051, 0.000000051, -1.000000051], dtype=np.float32),
+        np.array([1.000000051, 0.000000051, -1.000000051], dtype=np.float64),
+        np.array([np.nan, np.nan, np.nan], dtype=np.float32),
+        np.array([np.nan, np.nan, np.nan], dtype=np.float64),
+        np.array([np.inf, -np.inf, np.nan], dtype=np.float32),
+        np.array([np.inf, -np.inf, np.nan], dtype=np.float64),
+        np.array([1, 2, 3, 4, 5, 6], dtype=np.float32)[::2],
+        np.array([1, 2, 3, 4, 5, 6], dtype=np.float64)[::2],
+        np.array([1, 2, 3, 4, 5, 6], dtype=np.float32)[::-2],
+        np.array([1, 2, 3, 4, 5, 6], dtype=np.float64)[::-2],
+    ))
+    @pytest.mark.parametrize('dup', (False, True))
+    @pytest.mark.parametrize('rnd', (False, True))
+    def test_coords_add_vectors_masks(self, positions, vector, dup, rnd):
+        comp_masks = self.gen_masks(len(positions), duplicates=dup, random=rnd)
+        vectors = np.repeat(vector[None, :], len(comp_masks), axis=0)
+        ref = positions.copy()
+        for i, mask in enumerate(comp_masks):
+            if isinstance(mask, slice):
+                ref[mask] += vectors[i]
+            else:
+                print(np.asarray(mask))
+                for j in mask:
+                    ref[j] += vectors[i]
+        _coords_add_vectors(positions, vectors, compound_masks=comp_masks)
+        assert_equal(positions, ref)
 
 
-@pytest.mark.parametrize('values', (
-    [],                  # empty array
-    [-999],              # single value array
-    [1, 1, 1, 1],        # all identical
-    [2, 3, 5, 7],        # all different, monotonic
-    [5, 2, 7, 3],        # all different, non-monotonic
-    [1, 2, 2, 4, 4, 6],  # duplicates, monotonic
-    [1, 2, 2, 6, 4, 4],  # duplicates, non-monotonic
-    [4, 2, 6, 1, 4, 2]   # duplicates, scrambled
-))
-def test_unique_masks_int_1d(values):
-    array = np.array(values, dtype=np.intp)
-    ismonotonic = len(array) > 0
-    if len(array) > 1:
-        ismonotonic = np.all((array[1:] - array[:-1]) >= 0)
-    ref_unique = np.unique(values)
-    ref_masks = np.empty(len(ref_unique), dtype=object)
-    for i in range(len(ref_unique)):
-        ref_masks[i] = (array == ref_unique[i]).nonzero()
-        if ismonotonic:
-            ref_masks[i] = slice(ref_masks[i][0][0], ref_masks[i][0][-1] + 1, 1)
-    masks = unique_masks_int_1d(array)
-    assert type(masks) == type(ref_masks)
-    assert masks.dtype == ref_masks.dtype
-    assert len(masks) == len(ref_masks)
-    for i in range(len(masks)):
-        if ismonotonic:
-            assert isinstance(masks[i], slice)
+    @pytest.mark.parametrize('positions', (
+        np.array([[]], dtype=np.float32),
+        np.zeros(3, dtype=np.float32),
+        np.zeros((2, 2), dtype=np.float32),
+        np.zeros((1, 1, 3), dtype=np.float32),
+        np.zeros((1, 4), dtype=np.float32)
+    ))
+    @pytest.mark.parametrize('masks', (None, np.empty(2, dtype=object)))
+    def test_coords_add_vectors_wrong_pos_shape(self, positions, masks):
+        if masks is not None:
+            vectors = np.zeros((len(masks), 3), dtype=np.float32)
         else:
-            assert isinstance(masks[i], tuple)
-            assert len(masks[i]) == 1
-            assert isinstance(masks[i][0], np.ndarray)
-            assert masks[i][0].dtype == np.intp
-        assert_equal(masks[i], ref_masks[i])
-
-@pytest.mark.parametrize('values, ref', (
-    ([-3], True),                   # length-1 array, negative
-    ([3], True),                    # length-1 array, positive
-    ([0], True),                    # length-1 array, zero
-    ([-5, -4], True),               # length-2 contiguous range
-    ([1, 2, 3, 4, 5], True),        # contiguous range, positive
-    ([-5, -4, -3, -2, -1], True),   # contiguous range, negative
-    ([-2, -1, 0, 1, 2], True),      # contiguous range, neg to pos
-    ([], False),                    # empty array
-    ([0, 0], False),                # length-2 array, zeros
-    ([-3, -4], False),              # length-2 inverted range
-    ([5, 4, 3, 2, 1], False),       # inverted range, positive
-    ([-1, -2, -3, -4, -5], False),  # inverted range, negative
-    ([2, 1, 0, -1, -2], False),     # inverted range, pos to neg
-    ([1, 3, 5, 7, 9], False),       # strided range, positive
-    ([-9, -7, -5, -3, -1], False),  # strided range, negative
-    ([-5, -3, -1, 1, 3], False),    # strided range, neg to pos
-    ([3, 1, -1, -3, -5], False),    # inverted strided range, pos to neg
-    ([1, 1, 1, 1], False),          # all identical
-    ([2, 3, 5, 7], False),          # monotonic
-    ([5, 2, 7, 3], False),          # non-monotonic
-    ([1, 2, 2, 3, 4], False),       # range with middle duplicates
-    ([1, 2, 3, 4, 4], False),       # range with end duplicates
-    ([1, 1, 2, 3, 4], False),       # range with start duplicates
-    ([-1, 2, 2, 4, 3], False)       # duplicates, non-monotonic
-))
-def test_iscontiguous_int_1d(values, ref):
-    array = np.array(values, dtype=np.intp)
-    res = iscontiguous_int_1d(array)
-    assert_equal(res, ref)
-    assert type(res) == bool
+            vectors = np.zeros((len(positions), 3), dtype=np.float32)
+        with pytest.raises(ValueError):
+            _coords_add_vectors(positions, vectors, compound_masks=masks)
 
 
-@pytest.mark.parametrize('arr', (
-    [],                       # empty array
-    [1],                      # single value array
-    [1, 1, 1, 1],             # all identical
-    [0, 3, 5, 7],             # all different, monotonic
-    [5, 2, 7, 3],             # all different, non-monotonic
-    [-1, -1, 2, 2, 4, 4, 6],  # duplicates, monotonic
-    [1, 2, 2, 6, 4, 4, -1],   # duplicates, non-monotonic
-    [4, 2, 6, 1, 4, 2, -1]    # duplicates, scrambled
-))
-@pytest.mark.parametrize('value', (-1, 0, 1, 2, 3, 4, 5, 6, 7))
-def test_argwhere_int_1d(arr, value):
-    arr = np.array(arr, dtype=np.intp)
-    ref = np.argwhere(arr == value).ravel()
-    res = argwhere_int_1d(arr, value)
-    assert_equal(res, ref)
-    assert type(res) == type(ref)
-    assert res.dtype == ref.dtype
+    @pytest.mark.parametrize('vectors', (
+        np.array([[]], dtype=np.float32),
+        np.zeros((3, 1), dtype=np.float32),
+        np.zeros((1, 2, 3), dtype=np.float32),
+        np.zeros((0, 5), dtype=np.float32),
+        np.zeros(4, dtype=np.float32)
+    ))
+    def test_coords_add_vectors_wrong_vec_shape(self, vectors):
+        positions = np.zeros((len(vectors), 3), dtype=np.float32)
+        with pytest.raises(ValueError):
+            _coords_add_vectors(positions, vectors, compound_masks=None)
+        masks = np.empty(len(vectors), dtype=object)
+        with pytest.raises(ValueError):
+            _coords_add_vectors(positions, vectors, compound_masks=masks)
 
 
-@pytest.mark.parametrize('indices, ref', (
-    ([5], slice(5, 6, 1)),               # single value array
-    ([0, 1], slice(0, 2, 1)),            # two value array, stride 1
-    ([2, 12], slice(2, 13, 10)),         # two value array, stride 10
-    ([1, 0], slice(1, None, -1)),        # two value array, stride -1
-    ([12, 1], slice(12, 0, -11)),        # two value array, stride -11
-    ([0, 1, 2, 3], slice(0, 4, 1)),      # monotonic, stride 1
-    ([0, 2, 4, 6], slice(0, 7, 2)),      # monotonic, stride 2
-    ([2, 3, 4, 5], slice(2, 6, 1)),      # monotonic with offset, stride 1
-    ([3, 5, 7, 9], slice(3, 10, 2)),     # monotonic with offset, stride 2
-    ([3, 2, 1, 0], slice(3, None, -1)),  # monotonic, stride -1
-    ([9, 6, 3, 0], slice(9, None, -3)),  # monotonic, stride -3
-    ([7, 6, 5, 4], slice(7, 3, -1)),     # monotonic with offset, stride -1
-    ([14, 10, 6], slice(14, 5, -4))      # monotonic with offset, stride -4
-))
-def test_indices_to_slice_1d_slice(indices, ref):
-    ix = np.array(indices, dtype=np.intp)
-    res = indices_to_slice_1d(ix)
-    assert isinstance(res, slice)
-    assert res == ref
-    values = np.arange(60, dtype=np.float32).reshape((-1, 3))
-    fancy_indexed = values[ix]
-    view = values[res]
-    assert not view.flags['OWNDATA']  # the purpose of indices_to_slice_1d
-    assert_equal(view, fancy_indexed)
+    def test_coords_add_vectors_wrong_masks_shape(self):
+        positions = np.zeros((2, 3), dtype=np.float32)
+        vectors = np.zeros((2, 3), dtype=np.float32)
+        masks = np.empty(1, dtype=object)
+        with pytest.raises(ValueError):
+            _coords_add_vectors(positions, vectors, compound_masks=masks)
 
 
-@pytest.mark.parametrize('indices', (
-    [],                       # empty array
-    [1, 1, 1, 1],             # all identical
-    [0, 3, 5, 7],             # all different, monotonic, non-uniform stride
-    [5, 2, 7, 3],             # all different, non-monotonic
-    [0, 0, 2, 2, 4, 4, 6],    # duplicates, monotonic
-    [1, 2, 2, 6, 4, 4, 1],    # duplicates, non-monotonic
-    [4, 2, 6, 1, 4, 2, 1],    # duplicates, scrambled
-    [-1, 0, 1, 2, 3, 4, 5],   # monotonic, stride 1, negative values
-    [1, 0, -1, -2, -3, -4],   # monotonic, stride -1, negative values
-    [-3, -1, 1, 3, 5, 7],     # monotonic, stride 2, negative values
-    [3, 0, -3, -6, -9, -12]   # monotonic, stride -3, negative values
-))
-def test_indices_to_slice_1d_noslice(indices):
-    ix = np.array(indices, dtype=np.intp)
-    assert indices_to_slice_1d(ix) is ix
+    @pytest.mark.parametrize('coords', (
+        np.empty((0, 3), dtype=np.float32),
+        np.array([[1, 2, 3]], dtype=np.float32),
+        np.reshape(np.arange(-30, 30, dtype=np.float32), (-1, 3))
+    ))
+    @pytest.mark.parametrize('check_weights', (False, True))
+    @pytest.mark.parametrize('ret_masks', (False, True))
+    def test_coords_center_noweights_nocomp(self, coords, check_weights,
+                                            ret_masks):
+        if len(coords) < 2:
+            ref = coords.astype(np.float64)
+        else:
+            ref = coords.mean(axis=0, dtype=np.float64).reshape(-1, 3)
+        res = coords_center(coords, weights=None, compound_indices=None,
+                            check_weights=check_weights,
+                            return_compound_masks=ret_masks)
+        assert res.dtype == np.float64
+        assert res.shape == (int(len(coords) != 0), 3)
+        assert_equal(res, ref)
+
+
+    @pytest.mark.parametrize('coords', (
+        np.empty((0, 3), dtype=np.float32),
+        np.array([[1, 2, 3]], dtype=np.float32),
+        np.reshape(np.arange(-30, 30, dtype=np.float32), (-1, 3))
+    ))
+    @pytest.mark.parametrize('check_weights', (False, True))
+    @pytest.mark.parametrize('ret_masks', (False, True))
+    def test_coords_center_weights_nocomp(self, coords, check_weights,
+                                          ret_masks):
+        weights = np.arange(1, len(coords) + 1, dtype=np.float64)
+        if len(coords) == 0:
+            ref = coords.astype(np.float64)
+        else:
+            ref = np.average(coords, axis=0, weights=weights).reshape((1, 3))
+        res = coords_center(coords, weights=weights, compound_indices=None,
+                            check_weights=check_weights,
+                            return_compound_masks=ret_masks)
+        assert res.dtype == np.float64
+        assert res.shape == (int(len(coords) != 0), 3)
+        assert_almost_equal(res, ref, decimal=self.precision)
+
+
+    @pytest.mark.parametrize('coords, comp_ix', (
+        (np.empty((0, 3), dtype=np.float32),
+         np.empty(0, dtype=np.intp)),
+        (np.array([[1, 2, 3]], dtype=np.float32),
+         np.array([-999], dtype=np.intp)),
+        (np.reshape(np.arange(-10, 20, dtype=np.float32), (-1, 3)),
+         np.array([0, 0, 0, 1, 2, 2, 2, 3, 3, 4], dtype=np.intp)),
+        (np.reshape(np.arange(-20, 10, dtype=np.float32), (-1, 3)),
+         np.array([4, -2, 0, 1, -2, 0, 3, 3, 0, -2], dtype=np.intp)),
+    ))
+    @pytest.mark.parametrize('check_weights', (False, True))
+    @pytest.mark.parametrize('ret_masks', (False, True))
+    def test_coords_center_noweights_comp(self, coords, comp_ix, check_weights,
+                                          ret_masks):
+        unique_comp_ix = np.unique(comp_ix)
+        if len(coords) < 2:
+            ref = coords.astype(np.float64)
+        else:
+            ref = np.empty((len(unique_comp_ix), 3), dtype=np.float64)
+            for i, uix in enumerate(unique_comp_ix):
+                mask = (comp_ix == uix).nonzero()
+                ref[i] = coords[mask].mean(axis=0, dtype=np.float64)
+        res = coords_center(coords, weights=None, compound_indices=comp_ix,
+                            check_weights=check_weights,
+                            return_compound_masks=ret_masks)
+        if ret_masks:
+            ref_masks = unique_masks_int_1d(comp_ix, assume_unsorted=True)
+            res, res_masks = res
+            assert res_masks.dtype == object
+            assert len(res_masks) == len(ref_masks)
+            for i in range(len(res_masks)):
+                assert_equal(np.asarray(res_masks[i]), np.asarray(ref_masks[i]))
+        assert res.dtype == np.float64
+        assert res.shape == (len(unique_comp_ix), 3)
+        assert_almost_equal(res, ref, decimal=self.precision)
+
+
+    @pytest.mark.parametrize('coords, weights, comp_ix', (
+        (np.empty((0, 3), dtype=np.float32),
+         np.empty(0, dtype=np.float64),
+         np.empty(0, dtype=np.intp)),
+        (np.array([[1, 2, 3]], dtype=np.float32),
+         np.array([2], dtype=np.float64),
+         np.array([-999], dtype=np.intp)),
+        (np.reshape(np.arange(-10, 20, dtype=np.float32), (-1, 3)),
+         np.array([1, 1, 1, 2, 3, 3, 3, 4, 4, 5], dtype=np.float64),
+         np.array([0, 0, 0, 1, 2, 2, 2, 3, 3, 4], dtype=np.intp)),
+        (np.reshape(np.arange(-20, 10, dtype=np.float32), (-1, 3)),
+         np.array([4, -1, 1, 1, -2, 1, 2, 3, 5, -2], dtype=np.float64),
+         np.array([4, -2, 0, 1, -2, 0, 3, 3, 0, -2], dtype=np.intp)),
+    ))
+    @pytest.mark.parametrize('check_weights', (False, True))
+    @pytest.mark.parametrize('ret_masks', (False, True))
+    def test_coords_center_weights_comp(self, coords, weights, comp_ix,
+                                        check_weights, ret_masks):
+        unique_comp_ix = np.unique(comp_ix)
+        if len(coords) == 0:
+            ref = coords.astype(np.float64)
+        else:
+            ref = np.empty((len(unique_comp_ix), 3), dtype=np.float64)
+            for i, uix in enumerate(unique_comp_ix):
+                mask = (comp_ix == uix).nonzero()
+                ref[i] = np.average(coords[mask], axis=0, weights=weights[mask])
+        res = coords_center(coords, weights=weights, compound_indices=comp_ix,
+                            check_weights=check_weights,
+                            return_compound_masks=ret_masks)
+        if ret_masks:
+            ref_masks = unique_masks_int_1d(comp_ix, assume_unsorted=True)
+            res, res_masks = res
+            assert res_masks.dtype == object
+            assert len(res_masks) == len(ref_masks)
+            for i in range(len(res_masks)):
+                assert_equal(np.asarray(res_masks[i]), np.asarray(ref_masks[i]))
+        assert res.dtype == np.float64
+        assert res.shape == (len(unique_comp_ix), 3)
+        assert_almost_equal(res, ref, decimal=self.precision)
+
+
+    @pytest.mark.parametrize('coords', (
+        np.empty((0, 3), dtype=np.float32),
+        np.array([[1, 2, 3]], dtype=np.float32),
+        np.reshape(np.arange(-30, 30, dtype=np.float32), (-1, 3))
+    ))
+    @pytest.mark.parametrize('check_weights', (False, True))
+    @pytest.mark.parametrize('ret_masks', (False, True))
+    def test_coords_center_zero_weights_nocomp(self, coords, check_weights,
+                                               ret_masks):
+        weights = np.zeros(len(coords), dtype=np.float64)
+        if check_weights and len(coords) > 0:
+            with pytest.raises(ValueError):
+                res = coords_center(coords, weights=weights,
+                                    compound_indices=None,
+                                    check_weights=check_weights,
+                                    return_compound_masks=ret_masks)
+        else:
+            if len(coords) == 0:
+                ref = coords.astype(np.float64)
+            else:
+                ref = np.full((1, 3), np.nan, dtype=np.float64)
+            res = coords_center(coords, weights=weights, compound_indices=None,
+                                check_weights=check_weights,
+                                return_compound_masks=ret_masks)
+            assert res.dtype == np.float64
+            assert res.shape == (int(len(coords) != 0), 3)
+            assert_equal(res, ref)
+
+
+    @pytest.mark.parametrize('coords, weights, comp_ix', (
+        (np.empty((0, 3), dtype=np.float32),
+         np.empty(0, dtype=np.float64),
+         np.empty(0, dtype=np.intp)),
+        (np.array([[1, 2, 3]], dtype=np.float32),
+         np.array([0], dtype=np.float64),
+         np.array([-999], dtype=np.intp)),
+        (np.reshape(np.arange(-10, 20, dtype=np.float32), (-1, 3)),
+         np.array([1, 1, 1, 2, -1, 2, -1, 1, 1, 5], dtype=np.float64),
+         np.array([0, 0, 0, 1, 2, 2, 2, 3, 3, 4], dtype=np.intp)),
+        (np.reshape(np.arange(-20, 10, dtype=np.float32), (-1, 3)),
+         np.array([4, -1, 1, 1, -2, 1, 2, -2, 5, -2], dtype=np.float64),
+         np.array([4, -2, 0, 1, -2, 0, 3, 3, 0, -2], dtype=np.intp)),
+    ))
+    @pytest.mark.parametrize('check_weights', (False, True))
+    @pytest.mark.parametrize('ret_masks', (False, True))
+    def test_coords_center_zero_weights_comp(self, coords, weights, comp_ix,
+                                             check_weights, ret_masks):
+        if check_weights and len(coords) > 0:
+            with pytest.raises(ValueError):
+                res = coords_center(coords, weights=weights,
+                                    compound_indices=comp_ix,
+                                    check_weights=check_weights,
+                                    return_compound_masks=ret_masks)
+        else:
+            unique_comp_ix = np.unique(comp_ix)
+            if len(coords) == 0:
+                ref = coords.astype(np.float64)
+            else:
+                ref = np.empty((len(unique_comp_ix), 3), dtype=np.float64)
+                for i, uix in enumerate(unique_comp_ix):
+                    m = (comp_ix == uix).nonzero()
+                    inv_sum_weights = 1.0 / weights[m].sum()
+                    if not np.isfinite(inv_sum_weights):
+                        ref[i] = np.nan
+                    else:
+                        ref[i] = (coords[m] * weights[m][:, None]).sum(axis=0)
+                        ref[i] *= inv_sum_weights
+                res = coords_center(coords, weights=weights,
+                                    compound_indices=comp_ix,
+                                    check_weights=check_weights,
+                                    return_compound_masks=ret_masks)
+                if ret_masks:
+                    ref_masks = unique_masks_int_1d(comp_ix,
+                                                    assume_unsorted=True)
+                    res, res_masks = res
+                    assert res_masks.dtype == object
+                    assert len(res_masks) == len(ref_masks)
+                    for i in range(len(res_masks)):
+                        assert_equal(np.asarray(res_masks[i]),
+                                     np.asarray(ref_masks[i]))
+                assert res.dtype == np.float64
+                assert res.shape == (len(unique_comp_ix), 3)
+                assert_almost_equal(res, ref, decimal=self.precision)
+
+
+    @pytest.mark.parametrize('coords, weights, comp_ix', (
+        (np.empty((0, 2), dtype=np.float32),
+         np.empty(0, dtype=np.float64),
+         np.empty(0, dtype=np.intp)),
+        (np.empty((0, 2), dtype=np.float32),
+         None,
+         np.empty(0, dtype=np.intp)),
+        (np.empty((0, 2), dtype=np.float32),
+         None,
+         None),
+        (np.array([[1, 2, 3]], dtype=np.float32),
+         np.array([1, 1], dtype=np.float64),
+         np.array([0], dtype=np.intp)),
+        (np.array([[1, 2, 3]], dtype=np.float32),
+         None,
+         np.array([0, 0], dtype=np.intp)),
+        (np.array([[1, 2, 3]], dtype=np.float32),
+         np.array([1, 1], dtype=np.float64),
+         None),
+        (np.array([[1, 2, 3]], dtype=np.float32),
+         np.array([1, 1], dtype=np.float64),
+         np.array([0, 0], dtype=np.intp)),
+    ))
+    @pytest.mark.parametrize('check_weights', (False, True))
+    @pytest.mark.parametrize('ret_masks', (False, True))
+    def test_coords_center_wrong_shapes(self, coords, weights, comp_ix,
+                                        check_weights, ret_masks):
+        with pytest.raises(ValueError):
+            res = coords_center(coords, weights=weights,
+                                compound_indices=comp_ix,
+                                check_weights=check_weights,
+                                return_compound_masks=ret_masks)
+
+
+
+class TestInt1dFunctions(object):
+
+    @pytest.mark.parametrize('values', (
+        [],                  # empty array
+        [-999],              # single value array
+        [1, 1, 1, 1],        # all identical
+        [2, 3, 5, 7],        # all different, monotonic
+        [5, 2, 7, 3],        # all different, non-monotonic
+        [1, 2, 2, 4, 4, 6],  # duplicates, monotonic
+        [1, 2, 2, 6, 4, 4],  # duplicates, non-monotonic
+        [4, 2, 6, 1, 4, 2]   # duplicates, scrambled
+    ))
+    @pytest.mark.parametrize('counts', (True, False))
+    @pytest.mark.parametrize('masks', (True, False))
+    @pytest.mark.parametrize('unsorted', (True, False))
+    def test_unique_int_1d(self, values, counts, masks, unsorted):
+        array = np.array(values, dtype=np.intp)
+        ref = np.unique(array)
+        res = unique_int_1d(array, return_counts=counts, return_masks=masks,
+                            assume_unsorted=unsorted)
+        if counts or masks:
+            res = res[0]
+        assert_equal(res, ref)
+        assert type(res) == type(ref)
+        assert res.dtype == ref.dtype
+
+
+    @pytest.mark.parametrize('values', (
+        [],                  # empty array
+        [-999],              # single value array
+        [1, 1, 1, 1],        # all identical
+        [2, 3, 5, 7],        # all different, monotonic
+        [5, 2, 7, 3],        # all different, non-monotonic
+        [1, 2, 2, 4, 4, 6],  # duplicates, monotonic
+        [1, 2, 2, 6, 4, 4],  # duplicates, non-monotonic
+        [4, 2, 6, 1, 4, 2]   # duplicates, scrambled
+    ))
+    @pytest.mark.parametrize('masks', (True, False))
+    @pytest.mark.parametrize('unsorted', (True, False))
+    def test_unique_int_1d_return_counts(self, values, masks, unsorted):
+        array = np.array(values, dtype=np.intp)
+        _, ref_counts = np.unique(array, return_counts=True)
+        res = unique_int_1d(array, return_counts=True, return_masks=masks,
+                            assume_unsorted=unsorted)
+        counts = res[1]
+        assert_equal(counts, ref_counts)
+        assert type(counts) == type(ref_counts)
+        assert counts.dtype == ref_counts.dtype
+
+
+    @pytest.mark.parametrize('values', (
+        [],                  # empty array
+        [-999],              # single value array
+        [1, 1, 1, 1],        # all identical
+        [2, 3, 5, 7],        # all different, monotonic
+        [5, 2, 7, 3],        # all different, non-monotonic
+        [1, 2, 2, 4, 4, 6],  # duplicates, monotonic
+        [1, 2, 2, 6, 4, 4],  # duplicates, non-monotonic
+        [4, 2, 6, 1, 4, 2]   # duplicates, scrambled
+    ))
+    @pytest.mark.parametrize('counts', (True, False))
+    @pytest.mark.parametrize('unsorted', (True, False))
+    def test_unique_int_1d_return_masks(self, values, counts, unsorted):
+        array = np.array(values, dtype=np.intp)
+        ref_masks = unique_masks_int_1d(array, assume_unsorted=unsorted)
+        res = unique_int_1d(array, return_counts=counts, return_masks=True,
+                            assume_unsorted=unsorted)
+        if counts:
+            masks = res[2]
+        else:
+            masks = res[1]
+        assert type(masks) == type(ref_masks)
+        assert masks.dtype == ref_masks.dtype
+        assert len(masks) == len(ref_masks)
+        for i in range(len(masks)):
+            assert isinstance(masks[i], slice) or \
+                masks[i].__class__.__name__ == '_memoryviewslice'
+            if isinstance(masks[i], slice):
+                assert_equal(masks[i], ref_masks[i])
+            else:
+                assert_equal(np.asarray(masks[i]), np.asarray(ref_masks[i]))
+
+
+    @pytest.mark.parametrize('values', (
+        [],                  # empty array
+        [-999],              # single value array
+        [1, 1, 1, 1],        # all identical
+        [2, 3, 5, 7],        # all different, monotonic
+        [5, 2, 7, 3],        # all different, non-monotonic
+        [1, 2, 2, 4, 4, 6],  # duplicates, monotonic
+        [1, 2, 2, 6, 4, 4],  # duplicates, non-monotonic
+        [4, 2, 6, 1, 4, 2]   # duplicates, scrambled
+    ))
+    @pytest.mark.parametrize('unsorted', (True, False))
+    def test_unique_masks_int_1d(self, values, unsorted):
+        array = np.array(values, dtype=np.intp)
+        ismonotonic = len(array) > 0
+        if len(array) > 1:
+            ismonotonic = np.all((array[1:] - array[:-1]) >= 0)
+        ref_unique = np.unique(values)
+        ref_masks = np.empty(len(ref_unique), dtype=object)
+        for i in range(len(ref_unique)):
+            ref_masks[i] = (array == ref_unique[i]).nonzero()[0]
+            if ismonotonic and (not unsorted or len(array) == 1):
+                ref_masks[i] = slice(ref_masks[i][0], ref_masks[i][-1] + 1, 1)
+        masks = unique_masks_int_1d(array, assume_unsorted=unsorted)
+        assert type(masks) == type(ref_masks)
+        assert masks.dtype == ref_masks.dtype
+        assert len(masks) == len(ref_masks)
+        for i in range(len(masks)):
+            if ismonotonic and (not unsorted or len(array) == 1):
+                assert isinstance(masks[i], slice)
+                assert_equal(masks[i], ref_masks[i])
+            else:
+                assert masks[i].__class__.__name__ == '_memoryviewslice'
+                assert len(masks[i]) == len(ref_masks[i])
+                assert np.asarray(masks[i]).dtype == np.intp
+                assert_equal(np.asarray(masks[i]), ref_masks[i])
+
+    @pytest.mark.parametrize('values, ref', (
+        ([-3], True),                   # length-1 array, negative
+        ([3], True),                    # length-1 array, positive
+        ([0], True),                    # length-1 array, zero
+        ([-5, -4], True),               # length-2 contiguous range
+        ([1, 2, 3, 4, 5], True),        # contiguous range, positive
+        ([-5, -4, -3, -2, -1], True),   # contiguous range, negative
+        ([-2, -1, 0, 1, 2], True),      # contiguous range, neg to pos
+        ([], False),                    # empty array
+        ([0, 0], False),                # length-2 array, zeros
+        ([-3, -4], False),              # length-2 inverted range
+        ([5, 4, 3, 2, 1], False),       # inverted range, positive
+        ([-1, -2, -3, -4, -5], False),  # inverted range, negative
+        ([2, 1, 0, -1, -2], False),     # inverted range, pos to neg
+        ([1, 3, 5, 7, 9], False),       # strided range, positive
+        ([-9, -7, -5, -3, -1], False),  # strided range, negative
+        ([-5, -3, -1, 1, 3], False),    # strided range, neg to pos
+        ([3, 1, -1, -3, -5], False),    # inverted strided range, pos to neg
+        ([1, 1, 1, 1], False),          # all identical
+        ([2, 3, 5, 7], False),          # monotonic
+        ([5, 2, 7, 3], False),          # non-monotonic
+        ([1, 2, 2, 3, 4], False),       # range with middle duplicates
+        ([1, 2, 3, 4, 4], False),       # range with end duplicates
+        ([1, 1, 2, 3, 4], False),       # range with start duplicates
+        ([-1, 2, 2, 4, 3], False)       # duplicates, non-monotonic
+    ))
+    def test_iscontiguous_int_1d(self, values, ref):
+        array = np.array(values, dtype=np.intp)
+        res = iscontiguous_int_1d(array)
+        assert_equal(res, ref)
+        assert type(res) == bool
+
+
+    @pytest.mark.parametrize('arr', (
+        [],                       # empty array
+        [1],                      # single value array
+        [1, 1, 1, 1],             # all identical
+        [0, 3, 5, 7],             # all different, monotonic
+        [5, 2, 7, 3],             # all different, non-monotonic
+        [-1, -1, 2, 2, 4, 4, 6],  # duplicates, monotonic
+        [1, 2, 2, 6, 4, 4, -1],   # duplicates, non-monotonic
+        [4, 2, 6, 1, 4, 2, -1]    # duplicates, scrambled
+    ))
+    @pytest.mark.parametrize('value', (-1, 0, 1, 2, 3, 4, 5, 6, 7))
+    def test_argwhere_int_1d(self, arr, value):
+        arr = np.array(arr, dtype=np.intp)
+        ref = np.argwhere(arr == value).ravel()
+        res = argwhere_int_1d(arr, value)
+        assert_equal(res, ref)
+        assert type(res) == type(ref)
+        assert res.dtype == ref.dtype
+
+
+    @pytest.mark.parametrize('indices, ref', (
+        ([5], slice(5, 6, 1)),               # single value array
+        ([0, 1], slice(0, 2, 1)),            # two value array, stride 1
+        ([2, 12], slice(2, 13, 10)),         # two value array, stride 10
+        ([1, 0], slice(1, None, -1)),        # two value array, stride -1
+        ([12, 1], slice(12, 0, -11)),        # two value array, stride -11
+        ([0, 1, 2, 3], slice(0, 4, 1)),      # monotonic, stride 1
+        ([0, 2, 4, 6], slice(0, 7, 2)),      # monotonic, stride 2
+        ([2, 3, 4, 5], slice(2, 6, 1)),      # monotonic with offset, stride 1
+        ([3, 5, 7, 9], slice(3, 10, 2)),     # monotonic with offset, stride 2
+        ([3, 2, 1, 0], slice(3, None, -1)),  # monotonic, stride -1
+        ([9, 6, 3, 0], slice(9, None, -3)),  # monotonic, stride -3
+        ([7, 6, 5, 4], slice(7, 3, -1)),     # monotonic with offset, stride -1
+        ([14, 10, 6], slice(14, 5, -4))      # monotonic with offset, stride -4
+    ))
+    def test_indices_to_slice_1d_slice(self, indices, ref):
+        ix = np.array(indices, dtype=np.intp)
+        res = indices_to_slice_1d(ix)
+        assert isinstance(res, slice)
+        assert res == ref
+        values = np.arange(60, dtype=np.float32).reshape((-1, 3))
+        fancy_indexed = values[ix]
+        view = values[res]
+        assert not view.flags['OWNDATA']  # the purpose of indices_to_slice_1d
+        assert_equal(view, fancy_indexed)
+
+
+    @pytest.mark.parametrize('indices', (
+        [],                       # empty array
+        [1, 1, 1, 1],             # all identical
+        [0, 3, 5, 7],             # all different, monotonic, non-uniform stride
+        [5, 2, 7, 3],             # all different, non-monotonic
+        [0, 0, 2, 2, 4, 4, 6],    # duplicates, monotonic
+        [1, 2, 2, 6, 4, 4, 1],    # duplicates, non-monotonic
+        [4, 2, 6, 1, 4, 2, 1],    # duplicates, scrambled
+        [-1, 0, 1, 2, 3, 4, 5],   # monotonic, stride 1, negative values
+        [1, 0, -1, -2, -3, -4],   # monotonic, stride -1, negative values
+        [-3, -1, 1, 3, 5, 7],     # monotonic, stride 2, negative values
+        [3, 0, -3, -6, -9, -12]   # monotonic, stride -3, negative values
+    ))
+    def test_indices_to_slice_1d_noslice(self, indices):
+        ix = np.array(indices, dtype=np.intp)
+        assert indices_to_slice_1d(ix) is ix
+
 
 
 @pytest.mark.parametrize('edges,ref', [

--- a/testsuite/MDAnalysisTests/lib/test_util.py
+++ b/testsuite/MDAnalysisTests/lib/test_util.py
@@ -39,7 +39,7 @@ import MDAnalysis as mda
 import MDAnalysis.lib.util as util
 import MDAnalysis.lib.mdamath as mdamath
 from MDAnalysis.lib.util import (cached, static_variables, warn_if_not_unique,
-                                 check_coords)
+                                 check_coords, check_compound)
 from MDAnalysis.core.topologyattrs import Bonds
 from MDAnalysis.exceptions import NoDataError, DuplicateWarning
 
@@ -1962,3 +1962,33 @@ class TestCheckBox(object):
         with pytest.raises(ValueError):
             wrongbox = np.ones((3, 3), dtype=np.float32)
             boxtype, checked_box = util.check_box(wrongbox)
+
+
+class TestCheckCompound(object):
+
+    @pytest.mark.parametrize('compound, ref', (
+        ('aToMs', 'atoms'),
+        ('gRoUp', 'group'),
+        ('rEsIdUeS', 'residues'),
+        ('sEgMeNtS', 'segments'),
+        ('mOlEcUlEs', 'molecules'),
+        ('fRaGmEnTs', 'fragments')
+    ))
+    @pytest.mark.parametrize('atoms', (True, False))
+    def test_check_compound(self, compound, ref, atoms):
+        if (not atoms) and (ref == 'atoms'):
+            with pytest.raises(ValueError):
+               check_compound(compound, atoms=atoms)
+        else: 
+            assert check_compound(compound, atoms=atoms) == ref
+
+    @pytest.mark.parametrize('atoms', (True, False))
+    def test_check_compound_wrongname(self, atoms):
+        with pytest.raises(ValueError):
+            check_compound('random_bs', atoms=atoms)
+
+    @pytest.mark.parametrize('compound', (("atoms",), ["molecules"], 0))
+    @pytest.mark.parametrize('atoms', (True, False))
+    def test_check_compound_wrong_type(self, compound, atoms):
+        with pytest.raises(AttributeError):
+            check_compound(compound, atoms=atoms)


### PR DESCRIPTION
Fixes #2210 

Changes made in this Pull Request:
 - Changed `coordinates.base.Timestep.order` to 'C'
 - Added optional keywords `return_counts`, `return_masks`, and `assume_unsorted` to `lib.util.unique_int_1d()` and improved its performance
 - Added `lib.util.iscontiguous_int_1d()`
 - Added `lib.util.indices_to_slice_1d()`
 - Added `*Group.iscontiguous` property
 - Added `*Group._ix_or_slice` property
 - Added `AtomGroup._positions_view_or_copy` property returning a view for sliceable AtomGroups (otherwise a copy)
 - Added `AtomGroup._positions_c_view_or_copy` property returning a C-contiguous view for contiguous AtomGroups (otherwise a copy)
 - Added `lib.util.unique_masks_int_1d()`
 - Added `lib.util.argwhere_int_1d()` (will be used in a future PR for faster unwrapping)
 - Added `lib.util.check_compound()`
 - Added `AtomGroup.compound_indices()`
 - Added `lib.util.coords_add_vector()`
 - Added `lib.util._coords_add_vectors()`
 - Replaced `Universe._fragdict` by `Universe._fraginfo` property (accelerates `AtomGroup.fragments` and `AtomGroup.fragindices`)
 - Improved performance of `*Group.center()`, especially for per-compound computations and contiguous AtomGroups
 - Improved performance of `*Group.wrap()`, especially for per-compound computations and  contiguous AtomGroups (up to a factor of **39.3**)

PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
