### PR TITLE
Added Cython Coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,7 @@
 [run]
 branch = True
 source = MDAnalysis
+plugins = Cython.Coverage
 omit =
     */migration/*
     */MDAnalysis/tests/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ env:
     - PYTEST_LIST="testsuite/MDAnalysisTests"
     - MAIN_CMD="pytest ${PYTEST_LIST}"
     - SETUP_CMD="${PYTEST_FLAGS}"
-    - BUILD_CMD="pip install -v package/ && (cd testsuite/ && python setup.py build)"
+    - BUILD_CMD="pip install -e package/ && (cd testsuite/ && python setup.py build)"
     - CONDA_MIN_DEPENDENCIES="mmtf-python mock six biopython networkx cython joblib matplotlib scipy griddataformats hypothesis gsd codecov"
     - CONDA_DEPENDENCIES="${CONDA_MIN_DEPENDENCIES} seaborn>=0.7.0 clustalw=2.1 netcdf4 scikit-learn"
     - CONDA_CHANNELS='biobuilds conda-forge'

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ env:
     - PIP_DEPENDENCIES="duecredit"
     - NUMPY_VERSION=stable
     - INSTALL_HOLE="true"
+    - CYTHON_TRACE_NOGIL=1
 
   matrix:
     # Run a coverage test for most versions

--- a/package/.coveragerc
+++ b/package/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+plugins = Cython.Coverage

--- a/package/setup.py
+++ b/package/setup.py
@@ -424,7 +424,7 @@ def extensions(config):
         extensions = cythonize(
             pre_exts,
             compiler_directives={'linetrace' : cython_linetrace,
-                                 'embedsignature' : cython_linetrace},
+                                 'embedsignature' : False},
         )
         if cython_linetrace:
             print("Cython coverage will be enabled")

--- a/package/setup.py
+++ b/package/setup.py
@@ -94,7 +94,7 @@ try:
               "parallelization module".format(
                Cython.__version__, required_version))
         cython_found = False
-    cython_linetrace = True
+    cython_linetrace = bool(os.environ.get('CYTHON_TRACE_NOGIL', False))
 except ImportError:
     cython_found = False
     if not is_release:

--- a/package/setup.py
+++ b/package/setup.py
@@ -94,6 +94,7 @@ try:
               "parallelization module".format(
                Cython.__version__, required_version))
         cython_found = False
+    cython_linetrace = True
 except ImportError:
     cython_found = False
     if not is_release:
@@ -320,6 +321,10 @@ def extensions(config):
     else:
         mathlib = ['m']
 
+    if cython_linetrace:
+        extra_compile_args.append("-DCYTHON_TRACE_NOGIL")
+        cpp_extra_compile_args.append("-DCYTHON_TRACE_NOGIL")
+
     libdcd = MDAExtension('MDAnalysis.lib.formats.libdcd',
                           ['MDAnalysis/lib/formats/libdcd' + source_suffix],
                           include_dirs=include_dirs + ['MDAnalysis/lib/formats/include'],
@@ -416,7 +421,13 @@ def extensions(config):
 
     cython_generated = []
     if use_cython:
-        extensions = cythonize(pre_exts)
+        extensions = cythonize(
+            pre_exts,
+            compiler_directives={'linetrace' : cython_linetrace,
+                                 'embedsignature' : cython_linetrace},
+        )
+        if cython_linetrace:
+            print("Cython coverage will be enabled")
         for pre_ext, post_ext in zip(pre_exts, extensions):
             for source in post_ext.sources:
                 if source not in pre_ext.sources:
@@ -608,7 +619,7 @@ if __name__ == '__main__':
     )
 
     # Releases keep their cythonized stuff for shipping.
-    if not config.get('keep_cythonized', default=is_release):
+    if not config.get('keep_cythonized', default=is_release) and not cython_linetrace:
         for cythonized in cythonfiles:
             try:
                 os.unlink(cythonized)


### PR DESCRIPTION
Changes made in this Pull Request:
 - Sorry, I messed up some commits in the last one. Anyway, even by forcing `cython_linetrace = True` the codecov report doesn't show coverage for .pyx files. Locally works perfectly with `pytest-cov`. The sample html output is here. Any suggestions?

![image](https://user-images.githubusercontent.com/20499290/56348554-4fc10b80-61e4-11e9-9b6d-acda6be91d86.png)


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
