### PR TITLE
Addresses pytest 5.1.0 failures

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -130,6 +130,8 @@ Deprecations
     method to be used, this is done automatically in run()
     
 Testsuite
+  * Raised minimum pytest version to 3.3.0, warns now uses the `match` 
+    argument instead of `match_expr` (Issue #2329)
   * Add tests for the new water bridge analysis (PR #2087)
 
 11/06/18 richardjgowers

--- a/testsuite/MDAnalysisTests/lib/test_util.py
+++ b/testsuite/MDAnalysisTests/lib/test_util.py
@@ -1861,7 +1861,8 @@ def test_deprecate(old_name, new_name, remove, message, release="2.7.1"):
                              new_name=new_name,
                              release=release, remove=remove,
                              message=message)
-    with pytest.warns(DeprecationWarning, match_expr="`.+` is deprecated"):
+    # match_expr changed to match (Issue 2329)
+    with pytest.warns(DeprecationWarning, match="`.+` is deprecated"):
         oldfunc(42)
 
     doc = oldfunc.__doc__

--- a/testsuite/setup.py
+++ b/testsuite/setup.py
@@ -178,7 +178,7 @@ if __name__ == '__main__':
           },
           install_requires=[
               'MDAnalysis=={0!s}'.format(RELEASE),  # same as this release!
-              'pytest>=3.1.2',
+              'pytest>=3.3.0', # Raised to 3.3.0 due to Issue 2329
               'hypothesis',
               'psutil>=4.0.2',
               'mock>=2.0.0',  # replace with unittest.mock in python 3 only version


### PR DESCRIPTION
Fixes #2329 

Just creating this PR ahead of responses to #2329, if raising the pytest version is not desired at this point, I don't mind deleting the PR.

Changes made in this Pull Request:
 - Raised the minimum pytest version to 3.3.0 from 3.1.2.
 - Changed the `match_expr` keyword to `match` in pytest.warns which was causing issues with pytest 5.1.0 (see #2329 ). 


PR Checklist
------------
 - [ ] Tests? - Fixes existing test
 - [ ] Docs? - No docs associated as far as I am aware
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
