### PR TITLE
Changes cell_angle units to degree (Issue #2327)

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,12 +13,14 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-mm/dd/yy ??? This could be you
+mm/dd/yy IAlibay
 
   * 0.20.1
 Enhancements
 
 Fixes
+  * The NetCDF writer now writes `cell_angle` units as `degree` instead of
+    `degrees` in accordance with the AMBER NetCDF convention (Issue #2327).
 
 
 

--- a/package/MDAnalysis/coordinates/TRJ.py
+++ b/package/MDAnalysis/coordinates/TRJ.py
@@ -847,10 +847,13 @@ class NCDFWriter(base.WriterBase):
     .. versionchanged:: 0.17.0
        Use fast :mod:`netCDF4` for writing but fall back to slow
        :mod:`scipy.io.netcdf` if :mod:`netCDF4` is not available.
+    .. versionchanged:: 0.20.1
+       Changes the `cell_angles` unit to the AMBER NetCDF convention standard
+       of `degree` instead of the `degrees` written in previous version of
+       MDAnalysis (Issue #2327).
 
     .. TODO:
-       * Change the `cell_angles` units to `degree`, implement `scale_factor`
-         handling (Issue #2327).
+       * Implement `scale_factor` handling (Issue #2327).
 
     """
 
@@ -967,7 +970,7 @@ class NCDFWriter(base.WriterBase):
 
             cell_angles = ncfile.createVariable('cell_angles', 'f8',
                                                 ('frame', 'cell_angular'))
-            setattr(cell_angles, 'units', 'degrees')
+            setattr(cell_angles, 'units', 'degree')
 
             cell_angular = ncfile.createVariable('cell_angular', 'c',
                                                  ('cell_angular', 'label'))

--- a/testsuite/MDAnalysisTests/coordinates/test_netcdf.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_netcdf.py
@@ -37,7 +37,7 @@ from MDAnalysis.coordinates.TRJ import NCDFReader
 
 from MDAnalysisTests.datafiles import (PFncdf_Top, PFncdf_Trj,
                                        GRO, TRR, XYZ_mini,
-                                       PRM_NCBOX, TRJ_NCBOX)
+                                       PRM_NCBOX, TRJ_NCBOX, DLP_CONFIG)
 from MDAnalysisTests.coordinates.test_trj import _TRJReaderTest
 from MDAnalysisTests.coordinates.reference import (RefVGV, RefTZ2)
 from MDAnalysisTests import make_Universe
@@ -795,30 +795,6 @@ class _NCDFWriterTest(object):
                                       self.prec,
                                       err_msg="unitcells are not identical")
 
-    @pytest.mark.parametrize('var, expected', (
-        ('coordinates', 'angstrom'),
-        ('time', 'picosecond'),
-        ('cell_lengths', 'angstrom'),
-        ('cell_angles', 'degree'),
-        ('velocities', 'angstrom/picosecond'),
-    ))
-    def test_writer_units(self, universe, outfile, var, expected):
-        """Tests that the writer adheres to AMBER convention units
-        TODO: switch to input trajectory that also has force information.
-        """
-        trr = mda.Universe(GRO, TRR)
-
-        with mda.Writer(outfile, trr.trajectory.n_atoms, velocities=True,
-                        format='ncdf') as W:
-            for ts in trr.trajectory:
-                W.write_next_timestep(ts)
-
-        with netcdf.netcdf_file(outfile, mode='r') as ncdf:
-            unit = ncdf.variables[var].units.decode('utf-8')
-            assert_equal(unit, expected)
-
-        del trr
-
 
 class TestNCDFWriter(_NCDFWriterTest, RefVGV):
     pass
@@ -897,6 +873,33 @@ class TestNCDFWriterVelsForces(object):
                     getattr(ts, 'forces')
 
         u.trajectory.close()
+
+
+class TestNCDFWriterUnits(object):
+    """Tests that the writer adheres to AMBER convention units"""
+    @pytest.fixture()
+    def outfile(self, tmpdir):
+        return str(tmpdir) + 'ncdf-writer-1.ncdf'
+
+    @pytest.mark.parametrize('var, expected', (
+        ('coordinates', 'angstrom'),
+        ('time', 'picosecond'),
+        ('cell_lengths', 'angstrom'),
+        ('cell_angles', 'degree'),
+        ('velocities', 'angstrom/picosecond'),
+        ('forces', 'kilocalorie/mole/angstrom')
+    ))
+    def test_writer_units(self, outfile, var, expected):
+        trr = mda.Universe(DLP_CONFIG, format='CONFIG')
+
+        with mda.Writer(outfile, trr.trajectory.n_atoms, velocities=True,
+                        forces=True, format='ncdf') as W:
+            for ts in trr.trajectory:
+                W.write_next_timestep(ts)
+
+        with netcdf.netcdf_file(outfile, mode='r') as ncdf:
+            unit = ncdf.variables[var].units.decode('utf-8')
+            assert_equal(unit, expected)
 
 
 class TestNCDFWriterErrors(object):


### PR DESCRIPTION
Partly fixes #2327 

Apologies, this is very much a micro commit. Since I didn't manage to get this through before 0.20.0, I thought I might as well get it done asap so that the reader units deprecation makes more sense in 1.0.

A PR addressing the rest of #2327 is in progress, but considering how close we are to the start of term, it might get stalled for a few months.

Changes made in this Pull Request:
 - Changes the units of the `cell_angle` variable in the NetCDF writer to `degree` instead of `degrees`.
 - Adds tests for units of files created by the NetCDF writer.


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
