### PR TITLE
Sp box

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -87,6 +87,8 @@ Fixes
   * *Group.wrap() is now guaranteed to only work on atoms actually belonging to
     the calling group. (Issue #2203, PR #2204)
   * Fixed documentation of MDAnalysis.analysis.contacts
+  * Enforced consistent dtype (numpy.float32) of Universe.dimensions and
+    Timestep.dimensions for all Universes and Readers (Issue #2190, PR #2213)
 
 Deprecations
   * analysis.polymer.PersistenceLength no longer requires the perform_fit()

--- a/package/MDAnalysis/coordinates/memory.py
+++ b/package/MDAnalysis/coordinates/memory.py
@@ -372,10 +372,10 @@ class MemoryReader(base.ProtoReader):
         self.ts = self._Timestep(self.n_atoms, **kwargs)
         self.ts.dt = dt
         if dimensions is None:
-            dimensions = np.zeros((self.n_frames, 6), dtype=np.float64)
+            dimensions = np.zeros((self.n_frames, 6), dtype=np.float32)
         else:
             try:
-                dimensions = np.asarray(dimensions, dtype=np.float64)
+                dimensions = np.asarray(dimensions, dtype=np.float32)
             except ValueError:
                 raise TypeError("'dimensions' must be array-like got {}"
                                 "".format(type(dimensions)))

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -488,7 +488,7 @@ class Universe(object):
 
         if trajectory:
             coords = np.zeros((1, n_atoms, 3), dtype=np.float32)
-            dims = np.zeros(6, dtype=np.float64)
+            dims = np.zeros(6, dtype=np.float32)
             vels = np.zeros_like(coords) if velocities else None
             forces = np.zeros_like(coords) if forces else None
 
@@ -658,7 +658,7 @@ class Universe(object):
 
             velocities = np.zeros_like(coordinates) if has_vels else None
             forces = np.zeros_like(coordinates) if has_fors else None
-            dimensions = (np.zeros((n_frames, 6), dtype=np.float64)
+            dimensions = (np.zeros((n_frames, 6), dtype=np.float32)
                           if has_dims else None)
 
             for i, ts in enumerate(self.trajectory[start:stop:step]):

--- a/package/MDAnalysis/lib/_cutil.pyx
+++ b/package/MDAnalysis/lib/_cutil.pyx
@@ -222,9 +222,7 @@ def make_whole(atomgroup, reference_atom=None, inplace=True):
             raise ValueError("Reference atom not in atomgroup")
         ref = ix_to_rel[reference_atom.ix]
 
-    box = atomgroup.dimensions.astype(np.float32)
-    # TODO: remove astype(np.float32) once all universes return float32 boxes
-
+    box = atomgroup.dimensions
     for i in range(3):
         half_box[i] = 0.5 * box[i]
         if box[i] == 0.0:

--- a/testsuite/MDAnalysisTests/coordinates/base.py
+++ b/testsuite/MDAnalysisTests/coordinates/base.py
@@ -695,10 +695,12 @@ class BaseTimestepTest(object):
             with pytest.raises(NotImplementedError):
                 getattr(ts, "dimensions")
 
-    def test_dimensions_set_box(self, ts):
+    @pytest.mark.parametrize('dtype', (int, np.float32, np.float64))
+    def test_dimensions_set_box(self, ts, dtype):
         if self.set_box:
-            ts.dimensions = self.newbox
-            assert_allclose(ts._unitcell, self.unitcell)
+            ts.dimensions = self.newbox.astype(dtype)
+            assert ts.dimensions.dtype == np.float32
+            assert_equal(ts._unitcell, self.unitcell)
             assert_allclose(ts.dimensions, self.newbox)
         else:
             pass
@@ -726,9 +728,9 @@ class BaseTimestepTest(object):
     def test_coordinate_getter_shortcuts(self, ts):
         """testing that reading _x, _y, and _z works as expected
         # (Issue 224) (TestTimestep)"""
-        assert_allclose(ts._x, ts._pos[:, 0])
-        assert_allclose(ts._y, ts._pos[:, 1])
-        assert_allclose(ts._z, ts._pos[:, 2])
+        assert_equal(ts._x, ts._pos[:, 0])
+        assert_equal(ts._y, ts._pos[:, 1])
+        assert_equal(ts._z, ts._pos[:, 2])
 
     def test_coordinate_setter_shortcuts(self, ts):
         # Check that _x _y and _z are read only

--- a/testsuite/MDAnalysisTests/coordinates/test_copying.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_copying.py
@@ -175,6 +175,8 @@ def test_timestep_copied(ref_reader):
 
     assert_equal(ref_reader.ts.positions, new.ts.positions)
     assert_almost_equal(new.ts.dimensions, newbox, decimal=4)
+    assert ref_reader.ts.positions.dtype == np.float32
+    assert new.ts.positions.dtype == np.float32
 
 
 @pytest.mark.skipif(shares_memory == False,

--- a/testsuite/MDAnalysisTests/coordinates/test_dms.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_dms.py
@@ -93,8 +93,10 @@ class TestDMSTimestep(BaseTimestepTest):
                 'z': np.array([0, 0, 12.])}
     uni_args = (DMS,)
 
-    def test_dimensions_set_box(self, ts):
-        ts.dimensions = self.newbox
+    @pytest.mark.parametrize('dtype', (int, np.float32, np.float64))
+    def test_dimensions_set_box(self, ts, dtype):
+        ts.dimensions = self.newbox.astype(dtype)
+        assert ts.dimensions.dtype == np.float32
         assert_equal(ts.dimensions, self.newbox)
         assert_equal(ts._unitcell, self.unitcell)
 

--- a/testsuite/MDAnalysisTests/core/test_universe.py
+++ b/testsuite/MDAnalysisTests/core/test_universe.py
@@ -288,11 +288,13 @@ class TestUniverse(object):
         with pytest.raises(NotImplementedError):
             cPickle.dumps(u, protocol = cPickle.HIGHEST_PROTOCOL)
 
-    def test_set_dimensions(self):
+    @pytest.mark.parametrize('dtype', (int, np.float32, np.float64))
+    def test_set_dimensions(self, dtype):
         u = mda.Universe(PSF, DCD)
-        box = np.array([10, 11, 12, 90, 90, 90])
-        u.dimensions = np.array([10, 11, 12, 90, 90, 90])
+        box = np.array([10, 11, 12, 90, 90, 90], dtype=dtype)
+        u.dimensions = box
         assert_allclose(u.dimensions, box)
+        assert u.dimensions.dtype == np.float32
 
 
 # remove for 1.0

--- a/testsuite/MDAnalysisTests/lib/test_util.py
+++ b/testsuite/MDAnalysisTests/lib/test_util.py
@@ -496,6 +496,7 @@ class TestMakeWhole(object):
         assert_array_equal(ag.positions, orig_pos)
 
     def test_double_precision_box(self):
+        # This test could in principle be removed since PR #2213
         # universe with double precision box containing a 2-atom molecule
         # broken accross a corner:
         u = mda.Universe.empty(
@@ -510,7 +511,7 @@ class TestMakeWhole(object):
         ts = u.trajectory.ts
         ts.frame = 0
         ts.dimensions = [10, 10, 10, 90, 90, 90]
-        assert ts.dimensions.dtype == np.float64
+        #assert ts.dimensions.dtype == np.float64  # not applicable since #2213
         ts.positions = np.array([[1, 1, 1,], [9, 9, 9]], dtype=np.float32)
         u.add_TopologyAttr(Bonds([(0, 1)]))
         mdamath.make_whole(u.atoms)


### PR DESCRIPTION
Fixes #2190

Changes made in this Pull Request:
 - Enforced `dtype=numpy.float32` for `Universe.dimensions` and `Timestep.dimensions`

I searched the code base and found the same lines as indicated by @jbarnoud and @PicoCentauri in the discussion of #2190 (see comments of [@jbarnoud](https://github.com/MDAnalysis/mdanalysis/issues/2190#issuecomment-458902209) and [@PicoCentauri](https://github.com/MDAnalysis/mdanalysis/issues/2190#issuecomment-458908655)).

No calls of `numpy.astype()` to make @richardjgowers happy. :wink:

Checks for valid boxes as outlined in my [comment](https://github.com/MDAnalysis/mdanalysis/issues/2190#issuecomment-462355339) are not included since that requires a more in-depth discussion about what defines a valid box (semi-periodic systems, negative angles, etc.).

I don't think we need to adjust the docs, right?

PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
