### PR TITLE
Temporarily pin GSD to 1.7.0 (py2.7 failures)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ env:
     - MAIN_CMD="pytest ${PYTEST_LIST}"
     - SETUP_CMD="${PYTEST_FLAGS}"
     - BUILD_CMD="pip install -e package/ && (cd testsuite/ && python setup.py build)"
+    # Temporarily pinning gsd to 1.7.0 (Issue #2317)
     - CONDA_MIN_DEPENDENCIES="mmtf-python mock six biopython networkx cython joblib matplotlib scipy griddataformats hypothesis gsd=1.7.0 codecov"
     - CONDA_DEPENDENCIES="${CONDA_MIN_DEPENDENCIES} seaborn>=0.7.0 clustalw=2.1 netcdf4 scikit-learn"
     - CONDA_CHANNELS='biobuilds conda-forge'

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ env:
     - MAIN_CMD="pytest ${PYTEST_LIST}"
     - SETUP_CMD="${PYTEST_FLAGS}"
     - BUILD_CMD="pip install -e package/ && (cd testsuite/ && python setup.py build)"
-    - CONDA_MIN_DEPENDENCIES="mmtf-python mock six biopython networkx cython joblib matplotlib scipy griddataformats hypothesis gsd codecov"
+    - CONDA_MIN_DEPENDENCIES="mmtf-python mock six biopython networkx cython joblib matplotlib scipy griddataformats hypothesis gsd=1.7.0 codecov"
     - CONDA_DEPENDENCIES="${CONDA_MIN_DEPENDENCIES} seaborn>=0.7.0 clustalw=2.1 netcdf4 scikit-learn"
     - CONDA_CHANNELS='biobuilds conda-forge'
     - CONDA_CHANNEL_PRIORITY=True

--- a/package/setup.py
+++ b/package/setup.py
@@ -559,6 +559,7 @@ if __name__ == '__main__':
           'mock',
     ]
     if not os.name == 'nt':
+        # GSD p2.7 support dropped in 1.8.0, temporarily pinning (#2317)
         if sys.version_info[:2] == (2, 7):
             install_requires.append('gsd>=1.4.0,<1.8.0')
         else:

--- a/package/setup.py
+++ b/package/setup.py
@@ -559,7 +559,10 @@ if __name__ == '__main__':
           'mock',
     ]
     if not os.name == 'nt':
-        install_requires.append('gsd>=1.4.0')
+        if sys.version_info[:2] == (2, 7):
+            install_requires.append('gsd>=1.4.0,<1.8.0')
+        else:
+            install_requires.append('gsd>=1.4.0')
 
     setup(name='MDAnalysis',
           version=RELEASE,


### PR DESCRIPTION
Temporarily fixes #2317

Changes made in this Pull Request:
 - Pins GSD to 1.7.0 due to py2.7 support being dropped in 1.8.0

PR Checklist
------------
 - [ ] Tests? (not needed)
 - [x] Docs?
 - [ ] CHANGELOG updated? (omitted since it's temporary)
 - [x] Issue raised/referenced?
