### PR TITLE
MAINT: compensate for NumPy load change

### DIFF
--- a/package/MDAnalysis/analysis/encore/utils.py
+++ b/package/MDAnalysis/analysis/encore/utils.py
@@ -122,7 +122,7 @@ class TriangularMatrix(object):
         fname : str
             Name of the file to be loaded.
         """
-        loaded = np.load(fname)
+        loaded = np.load(fname, allow_pickle=True)
 
         if loaded['metadata'].shape != ():
             if loaded['metadata']['number of frames'] != self.size:


### PR DESCRIPTION
Fixes recent CI failures -- see for example #1991.

Related to: https://github.com/numpy/numpy/pull/12889
And CVE: https://nvd.nist.gov/vuln/detail/CVE-2019-6446

Basically, someone decided it would be a good idea to open a government / software vulnerability ticket because `np.load()` had `allow_pickle=True` as the default, which theoretically might be exploited to execute arbitrary code.

`MDAnalysis` has a usage of `np.load()` in the encore machinery that was depending on the original default, which has now been switched to comply with the CVE (otherwise, various corporations / government orgs can't use latest NumPy with an outsanding CVE).

My fix here is the simplest one possible. Of course, one might argue that someone could just open a CVE about MDAnalysis now, but seriously maybe we can just patch to restore the original behavior and move on?

If we *really* want to be more secure, I suspect we may need a new kwarg somewhere in the encore machinery, which we might use in our testing, but not make the default to users. 

So, maybe using `loadz(self, fname, allow_pickle=False):` as a new signature, with `True` used in our testing. I suppose that may be a little more secure, but haven't tested this locally yet to see the implications.