### PR TITLE
use older miniconda for appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,7 +22,9 @@ environment:
         APPVEYOR_SKIP_FINALIZE_ON_EXIT: true
         TEST_TIMEOUT: 1000
         PYTHON: "C:\\conda"
-        MINICONDA_VERSION: "latest"
+        # Temporarily fall back to default MINICONDA_VERSION in ci-helpers until https://github.com/MDAnalysis/mdanalysis/issues/2311
+        # is fixed in ci-helpers https://github.com/astropy/ci-helpers/issues/406
+        # MINICONDA_VERSION: "latest"
 
     matrix:
         - PYTHON_VERSION: 3.6

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,9 +7,6 @@ max_jobs: 100
 cache:
     - '%LOCALAPPDATA%\pip\Cache'
 
-image:
-    - Visual Studio 2015
-
 environment:
     global:
         CONDA_CHANNELS: conda-forge


### PR DESCRIPTION
Fixes #2311 

Changes made in this Pull Request:
 - let miniconda default to old version (4.5.x) instead of using *latest*
 -  temporary fix (until https://github.com/astropy/ci-helpers/issues/406 properly addresses the issue)


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?
