### PR TITLE
Add unwrap to radius_of_gyration

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -61,6 +61,7 @@ Enhancements
   * added unwrap keyword to center_of_mass (PR #2286)
   * added unwrap keyword to moment_of_inertia (PR #2287)
   * added unwrap keyword to asphericity (PR #2290)
+  * added unwrap keyword to radius_of_gyration (PR #2299)
 
 Changes
   * added official support for Python 3.7 (PR #1963)

--- a/testsuite/MDAnalysisTests/core/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/core/test_atomgroup.py
@@ -859,6 +859,7 @@ class TestUnwrapFlag(object):
                 [-211.8997285, 7059.07470427, -91.32156884],
                 [-721.50785456, -91.32156884, 6509.31735029]]),
             'Asph': 0.02060121,
+            'ROG': 27.713009,
         }
 
     @pytest.fixture()
@@ -874,6 +875,7 @@ class TestUnwrapFlag(object):
                              [-1330.489, 19315.253,  3306.212],
                              [ 2938.243,  3306.212,  8990.481]]),
             'Asph': 0.2969491080,
+            'ROG': 40.686541,
         }
 
     @pytest.fixture()
@@ -886,6 +888,7 @@ class TestUnwrapFlag(object):
                 [0.0, 98.6542, 0.0],
                 [0.0, 0.0, 98.65421327]]),
             'Asph': 1.0,
+            'ROG': 0.9602093,
         }
 
     @pytest.fixture()
@@ -898,6 +901,7 @@ class TestUnwrapFlag(object):
                 [0.0, 132.673, 0.0],
                 [0.0, 0.0, 132.673]]),
             'Asph': 1.0,
+            'ROG': 1.1135230,
         }
 
     def test_default_residues(self, ag, ref_noUnwrap_residues):
@@ -905,12 +909,14 @@ class TestUnwrapFlag(object):
         assert_almost_equal(ag.center_of_mass(compound='residues'), ref_noUnwrap_residues['COM'], self.prec)
         assert_almost_equal(ag.moment_of_inertia(compound='residues'), ref_noUnwrap_residues['MOI'], self.prec)
         assert_almost_equal(ag.asphericity(compound='residues'), ref_noUnwrap_residues['Asph'], self.prec)
+        assert_almost_equal(ag.radius_of_gyration(compound='residues'), ref_noUnwrap_residues['ROG'], self.prec)
 
     def test_UnWrapFlag_residues(self, ag, ref_Unwrap_residues):
         assert_almost_equal(ag.center_of_geometry(unwrap=True, compound='residues'), ref_Unwrap_residues['COG'], self.prec)
         assert_almost_equal(ag.center_of_mass(unwrap=True, compound='residues'), ref_Unwrap_residues['COM'], self.prec)
         assert_almost_equal(ag.moment_of_inertia(unwrap=True, compound='residues'), ref_Unwrap_residues['MOI'], self.prec)
         assert_almost_equal(ag.asphericity(unwrap=True, compound='residues'), ref_Unwrap_residues['Asph'], self.prec)
+        assert_almost_equal(ag.radius_of_gyration(unwrap=True, compound='residues'), ref_Unwrap_residues['ROG'], self.prec)
 
     def test_default(self, ref_noUnwrap):
         u = UnWrapUniverse(is_triclinic=False)
@@ -922,6 +928,7 @@ class TestUnwrapFlag(object):
         assert_almost_equal(group.center_of_mass(), ref_noUnwrap['COM'], self.prec)
         assert_almost_equal(group.moment_of_inertia(), ref_noUnwrap['MOI'], self.prec)
         assert_almost_equal(group.asphericity(), ref_noUnwrap['Asph'], self.prec)
+        assert_almost_equal(group.radius_of_gyration(), ref_noUnwrap['ROG'], self.prec)
 
     def test_UnWrapFlag(self, ref_Unwrap):
         u = UnWrapUniverse(is_triclinic=False)
@@ -932,6 +939,7 @@ class TestUnwrapFlag(object):
         assert_almost_equal(group.center_of_mass(unwrap=True), ref_Unwrap['COM'], self.prec)
         assert_almost_equal(group.moment_of_inertia(unwrap=True), ref_Unwrap['MOI'], self.prec)
         assert_almost_equal(group.asphericity(unwrap=True), ref_Unwrap['Asph'], self.prec)
+        assert_almost_equal(group.radius_of_gyration(unwrap=True), ref_Unwrap['ROG'], self.prec)
 
 
 class TestPBCFlag(object):


### PR DESCRIPTION
Fixes #1760 

Changes made in this Pull Request:
 - Adds unwrap keyword to radius of gyration


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
