### PR TITLE
Unpin GSD from version 1.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,7 @@ env:
     - MAIN_CMD="pytest ${PYTEST_LIST}"
     - SETUP_CMD="${PYTEST_FLAGS}"
     - BUILD_CMD="pip install -e package/ && (cd testsuite/ && python setup.py build)"
-    # Temporarily pinning gsd to 1.7.0 (Issue #2317)
-    - CONDA_MIN_DEPENDENCIES="mmtf-python mock six biopython networkx cython joblib matplotlib scipy griddataformats hypothesis gsd=1.7.0 codecov"
+    - CONDA_MIN_DEPENDENCIES="mmtf-python mock six biopython networkx cython joblib matplotlib scipy griddataformats hypothesis gsd codecov"
     - CONDA_DEPENDENCIES="${CONDA_MIN_DEPENDENCIES} seaborn>=0.7.0 clustalw=2.1 netcdf4 scikit-learn"
     - CONDA_CHANNELS='biobuilds conda-forge'
     - CONDA_CHANNEL_PRIORITY=True

--- a/package/setup.py
+++ b/package/setup.py
@@ -559,11 +559,7 @@ if __name__ == '__main__':
           'mock',
     ]
     if not os.name == 'nt':
-        # GSD p2.7 support dropped in 1.8.0, temporarily pinning (#2317)
-        if sys.version_info[:2] == (2, 7):
-            install_requires.append('gsd>=1.4.0,<1.8.0')
-        else:
-            install_requires.append('gsd>=1.4.0')
+        install_requires.append('gsd>=1.4.0')
 
     setup(name='MDAnalysis',
           version=RELEASE,


### PR DESCRIPTION
Reverts #2320 

Changes made in this Pull Request:
 - As per https://github.com/glotzerlab/gsd/issues/30 the py2.7 packages for GSD 1.8.0 have now been labelled as `broken` on conda-forge and shouldn't be picked up by travis-ci anymore.
- I have therefore unpinned the version from 1.7.0.
- <s>However, since the max version for py2.7 is now 1.7.0, I haven't changed setup.py, I can revert that too if the consensus is that it isn't necessary.</s>


PR Checklist
------------
 - [ ] Tests? - Not needed
 - [ ] Docs? - Not needed
 - [ ] CHANGELOG updated? - Not needed
 - [x] Issue raised/referenced?
