### PR TITLE
updated docs for transformations

### DIFF
--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -836,7 +836,7 @@ class Masses(AtomAttr):
     @warn_if_not_unique
     def total_mass(group, compound='group'):
         """Total mass of (compounds of) the group.
-        
+
         Computes the total mass of :class:`Atoms<Atom>` in the group.
         Total masses per :class:`Residue`, :class:`Segment`, molecule, or
         fragment can be obtained by setting the `compound` parameter
@@ -1213,7 +1213,7 @@ class Charges(AtomAttr):
     @warn_if_not_unique
     def total_charge(group, compound='group'):
         """Total charge of (compounds of) the group.
-        
+
         Computes the total charge of :class:`Atoms<Atom>` in the group.
         Total charges per :class:`Residue`, :class:`Segment`, molecule, or
         fragment can be obtained by setting the `compound` parameter
@@ -1468,6 +1468,7 @@ class Resnames(ResidueAttr):
         select protein residues.
 
         :exc:`TypeError` if an unknown *format* is selected.
+
 
         .. versionadded:: 0.9.0
         """

--- a/package/MDAnalysis/transformations/__init__.py
+++ b/package/MDAnalysis/transformations/__init__.py
@@ -26,18 +26,18 @@
 Trajectory transformations --- :mod:`MDAnalysis.transformations`
 ================================================================
 
-The transformations submodule contains a collection of functions to modify the 
+The transformations submodule contains a collection of functions to modify the
 trajectory. Coordinate transformations, such as PBC corrections and molecule fitting
-are often required for some analyses and visualization, and the functions in this 
-module allow transformations to be applied on-the-fly. 
+are often required for some analyses and visualization, and the functions in this
+module allow transformations to be applied on-the-fly.
 These transformation functions can be called by the user for any given
 timestep of the trajectory, added as a workflow using :meth:`add_transformations`
 of the :mod:`~MDAnalysis.coordinates.base` module, or upon Universe creation using
-the keyword argument `transformations`. Note that in the two latter cases, the 
+the keyword argument `transformations`. Note that in the two latter cases, the
 workflow cannot be changed after being defined.
 
-In addition to the specific arguments that each transformation can take, they also 
-contain a wrapped function that takes a `Timestep` object as argument. 
+In addition to the specific arguments that each transformation can take, they also
+contain a wrapped function that takes a `Timestep` object as argument.
 So, a transformation can be roughly defined as follows:
 
 .. code-block:: python
@@ -47,48 +47,13 @@ So, a transformation can be roughly defined as follows:
             def wrapped(ts):
                 # apply changes to the Timestep object
                 return ts
-            
+
             return wrapped
 
 
 See `MDAnalysis.transformations.translate` for a simple example.
 
-Currently implemented transformations are:
-    
-    - translate: translate the coordinates of a given trajectory frame by a given vector.
-    - center_in_box: translate the coordinates of a given trajectory frame so that a given
-      AtomGroup is centered in the unit cell
-    - rotateby: rotates the coordinates by a given angle arround an axis formed by a direction 
-      and a point    
 
-Examples
---------
-
-e.g. translate the coordinates of a frame:
-
-.. code-block:: python
-
-    u = MDAnalysis.Universe(topology, trajectory)
-    new_ts = MDAnalysis.transformations.translate([1,1,1])(u.trajectory.ts)
-
-e.g. create a workflow and adding it to the trajectory:
-
-.. code-block:: python
-
-    u = MDAnalysis.Universe(topology, trajectory)
-    workflow = [MDAnalysis.transformations.translate([1,1,1]), 
-                MDAnalysis.transformations.translate([1,2,3])]
-    u.trajetory.add_transformations(*workflow)
-
-e.g. giving a workflow as a keyword argument when defining the universe:
-
-.. code-block:: python
-    
-    workflow = [MDAnalysis.transformations.translate([1,1,1]), 
-                MDAnalysis.transformations.translate([1,2,3])]
-    u = MDAnalysis.Universe(topology, trajectory, transformations = *workflow)
-    
-    
 """
 
 from __future__ import absolute_import

