### PR TITLE
Issue 2232 psf bz2

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -68,6 +68,7 @@ Changes
   * bump minimum numpy version to 1.13.3
 
 Fixes
+  * fixed reading bz2 compressed psf files (Issue #2232)
   * fixed mol2 comment header handling (Issue #2261)
   * fixed reading PDB files with partial CRYST lines (Issue #2252)
   * fixed transformation tests not being run (Issue #2241)

--- a/package/MDAnalysis/topology/PSFParser.py
+++ b/package/MDAnalysis/topology/PSFParser.py
@@ -122,14 +122,14 @@ class PSFParser(TopologyReaderBase):
             next(psffile)
             title = next(psffile).split()
             if not (title[1] == "!NTITLE"):
-                err = "{0} is not a valid PSF file".format(psffile.name)
+                err = "{0} is not a valid PSF file".format(self.filename)
                 logger.error(err)
                 raise ValueError(err)
             # psfremarks = [psffile.next() for i in range(int(title[0]))]
             for _ in range(int(title[0])):
                 next(psffile)
             logger.debug("PSF file {0}: format {1}"
-                         "".format(psffile.name, self._format))
+                         "".format(self.filename, self._format))
 
             # Atoms first and mandatory
             top = self._parse_sec(

--- a/testsuite/MDAnalysisTests/topology/test_psf.py
+++ b/testsuite/MDAnalysisTests/topology/test_psf.py
@@ -57,7 +57,7 @@ class TestPSFParser(ParserBase):
         if request.param == 'uncompressed':
             return self.ref_filename
         else:
-            fn = tmpdir.join('file.psf.bz2')
+            fn = str(tmpdir.join('file.psf.bz2'))
             with open(self.ref_filename, 'rb') as f:
                 stuff = f.read()
             buf = bz2.compress(stuff)

--- a/testsuite/MDAnalysisTests/topology/test_psf.py
+++ b/testsuite/MDAnalysisTests/topology/test_psf.py
@@ -23,6 +23,8 @@
 from __future__ import absolute_import
 from numpy.testing import assert_equal
 
+import pytest
+import bz2
 import MDAnalysis as mda
 
 from MDAnalysisTests.topology.base import ParserBase
@@ -49,6 +51,19 @@ class TestPSFParser(ParserBase):
     expected_n_atoms = 3341
     expected_n_residues = 214
     expected_n_segments = 1
+
+    @pytest.fixture(params=['uncompressed', 'bz2'])
+    def filename(self, request, tmpdir):
+        if request.param == 'uncompressed':
+            return self.ref_filename
+        else:
+            fn = tmpdir.join('file.psf.bz2')
+            with open(self.ref_filename, 'rb') as f:
+                stuff = f.read()
+            buf = bz2.compress(stuff)
+            with open(fn, 'wb') as out:
+                out.write(buf)
+            return fn
 
     def test_bonds_total_counts(self, top):
         assert len(top.bonds.values) == 3365


### PR DESCRIPTION
Fixes #2232

Changes made in this Pull Request:
 - use `self.filename` rather than the `.name` attribute of the thing we open to workaround the bug with bz2files

I used a fixture to not have to add another file to the testsuite


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
