### PR TITLE
TST: add backup pytest for MacOS CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,6 +104,7 @@ script:
   - cd ${TRAVIS_BUILD_DIR}
   - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then ulimit -S -n 2048; fi
   - echo $MAIN_CMD $SETUP_CMD
+  - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then pip install pytest; fi
   - eval $MAIN_CMD $SETUP_CMD
 
 after_success:


### PR DESCRIPTION
see MacOS CI problem: https://github.com/MDAnalysis/mdanalysis/pull/2239#issuecomment-480983488

I think CI helpers conda install of pytest is failing fairly consistently now for some reason

<details>

```
Preparing transaction: ...working... done

Verifying transaction: ...working... done

Executing transaction: ...working... failed

ERROR conda.core.link:_execute(507): An error occurred while installing package 'conda-forge::atomicwrites-1.3.0-py_0'.

FileNotFoundError(2, "No such file or directory: '/Users/travis/miniconda/envs/test/bin/python3.6'")

Attempting to roll back.



Rolling back transaction: ...working... done



FileNotFoundError(2, "No such file or directory: '/Users/travis/miniconda/envs/test/bin/python3.6'")
```
</details>

Although mixing conda and pip installs in the workflow is probably not advisable long term, this might be a suitable hold-over. Let's see what happens I guess..