--- a/package/doc/sphinx/source/documentation_pages/trajectory_transformations.rst
+++ b/package/doc/sphinx/source/documentation_pages/trajectory_transformations.rst
@@ -1,19 +1,20 @@
 .. Contains the formatted docstrings for the transformations located in 'mdanalysis/MDAnalysis/transformations'
 .. _transformations:
 
-**************************
-Trajectory transformations
-**************************
+*********************************************************
+Trajectory transformations ("on-the-fly" transformations)
+*********************************************************
 
 .. module:: MDAnalysis.transformations
 
-The transformations submodule :mod:`MDAnalysis.transformations` contains a
-collection of functions to modify the trajectory. Coordinate transformations,
-such as PBC corrections and molecule fitting are often required for some
-analyses and visualization, and the functions in this module allow
-transformations to be applied on-the-fly.  These transformation functions
-(``transformation_1`` and ``transformation_2`` in the following example) can be
-called by the user for any given :class:`Timestep` of the trajectory,
+In MDAnalysis, a *transformation* is a function that modifies the data
+for the current :class:`Timestep` and returns the
+:class:`Timestep`. For instance, coordinate transformations, such as
+PBC corrections and molecule fitting are often required for some
+analyses and visualization. Transformation functions
+(``transformation_1`` and ``transformation_2`` in the following
+example) can be called by the user for any given :class:`Timestep` of
+the trajectory,
 
 .. code-block:: python
 
@@ -22,17 +23,55 @@ called by the user for any given :class:`Timestep` of the trajectory,
     for ts in u.trajectory:
        ts = transformation_2(transformation_1(ts))
 
-where they change the coordinates of the timestep ``ts`` in place.  However, it
-is much more convenient to associate a whole workflow of transformations with a
-trajectory and have the transformations be called automatically. One can add a
-workflow (a sequence of transformations) using the
-:meth:`Universe.trajectory.add_transformations
-<MDAnalysis.coordinates.base.ReaderBase.add_transformations>` method of a
-trajectory,
+where they change the coordinates of the timestep ``ts`` in
+place. There is nothing special about these transformations except
+that they have to be written in such a way that they change the
+:class:`Timestep` in place.
+
+As described under :ref:`workflows`, multiple transformations can be
+grouped together and associated with a trajectory so that the
+trajectory is **transformed on-the-fly**, i.e., the data read from the
+trajectory file will be changed before it is made available in, say,
+the :attr:`AtomGroup.positions` attribute.
+
+The  submodule :mod:`MDAnalysis.transformations` contains a
+collection of transformations (see :ref:`transformations-module`) that
+can be immediately used but one can always write custom
+transformations (see :ref:`custom-transformations`).
+
+
+.. _workflows:
+
+Workflows
+---------
+
+Instead of manually applying transformations, it is much more
+convenient to associate a whole *workflow* of transformations with a
+trajectory and have the transformations be called automatically.
+
+A workflow is a sequence (tuple or list) of transformation functions
+that will be applied in this order. For example,
 
 .. code-block:: python
 
-    workflow = [transformation_1, transformation_2]    
+    workflow = [transformation_1, transformation_2]
+    
+would effectively result in
+
+.. code-block:: python
+		
+     ts = transformation_2(transformation_1(ts))
+
+for every time step in the trajectory.
+
+One can add a workflow using the
+:meth:`Universe.trajectory.add_transformations
+<MDAnalysis.coordinates.base.ReaderBase.add_transformations>` method
+of a trajectory (where the list ``workflow`` is taken from the example
+above),
+
+.. code-block:: python
+
     u.trajectory.add_transformations(*workflow)
 
 or upon :class:`Universe <MDAnalysis.core.universe.Universe>`
