### PR TITLE
Allow ChainReader to accept format keyword

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -79,6 +79,7 @@ Changes
   * changed the water bridge analysis output format (PR #2087)
 
 Fixes
+  * fixed ChainReader setting format with format keyword (Issue #2334)
   * fixed lack of check for scaling of NCDFReader velocities (Issue #2323)
   * fixed PDBReader and PDBWriter newlines for PDB header (Issue #2324)
   * fixes ProgressMeter issues with older Jupyter Lab versions (Issue #2078)

--- a/package/MDAnalysis/coordinates/GRO.py
+++ b/package/MDAnalysis/coordinates/GRO.py
@@ -178,10 +178,7 @@ class GROReader(base.SingleFrameReaderBase):
         with util.openany(self.filename, 'rt') as grofile:
             # Read first two lines to get number of atoms
             grofile.readline()
-            try:
-                self.n_atoms = n_atoms = int(grofile.readline())
-            except ValueError:
-                raise ValueError('Invalid GRO file: second line is not number of atoms.')
+            self.n_atoms = n_atoms = int(grofile.readline())
             self.ts = ts = self._Timestep(n_atoms, **self._ts_kwargs)
             # Always try, and maybe add them later
             velocities = np.zeros((n_atoms, 3), dtype=np.float32)

--- a/package/MDAnalysis/coordinates/GRO.py
+++ b/package/MDAnalysis/coordinates/GRO.py
@@ -178,7 +178,10 @@ class GROReader(base.SingleFrameReaderBase):
         with util.openany(self.filename, 'rt') as grofile:
             # Read first two lines to get number of atoms
             grofile.readline()
-            self.n_atoms = n_atoms = int(grofile.readline())
+            try:
+                self.n_atoms = n_atoms = int(grofile.readline())
+            except ValueError:
+                raise ValueError('Invalid GRO file: second line is not number of atoms.')
             self.ts = ts = self._Timestep(n_atoms, **self._ts_kwargs)
             # Always try, and maybe add them later
             velocities = np.zeros((n_atoms, 3), dtype=np.float32)

--- a/package/MDAnalysis/coordinates/core.py
+++ b/package/MDAnalysis/coordinates/core.py
@@ -78,10 +78,14 @@ def reader(filename, format=None, **kwargs):
     if isinstance(filename, tuple):
         Reader = get_reader_for(filename[0],
                                 format=filename[1])
-        return Reader(filename[0], **kwargs)
+        filename = filename[0]
     else:
         Reader = get_reader_for(filename, format=format)
+    try:
         return Reader(filename, **kwargs)
+    except ValueError:
+        raise ValueError('Unable to read {fn} with {r}.'.format(fn=filename,
+                                                                r=Reader))
 
 
 def writer(filename, n_atoms=None, **kwargs):

--- a/package/MDAnalysis/coordinates/core.py
+++ b/package/MDAnalysis/coordinates/core.py
@@ -46,7 +46,7 @@ from ..lib.mdamath import triclinic_box, triclinic_vectors, box_volume
 from ..core._get_readers import get_reader_for, get_writer_for
 
 
-def reader(filename, **kwargs):
+def reader(filename, format=None, **kwargs):
     """Provide a trajectory reader instance for *filename*.
 
     This function guesses the file format from the extension of *filename* and
@@ -80,7 +80,7 @@ def reader(filename, **kwargs):
                                 format=filename[1])
         return Reader(filename[0], **kwargs)
     else:
-        Reader = get_reader_for(filename)
+        Reader = get_reader_for(filename, format=format)
         return Reader(filename, **kwargs)
 
 

--- a/package/MDAnalysis/coordinates/core.py
+++ b/package/MDAnalysis/coordinates/core.py
@@ -84,7 +84,7 @@ def reader(filename, format=None, **kwargs):
     try:
         return Reader(filename, **kwargs)
     except ValueError:
-        raise ValueError('Unable to read {fn} with {r}.'.format(fn=filename,
+        raise TypeError('Unable to read {fn} with {r}.'.format(fn=filename,
                                                                 r=Reader))
 
 

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -601,7 +601,7 @@ class Universe(object):
         # supply number of atoms for readers that cannot do it for themselves
         kwargs['n_atoms'] = self.atoms.n_atoms
 
-        self.trajectory = reader(filename, **kwargs)
+        self.trajectory = reader(filename, format=format, **kwargs)
         if self.trajectory.n_atoms != len(self.atoms):
             raise ValueError("The topology and {form} trajectory files don't"
                              " have the same number of atoms!\n"

--- a/testsuite/MDAnalysisTests/coordinates/test_chainreader.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_chainreader.py
@@ -200,14 +200,29 @@ class TestChainReaderFormats(object):
         assert universe.trajectory.n_frames == 21
         assert_equal(universe.trajectory.filenames, [PDB, XTC, TRR])
 
+    def test_set_format_tuples_and_format(self):
+        universe = mda.Universe(GRO, [(PDB, 'pdb'), GRO, GRO, (XTC, 'xtc'), 
+                                      (TRR, 'trr')], format='gro')
+        assert universe.trajectory.n_frames == 23
+        assert_equal(universe.trajectory.filenames, [PDB, GRO, GRO, XTC, TRR])
+        
+        with pytest.raises(TypeError) as errinfo:
+            mda.Universe(GRO, [(PDB, 'pdb'), GRO, GRO, (XTC, 'xtc'), 
+                                      (TRR, 'trr')], format='pdb')
+        assert 'Unable to read' in str(errinfo.value)
+
+
     def test_set_one_format_tuple(self):
         universe = mda.Universe(PSF, [(PDB_small, 'pdb'), DCD])
         assert universe.trajectory.n_frames == 99
 
     def test_set_all_formats(self):
-        with pytest.raises(ValueError) as errinfo:
+        with pytest.raises(TypeError) as errinfo:
             mda.Universe(PDB, [PDB, GRO], format='gro')
         assert 'Unable to read' in str(errinfo.value)
+
+        universe = mda.Universe(GRO, [PDB, PDB, PDB], format='pdb')
+        assert_equal(universe.trajectory.filenames, [PDB, PDB, PDB])
 
 
 def build_trajectories(folder, sequences, fmt='xtc'):

--- a/testsuite/MDAnalysisTests/coordinates/test_chainreader.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_chainreader.py
@@ -205,8 +205,9 @@ class TestChainReaderFormats(object):
         assert universe.trajectory.n_frames == 99
 
     def test_set_all_formats(self):
-        universe = mda.Universe(PSF, [PDB_small, PDB_closed], format='pdb')
-        assert universe.trajectory.n_frames == 2
+        with pytest.raises(ValueError) as errinfo:
+            mda.Universe(PDB, [PDB, GRO], format='gro')
+        assert str(errinfo.value) == 'Invalid GRO file: second line is not number of atoms.'
 
 
 def build_trajectories(folder, sequences, fmt='xtc'):

--- a/testsuite/MDAnalysisTests/coordinates/test_chainreader.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_chainreader.py
@@ -207,7 +207,7 @@ class TestChainReaderFormats(object):
     def test_set_all_formats(self):
         with pytest.raises(ValueError) as errinfo:
             mda.Universe(PDB, [PDB, GRO], format='gro')
-        assert str(errinfo.value) == 'Invalid GRO file: second line is not number of atoms.'
+        assert 'Unable to read' in str(errinfo.value)
 
 
 def build_trajectories(folder, sequences, fmt='xtc'):


### PR DESCRIPTION
Fixes #2334 

Changes made in this Pull Request:
 - Passed `format` argument from `ChainReader` through to `core._get_readers.get_reader_for`

PR Checklist
------------
 - [x] Tests?
 - [ ] Docs? <-- leaving this until after #2322  
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?