### PR TITLE
Fix docstring typo in AnalysisFromFunction

### DIFF
--- a/package/MDAnalysis/analysis/base.py
+++ b/package/MDAnalysis/analysis/base.py
@@ -232,9 +232,9 @@ class AnalysisFromFunction(AnalysisBase):
             trajectory to iterate over. If ``None`` the first AtomGroup found in
             args and kwargs is used as a source for the trajectory.
         *args : list
-           arguments for ``function``
+            arguments for ``function``
         **kwargs : dict
-           arugments for ``function`` and ``AnalysisBase``
+            arguments for ``function`` and ``AnalysisBase``
 
         """
         if (trajectory is not None) and (not isinstance(


### PR DESCRIPTION
I do not want to start an arugment, but I found a typo.

Changes made in this Pull Request:
 - Typo fixed
 - Added hanging indent to match indent in docstring.