### PR TITLE
Fixes transformation tests not running.

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -119,7 +119,7 @@ Chronological list of authors
   - Ninad Bhat
   - Fenil Suchak
   - Yibo Zhang
-
+  - Luís Pedro Borges Araújo
 
 External code
 -------------

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -64,6 +64,7 @@ Changes
   * changed fudge_factor in guess_bonds to deal with new vdw radii (#2138, PR #2142)
 
 Fixes
+  * fixed transformation tests not being run (Issue #2241)
   * fixed the segmentation fault in capped_distances (Issue #2164, PR #2169)
   * fixed gcc support in MacOS (Issue #2162, PR #2163)
   * fixed error when reading bonds/angles/dihedrals from gsd file (Issue #2152,

--- a/testsuite/MDAnalysisTests/transformations/__init__.py
+++ b/testsuite/MDAnalysisTests/transformations/__init__.py
@@ -1,0 +1,1 @@
+# transformation tests


### PR DESCRIPTION
Fixes #2241

Referenced in #2208 

Changes made in this Pull Request:
 -  Added the missing `__init__.py` file in `/testsuite/MDAnalysisTests/transformations/` that was preventing the transformation tests from running.

- Updated `AUTHORS` and `CHANGELOG`

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [X] CHANGELOG updated?
 - [X] Issue raised/referenced?