@@ -42,11 +81,21 @@ creation using the keyword argument `transformations`:
     
     u = MDAnalysis.Universe(topology, trajectory, transformations=workflow)
 
-Note that in the two latter cases, the workflow cannot be changed after having
+Note that in these two cases, the workflow cannot be changed after having
 being added.
 
-A simple transformation that takes no other arguments but a :class:`Timestep` can be defined
-as the following example:
+
+.. _custom-transformations:
+
+Creating transformations
+------------------------
+
+A *transformation* is a function that takes a
+:class:`~MDAnalysis.coordinates.base.Timestep` as input, modifies it, and
+returns it.
+
+A simple transformation that takes no other arguments but a :class:`Timestep`
+can be defined as the following example:
 
 .. code-block:: python
 
@@ -58,10 +107,10 @@ as the following example:
     	return ts
 
 
-If the transformation requires other arguments besides the :class:`Timestep`, the transformation 
-takes these arguments, while a wrapped function takes the :class:`Timestep` object as 
-argument. 
-So, a transformation can be roughly defined as follows:
+If the transformation requires other arguments besides the :class:`Timestep`,
+the transformation takes these arguments, while a wrapped function takes the
+:class:`Timestep` object as argument.  So, a transformation can be roughly
+defined as follows:
 
 .. code-block:: python
 
@@ -89,19 +138,42 @@ above function can be written as:
     up_by_2 = functools.partial(up_by_x, distance=2)
 
 
-See :func:`MDAnalysis.transformations.translate` for a simple example.    
+See :func:`MDAnalysis.transformations.translate` for a simple
+example of such a type of function.
+
+
+.. _transformations-module:
+
+Transformations in MDAnalysis
+-----------------------------
+
+The module :mod:`MDAnalysis.transformations` contains transformations that can
+be immediately used in your own :ref:`workflows<workflows>`. In order to use
+any of these transformations, the module must first be imported:
+
+.. code-block:: python
+
+   import MDAnalysis.transformations
+
+A workflow can then be added to a trajectory as described above.
+
+See :ref:`implemented-transformations` for more on the existing
+transformations in :mod:`MDAnalysis.transformations`.
     
 
-.. rubric:: Examples
+How to transformations
+----------------------
 
-Translating the coordinates of a frame:
+Translating the coordinates of a single frame (although one would normally add
+the transformation to a :ref:`workflow<workflows>`, as shown in the subsequent
+examples):
 
 .. code-block:: python
 
     u = MDAnalysis.Universe(topology, trajectory)
     new_ts = MDAnalysis.transformations.translate([1,1,1])(u.trajectory.ts)
-
-e.g. create a workflow and adding it to the trajectory:
+    
+Create a workflow and add it to the trajectory:
 
 .. code-block:: python
 
@@ -110,7 +182,7 @@ e.g. create a workflow and adding it to the trajectory:
                 MDAnalysis.transformations.translate([1,2,3])]
     u.trajectory.add_transformations(*workflow)
 
-e.g. giving a workflow as a keyword argument when defining the universe:
+Giving a workflow as a keyword argument when defining the universe:
 
 .. code-block:: python
     
@@ -118,8 +190,11 @@ e.g. giving a workflow as a keyword argument when defining the universe:
                 MDAnalysis.transformations.translate([1,2,3])]
     u = MDAnalysis.Universe(topology, trajectory, transformations=workflow)
     
-    
-.. rubric:: Currently implemented transformations
+
+.. _implemented-transformations:
+
+Currently implemented transformations
+-------------------------------------
 
 .. toctree::
    


### PR DESCRIPTION
Fixes #2246

Changes made in this Pull Request:
- made clear that MDAnalysis.transformations needs to be imported
- define what a "transformation" and a "workflow" is
- more structure
- removed docs from transformations/__init__.py: they are not used
  and text was repeated in trajectory_transformation.rst; only minimal
  docs are left so that help() shows something


PR Checklist
------------
 - n/a Tests?
 - [x] Docs?
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?
