### PR TITLE
MAINT: bumpy minimum NumPy required to 1.13.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ env:
     - PYTHON_VERSION=3.7 CODECOV="true" SETUP_CMD="${PYTEST_FLAGS} --cov=MDAnalysis"
     - PYTHON_VERSION=3.6 CODECOV="true" SETUP_CMD="${PYTEST_FLAGS} --cov=MDAnalysis"
     - PYTHON_VERSION=2.7 CODECOV="true" SETUP_CMD="${PYTEST_FLAGS} --cov=MDAnalysis"
-    - NUMPY_VERSION=1.10.4
+    - NUMPY_VERSION=1.13.3
     - NUMPY_VERSION=dev  EVENT_TYPE="cron"
 
 matrix:

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -16,7 +16,7 @@ The rules for this file:
 mm/dd/yy micaela-matta, xiki-tempula, zemanj, mattwthompson, orbeckst, aliehlen,
          dpadula85, jbarnoud, manuel.nuno.melo, richardjgowers, mattwthompson,
          ayushsuhane, picocentauri, NinadBhat, bieniekmateusz, p-j-smith, Lp0lp,
-         IAlibay
+         IAlibay, tyler.je.reddy
 
   * 0.20.0
 
@@ -65,6 +65,7 @@ Changes
     invalid, an all-zero array or zero is returned, respectively. (Issue #2200,
     PR #2201)
   * changed fudge_factor in guess_bonds to deal with new vdw radii (#2138, PR #2142)
+  * bump minimum numpy version to 1.13.3
 
 Fixes
   * fixed mol2 comment header handling (Issue #2261)

--- a/package/setup.py
+++ b/package/setup.py
@@ -188,7 +188,7 @@ def get_numpy_include():
         import numpy as np
     except ImportError:
         print('*** package "numpy" not found ***')
-        print('MDAnalysis requires a version of NumPy (>=1.10.4), even for setup.')
+        print('MDAnalysis requires a version of NumPy (>=1.13.3), even for setup.')
         print('Please get it from http://numpy.scipy.org/ or install it through '
               'your package manager.')
         sys.exit(-1)
@@ -547,7 +547,7 @@ if __name__ == '__main__':
     exts, cythonfiles = extensions(config)
 
     install_requires = [
-          'numpy>=1.10.4',
+          'numpy>=1.13.3',
           'biopython>=1.71',
           'networkx>=1.0',
           'GridDataFormats>=0.4.0',
@@ -587,13 +587,13 @@ if __name__ == '__main__':
                         ],
           },
           ext_modules=exts,
-          requires=['numpy (>=1.10.4)', 'biopython (>= 1.71)', 'mmtf (>=1.0.0)',
+          requires=['numpy (>=1.13.3)', 'biopython (>= 1.71)', 'mmtf (>=1.0.0)',
                     'networkx (>=1.0)', 'GridDataFormats (>=0.3.2)', 'joblib',
                     'scipy (>=1.0.0)', 'matplotlib (>=1.5.1)'],
           # all standard requirements are available through PyPi and
           # typically can be installed without difficulties through setuptools
           setup_requires=[
-              'numpy>=1.10.4',
+              'numpy>=1.13.3',
           ],
           install_requires=install_requires,
           # extras can be difficult to install through setuptools and/or


### PR DESCRIPTION
Fixes #2272

I adjusted the minimum required NumPy version to `1.13.3` for the relevant machinery I could find specifying `1.10.4` using `git grep` on our code base, but I did this quickly so we'll see what CI says.

I added a CHANGELOG entry too--one thought that occurred to me that is that people who put in review effort might not get acknowledged in that log, but that's a debate for another time maybe.

Also perhaps for another time, given current bandwidth, is establishing a clearer policy on major dependency version bumps, as noted in linked issue I think.



