### PR TITLE
Improved Exception handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ MDAnalysis.log
 authors.py
 # Ignore the .DS_Store file in the osx file system
 *.DS_Store
+# ignore files from tests
+.hypothesis/

--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -124,6 +124,7 @@ Chronological list of authors
   - Rocco Meli
   - Lily Wang
   - Matthijs Tadema
+  - Joao Miguel Correia Teixeira
 
 External code
 -------------

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -22,9 +22,8 @@ Fixes
 
 Enhancements
   * Exception handling: exception that derive from other exceptions are now
-    raise `from` catched Exception.
-  * Custom Exceptions are `raise`ed `from None` instead of from catched
-    Exception.
+    raise `from` caught Exception
+  * Custom Exceptions are `raise`ed `from None`
 
 09/05/19 IAlibay, richardjgowers
 

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,14 +13,18 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-mm/dd/yy ???
+
+mm/dd/yy joaomcteixeira,
 
   * 0.20.2
 
 Fixes
 
 Enhancements
-
+  * Exception handling: exception that derive from other exceptions are now
+    raise `from` catched Exception.
+  * Custom Exceptions are `raise`ed `from None` instead of from catched
+    Exception.
 
 09/05/19 IAlibay, richardjgowers
 

--- a/package/MDAnalysis/analysis/align.py
+++ b/package/MDAnalysis/analysis/align.py
@@ -507,11 +507,12 @@ def alignto(mobile, reference, select="all", weights=None,
             # treat subselection as AtomGroup
             mobile_atoms = subselection.atoms
         except AttributeError:
-            error_ = TypeError(
-                "subselection must be a selection string, an"
-                " AtomGroup or Universe or None"
-                )
-            raise_from(error_, None)
+            raise_from(
+                TypeError(
+                    "subselection must be a selection string, an"
+                    " AtomGroup or Universe or None"
+                    ),
+                None)
 
     # _fit_to DOES subtract center of mass, will provide proper min_rmsd
     mobile_atoms, new_rmsd = _fit_to(mobile_coordinates, ref_coordinates,

--- a/package/MDAnalysis/analysis/align.py
+++ b/package/MDAnalysis/analysis/align.py
@@ -506,9 +506,9 @@ def alignto(mobile, reference, select="all", weights=None,
         try:
             # treat subselection as AtomGroup
             mobile_atoms = subselection.atoms
-        except AttributeError:
+        except AttributeError as e:
             raise TypeError("subselection must be a selection string, an"
-                            " AtomGroup or Universe or None")
+                            " AtomGroup or Universe or None") from e
 
     # _fit_to DOES subtract center of mass, will provide proper min_rmsd
     mobile_atoms, new_rmsd = _fit_to(mobile_coordinates, ref_coordinates,
@@ -1167,7 +1167,7 @@ def get_matching_atoms(ag1, ag2, tol_mass=0.1, strict=False):
                   "Try to improve your selections for mobile and reference.").format(
                       ag1.n_atoms, ag2.n_atoms)
         logger.error(errmsg)
-        raise SelectionError(errmsg)
+        raise SelectionError(errmsg) from None
 
     if np.any(mass_mismatches):
         # Test 2 failed.

--- a/package/MDAnalysis/analysis/align.py
+++ b/package/MDAnalysis/analysis/align.py
@@ -190,7 +190,7 @@ import warnings
 import logging
 
 from six.moves import range, zip, zip_longest
-from six import string_types
+from six import raise_from, string_types
 
 import numpy as np
 
@@ -506,9 +506,12 @@ def alignto(mobile, reference, select="all", weights=None,
         try:
             # treat subselection as AtomGroup
             mobile_atoms = subselection.atoms
-        except AttributeError as e:
-            raise TypeError("subselection must be a selection string, an"
-                            " AtomGroup or Universe or None") from e
+        except AttributeError:
+            error_ = TypeError(
+                "subselection must be a selection string, an"
+                " AtomGroup or Universe or None"
+                )
+            raise_from(error_, None)
 
     # _fit_to DOES subtract center of mass, will provide proper min_rmsd
     mobile_atoms, new_rmsd = _fit_to(mobile_coordinates, ref_coordinates,
@@ -1167,7 +1170,7 @@ def get_matching_atoms(ag1, ag2, tol_mass=0.1, strict=False):
                   "Try to improve your selections for mobile and reference.").format(
                       ag1.n_atoms, ag2.n_atoms)
         logger.error(errmsg)
-        raise SelectionError(errmsg) from None
+        raise_from(SelectionError(errmsg), None)
 
     if np.any(mass_mismatches):
         # Test 2 failed.

--- a/package/MDAnalysis/analysis/density.py
+++ b/package/MDAnalysis/analysis/density.py
@@ -161,7 +161,7 @@ can be used in downstream processing).
 
 from __future__ import print_function, division, absolute_import
 from six.moves import range, zip
-from six import string_types
+from six import raise_from, string_types
 
 import numpy as np
 import sys
@@ -372,12 +372,15 @@ class Density(Grid):
                 try:
                     units.conversion_factor[unit_type][value]
                     self.units[unit_type] = value
-                except KeyError as e:
-                    raise ValueError('Unit ' + str(value) + ' of type ' + str(unit_type) + ' is not recognized.') from e
-        except AttributeError as e:
+                except KeyError:
+                    raise_from(
+                        ValueError('Unit ' + str(value) + ' of type ' + str(unit_type) + ' is not recognized.'),
+                        None,
+                        )
+        except AttributeError:
             errmsg = '"unit" must be a dictionary with keys "length" and "density.'
             logger.fatal(errmsg)
-            raise ValueError(errmsg) from e
+            raise_from(ValueError(errmsg), None)
         # need at least length and density (can be None)
         if 'length' not in self.units:
             raise ValueError('"unit" must contain a unit for "length".')
@@ -485,8 +488,11 @@ class Density(Grid):
         try:
             self.grid *= units.get_conversion_factor('density',
                                                      self.units['density'], unit)
-        except KeyError as e:
-            raise ValueError("The name of the unit ({0!r} supplied) must be one of:\n{1!r}".format(unit, units.conversion_factor['density'].keys())) from e
+        except KeyError:
+            raise_from(
+                ValueError("The name of the unit ({0!r} supplied) must be one of:\n{1!r}".format(unit, units.conversion_factor['density'].keys())),
+                None,
+                )
         self.units['density'] = unit
 
     def __repr__(self):
@@ -526,14 +532,14 @@ def _set_user_grid(gridcenter, xdim, ydim, zdim, smin, smax):
     # Check user inputs
     try:
         gridcenter = np.asarray(gridcenter, dtype=np.float32)
-    except ValueError as e:
-        raise ValueError("Non-number values assigned to gridcenter") from e
+    except ValueError:
+        raise_from(ValueError("Non-number values assigned to gridcenter"), None)
     if gridcenter.shape != (3,):
         raise ValueError("gridcenter must be a 3D coordinate")
     try:
         xyzdim = np.array([xdim, ydim, zdim], dtype=np.float32)
-    except ValueError as e:
-        raise ValueError("xdim, ydim, and zdim must be numbers") from e
+    except ValueError:
+        raise_from(ValueError("xdim, ydim, and zdim must be numbers"), None)
 
     # Set min/max by shifting by half the edge length of each dimension
     umin = gridcenter - xyzdim/2

--- a/package/MDAnalysis/analysis/density.py
+++ b/package/MDAnalysis/analysis/density.py
@@ -372,12 +372,12 @@ class Density(Grid):
                 try:
                     units.conversion_factor[unit_type][value]
                     self.units[unit_type] = value
-                except KeyError:
-                    raise ValueError('Unit ' + str(value) + ' of type ' + str(unit_type) + ' is not recognized.')
-        except AttributeError:
+                except KeyError as e:
+                    raise ValueError('Unit ' + str(value) + ' of type ' + str(unit_type) + ' is not recognized.') from e
+        except AttributeError as e:
             errmsg = '"unit" must be a dictionary with keys "length" and "density.'
             logger.fatal(errmsg)
-            raise ValueError(errmsg)
+            raise ValueError(errmsg) from e
         # need at least length and density (can be None)
         if 'length' not in self.units:
             raise ValueError('"unit" must contain a unit for "length".')
@@ -485,8 +485,8 @@ class Density(Grid):
         try:
             self.grid *= units.get_conversion_factor('density',
                                                      self.units['density'], unit)
-        except KeyError:
-            raise ValueError("The name of the unit ({0!r} supplied) must be one of:\n{1!r}".format(unit, units.conversion_factor['density'].keys()))
+        except KeyError as e:
+            raise ValueError("The name of the unit ({0!r} supplied) must be one of:\n{1!r}".format(unit, units.conversion_factor['density'].keys())) from e
         self.units['density'] = unit
 
     def __repr__(self):
@@ -526,14 +526,14 @@ def _set_user_grid(gridcenter, xdim, ydim, zdim, smin, smax):
     # Check user inputs
     try:
         gridcenter = np.asarray(gridcenter, dtype=np.float32)
-    except ValueError:
-        raise ValueError("Non-number values assigned to gridcenter")
+    except ValueError as e:
+        raise ValueError("Non-number values assigned to gridcenter") from e
     if gridcenter.shape != (3,):
-        raise ValueError("gridcenter must be a 3D coordinate")
+        raise ValueError("gridcenter must be a 3D coordinate") from e
     try:
         xyzdim = np.array([xdim, ydim, zdim], dtype=np.float32)
-    except ValueError:
-        raise ValueError("xdim, ydim, and zdim must be numbers")
+    except ValueError as e:
+        raise ValueError("xdim, ydim, and zdim must be numbers") from e
 
     # Set min/max by shifting by half the edge length of each dimension
     umin = gridcenter - xyzdim/2

--- a/package/MDAnalysis/analysis/density.py
+++ b/package/MDAnalysis/analysis/density.py
@@ -529,7 +529,7 @@ def _set_user_grid(gridcenter, xdim, ydim, zdim, smin, smax):
     except ValueError as e:
         raise ValueError("Non-number values assigned to gridcenter") from e
     if gridcenter.shape != (3,):
-        raise ValueError("gridcenter must be a 3D coordinate") from e
+        raise ValueError("gridcenter must be a 3D coordinate")
     try:
         xyzdim = np.array([xdim, ydim, zdim], dtype=np.float32)
     except ValueError as e:

--- a/package/MDAnalysis/analysis/hbonds/hbond_autocorrel.py
+++ b/package/MDAnalysis/analysis/hbonds/hbond_autocorrel.py
@@ -206,6 +206,7 @@ Classes
 """
 from __future__ import division, absolute_import
 from six.moves import zip
+from six import raise_from
 
 import numpy as np
 import scipy.optimize
@@ -300,8 +301,8 @@ class HydrogenBondAutoCorrel(object):
         # check that slicing is possible
         try:
             self.u.trajectory[0]
-        except Exception as e:
-            raise ValueError("Trajectory must support slicing") from e
+        except Exception:
+            raise_from(ValueError("Trajectory must support slicing"), None)
 
         self.h = hydrogens
         self.a = acceptors

--- a/package/MDAnalysis/analysis/hbonds/hbond_autocorrel.py
+++ b/package/MDAnalysis/analysis/hbonds/hbond_autocorrel.py
@@ -300,8 +300,8 @@ class HydrogenBondAutoCorrel(object):
         # check that slicing is possible
         try:
             self.u.trajectory[0]
-        except:
-            raise ValueError("Trajectory must support slicing")
+        except Exception as e:
+            raise ValueError("Trajectory must support slicing") from e
 
         self.h = hydrogens
         self.a = acceptors

--- a/package/MDAnalysis/analysis/hole.py
+++ b/package/MDAnalysis/analysis/hole.py
@@ -1030,7 +1030,7 @@ class HOLE(BaseHOLE):
         except subprocess.CalledProcessError as err:
             os.unlink(tmp_sos)
             logger.fatal("sph_process failed ({0})".format(err.returncode))
-            raise OSError(err.returncode, "sph_process failed")
+            raise OSError(err.returncode, "sph_process failed") from err
         except:
             os.unlink(tmp_sos)
             raise
@@ -1045,7 +1045,7 @@ class HOLE(BaseHOLE):
                     stderr=FNULL)
         except subprocess.CalledProcessError as err:
             logger.fatal("sos_triangle failed ({0})".format(err.returncode))
-            raise OSError(err.returncode, "sos_triangle failed")
+            raise OSError(err.returncode, "sos_triangle failed") from err
         finally:
             os.unlink(tmp_sos)
 

--- a/package/MDAnalysis/analysis/hole.py
+++ b/package/MDAnalysis/analysis/hole.py
@@ -1030,7 +1030,7 @@ class HOLE(BaseHOLE):
         except subprocess.CalledProcessError as err:
             os.unlink(tmp_sos)
             logger.fatal("sph_process failed ({0})".format(err.returncode))
-            raise OSError(err.returncode, "sph_process failed") from err
+            six.raise_from(OSError(err.returncode, "sph_process failed"), None)
         except:
             os.unlink(tmp_sos)
             raise
@@ -1045,7 +1045,7 @@ class HOLE(BaseHOLE):
                     stderr=FNULL)
         except subprocess.CalledProcessError as err:
             logger.fatal("sos_triangle failed ({0})".format(err.returncode))
-            raise OSError(err.returncode, "sos_triangle failed") from err
+            six.raise_from(OSError(err.returncode, "sos_triangle failed"), None)
         finally:
             os.unlink(tmp_sos)
 

--- a/package/MDAnalysis/analysis/nuclinfo.py
+++ b/package/MDAnalysis/analysis/nuclinfo.py
@@ -712,10 +712,15 @@ def hydroxyl(universe, seg, i):
     try:
         hydr = h.dihedral.value() % 360
     except ValueError:
-        errmsg = (
-            "Resid {0} does not contain atoms C1', C2', O2', H2' but atoms {1}"
-             )
-        raise_from(ValueError(errmsg.format(i, str(list(h.atoms)))), None)
+        raise_from(
+            ValueError(
+                (
+                    "Resid {0} does not contain atoms C1', C2', O2', H2' "
+                    "but atoms {1}"
+                    ).format(i, str(list(h.atoms)))
+                ),
+            None)
+
     return hydr
 
 

--- a/package/MDAnalysis/analysis/nuclinfo.py
+++ b/package/MDAnalysis/analysis/nuclinfo.py
@@ -710,9 +710,11 @@ def hydroxyl(universe, seg, i):
                               "atom {0!s} {1!s} H2'".format(seg, i))
     try:
         hydr = h.dihedral.value() % 360
-    except ValueError:
-        raise ValueError("Resid {0} does not contain atoms C1', C2', O2', H2' but atoms {1}"
-                         .format(i, str(list(h.atoms))))
+    except ValueError as e:
+        errmsg = (
+            "Resid {0} does not contain atoms C1', C2', O2', H2' but atoms {1}"
+             )
+        raise ValueError(errmsg.format(i, str(list(h.atoms)))) from e
     return hydr
 
 

--- a/package/MDAnalysis/analysis/nuclinfo.py
+++ b/package/MDAnalysis/analysis/nuclinfo.py
@@ -107,6 +107,7 @@ from __future__ import division, absolute_import
 
 import numpy as np
 from math import pi, sin, cos, atan2, sqrt, pow
+from six import raise_from
 
 from MDAnalysis.lib import mdamath
 
@@ -710,11 +711,11 @@ def hydroxyl(universe, seg, i):
                               "atom {0!s} {1!s} H2'".format(seg, i))
     try:
         hydr = h.dihedral.value() % 360
-    except ValueError as e:
+    except ValueError:
         errmsg = (
             "Resid {0} does not contain atoms C1', C2', O2', H2' but atoms {1}"
              )
-        raise ValueError(errmsg.format(i, str(list(h.atoms)))) from e
+        raise_from(ValueError(errmsg.format(i, str(list(h.atoms)))), None)
     return hydr
 
 

--- a/package/MDAnalysis/analysis/polymer.py
+++ b/package/MDAnalysis/analysis/polymer.py
@@ -62,6 +62,7 @@ using MDAnalysis.
 """
 from __future__ import division, absolute_import
 from six.moves import range
+from six import raise_from
 
 import numpy as np
 import scipy.optimize
@@ -248,7 +249,7 @@ class PersistenceLength(AnalysisBase):
         try:
             self.results
         except AttributeError:
-            raise NoDataError("Use the run method first") from None
+            raise_from(NoDataError("Use the run method first"), None)
         self.x = np.arange(len(self.results)) * self.lb
 
         self.lp = fit_exponential_decay(self.x, self.results)

--- a/package/MDAnalysis/analysis/polymer.py
+++ b/package/MDAnalysis/analysis/polymer.py
@@ -247,8 +247,8 @@ class PersistenceLength(AnalysisBase):
         """Fit the results to an exponential decay"""
         try:
             self.results
-        except AttributeError:
-            raise NoDataError("Use the run method first")
+        except AttributeError as e:
+            raise NoDataError("Use the run method first") from e
         self.x = np.arange(len(self.results)) * self.lb
 
         self.lp = fit_exponential_decay(self.x, self.results)

--- a/package/MDAnalysis/analysis/polymer.py
+++ b/package/MDAnalysis/analysis/polymer.py
@@ -247,8 +247,8 @@ class PersistenceLength(AnalysisBase):
         """Fit the results to an exponential decay"""
         try:
             self.results
-        except AttributeError as e:
-            raise NoDataError("Use the run method first") from e
+        except AttributeError:
+            raise NoDataError("Use the run method first") from None
         self.x = np.arange(len(self.results)) * self.lb
 
         self.lp = fit_exponential_decay(self.x, self.results)

--- a/package/MDAnalysis/analysis/psa.py
+++ b/package/MDAnalysis/analysis/psa.py
@@ -266,10 +266,14 @@ def get_path_metric_func(name):
     try:
         return path_metrics[name]
     except KeyError as key:
-        errmsg = ('Path metric "{}" not found. Valid selections: {}'
-                  ''.format(key, " ".join('"{}"'.format(n)
-                                           for n in path_metrics.keys())))
-        raise_from(KeyError(errmsg), None)
+        raise_from(
+            KeyError(
+                'Path metric "{}" not found. Valid selections: {}'.format(
+                    key,
+                    " ".join('"{}"'.format(n) for n in path_metrics.keys())
+                    )
+                ),
+            None)
 
 
 def sqnorm(v, axis=None):

--- a/package/MDAnalysis/analysis/psa.py
+++ b/package/MDAnalysis/analysis/psa.py
@@ -215,7 +215,7 @@ from __future__ import division, absolute_import, print_function
 
 import six
 from six.moves import range, cPickle, zip
-from six import string_types
+from six import raise_from, string_types
 
 import os
 import warnings
@@ -269,7 +269,7 @@ def get_path_metric_func(name):
         errmsg = ('Path metric "{}" not found. Valid selections: {}'
                   ''.format(key, " ".join('"{}"'.format(n)
                                            for n in path_metrics.keys())))
-        raise KeyError(errmsg) from key
+        raise_from(KeyError(errmsg), None)
 
 
 def sqnorm(v, axis=None):
@@ -1865,8 +1865,8 @@ class PSAnalysis(object):
 
         try:
             import seaborn.apionly as sns
-        except ImportError as e:
-            raise ImportError(
+        except ImportError:
+            raise_from(ImportError(
                 """ERROR --- The seaborn package cannot be found!
 
                 The seaborn API could not be imported. Please install it first.
@@ -1881,7 +1881,9 @@ class PSAnalysis(object):
 
                 and install in the usual manner.
                 """
-            ) from e
+                ),
+                None,
+                )
 
         if self.D is None:
             raise ValueError(
@@ -1974,8 +1976,8 @@ class PSAnalysis(object):
         from matplotlib.pyplot import figure, savefig, tight_layout, clf, show
         try:
             import seaborn.apionly as sns
-        except ImportError as e:
-            raise ImportError(
+        except ImportError:
+            raise_from(ImportError(
                 """ERROR --- The seaborn package cannot be found!
 
                 The seaborn API could not be imported. Please install it first.
@@ -1990,7 +1992,9 @@ class PSAnalysis(object):
 
                 and install in the usual manner.
                 """
-            ) from e
+                ),
+                None,
+                )
 
         colors = sns.xkcd_palette(["cherry", "windows blue"])
 

--- a/package/MDAnalysis/analysis/psa.py
+++ b/package/MDAnalysis/analysis/psa.py
@@ -266,9 +266,10 @@ def get_path_metric_func(name):
     try:
         return path_metrics[name]
     except KeyError as key:
-        raise KeyError('Path metric "{}" not found. Valid selections: {}'
-                       ''.format(key, " ".join('"{}"'.format(n)
-                                               for n in path_metrics.keys())))
+        errmsg = ('Path metric "{}" not found. Valid selections: {}'
+                  ''.format(key, " ".join('"{}"'.format(n)
+                                           for n in path_metrics.keys())))
+        raise KeyError(errmsg) from key
 
 
 def sqnorm(v, axis=None):
@@ -1864,7 +1865,7 @@ class PSAnalysis(object):
 
         try:
             import seaborn.apionly as sns
-        except ImportError:
+        except ImportError as e:
             raise ImportError(
                 """ERROR --- The seaborn package cannot be found!
 
@@ -1880,7 +1881,7 @@ class PSAnalysis(object):
 
                 and install in the usual manner.
                 """
-            )
+            ) from e
 
         if self.D is None:
             raise ValueError(
@@ -1973,7 +1974,7 @@ class PSAnalysis(object):
         from matplotlib.pyplot import figure, savefig, tight_layout, clf, show
         try:
             import seaborn.apionly as sns
-        except ImportError:
+        except ImportError as e:
             raise ImportError(
                 """ERROR --- The seaborn package cannot be found!
 
@@ -1989,7 +1990,7 @@ class PSAnalysis(object):
 
                 and install in the usual manner.
                 """
-            )
+            ) from e
 
         colors = sns.xkcd_palette(["cherry", "windows blue"])
 

--- a/package/MDAnalysis/analysis/rms.py
+++ b/package/MDAnalysis/analysis/rms.py
@@ -286,17 +286,17 @@ def process_selection(select):
     elif type(select) is tuple:
         try:
             select = {'mobile': select[0], 'reference': select[1]}
-        except IndexError:
+        except IndexError as e:
             raise IndexError("select must contain two selection strings "
-                             "(reference, mobile)")
+                             "(reference, mobile)") from e
     elif type(select) is dict:
         # compatability hack to use new nomenclature
         try:
             select['mobile']
             select['reference']
-        except KeyError:
+        except KeyError as e:
             raise KeyError("select dictionary must contain entries for keys "
-                           "'mobile' and 'reference'.")
+                           "'mobile' and 'reference'.") from e
     else:
         raise TypeError("'select' must be either a string, 2-tuple, or dict")
     select['mobile'] = asiterable(select['mobile'])

--- a/package/MDAnalysis/analysis/rms.py
+++ b/package/MDAnalysis/analysis/rms.py
@@ -136,7 +136,7 @@ Analysis classes
 from __future__ import division, absolute_import
 
 from six.moves import zip
-from six import string_types
+from six import raise_from, string_types
 
 import numpy as np
 
@@ -286,17 +286,25 @@ def process_selection(select):
     elif type(select) is tuple:
         try:
             select = {'mobile': select[0], 'reference': select[1]}
-        except IndexError as e:
-            raise IndexError("select must contain two selection strings "
-                             "(reference, mobile)") from e
+        except IndexError:
+            raise_from(IndexError(
+                "select must contain two selection strings "
+                "(reference, mobile)"),
+                None,
+                )
     elif type(select) is dict:
         # compatability hack to use new nomenclature
         try:
             select['mobile']
             select['reference']
-        except KeyError as e:
-            raise KeyError("select dictionary must contain entries for keys "
-                           "'mobile' and 'reference'.") from e
+        except KeyError:
+            raise_from(
+                KeyError(
+                    "select dictionary must contain entries for keys "
+                    "'mobile' and 'reference'."
+                    ),
+                None,
+                )
     else:
         raise TypeError("'select' must be either a string, 2-tuple, or dict")
     select['mobile'] = asiterable(select['mobile'])

--- a/package/MDAnalysis/auxiliary/XVG.py
+++ b/package/MDAnalysis/auxiliary/XVG.py
@@ -318,13 +318,13 @@ class XVGFileReader(base.AuxFileReader):
                 # see if we've set n_cols yet...
                 try:
                     auxstep._n_cols
-                except AttributeError as e:
+                except AttributeError:
                     # haven't set n_cols yet; set now
                     auxstep._n_cols = len(auxstep._data)
                 if len(auxstep._data) != auxstep._n_cols:
                     raise ValueError('Step {0} has {1} columns instead of '
                                      '{2}'.format(self.step, len(auxstep._data),
-                                                  auxstep._n_cols)) from e
+                                                  auxstep._n_cols))
                 return auxstep
             # line is comment only - move to next
             line = next(self.auxfile)

--- a/package/MDAnalysis/auxiliary/XVG.py
+++ b/package/MDAnalysis/auxiliary/XVG.py
@@ -148,9 +148,9 @@ class XVGStep(base.AuxStep):
         if isinstance(key, numbers.Integral):
             try:
                 return self._data[key]
-            except IndexError:
+            except IndexError as e:
                 raise ValueError('{} not a valid index for data with {} '
-                                 'columns'.format(key, len(self._data)))
+                                 'columns'.format(key, len(self._data))) from e
         else:
             return np.array([self._select_data(i) for i in key])
 
@@ -318,13 +318,13 @@ class XVGFileReader(base.AuxFileReader):
                 # see if we've set n_cols yet...
                 try:
                     auxstep._n_cols
-                except AttributeError:
+                except AttributeError as e:
                     # haven't set n_cols yet; set now
                     auxstep._n_cols = len(auxstep._data)
                 if len(auxstep._data) != auxstep._n_cols:
                     raise ValueError('Step {0} has {1} columns instead of '
                                      '{2}'.format(self.step, len(auxstep._data),
-                                                  auxstep._n_cols))
+                                                  auxstep._n_cols)) from e
                 return auxstep
             # line is comment only - move to next
             line = next(self.auxfile)

--- a/package/MDAnalysis/auxiliary/XVG.py
+++ b/package/MDAnalysis/auxiliary/XVG.py
@@ -69,6 +69,7 @@ supported (the readers will stop at the first line starting '&').
 from __future__ import absolute_import
 
 from six.moves import range
+from six import raise_from
 
 import numbers
 import os
@@ -148,9 +149,14 @@ class XVGStep(base.AuxStep):
         if isinstance(key, numbers.Integral):
             try:
                 return self._data[key]
-            except IndexError as e:
-                raise ValueError('{} not a valid index for data with {} '
-                                 'columns'.format(key, len(self._data))) from e
+            except IndexError:
+                raise_from(
+                    ValueError(
+                        '{} not a valid index for data with {} '
+                        'columns'.format(key, len(self._data))
+                        ),
+                    None
+                    )
         else:
             return np.array([self._select_data(i) for i in key])
 

--- a/package/MDAnalysis/auxiliary/core.py
+++ b/package/MDAnalysis/auxiliary/core.py
@@ -85,8 +85,9 @@ def get_auxreader_for(auxdata=None, format=None):
         try:
             return _AUXREADERS[format]
         except KeyError:
-            errmsg = "Unknown auxiliary data format {0}".format(format)
-            raise_from(ValueError(errmsg), None)
+            raise_from(
+                ValueError("Unknown auxiliary data format {0}".format(format)),
+                None)
 
 def auxreader(auxdata, format=None, **kwargs):
     """ Return an auxiliary reader instance for *auxdata*.

--- a/package/MDAnalysis/auxiliary/core.py
+++ b/package/MDAnalysis/auxiliary/core.py
@@ -74,14 +74,15 @@ def get_auxreader_for(auxdata=None, format=None):
         format = format.upper()
         try:
             return _AUXREADERS[format]
-        except KeyError:
+        except KeyError as e:
             raise ValueError("Unknown auxiliary data format for auxdata: "
-                             "{0}".format(auxdata))
+                             "{0}".format(auxdata)) from e
     else:
         try:
             return _AUXREADERS[format]
-        except KeyError:
-            raise ValueError("Unknown auxiliary data format {0}".format(format))
+        except KeyError as e:
+            errmsg = "Unknown auxiliary data format {0}".format(format)
+            raise ValueError(errmsg) from e
 
 def auxreader(auxdata, format=None, **kwargs):
     """ Return an auxiliary reader instance for *auxdata*.

--- a/package/MDAnalysis/auxiliary/core.py
+++ b/package/MDAnalysis/auxiliary/core.py
@@ -30,7 +30,7 @@ Common functions for auxiliary reading --- :mod:`MDAnalysis.auxiliary.core`
 """
 from __future__ import absolute_import
 
-from six import string_types
+from six import raise_from, string_types
 
 from . import _AUXREADERS
 from ..lib import util
@@ -74,15 +74,19 @@ def get_auxreader_for(auxdata=None, format=None):
         format = format.upper()
         try:
             return _AUXREADERS[format]
-        except KeyError as e:
-            raise ValueError("Unknown auxiliary data format for auxdata: "
-                             "{0}".format(auxdata)) from e
+        except KeyError:
+            raise_from(
+                ValueError(
+                    "Unknown auxiliary data format for auxdata: "
+                    "{0}".format(auxdata)),
+                None
+                )
     else:
         try:
             return _AUXREADERS[format]
-        except KeyError as e:
+        except KeyError:
             errmsg = "Unknown auxiliary data format {0}".format(format)
-            raise ValueError(errmsg) from e
+            raise_from(ValueError(errmsg), None)
 
 def auxreader(auxdata, format=None, **kwargs):
     """ Return an auxiliary reader instance for *auxdata*.

--- a/package/MDAnalysis/coordinates/CRD.py
+++ b/package/MDAnalysis/coordinates/CRD.py
@@ -32,6 +32,7 @@ Read and write coordinates in CHARMM CARD coordinate format (suffix
 from __future__ import absolute_import
 
 from six.moves import zip, range
+from six import raise_from
 
 import itertools
 import numpy as np
@@ -80,9 +81,13 @@ class CRDReader(base.SingleFrameReaderBase):
                         coords_list.append(np.array(line[45:100].split()[0:3], dtype=float))
                     else:
                         coords_list.append(np.array(line[20:50].split()[0:3], dtype=float))
-                except Exception as e:
-                    raise ValueError("Check CRD format at line {0}: {1}"
-                                     "".format(linenum, line.rstrip())) from e
+                except Exception:
+                    raise_from(
+                        ValueError(
+                            "Check CRD format at line {0}: {1}"
+                            "".format(linenum, line.rstrip())),
+                        None
+                        )
 
         self.n_atoms = len(coords_list)
 

--- a/package/MDAnalysis/coordinates/CRD.py
+++ b/package/MDAnalysis/coordinates/CRD.py
@@ -80,9 +80,9 @@ class CRDReader(base.SingleFrameReaderBase):
                         coords_list.append(np.array(line[45:100].split()[0:3], dtype=float))
                     else:
                         coords_list.append(np.array(line[20:50].split()[0:3], dtype=float))
-                except:
+                except Exception as e:
                     raise ValueError("Check CRD format at line {0}: {1}"
-                                     "".format(linenum, line.rstrip()))
+                                     "".format(linenum, line.rstrip())) from e
 
         self.n_atoms = len(coords_list)
 

--- a/package/MDAnalysis/coordinates/GRO.py
+++ b/package/MDAnalysis/coordinates/GRO.py
@@ -106,6 +106,8 @@ strings for writing lines in ``.gro`` files.  These are as follows:
 from __future__ import absolute_import
 
 from six.moves import range, zip
+from six import raise_from
+
 import itertools
 import warnings
 
@@ -366,11 +368,11 @@ class GROWriter(base.WriterBase):
             ag_or_ts = obj.atoms
             # can write from selection == Universe (Issue 49)
 
-        except AttributeError as e:
+        except AttributeError:
             if isinstance(obj, base.Timestep):
                 ag_or_ts = obj.copy()
             else:
-                raise TypeError("No Timestep found in obj argument") from e
+                raise_from(TypeError("No Timestep found in obj argument"), None)
 
         try:
             velocities = ag_or_ts.velocities

--- a/package/MDAnalysis/coordinates/GRO.py
+++ b/package/MDAnalysis/coordinates/GRO.py
@@ -366,11 +366,11 @@ class GROWriter(base.WriterBase):
             ag_or_ts = obj.atoms
             # can write from selection == Universe (Issue 49)
 
-        except AttributeError:
+        except AttributeError as e:
             if isinstance(obj, base.Timestep):
                 ag_or_ts = obj.copy()
             else:
-                raise TypeError("No Timestep found in obj argument")
+                raise TypeError("No Timestep found in obj argument") from e
 
         try:
             velocities = ag_or_ts.velocities

--- a/package/MDAnalysis/coordinates/GSD.py
+++ b/package/MDAnalysis/coordinates/GSD.py
@@ -105,8 +105,8 @@ class GSDReader(base.ReaderBase):
     def _read_frame(self, frame):
         try :
             myframe = self._file[frame]
-        except IndexError :
-            raise IOError
+        except IndexError as e:
+            raise IOError from e
 
         # set frame number
         self._frame = frame

--- a/package/MDAnalysis/coordinates/GSD.py
+++ b/package/MDAnalysis/coordinates/GSD.py
@@ -46,6 +46,7 @@ Classes
 
 """
 from __future__ import absolute_import, division
+from six import raise_from
 
 import numpy as np
 import os
@@ -101,8 +102,8 @@ class GSDReader(base.ReaderBase):
     def _read_frame(self, frame):
         try :
             myframe = self._file[frame]
-        except IndexError as e:
-            raise IOError from e
+        except IndexError:
+            raise_from(IOError, None)
 
         # set frame number
         self._frame = frame

--- a/package/MDAnalysis/coordinates/LAMMPS.py
+++ b/package/MDAnalysis/coordinates/LAMMPS.py
@@ -160,8 +160,9 @@ class DCDWriter(DCD.DCDWriter):
             try:
                 if units.unit_types[unit] != unit_type:
                     raise TypeError("LAMMPS DCDWriter: wrong unit {0!r} for unit type {1!r}".format(unit, unit_type))
-            except KeyError:
-                raise ValueError("LAMMPS DCDWriter: unknown unit {0!r}".format(unit))
+            except KeyError as e:
+                errmsg = ("LAMMPS DCDWriter: unknown unit {0!r}".format(unit))
+                raise ValueError(errmsg) from e
         super(DCDWriter, self).__init__(*args, **kwargs)
 
 
@@ -340,10 +341,10 @@ class DATAWriter(base.WriterBase):
             try:
                 self.f.write('{:d} {:d} '.format(i, int(bond.type))+\
                         ' '.join((bond.atoms.indices + 1).astype(str))+'\n')
-            except TypeError:
+            except TypeError as e:
                 raise TypeError('LAMMPS DATAWriter: Trying to write bond, '
                                 'but bond type {} is not '
-                                'numerical.'.format(bond.type))
+                                'numerical.'.format(bond.type)) from e
 
     def _write_dimensions(self, dimensions):
         """Convert dimensions to triclinic vectors, convert lengths to native
@@ -401,9 +402,9 @@ class DATAWriter(base.WriterBase):
         # check that types can be converted to ints if they aren't ints already
         try:
             atoms.types.astype(np.int32)
-        except ValueError:
+        except ValueError as e:
             raise ValueError('LAMMPS.DATAWriter: atom types must be '+
-                    'convertible to integers')
+                    'convertible to integers') from e
 
         try:
             velocities = atoms.velocities

--- a/package/MDAnalysis/coordinates/LAMMPS.py
+++ b/package/MDAnalysis/coordinates/LAMMPS.py
@@ -162,8 +162,9 @@ class DCDWriter(DCD.DCDWriter):
                 if units.unit_types[unit] != unit_type:
                     raise TypeError("LAMMPS DCDWriter: wrong unit {0!r} for unit type {1!r}".format(unit, unit_type))
             except KeyError:
-                errmsg = ("LAMMPS DCDWriter: unknown unit {0!r}".format(unit))
-                raise_from(ValueError(errmsg), None)
+                raise_from(
+                    ValueError("LAMMPS DCDWriter: unknown unit {0!r}".format(unit)),
+                    None)
         super(DCDWriter, self).__init__(*args, **kwargs)
 
 

--- a/package/MDAnalysis/coordinates/LAMMPS.py
+++ b/package/MDAnalysis/coordinates/LAMMPS.py
@@ -404,9 +404,12 @@ class DATAWriter(base.WriterBase):
         # check that types can be converted to ints if they aren't ints already
         try:
             atoms.types.astype(np.int32)
-        except ValueError as e:
-            raise ValueError('LAMMPS.DATAWriter: atom types must be '+
-                    'convertible to integers') from e
+        except ValueError:
+            raise_from(
+                ValueError(
+                    'LAMMPS.DATAWriter: atom types must be '
+                    'convertible to integers'),
+                    None)
 
         try:
             velocities = atoms.velocities

--- a/package/MDAnalysis/coordinates/LAMMPS.py
+++ b/package/MDAnalysis/coordinates/LAMMPS.py
@@ -124,6 +124,7 @@ Classes
 from __future__ import absolute_import
 
 from six.moves import zip, range, map
+from six import raise_from
 import os
 import numpy as np
 
@@ -160,9 +161,9 @@ class DCDWriter(DCD.DCDWriter):
             try:
                 if units.unit_types[unit] != unit_type:
                     raise TypeError("LAMMPS DCDWriter: wrong unit {0!r} for unit type {1!r}".format(unit, unit_type))
-            except KeyError as e:
+            except KeyError:
                 errmsg = ("LAMMPS DCDWriter: unknown unit {0!r}".format(unit))
-                raise ValueError(errmsg) from e
+                raise_from(ValueError(errmsg), None)
         super(DCDWriter, self).__init__(*args, **kwargs)
 
 
@@ -341,10 +342,11 @@ class DATAWriter(base.WriterBase):
             try:
                 self.f.write('{:d} {:d} '.format(i, int(bond.type))+\
                         ' '.join((bond.atoms.indices + 1).astype(str))+'\n')
-            except TypeError as e:
-                raise TypeError('LAMMPS DATAWriter: Trying to write bond, '
+            except TypeError:
+                raise_from(TypeError('LAMMPS DATAWriter: Trying to write bond, '
                                 'but bond type {} is not '
-                                'numerical.'.format(bond.type)) from e
+                                'numerical.'.format(bond.type)),
+                            None)
 
     def _write_dimensions(self, dimensions):
         """Convert dimensions to triclinic vectors, convert lengths to native

--- a/package/MDAnalysis/coordinates/MOL2.py
+++ b/package/MDAnalysis/coordinates/MOL2.py
@@ -218,9 +218,9 @@ class MOL2Reader(base.ReaderBase):
         unitcell = np.zeros(6, dtype=np.float32)
         try:
             block = self.frames[frame]
-        except IndexError:
+        except IndexError as e:
             raise IOError("Invalid frame {0} for trajectory with length {1}"
-                          "".format(frame, len(self)))
+                          "".format(frame, len(self))) from e
 
         sections, coords = self.parse_block(block)
 
@@ -313,9 +313,9 @@ class MOL2Writer(base.WriterBase):
 
         try:
             molecule = ts.data['molecule']
-        except KeyError:
+        except KeyError as e:
             raise NotImplementedError(
-                "MOL2Writer cannot currently write non MOL2 data")
+                "MOL2Writer cannot currently write non MOL2 data") from e
 
         # Need to remap atom indices to 1 based in this selection
         mapping = {a: i for i, a in enumerate(obj.atoms, start=1)}

--- a/package/MDAnalysis/coordinates/MOL2.py
+++ b/package/MDAnalysis/coordinates/MOL2.py
@@ -112,6 +112,7 @@ MOL2 format notes
 
 """
 from __future__ import absolute_import
+from six import raise_from
 
 import numpy as np
 
@@ -218,9 +219,10 @@ class MOL2Reader(base.ReaderBase):
         unitcell = np.zeros(6, dtype=np.float32)
         try:
             block = self.frames[frame]
-        except IndexError as e:
-            raise IOError("Invalid frame {0} for trajectory with length {1}"
-                          "".format(frame, len(self))) from e
+        except IndexError:
+            raise_from(IOError("Invalid frame {0} for trajectory with length {1}"
+                          "".format(frame, len(self))),
+                       None)
 
         sections, coords = self.parse_block(block)
 
@@ -313,9 +315,10 @@ class MOL2Writer(base.WriterBase):
 
         try:
             molecule = ts.data['molecule']
-        except KeyError as e:
-            raise NotImplementedError(
-                "MOL2Writer cannot currently write non MOL2 data") from e
+        except KeyError:
+            raise_from(NotImplementedError(
+                "MOL2Writer cannot currently write non MOL2 data"),
+                None)
 
         # Need to remap atom indices to 1 based in this selection
         mapping = {a: i for i, a in enumerate(obj.atoms, start=1)}

--- a/package/MDAnalysis/coordinates/PDB.py
+++ b/package/MDAnalysis/coordinates/PDB.py
@@ -835,9 +835,9 @@ class PDBWriter(base.WriterBase):
         if ts is None:
             try:
                 ts = self.ts
-            except AttributeError as e:
+            except AttributeError:
                 raise NoDataError("PBDWriter: no coordinate data to write to "
-                                  "trajectory file") from e
+                                  "trajectory file") from None
         self._check_pdb_coordinates()
         self._write_timestep(ts, **kwargs)
 

--- a/package/MDAnalysis/coordinates/PDB.py
+++ b/package/MDAnalysis/coordinates/PDB.py
@@ -143,7 +143,7 @@ Classes
 from __future__ import absolute_import
 
 from six.moves import range, zip
-from six import StringIO, BytesIO
+from six import raise_from, StringIO, BytesIO
 
 import io
 import os
@@ -366,8 +366,8 @@ class PDBReader(base.ReaderBase):
         try:
             start = self._start_offsets[frame]
             stop = self._stop_offsets[frame]
-        except IndexError as e:  # out of range of known frames
-            raise IOError from e
+        except IndexError:  # out of range of known frames
+            raise_from(IOError, None)
 
         pos = 0
         occupancy = np.ones(self.n_atoms)
@@ -836,8 +836,12 @@ class PDBWriter(base.WriterBase):
             try:
                 ts = self.ts
             except AttributeError:
-                raise NoDataError("PBDWriter: no coordinate data to write to "
-                                  "trajectory file") from None
+                raise_from(
+                    NoDataError(
+                        "PBDWriter: no coordinate data to write to "
+                        "trajectory file"
+                        ),
+                    None)
         self._check_pdb_coordinates()
         self._write_timestep(ts, **kwargs)
 

--- a/package/MDAnalysis/coordinates/PDB.py
+++ b/package/MDAnalysis/coordinates/PDB.py
@@ -366,8 +366,8 @@ class PDBReader(base.ReaderBase):
         try:
             start = self._start_offsets[frame]
             stop = self._stop_offsets[frame]
-        except IndexError:  # out of range of known frames
-            raise IOError
+        except IndexError as e:  # out of range of known frames
+            raise IOError from e
 
         pos = 0
         occupancy = np.ones(self.n_atoms)
@@ -835,9 +835,9 @@ class PDBWriter(base.WriterBase):
         if ts is None:
             try:
                 ts = self.ts
-            except AttributeError:
+            except AttributeError as e:
                 raise NoDataError("PBDWriter: no coordinate data to write to "
-                                  "trajectory file")
+                                  "trajectory file") from e
         self._check_pdb_coordinates()
         self._write_timestep(ts, **kwargs)
 

--- a/package/MDAnalysis/coordinates/TRJ.py
+++ b/package/MDAnalysis/coordinates/TRJ.py
@@ -566,10 +566,13 @@ class NCDFReader(base.ReaderBase):
             # the number of frames from somewhere such as the time variable:
             if self.n_frames is None:
                 self.n_frames = self.trjfile.variables['time'].shape[0]
-        except KeyError as e:
-            errmsg = ("NCDF trajectory {0} does not contain frame "
-                      "information".format(self.filename))
-            raise_from(ValueError(errmsg), None)
+        except KeyError:
+            raise_from(
+                ValueError(
+                    ("NCDF trajectory {0} does not contain frame "
+                     "information").format(self.filename)
+                    ),
+                None)
 
         try:
             self.remarks = self.trjfile.title

--- a/package/MDAnalysis/coordinates/TRJ.py
+++ b/package/MDAnalysis/coordinates/TRJ.py
@@ -569,7 +569,7 @@ class NCDFReader(base.ReaderBase):
         except KeyError as e:
             errmsg = ("NCDF trajectory {0} does not contain frame "
                       "information".format(self.filename))
-            raise ValueError(errmsg) from e
+            raise_from(ValueError(errmsg), None)
 
         try:
             self.remarks = self.trjfile.title

--- a/package/MDAnalysis/coordinates/TRJ.py
+++ b/package/MDAnalysis/coordinates/TRJ.py
@@ -154,6 +154,8 @@ AMBER ASCII trajectories are recognised by the suffix '.trj',
 """
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
+from six import raise_from
+
 import scipy.io.netcdf
 import numpy as np
 import warnings
@@ -494,11 +496,11 @@ class NCDFReader(base.ReaderBase):
                           "Conventions)".format(self.filename))
                 logger.fatal(errmsg)
                 raise TypeError(errmsg)
-        except AttributeError as e:
+        except AttributeError:
             errmsg = "NCDF trajectory {0} is missing Conventions".format(
                       self.filename)
             logger.fatal(errmsg)
-            raise ValueError(errmsg) from e
+            raise_from(ValueError(errmsg), None)
 
         # AMBER NetCDF files should also have a ConventionVersion
         try:
@@ -509,10 +511,10 @@ class NCDFReader(base.ReaderBase):
                          ConventionVersion, self.version))
                 warnings.warn(wmsg)
                 logger.warning(wmsg)
-        except AttributeError as e:
+        except AttributeError:
             errmsg = "NCDF trajectory {0} is missing ConventionVersion".format(
                       self.filename)
-            raise ValueError(errmsg) from e
+            raise_from(ValueError(errmsg), None)
 
         # The AMBER NetCDF standard enforces 64 bit offsets
         if not self.trjfile.version_byte == 2:
@@ -529,9 +531,9 @@ class NCDFReader(base.ReaderBase):
             if not self.trjfile.dimensions['spatial'] == 3:
                 errmsg = "Incorrect spatial value for NCDF trajectory file"
                 raise TypeError(errmsg)
-        except KeyError as e:
+        except KeyError:
             errmsg = "NCDF trajectory does not contain spatial dimension"
-            raise ValueError(errmsg) from e
+            raise_from(ValueError(errmsg), None)
 
         # AMBER NetCDF specs require program and programVersion. Warn users
         # if those attributes do not exist
@@ -550,10 +552,10 @@ class NCDFReader(base.ReaderBase):
                           "Note: n_atoms can be None and then the ncdf value "
                           "is used!".format(n_atoms, self.n_atoms))
                 raise ValueError(errmsg)
-        except KeyError as e:
+        except KeyError:
             errmsg = ("NCDF trajectory {0} does not contain atom "
                       "information".format(self.filename))
-            raise ValueError(errmsg) from e
+            raise_from(ValueError(errmsg), None)
 
         try:
             self.n_frames = self.trjfile.dimensions['frame']
@@ -708,8 +710,8 @@ class NCDFReader(base.ReaderBase):
             ts = self.ts
         try:
             return self._read_frame(self._current_frame + 1)
-        except IndexError as e:
-            raise IOError from e
+        except IndexError:
+            raise_from(IOError, None)
 
     def _get_dt(self):
         t1 = self.trjfile.variables['time'][1]

--- a/package/MDAnalysis/coordinates/TRJ.py
+++ b/package/MDAnalysis/coordinates/TRJ.py
@@ -494,11 +494,11 @@ class NCDFReader(base.ReaderBase):
                           "Conventions)".format(self.filename))
                 logger.fatal(errmsg)
                 raise TypeError(errmsg)
-        except AttributeError:
+        except AttributeError as e:
             errmsg = "NCDF trajectory {0} is missing Conventions".format(
                       self.filename)
             logger.fatal(errmsg)
-            raise ValueError(errmsg)
+            raise ValueError(errmsg) from e
 
         # AMBER NetCDF files should also have a ConventionVersion
         try:
@@ -509,10 +509,10 @@ class NCDFReader(base.ReaderBase):
                          ConventionVersion, self.version))
                 warnings.warn(wmsg)
                 logger.warning(wmsg)
-        except AttributeError:
+        except AttributeError as e:
             errmsg = "NCDF trajectory {0} is missing ConventionVersion".format(
                       self.filename)
-            raise ValueError(errmsg)
+            raise ValueError(errmsg) from e
 
         # The AMBER NetCDF standard enforces 64 bit offsets
         if not self.trjfile.version_byte == 2:
@@ -529,9 +529,9 @@ class NCDFReader(base.ReaderBase):
             if not self.trjfile.dimensions['spatial'] == 3:
                 errmsg = "Incorrect spatial value for NCDF trajectory file"
                 raise TypeError(errmsg)
-        except KeyError:
+        except KeyError as e:
             errmsg = "NCDF trajectory does not contain spatial dimension"
-            raise ValueError(errmsg)
+            raise ValueError(errmsg) from e
 
         # AMBER NetCDF specs require program and programVersion. Warn users
         # if those attributes do not exist
@@ -550,10 +550,10 @@ class NCDFReader(base.ReaderBase):
                           "Note: n_atoms can be None and then the ncdf value "
                           "is used!".format(n_atoms, self.n_atoms))
                 raise ValueError(errmsg)
-        except KeyError:
+        except KeyError as e:
             errmsg = ("NCDF trajectory {0} does not contain atom "
                       "information".format(self.filename))
-            raise ValueError(errmsg)
+            raise ValueError(errmsg) from e
 
         try:
             self.n_frames = self.trjfile.dimensions['frame']
@@ -564,10 +564,10 @@ class NCDFReader(base.ReaderBase):
             # the number of frames from somewhere such as the time variable:
             if self.n_frames is None:
                 self.n_frames = self.trjfile.variables['time'].shape[0]
-        except KeyError:
+        except KeyError as e:
             errmsg = ("NCDF trajectory {0} does not contain frame "
                       "information".format(self.filename))
-            raise ValueError(errmsg)
+            raise ValueError(errmsg) from e
 
         try:
             self.remarks = self.trjfile.title
@@ -708,8 +708,8 @@ class NCDFReader(base.ReaderBase):
             ts = self.ts
         try:
             return self._read_frame(self._current_frame + 1)
-        except IndexError:
-            raise IOError
+        except IndexError as e:
+            raise IOError from e
 
     def _get_dt(self):
         t1 = self.trjfile.variables['time'][1]

--- a/package/MDAnalysis/coordinates/TRZ.py
+++ b/package/MDAnalysis/coordinates/TRZ.py
@@ -269,8 +269,8 @@ class TRZReader(base.ReaderBase):
                 ts._forces[:, 0] = data['fx']
                 ts._forces[:, 1] = data['fy']
                 ts._forces[:, 2] = data['fz']
-        except IndexError as e: # Raises indexerror if data has no data (EOF)
-            raise IOError from e
+        except IndexError: # Raises indexerror if data has no data (EOF)
+            six.raise_from(IOError, None)
         else:
             # Convert things read into MDAnalysis' native formats (nm -> angstroms)
             if self.convert_units:

--- a/package/MDAnalysis/coordinates/TRZ.py
+++ b/package/MDAnalysis/coordinates/TRZ.py
@@ -269,8 +269,8 @@ class TRZReader(base.ReaderBase):
                 ts._forces[:, 0] = data['fx']
                 ts._forces[:, 1] = data['fy']
                 ts._forces[:, 2] = data['fz']
-        except IndexError: # Raises indexerror if data has no data (EOF)
-            raise IOError
+        except IndexError as e: # Raises indexerror if data has no data (EOF)
+            raise IOError from e
         else:
             # Convert things read into MDAnalysis' native formats (nm -> angstroms)
             if self.convert_units:

--- a/package/MDAnalysis/coordinates/TXYZ.py
+++ b/package/MDAnalysis/coordinates/TXYZ.py
@@ -154,7 +154,7 @@ class TXYZReader(base.ReaderBase):
             ts.frame += 1
             return ts
         except (ValueError, IndexError) as err:
-            raise EOFError(err)
+            raise EOFError(err) from err
 
     def _reopen(self):
         self.close()

--- a/package/MDAnalysis/coordinates/TXYZ.py
+++ b/package/MDAnalysis/coordinates/TXYZ.py
@@ -47,6 +47,7 @@ Classes
 """
 from __future__ import absolute_import, division
 from six.moves import range
+from six import raise_from
 
 import numpy as np
 import os
@@ -153,8 +154,8 @@ class TXYZReader(base.ReaderBase):
             ts.positions = tmp_buf
             ts.frame += 1
             return ts
-        except (ValueError, IndexError) as err:
-            raise EOFError(err) from err
+        except (ValueError, IndexError):
+            raise_from(EOFError(err), None)
 
     def _reopen(self):
         self.close()

--- a/package/MDAnalysis/coordinates/TXYZ.py
+++ b/package/MDAnalysis/coordinates/TXYZ.py
@@ -154,7 +154,7 @@ class TXYZReader(base.ReaderBase):
             ts.positions = tmp_buf
             ts.frame += 1
             return ts
-        except (ValueError, IndexError):
+        except (ValueError, IndexError) as err:
             raise_from(EOFError(err), None)
 
     def _reopen(self):

--- a/package/MDAnalysis/coordinates/XYZ.py
+++ b/package/MDAnalysis/coordinates/XYZ.py
@@ -200,11 +200,11 @@ class XYZWriter(base.WriterBase):
         # but this is not tested.)
         try:
             atoms = obj.atoms
-        except AttributeError as e:
+        except AttributeError:
             if isinstance(obj, base.Timestep):
                 ts = obj
             else:
-                raise TypeError("No Timestep found in obj argument") from e
+                six.raise_from(TypeError("No Timestep found in obj argument"), None)
         else:
             if hasattr(obj, 'universe'):
                 # For AtomGroup and children (Residue, ResidueGroup, Segment)
@@ -376,7 +376,7 @@ class XYZReader(base.ReaderBase):
             ts.frame += 1
             return ts
         except (ValueError, IndexError) as err:
-            raise EOFError(err) from err
+            six.raise_from(EOFError(err), None)
 
     def _reopen(self):
         self.close()

--- a/package/MDAnalysis/coordinates/XYZ.py
+++ b/package/MDAnalysis/coordinates/XYZ.py
@@ -200,11 +200,11 @@ class XYZWriter(base.WriterBase):
         # but this is not tested.)
         try:
             atoms = obj.atoms
-        except AttributeError:
+        except AttributeError as e:
             if isinstance(obj, base.Timestep):
                 ts = obj
             else:
-                raise TypeError("No Timestep found in obj argument")
+                raise TypeError("No Timestep found in obj argument") from e
         else:
             if hasattr(obj, 'universe'):
                 # For AtomGroup and children (Residue, ResidueGroup, Segment)
@@ -376,7 +376,7 @@ class XYZReader(base.ReaderBase):
             ts.frame += 1
             return ts
         except (ValueError, IndexError) as err:
-            raise EOFError(err)
+            raise EOFError(err) from err
 
     def _reopen(self):
         self.close()

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -519,9 +519,11 @@ class Timestep(object):
             vel = self.velocities[sel, :]
         except NoDataError:
             vel = None
-        except Exception as e:
-            raise TypeError("Selection type must be compatible with slicing"
-                            " the coordinates") from e
+        except Exception:
+            six.raise_from(
+                TypeError("Selection type must be compatible with slicing"
+                          " the coordinates"),
+                None)
         try:
             force = self.forces[sel, :]
         except NoDataError:
@@ -2022,9 +2024,9 @@ class ProtoReader(six.with_metaclass(_Readermeta, IOBase)):
 
         try:
             self.transformations = transformations
-        except ValueError as e:
+        except ValueError:
             errmsg = "Can't add transformations again. Please create new Universe object"
-            raise ValueError(errmsg) from e
+            six.raise_from(ValueError(errmsg), None)
         else:
             self.ts = self._apply_transformations(self.ts)
 

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -2025,8 +2025,11 @@ class ProtoReader(six.with_metaclass(_Readermeta, IOBase)):
         try:
             self.transformations = transformations
         except ValueError:
-            errmsg = "Can't add transformations again. Please create new Universe object"
-            six.raise_from(ValueError(errmsg), None)
+            six.raise_from(
+                ValueError(
+                    "Can't add transformations again. "
+                    "Please create new Universe object"),
+                None)
         else:
             self.ts = self._apply_transformations(self.ts)
 

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -508,9 +508,13 @@ class Timestep(object):
         except NoDataError:
             # It's cool if there's no Data, we'll live
             pos = None
-        except Exception as e:
-            raise TypeError("Selection type must be compatible with slicing"
-                            " the coordinates") from e
+        except Exception:
+            six.raise_from(
+                TypeError(
+                    "Selection type must be compatible with slicing"
+                    " the coordinates"
+                    ),
+                None)
         try:
             vel = self.velocities[sel, :]
         except NoDataError:
@@ -522,9 +526,13 @@ class Timestep(object):
             force = self.forces[sel, :]
         except NoDataError:
             force = None
-        except Exception as e:
-            raise TypeError("Selection type must be compatible with slicing"
-                            " the coordinates") from e
+        except Exception:
+            six.raise_from(
+                TypeError(
+                    "Selection type must be compatible with slicing"
+                    " the coordinates"
+                    ),
+                None)
 
         new_TS = self.__class__.from_coordinates(
             positions=pos,
@@ -1408,7 +1416,7 @@ class ProtoReader(six.with_metaclass(_Readermeta, IOBase)):
             ts = self._read_next_timestep()
         except (EOFError, IOError):
             self.rewind()
-            raise StopIteration from None
+            six.raise_from(StopIteration, None)
         else:
             for auxname in self.aux_list:
                 ts = self._auxs[auxname].update_ts(ts)
@@ -1591,9 +1599,12 @@ class ProtoReader(six.with_metaclass(_Readermeta, IOBase)):
             for i in range(start, stop, step):
                 yield self._read_frame_with_aux(i)
             self.rewind()
-        except TypeError as e:  # if _read_frame not implemented
-            raise TypeError("{0} does not support slicing."
-                            "".format(self.__class__.__name__)) from e
+        except TypeError:  # if _read_frame not implemented
+            six.raise_from(
+                TypeError(
+                    "{0} does not support slicing."
+                    "".format(self.__class__.__name__)),
+                None)
 
     def check_slice_indices(self, start, stop, step):
         """Check frame indices are valid and clip to fit trajectory.
@@ -2176,8 +2187,8 @@ class WriterBase(six.with_metaclass(_Writermeta, IOBase)):
                 try:
                     # special case: can supply a Universe, too...
                     ts = obj.trajectory.ts
-                except AttributeError as e:
-                    raise TypeError("No Timestep found in obj argument") from e
+                except AttributeError:
+                    six.raise_from(TypeError("No Timestep found in obj argument"), None)
         return self.write_next_timestep(ts)
 
     def __del__(self):

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -508,23 +508,23 @@ class Timestep(object):
         except NoDataError:
             # It's cool if there's no Data, we'll live
             pos = None
-        except:
+        except Exception as e:
             raise TypeError("Selection type must be compatible with slicing"
-                            " the coordinates")
+                            " the coordinates") from e
         try:
             vel = self.velocities[sel, :]
         except NoDataError:
             vel = None
-        except:
+        except Exception as e:
             raise TypeError("Selection type must be compatible with slicing"
-                            " the coordinates")
+                            " the coordinates") from e
         try:
             force = self.forces[sel, :]
         except NoDataError:
             force = None
-        except:
+        except Exception as e:
             raise TypeError("Selection type must be compatible with slicing"
-                            " the coordinates")
+                            " the coordinates") from e
 
         new_TS = self.__class__.from_coordinates(
             positions=pos,
@@ -1408,7 +1408,7 @@ class ProtoReader(six.with_metaclass(_Readermeta, IOBase)):
             ts = self._read_next_timestep()
         except (EOFError, IOError):
             self.rewind()
-            raise StopIteration
+            raise StopIteration from None
         else:
             for auxname in self.aux_list:
                 ts = self._auxs[auxname].update_ts(ts)
@@ -1591,9 +1591,9 @@ class ProtoReader(six.with_metaclass(_Readermeta, IOBase)):
             for i in range(start, stop, step):
                 yield self._read_frame_with_aux(i)
             self.rewind()
-        except TypeError:  # if _read_frame not implemented
+        except TypeError as e:  # if _read_frame not implemented
             raise TypeError("{0} does not support slicing."
-                            "".format(self.__class__.__name__))
+                            "".format(self.__class__.__name__)) from e
 
     def check_slice_indices(self, start, stop, step):
         """Check frame indices are valid and clip to fit trajectory.
@@ -2011,8 +2011,9 @@ class ProtoReader(six.with_metaclass(_Readermeta, IOBase)):
 
         try:
             self.transformations = transformations
-        except ValueError:
-            raise ValueError("Can't add transformations again. Please create new Universe object")
+        except ValueError as e:
+            errmsg = "Can't add transformations again. Please create new Universe object"
+            raise ValueError(errmsg) from e
         else:
             self.ts = self._apply_transformations(self.ts)
 
@@ -2175,8 +2176,8 @@ class WriterBase(six.with_metaclass(_Writermeta, IOBase)):
                 try:
                     # special case: can supply a Universe, too...
                     ts = obj.trajectory.ts
-                except AttributeError:
-                    raise TypeError("No Timestep found in obj argument")
+                except AttributeError as e:
+                    raise TypeError("No Timestep found in obj argument") from e
         return self.write_next_timestep(ts)
 
     def __del__(self):

--- a/package/MDAnalysis/coordinates/core.py
+++ b/package/MDAnalysis/coordinates/core.py
@@ -83,9 +83,15 @@ def reader(filename, format=None, **kwargs):
         Reader = get_reader_for(filename, format=format)
     try:
         return Reader(filename, **kwargs)
-    except ValueError as e:
-        raise TypeError('Unable to read {fn} with {r}.'.format(fn=filename,
-                                                                r=Reader)) from e
+    except ValueError:
+        six.raise_from(
+            TypeError(
+                'Unable to read {fn} with {r}.'.format(
+                    fn=filename,
+                    r=Reader
+                    )
+                ),
+            None)
 
 
 def writer(filename, n_atoms=None, **kwargs):

--- a/package/MDAnalysis/coordinates/core.py
+++ b/package/MDAnalysis/coordinates/core.py
@@ -83,9 +83,9 @@ def reader(filename, format=None, **kwargs):
         Reader = get_reader_for(filename, format=format)
     try:
         return Reader(filename, **kwargs)
-    except ValueError:
+    except ValueError as e:
         raise TypeError('Unable to read {fn} with {r}.'.format(fn=filename,
-                                                                r=Reader))
+                                                                r=Reader)) from e
 
 
 def writer(filename, n_atoms=None, **kwargs):

--- a/package/MDAnalysis/coordinates/memory.py
+++ b/package/MDAnalysis/coordinates/memory.py
@@ -318,7 +318,7 @@ class MemoryReader(base.ProtoReader):
         except AttributeError as e:
             raise TypeError("The input has to be a numpy.ndarray that "
                             "corresponds to the layout specified by the "
-                            "'order' keyword.")
+                            "'order' keyword.") from e
 
         self.set_array(coordinate_array, order)
         self.n_frames = \
@@ -329,9 +329,9 @@ class MemoryReader(base.ProtoReader):
         if velocities is not None:
             try:
                 velocities = np.asarray(velocities, dtype=np.float32)
-            except ValueError:
+            except ValueError as e:
                 raise TypeError("'velocities' must be array-like got {}"
-                                "".format(type(velocities)))
+                                "".format(type(velocities))) from e
             # if single frame, make into array of 1 frame
             if velocities.ndim == 2:
                 velocities = velocities[np.newaxis, :, :]
@@ -347,9 +347,9 @@ class MemoryReader(base.ProtoReader):
         if forces is not None:
             try:
                 forces = np.asarray(forces, dtype=np.float32)
-            except ValueError:
+            except ValueError as e:
                 raise TypeError("'forces' must be array like got {}"
-                                "".format(type(forces)))
+                                "".format(type(forces))) from e
             if forces.ndim == 2:
                 forces = forces[np.newaxis, :, :]
             if not forces.shape == self.coordinate_array.shape:
@@ -376,9 +376,9 @@ class MemoryReader(base.ProtoReader):
         else:
             try:
                 dimensions = np.asarray(dimensions, dtype=np.float32)
-            except ValueError:
+            except ValueError as e:
                 raise TypeError("'dimensions' must be array-like got {}"
-                                "".format(type(dimensions)))
+                                "".format(type(dimensions))) from e
             if dimensions.shape == (6,):
                 # single box, tile this to trajectory length
                 # allows modifying the box of some frames

--- a/package/MDAnalysis/coordinates/memory.py
+++ b/package/MDAnalysis/coordinates/memory.py
@@ -185,6 +185,7 @@ Classes
 
 """
 from __future__ import absolute_import
+from six import raise_from
 import logging
 import errno
 import numpy as np
@@ -315,10 +316,11 @@ class MemoryReader(base.ProtoReader):
         try:
             if coordinate_array.ndim == 2 and coordinate_array.shape[1] == 3:
                 coordinate_array = coordinate_array[np.newaxis, :, :]
-        except AttributeError as e:
-            raise TypeError("The input has to be a numpy.ndarray that "
+        except AttributeError:
+            raise_from(TypeError("The input has to be a numpy.ndarray that "
                             "corresponds to the layout specified by the "
-                            "'order' keyword.") from e
+                            "'order' keyword."),
+                        None)
 
         self.set_array(coordinate_array, order)
         self.n_frames = \
@@ -329,9 +331,11 @@ class MemoryReader(base.ProtoReader):
         if velocities is not None:
             try:
                 velocities = np.asarray(velocities, dtype=np.float32)
-            except ValueError as e:
-                raise TypeError("'velocities' must be array-like got {}"
-                                "".format(type(velocities))) from e
+            except ValueError:
+                raise_from(
+                    TypeError("'velocities' must be array-like got {}"
+                              "".format(type(velocities))),
+                    None)
             # if single frame, make into array of 1 frame
             if velocities.ndim == 2:
                 velocities = velocities[np.newaxis, :, :]
@@ -347,9 +351,10 @@ class MemoryReader(base.ProtoReader):
         if forces is not None:
             try:
                 forces = np.asarray(forces, dtype=np.float32)
-            except ValueError as e:
-                raise TypeError("'forces' must be array like got {}"
-                                "".format(type(forces))) from e
+            except ValueError:
+                raise_from(TypeError("'forces' must be array like got {}"
+                                     "".format(type(forces))),
+                           None)
             if forces.ndim == 2:
                 forces = forces[np.newaxis, :, :]
             if not forces.shape == self.coordinate_array.shape:
@@ -376,9 +381,10 @@ class MemoryReader(base.ProtoReader):
         else:
             try:
                 dimensions = np.asarray(dimensions, dtype=np.float32)
-            except ValueError as e:
-                raise TypeError("'dimensions' must be array-like got {}"
-                                "".format(type(dimensions))) from e
+            except ValueError:
+                raise_from(TypeError("'dimensions' must be array-like got {}"
+                                     "".format(type(dimensions))),
+                           None)
             if dimensions.shape == (6,):
                 # single box, tile this to trajectory length
                 # allows modifying the box of some frames

--- a/package/MDAnalysis/core/__init__.py
+++ b/package/MDAnalysis/core/__init__.py
@@ -264,8 +264,9 @@ class Flag(object):
         if value is not None:
             try:
                 self.value = self.mapping[value]
-            except KeyError:
-                raise ValueError("flag must be None or one of " + str(self.mapping.keys()))
+            except KeyError as e:
+                errmsg = "flag must be None or one of " + str(self.mapping.keys())
+                raise ValueError(errmsg) from e
         return self.get()
 
     def prop(self):

--- a/package/MDAnalysis/core/__init__.py
+++ b/package/MDAnalysis/core/__init__.py
@@ -266,7 +266,7 @@ class Flag(object):
                 self.value = self.mapping[value]
             except KeyError:
                 six.raise_from(
-                    ValueError("flag must be None or one of " + str(self.mapping.keys()),
+                    ValueError("flag must be None or one of " + str(self.mapping.keys())),
                     None)
 
         return self.get()

--- a/package/MDAnalysis/core/__init__.py
+++ b/package/MDAnalysis/core/__init__.py
@@ -264,9 +264,9 @@ class Flag(object):
         if value is not None:
             try:
                 self.value = self.mapping[value]
-            except KeyError as e:
+            except KeyError:
                 errmsg = "flag must be None or one of " + str(self.mapping.keys())
-                raise ValueError(errmsg) from e
+                six.raise_from(ValueError(errmsg), None)
         return self.get()
 
     def prop(self):

--- a/package/MDAnalysis/core/__init__.py
+++ b/package/MDAnalysis/core/__init__.py
@@ -265,8 +265,10 @@ class Flag(object):
             try:
                 self.value = self.mapping[value]
             except KeyError:
-                errmsg = "flag must be None or one of " + str(self.mapping.keys())
-                six.raise_from(ValueError(errmsg), None)
+                six.raise_from(
+                    ValueError("flag must be None or one of " + str(self.mapping.keys()),
+                    None)
+
         return self.get()
 
     def prop(self):

--- a/package/MDAnalysis/core/_get_readers.py
+++ b/package/MDAnalysis/core/_get_readers.py
@@ -235,7 +235,8 @@ def get_parser_for(filename, format=None):
         try:
             rdr = get_reader_for(filename)
         except ValueError:
-            errmsg = (
+            raise_from(
+                ValueError(
                 "'{0}' isn't a valid topology format, nor a coordinate format\n"
                 "   from which a topology can be minimally inferred.\n"
                 "   You can use 'Universe(topology, ..., topology_format=FORMAT)'\n"
@@ -244,7 +245,7 @@ def get_parser_for(filename, format=None):
                 "   {1}\n"
                 "   See https://docs.mdanalysis.org/documentation_pages/topology/init.html#supported-topology-formats\n"
                 "   For missing formats, raise an issue at \n"
-                "   http://issues.mdanalysis.org".format(format, _PARSERS.keys()))
-            raise_from(ValueError(errmsg), None)
+                "   http://issues.mdanalysis.org".format(format, _PARSERS.keys())),
+                None)
         else:
             return _PARSERS['MINIMAL']

--- a/package/MDAnalysis/core/_get_readers.py
+++ b/package/MDAnalysis/core/_get_readers.py
@@ -96,7 +96,7 @@ def get_reader_for(filename, format=None):
     format = format.upper()
     try:
         return _READERS[format]
-    except KeyError:
+    except KeyError as e:
         raise ValueError(
             "Unknown coordinate trajectory format '{0}' for '{1}'. The FORMATs \n"
             "           {2}\n"
@@ -105,7 +105,7 @@ def get_reader_for(filename, format=None):
             "           Use the format keyword to explicitly set the format: 'Universe(...,format=FORMAT)'\n"
             "           For missing formats, raise an issue at "
             "http://issues.mdanalysis.org".format(
-                format, filename, _READERS.keys()))
+                format, filename, _READERS.keys())) from e
 
 
 def get_writer_for(filename, format=None, multiframe=None):
@@ -163,13 +163,13 @@ def get_writer_for(filename, format=None, multiframe=None):
     elif format is None:
         try:
             root, ext = util.get_ext(filename)
-        except (TypeError, AttributeError):
+        except (TypeError, AttributeError) as e:
             # An AttributeError is raised if filename cannot
             # be manipulated as a string.
             # A TypeError is raised in py3.6
             # "TypeError: expected str, bytes or os.PathLike object"
             raise ValueError('File format could not be guessed from "{0}"'
-                             .format(filename))
+                             .format(filename)) from e
         else:
             format = util.check_compressed_format(root, ext)
     format = format.upper()
@@ -191,8 +191,8 @@ def get_writer_for(filename, format=None, multiframe=None):
 
     try:
         return options[format]
-    except KeyError:
-        raise TypeError(errmsg.format(format))
+    except KeyError as e:
+        raise TypeError(errmsg.format(format)) from e
 
 
 def get_parser_for(filename, format=None):
@@ -230,8 +230,8 @@ def get_parser_for(filename, format=None):
     except KeyError:
         try:
             rdr = get_reader_for(filename)
-        except ValueError:
-            raise ValueError(
+        except ValueError as e:
+            errmsg = (
                 "'{0}' isn't a valid topology format, nor a coordinate format\n"
                 "   from which a topology can be minimally inferred.\n"
                 "   You can use 'Universe(topology, ..., topology_format=FORMAT)'\n"
@@ -241,5 +241,6 @@ def get_parser_for(filename, format=None):
                 "   See https://docs.mdanalysis.org/documentation_pages/topology/init.html#supported-topology-formats\n"
                 "   For missing formats, raise an issue at \n"
                 "   http://issues.mdanalysis.org".format(format, _PARSERS.keys()))
+            raise ValueError(errmsg) from e
         else:
             return _PARSERS['MINIMAL']

--- a/package/MDAnalysis/core/_get_readers.py
+++ b/package/MDAnalysis/core/_get_readers.py
@@ -20,6 +20,7 @@ circular imports.
 
 """
 from __future__ import absolute_import
+from six import raise_from
 
 import copy
 import inspect
@@ -96,8 +97,8 @@ def get_reader_for(filename, format=None):
     format = format.upper()
     try:
         return _READERS[format]
-    except KeyError as e:
-        raise ValueError(
+    except KeyError:
+        raise_from(ValueError(
             "Unknown coordinate trajectory format '{0}' for '{1}'. The FORMATs \n"
             "           {2}\n"
             "           are implemented in MDAnalysis.\n"
@@ -105,7 +106,8 @@ def get_reader_for(filename, format=None):
             "           Use the format keyword to explicitly set the format: 'Universe(...,format=FORMAT)'\n"
             "           For missing formats, raise an issue at "
             "http://issues.mdanalysis.org".format(
-                format, filename, _READERS.keys())) from e
+                format, filename, _READERS.keys())),
+                   None)
 
 
 def get_writer_for(filename, format=None, multiframe=None):
@@ -163,13 +165,15 @@ def get_writer_for(filename, format=None, multiframe=None):
     elif format is None:
         try:
             root, ext = util.get_ext(filename)
-        except (TypeError, AttributeError) as e:
+        except (TypeError, AttributeError):
             # An AttributeError is raised if filename cannot
             # be manipulated as a string.
             # A TypeError is raised in py3.6
             # "TypeError: expected str, bytes or os.PathLike object"
-            raise ValueError('File format could not be guessed from "{0}"'
-                             .format(filename)) from e
+            raise_from(
+                ValueError('File format could not be guessed from "{0}"'
+                             .format(filename)),
+                None)
         else:
             format = util.check_compressed_format(root, ext)
     format = format.upper()
@@ -191,8 +195,8 @@ def get_writer_for(filename, format=None, multiframe=None):
 
     try:
         return options[format]
-    except KeyError as e:
-        raise TypeError(errmsg.format(format)) from e
+    except KeyError:
+        raise_from(TypeError(errmsg.format(format)), None)
 
 
 def get_parser_for(filename, format=None):
@@ -230,7 +234,7 @@ def get_parser_for(filename, format=None):
     except KeyError:
         try:
             rdr = get_reader_for(filename)
-        except ValueError as e:
+        except ValueError:
             errmsg = (
                 "'{0}' isn't a valid topology format, nor a coordinate format\n"
                 "   from which a topology can be minimally inferred.\n"
@@ -241,6 +245,6 @@ def get_parser_for(filename, format=None):
                 "   See https://docs.mdanalysis.org/documentation_pages/topology/init.html#supported-topology-formats\n"
                 "   For missing formats, raise an issue at \n"
                 "   http://issues.mdanalysis.org".format(format, _PARSERS.keys()))
-            raise ValueError(errmsg) from e
+            raise_from(ValueError(errmsg), None)
         else:
             return _PARSERS['MINIMAL']

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -335,11 +335,12 @@ class _MutableBase(object):
                                   for parent in cls.mro()
                                   if parent in u._class_bases)
             except StopIteration:
-                raise TypeError("Attempted to instantiate class '{}' but "
+                raise_from(TypeError("Attempted to instantiate class '{}' but "
                                 "none of its parents are known to the "
                                 "universe. Currently possible parent "
                                 "classes are: {}".format(cls.__name__,
-                                    str(sorted(u._class_bases.keys()))))
+                                    str(sorted(u._class_bases.keys())))),
+                           None)
             newcls = u._classes[cls] = parent_cls._mix(cls)
             return object.__new__(newcls)
 
@@ -1494,8 +1495,10 @@ class GroupBase(_MutableBase):
                     try:
                         compound_indices = atoms.fragindices
                     except NoDataError:
-                        raise NoDataError("Cannot use compound='fragments', "
-                                          "this requires bonds.") from None
+                        raise_from(
+                            NoDataError("Cannot use compound='fragments', "
+                                        "this requires bonds."),
+                            None)
 
                 # compute required shifts:
                 if ctr == 'com':
@@ -2546,7 +2549,7 @@ class AtomGroup(GroupBase):
         try:
             return ts.forces[self.ix]
         except (AttributeError, NoDataError):
-            raise NoDataError("Timestep does not contain forces") from None
+            raise_from(NoDataError("Timestep does not contain forces"), None)
 
     @forces.setter
     def forces(self, values):
@@ -2554,7 +2557,7 @@ class AtomGroup(GroupBase):
         try:
             ts.forces[self.ix, :] = values
         except (AttributeError, NoDataError):
-            raise NoDataError("Timestep does not contain forces") from None
+            raise_from(NoDataError("Timestep does not contain forces"), None)
 
     @property
     def ts(self):
@@ -3669,7 +3672,7 @@ class Atom(ComponentBase):
         try:
             ts.velocities[self.ix, :] = values
         except (AttributeError, NoDataError):
-            raise NoDataError("Timestep does not contain velocities") from None
+            raise_from(NoDataError("Timestep does not contain velocities"), None)
 
     @property
     def force(self):
@@ -3700,7 +3703,7 @@ class Atom(ComponentBase):
         try:
             ts.forces[self.ix, :] = values
         except (AttributeError, NoDataError):
-            raise NoDataError("Timestep does not contain forces") from None
+            raise_from(NoDataError("Timestep does not contain forces"), None)
 
 
 class Residue(ComponentBase):

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -2904,11 +2904,13 @@ class AtomGroup(GroupBase):
                              'topology format in use.'.format(level)),
                        None)
         except KeyError:
-            errmsg = (
-                "level = '{0}' not supported, "
-                "must be one of {1}".format(level, accessors.keys())
-                )
-            raise_from(ValueError(errmsg), None)
+            raise_from(
+                ValueError(
+                    (
+                        "level = '{0}' not supported, "
+                        "must be one of {1}").format(level, accessors.keys())
+                        ),
+                None)
 
         return [self[levelindices == index] for index in
                 unique_int_1d(levelindices)]

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -774,15 +774,15 @@ class GroupBase(_MutableBase):
         elif comp == 'molecules':
             try:
                 compound_indices = atoms.molnums
-            except AttributeError as e:
+            except AttributeError:
                 raise NoDataError("Cannot use compound='molecules': "
-                                  "No molecule information in topology.") from e
+                                  "No molecule information in topology.") from None
         elif comp == 'fragments':
             try:
                 compound_indices = atoms.fragindices
-            except NoDataError as e:
+            except NoDataError:
                 raise NoDataError("Cannot use compound='fragments': "
-                                  "No bond information in topology.") from e
+                                  "No bond information in topology.") from None
         else:
             raise ValueError("Unrecognized compound definition: {}\nPlease use"
                              " one of 'group', 'residues', 'segments', "
@@ -984,15 +984,15 @@ class GroupBase(_MutableBase):
         elif comp == 'molecules':
             try:
                 compound_indices = atoms.molnums
-            except AttributeError as e:
+            except AttributeError:
                 raise NoDataError("Cannot use compound='molecules': "
-                                  "No molecule information in topology.") from e
+                                  "No molecule information in topology.") from None
         elif comp == 'fragments':
             try:
                 compound_indices = atoms.fragindices
-            except NoDataError as e:
+            except NoDataError:
                 raise NoDataError("Cannot use compound='fragments': "
-                                  "No bond information in topology.") from e
+                                  "No bond information in topology.") from None
         else:
             raise ValueError("Unrecognized compound definition: '{}'. Please "
                              "use one of 'group', 'residues', 'segments', "
@@ -1479,15 +1479,15 @@ class GroupBase(_MutableBase):
                 elif comp == 'molecules':
                     try:
                         compound_indices = atoms.molnums
-                    except AttributeError as e:
+                    except AttributeError:
                         raise NoDataError("Cannot use compound='molecules', "
-                                          "this requires molnums.") from e
+                                          "this requires molnums.") from None
                 else:  # comp == 'fragments'
                     try:
                         compound_indices = atoms.fragindices
-                    except NoDataError as e:
+                    except NoDataError:
                         raise NoDataError("Cannot use compound='fragments', "
-                                          "this requires bonds.") from e
+                                          "this requires bonds.") from None
 
                 # compute required shifts:
                 if ctr == 'com':
@@ -1641,9 +1641,9 @@ class GroupBase(_MutableBase):
             else:  # comp == 'molecules'
                 try:
                     compound_indices = unique_atoms.molnums
-                except AttributeError as e:
+                except AttributeError:
                     raise NoDataError("Cannot use compound='molecules', this "
-                                      "requires molnums.") from e
+                                      "requires molnums.") from None
             # Now process every compound:
             unique_compound_indices = unique_int_1d(compound_indices)
             positions = unique_atoms.positions
@@ -2503,16 +2503,16 @@ class AtomGroup(GroupBase):
         ts = self.universe.trajectory.ts
         try:
             return np.array(ts.velocities[self.ix])
-        except (AttributeError, NoDataError) as e:
-            raise NoDataError("Timestep does not contain velocities") from e
+        except (AttributeError, NoDataError):
+            raise NoDataError("Timestep does not contain velocities") from None
 
     @velocities.setter
     def velocities(self, values):
         ts = self.universe.trajectory.ts
         try:
             ts.velocities[self.ix, :] = values
-        except (AttributeError, NoDataError) as e:
-            raise NoDataError("Timestep does not contain velocities") from e
+        except (AttributeError, NoDataError):
+            raise NoDataError("Timestep does not contain velocities") from None
 
     @property
     def forces(self):
@@ -2537,16 +2537,16 @@ class AtomGroup(GroupBase):
         ts = self.universe.trajectory.ts
         try:
             return ts.forces[self.ix]
-        except (AttributeError, NoDataError) as e:
-            raise NoDataError("Timestep does not contain forces") from e
+        except (AttributeError, NoDataError):
+            raise NoDataError("Timestep does not contain forces") from None
 
     @forces.setter
     def forces(self, values):
         ts = self.universe.trajectory.ts
         try:
             ts.forces[self.ix, :] = values
-        except (AttributeError, NoDataError) as e:
-            raise NoDataError("Timestep does not contain forces") from e
+        except (AttributeError, NoDataError):
+            raise NoDataError("Timestep does not contain forces") from None
 
     @property
     def ts(self):
@@ -3648,16 +3648,16 @@ class Atom(ComponentBase):
         ts = self.universe.trajectory.ts
         try:
             return ts.velocities[self.ix].copy()
-        except (AttributeError, NoDataError) as e:
-            raise NoDataError("Timestep does not contain velocities") from e
+        except (AttributeError, NoDataError):
+            raise NoDataError("Timestep does not contain velocities") from None
 
     @velocity.setter
     def velocity(self, values):
         ts = self.universe.trajectory.ts
         try:
             ts.velocities[self.ix, :] = values
-        except (AttributeError, NoDataError) as e:
-            raise NoDataError("Timestep does not contain velocities") from e
+        except (AttributeError, NoDataError):
+            raise NoDataError("Timestep does not contain velocities") from None
 
     @property
     def force(self):
@@ -3679,16 +3679,16 @@ class Atom(ComponentBase):
         ts = self.universe.trajectory.ts
         try:
             return ts.forces[self.ix].copy()
-        except (AttributeError, NoDataError) as e:
-            raise NoDataError("Timestep does not contain forces") from e
+        except (AttributeError, NoDataError):
+            raise NoDataError("Timestep does not contain forces") from None
 
     @force.setter
     def force(self, values):
         ts = self.universe.trajectory.ts
         try:
             ts.forces[self.ix, :] = values
-        except (AttributeError, NoDataError) as e:
-            raise NoDataError("Timestep does not contain forces") from e
+        except (AttributeError, NoDataError):
+            raise NoDataError("Timestep does not contain forces") from None
 
 
 class Residue(ComponentBase):

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -122,12 +122,16 @@ def _unpickle(uhash, ix):
     except KeyError:
         # doesn't provide as nice an error message as before as only hash of universe is stored
         # maybe if we pickled the filename too we could do better...
-        errmsg = (
-            "Couldn't find a suitable Universe to unpickle AtomGroup onto "
-            "with Universe hash '{}'.  Available hashes: {}"
-            "".format(uhash, ', '.join([str(k)
-                                        for k in _ANCHOR_UNIVERSES.keys()])))
-        raise_from(RuntimeError(errmsg), None)
+        raise_from(
+            RuntimeError(
+                "Couldn't find a suitable Universe to unpickle AtomGroup onto "
+                "with Universe hash '{}'.  Available hashes: {}"
+                "".format(
+                    uhash,
+                    ', '.join([str(k) for k in _ANCHOR_UNIVERSES.keys()])
+                    )
+                ),
+            None)
     return u.atoms[ix]
 
 def _unpickle_uag(basepickle, selections, selstrs):
@@ -3258,12 +3262,15 @@ class ResidueGroup(GroupBase):
             try:
                 s_ix = [s.segindex for s in new]
             except AttributeError:
-                errmsg = ("Can only set ResidueGroup segments to Segment "
-                                "or SegmentGroup, not {}".format(
-                                    ', '.join(type(r) for r in new
+                raise_from(
+                    TypeError(
+                        "Can only set ResidueGroup segments to Segment "
+                        "or SegmentGroup, not {}".format(
+                            ', '.join(type(r) for r in new
                                               if not isinstance(r, Segment))
-                                ))
-                raise_from(TypeError(errmsg), None)
+                                )
+                        ),
+                    None)
         if not isinstance(s_ix, itertools.cycle) and len(s_ix) != len(self):
             raise ValueError("Incorrect size: {} for ResidueGroup of size: {}"
                              "".format(len(new), len(self)))

--- a/package/MDAnalysis/core/selection.py
+++ b/package/MDAnalysis/core/selection.py
@@ -722,7 +722,7 @@ class RangeSelection(Selection):
             try:
                 lower = int(val)
                 upper = None
-            except ValueError from e:
+            except ValueError as e:
                 # check if in appropriate format 'lower:upper' or 'lower-upper'
                 selrange = re.match("(\d+)[:-](\d+)", val)
                 if not selrange:

--- a/package/MDAnalysis/core/selection.py
+++ b/package/MDAnalysis/core/selection.py
@@ -488,8 +488,10 @@ class SelgroupSelection(Selection):
                             .format(grpname))
         try:
             self.grp = parser.selgroups[grpname]
-        except KeyError as e:
-            raise ValueError("Failed to find group: {0}".format(grpname)) from e
+        except KeyError:
+            six.raise_from(
+                ValueError("Failed to find group: {0}".format(grpname)),
+                None)
 
     def apply(self, group):
         mask = np.in1d(group.indices, self.grp.indices)
@@ -503,8 +505,10 @@ class FullSelgroupSelection(Selection):
         grpname = tokens.popleft()
         try:
             self.grp = parser.selgroups[grpname]
-        except KeyError as e:
-            raise ValueError("Failed to find group: {0}".format(grpname)) from e
+        except KeyError:
+            six.raise_from(
+                ValueError("Failed to find group: {0}".format(grpname)),
+                None)
 
     @deprecate(old_name='fullgroup', new_name='global group',
                message=' This will be removed in v0.15.0')
@@ -641,8 +645,8 @@ class ResidSelection(Selection):
             # if no icodes and icodes are part of selection, cause a fuss
             if (any(v[1] for v in self.uppers) or
                 any(v[1] for v in self.lowers)):
-                raise ValueError("Selection specified icodes, while the "
-                                 "topology doesn't have any.") from e
+                six.raise_from(ValueError("Selection specified icodes, while the "
+                                 "topology doesn't have any."), None)
 
         if not icodes is None:
             mask = self._sel_with_icodes(vals, icodes)
@@ -730,8 +734,8 @@ class RangeSelection(Selection):
                 # check if in appropriate format 'lower:upper' or 'lower-upper'
                 selrange = re.match("(\d+)[:-](\d+)", val)
                 if not selrange:
-                    raise ValueError(
-                        "Failed to parse number: {0}".format(val)) from e
+                    six.raise_from(ValueError(
+                        "Failed to parse number: {0}".format(val)), None)
                 lower, upper = np.int64(selrange.groups())
 
             lowers.append(lower)
@@ -1000,10 +1004,11 @@ class PropertySelection(Selection):
         self.prop = prop
         try:
             self.operator = self.ops[oper]
-        except KeyError as e:
-            raise ValueError(
+        except KeyError:
+            six.raise_from(ValueError(
                 "Invalid operator : '{0}' Use one of : '{1}'"
-                "".format(oper, self.ops.keys())) from e
+                "".format(oper, self.ops.keys())),
+                None)
         self.value = float(value)
 
     def apply(self, group):
@@ -1015,9 +1020,9 @@ class PropertySelection(Selection):
             elif self.prop == 'charge':
                 values = group.charges
             else:
-                raise SelectionError(
+                six.raise_from(SelectionError(
                     "Expected one of : {0}"
-                    "".format(['x', 'y', 'z', 'mass', 'charge'])) from None
+                    "".format(['x', 'y', 'z', 'mass', 'charge'])), None)
         else:
             values = group.positions[:, col]
 
@@ -1190,9 +1195,13 @@ class SelectionParser(object):
         try:
             return _SELECTIONDICT[op](self, self.tokens)
         except KeyError:
-            raise SelectionError("Unknown selection token: '{0}'".format(op)) from None
+            six.raise_from(
+                SelectionError("Unknown selection token: '{0}'".format(op)),
+                None)
         except ValueError as e:
-            raise SelectionError("Selection failed: '{0}'".format(e)) from None
+            six.raise_from(
+                SelectionError("Selection failed: '{0}'".format(e)),
+                None)
 
 
 # The module level instance

--- a/package/MDAnalysis/core/selection.py
+++ b/package/MDAnalysis/core/selection.py
@@ -1187,7 +1187,7 @@ class SelectionParser(object):
             return _SELECTIONDICT[op](self, self.tokens)
         except KeyError:
             raise SelectionError("Unknown selection token: '{0}'".format(op)) from None
-        except ValueError:
+        except ValueError as e:
             raise SelectionError("Selection failed: '{0}'".format(e)) from None
 
 

--- a/package/MDAnalysis/core/selection.py
+++ b/package/MDAnalysis/core/selection.py
@@ -1005,7 +1005,7 @@ class PropertySelection(Selection):
     def apply(self, group):
         try:
             col = {'x': 0, 'y': 1, 'z': 2}[self.prop]
-        except KeyError as e:
+        except KeyError:
             if self.prop == 'mass':
                 values = group.masses
             elif self.prop == 'charge':
@@ -1013,7 +1013,7 @@ class PropertySelection(Selection):
             else:
                 raise SelectionError(
                     "Expected one of : {0}"
-                    "".format(['x', 'y', 'z', 'mass', 'charge'])) from e
+                    "".format(['x', 'y', 'z', 'mass', 'charge'])) from None
         else:
             values = group.positions[:, col]
 
@@ -1185,10 +1185,10 @@ class SelectionParser(object):
 
         try:
             return _SELECTIONDICT[op](self, self.tokens)
-        except KeyError as e:
-            raise SelectionError("Unknown selection token: '{0}'".format(op)) from e
-        except ValueError as e:
-            raise SelectionError("Selection failed: '{0}'".format(e)) from e
+        except KeyError:
+            raise SelectionError("Unknown selection token: '{0}'".format(op)) from None
+        except ValueError:
+            raise SelectionError("Selection failed: '{0}'".format(e)) from None
 
 
 # The module level instance

--- a/package/MDAnalysis/core/selection.py
+++ b/package/MDAnalysis/core/selection.py
@@ -640,7 +640,7 @@ class ResidSelection(Selection):
         vals = group.resids
         try:  # optional attribute
             icodes = group.icodes
-        except (AttributeError, NoDataError) as e:
+        except (AttributeError, NoDataError):
             icodes = None
             # if no icodes and icodes are part of selection, cause a fuss
             if (any(v[1] for v in self.uppers) or
@@ -730,7 +730,7 @@ class RangeSelection(Selection):
             try:
                 lower = int(val)
                 upper = None
-            except ValueError as e:
+            except ValueError:
                 # check if in appropriate format 'lower:upper' or 'lower-upper'
                 selrange = re.match("(\d+)[:-](\d+)", val)
                 if not selrange:

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -486,9 +486,9 @@ class Atomnames(AtomAttr):
     def getattr__(atomgroup, name):
         try:
             return atomgroup._get_named_atom(name)
-        except selection.SelectionError:
+        except selection.SelectionError as e:
             raise AttributeError("'{0}' object has no attribute '{1}'".format(
-                    atomgroup.__class__.__name__, name))
+                    atomgroup.__class__.__name__, name)) from e
 
     def _get_named_atom(group, name):
         """Get all atoms with name *name* in the current AtomGroup.
@@ -1346,9 +1346,9 @@ class Resnames(ResidueAttr):
     def getattr__(residuegroup, resname):
         try:
             return residuegroup._get_named_residue(resname)
-        except selection.SelectionError:
+        except selection.SelectionError as e:
             raise AttributeError("'{0}' object has no attribute '{1}'".format(
-                    residuegroup.__class__.__name__, resname))
+                    residuegroup.__class__.__name__, resname)) from e
 
     transplants[ResidueGroup].append(('__getattr__', getattr__))
     # This transplant is hardcoded for now to allow for multiple getattr things
@@ -1483,7 +1483,7 @@ class Resnames(ResidueAttr):
         except KeyError as err:
             raise ValueError("AtomGroup contains a residue name '{0}' that "
                              "does not have a IUPAC protein 1-letter "
-                             "character".format(err.message))
+                             "character".format(err.message)) from err
         if format == "string":
             return sequence
         seq = Bio.Seq.Seq(sequence, alphabet=Bio.Alphabet.IUPAC.protein)
@@ -1588,9 +1588,9 @@ class Segids(SegmentAttr):
     def getattr__(segmentgroup, segid):
         try:
             return segmentgroup._get_named_segment(segid)
-        except selection.SelectionError:
+        except selection.SelectionError as e:
             raise AttributeError("'{0}' object has no attribute '{1}'".format(
-                    segmentgroup.__class__.__name__, segid))
+                    segmentgroup.__class__.__name__, segid)) from e
 
     transplants[SegmentGroup].append(
         ('__getattr__', getattr__))

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -486,9 +486,11 @@ class Atomnames(AtomAttr):
     def getattr__(atomgroup, name):
         try:
             return atomgroup._get_named_atom(name)
-        except selection.SelectionError as e:
-            raise AttributeError("'{0}' object has no attribute '{1}'".format(
-                    atomgroup.__class__.__name__, name)) from e
+        except selection.SelectionError:
+            six.raise_from(
+                AttributeError("'{0}' object has no attribute '{1}'".format(
+                    atomgroup.__class__.__name__, name)),
+                None)
 
     def _get_named_atom(group, name):
         """Get all atoms with name *name* in the current AtomGroup.
@@ -1346,9 +1348,11 @@ class Resnames(ResidueAttr):
     def getattr__(residuegroup, resname):
         try:
             return residuegroup._get_named_residue(resname)
-        except selection.SelectionError as e:
-            raise AttributeError("'{0}' object has no attribute '{1}'".format(
-                    residuegroup.__class__.__name__, resname)) from e
+        except selection.SelectionError:
+            six.raise_from(
+                AttributeError("'{0}' object has no attribute '{1}'".format(
+                    residuegroup.__class__.__name__, resname)),
+                    None)
 
     transplants[ResidueGroup].append(('__getattr__', getattr__))
     # This transplant is hardcoded for now to allow for multiple getattr things
@@ -1481,9 +1485,9 @@ class Resnames(ResidueAttr):
         try:
             sequence = "".join([convert_aa_code(r) for r in self.residues.resnames])
         except KeyError as err:
-            raise ValueError("AtomGroup contains a residue name '{0}' that "
+            six.raise_from(ValueError("AtomGroup contains a residue name '{0}' that "
                              "does not have a IUPAC protein 1-letter "
-                             "character".format(err.message)) from err
+                             "character".format(err.message)), None)
         if format == "string":
             return sequence
         seq = Bio.Seq.Seq(sequence, alphabet=Bio.Alphabet.IUPAC.protein)
@@ -1588,9 +1592,11 @@ class Segids(SegmentAttr):
     def getattr__(segmentgroup, segid):
         try:
             return segmentgroup._get_named_segment(segid)
-        except selection.SelectionError as e:
-            raise AttributeError("'{0}' object has no attribute '{1}'".format(
-                    segmentgroup.__class__.__name__, segid)) from e
+        except selection.SelectionError:
+            six.raise_from(
+                AttributeError("'{0}' object has no attribute '{1}'".format(
+                    segmentgroup.__class__.__name__, segid)),
+                None)
 
     transplants[SegmentGroup].append(
         ('__getattr__', getattr__))

--- a/package/MDAnalysis/core/topologyobjects.py
+++ b/package/MDAnalysis/core/topologyobjects.py
@@ -813,8 +813,11 @@ class TopologyGroup(object):
             return self._ags[2]
         except IndexError:
             nvert = _BTYPE_TO_SHAPE[self.btype]
-            errmsg = "TopologyGroup of {}s only has {} vertical AtomGroups"
-            raise_from(IndexError(errmsg.format(self.btype, nvert)), None)
+            raise_from(
+                IndexError(
+                    "TopologyGroup of {}s only has {} vertical AtomGroups".format(
+                        self.btype, nvert)),
+                None)
 
     @property
     def atom4(self):
@@ -823,8 +826,11 @@ class TopologyGroup(object):
             return self._ags[3]
         except IndexError:
             nvert = _BTYPE_TO_SHAPE[self.btype]
-            errmsg = "TopologyGroup of {}s only has {} vertical AtomGroups"
-            raise_from(IndexError(errmsg.format(self.btype, nvert)), None)
+            raise_from(
+                IndexError(
+                    "TopologyGroup of {}s only has {} vertical AtomGroups".format(
+                        self.btype, nvert)),
+                None)
 
     # Distance calculation methods below
     # "Slow" versions exist as a way of testing the Cython implementations

--- a/package/MDAnalysis/core/topologyobjects.py
+++ b/package/MDAnalysis/core/topologyobjects.py
@@ -31,6 +31,7 @@ The building blocks for MDAnalysis' description of topology
 from __future__ import print_function, absolute_import, division
 
 from six.moves import zip
+from six import raise_from
 import numbers
 import numpy as np
 import functools
@@ -810,20 +811,20 @@ class TopologyGroup(object):
         """The third atom in each TopologyObject in this Group"""
         try:
             return self._ags[2]
-        except IndexError as e:
+        except IndexError:
             nvert = _BTYPE_TO_SHAPE[self.btype]
             errmsg = "TopologyGroup of {}s only has {} vertical AtomGroups"
-            raise IndexError(errmsg.format(self.btype, nvert)) from e
+            raise_from(IndexError(errmsg.format(self.btype, nvert)), None)
 
     @property
     def atom4(self):
         """The fourth atom in each TopologyObject in this Group"""
         try:
             return self._ags[3]
-        except IndexError as e:
+        except IndexError:
             nvert = _BTYPE_TO_SHAPE[self.btype]
             errmsg = "TopologyGroup of {}s only has {} vertical AtomGroups"
-            raise IndexError(errmsg.format(self.btype, nvert)) from e
+            raise_from(IndexError(errmsg.format(self.btype, nvert)), None)
 
     # Distance calculation methods below
     # "Slow" versions exist as a way of testing the Cython implementations

--- a/package/MDAnalysis/core/topologyobjects.py
+++ b/package/MDAnalysis/core/topologyobjects.py
@@ -810,20 +810,20 @@ class TopologyGroup(object):
         """The third atom in each TopologyObject in this Group"""
         try:
             return self._ags[2]
-        except IndexError:
+        except IndexError as e:
             nvert = _BTYPE_TO_SHAPE[self.btype]
-            raise IndexError("TopologyGroup of {}s only has {} vertical AtomGroups"
-                             "".format(self.btype, nvert))
+            errmsg = "TopologyGroup of {}s only has {} vertical AtomGroups"
+            raise IndexError(errmsg.format(self.btype, nvert)) from e
 
     @property
     def atom4(self):
         """The fourth atom in each TopologyObject in this Group"""
         try:
             return self._ags[3]
-        except IndexError:
+        except IndexError as e:
             nvert = _BTYPE_TO_SHAPE[self.btype]
-            raise IndexError("TopologyGroup of {}s only has {} vertical AtomGroups"
-                             "".format(self.btype, nvert))
+            errmsg = "TopologyGroup of {}s only has {} vertical AtomGroups"
+            raise IndexError(errmsg.format(self.btype, nvert)) from e
 
     # Distance calculation methods below
     # "Slow" versions exist as a way of testing the Cython implementations

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -300,11 +300,11 @@ class Universe(object):
                         six.reraise(*sys.exc_info())
                     else:
                         # Runs when the parser fails
-                        errmsg = (
+                        six.raise_from(IOError(
                             "Failed to load from the topology file {0}"
                             " with parser {1}.\n"
-                            "Error: {2}".format(self.filename, parser, err))
-                        six.raise_from(IOError(errmsg), None)
+                            "Error: {2}".format(self.filename, parser, err)),
+                            None)
                 except (ValueError, NotImplementedError) as err:
                     six.raise_from(ValueError(
                         "Failed to construct topology from file {0}"
@@ -861,14 +861,13 @@ class Universe(object):
             try:
                 tcls = _TOPOLOGY_ATTRS[topologyattr]
             except KeyError:
-                errmsg = (
+                six.raise_from(ValueError(
                     "Unrecognised topology attribute name: '{}'."
                     "  Possible values: '{}'\n"
                     "To raise an issue go to: http://issues.mdanalysis.org"
                     "".format(
-                        topologyattr, ', '.join(sorted(_TOPOLOGY_ATTRS.keys())))
-                )
-                six.raise_from(ValueError(errmsg), None)
+                        topologyattr, ', '.join(sorted(_TOPOLOGY_ATTRS.keys())))),
+                    None)
             else:
                 topologyattr = tcls.from_blank(
                     n_atoms=self._topology.n_atoms,

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -309,7 +309,7 @@ class Universe(object):
                     raise ValueError(
                         "Failed to construct topology from file {0}"
                         " with parser {1}.\n"
-                        "Error: {2}".format(self.filename, parser, err)) from e
+                        "Error: {2}".format(self.filename, parser, err)) from err
 
             # generate and populate Universe version of each class
             self._generate_from_topology()

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -304,12 +304,12 @@ class Universe(object):
                             "Failed to load from the topology file {0}"
                             " with parser {1}.\n"
                             "Error: {2}".format(self.filename, parser, err))
-                        raise IOError(errmsg) from err
+                        six.raise_from(IOError(errmsg), None)
                 except (ValueError, NotImplementedError) as err:
-                    raise ValueError(
+                    six.raise_from(ValueError(
                         "Failed to construct topology from file {0}"
                         " with parser {1}.\n"
-                        "Error: {2}".format(self.filename, parser, err)) from err
+                        "Error: {2}".format(self.filename, parser, err)), None)
 
             # generate and populate Universe version of each class
             self._generate_from_topology()
@@ -509,8 +509,8 @@ class Universe(object):
         # created at the beginning of __init__.
         try:
             segment = self._instant_selectors[key]
-        except KeyError as e:
-            raise AttributeError('No attribute "{}".'.format(key)) from e
+        except KeyError:
+            six.raise_from(AttributeError('No attribute "{}".'.format(key)), None)
         else:
             warnings.warn("Instant selector Universe.<segid> "
                           "is deprecated and will be removed in 1.0. "
@@ -860,7 +860,7 @@ class Universe(object):
         if isinstance(topologyattr, six.string_types):
             try:
                 tcls = _TOPOLOGY_ATTRS[topologyattr]
-            except KeyError as e:
+            except KeyError:
                 errmsg = (
                     "Unrecognised topology attribute name: '{}'."
                     "  Possible values: '{}'\n"
@@ -868,7 +868,7 @@ class Universe(object):
                     "".format(
                         topologyattr, ', '.join(sorted(_TOPOLOGY_ATTRS.keys())))
                 )
-                raise ValueError(errmsg) from e
+                six.raise_from(ValueError(errmsg), None)
             else:
                 topologyattr = tcls.from_blank(
                     n_atoms=self._topology.n_atoms,

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -300,15 +300,16 @@ class Universe(object):
                         six.reraise(*sys.exc_info())
                     else:
                         # Runs when the parser fails
-                        raise IOError(
+                        errmsg = (
                             "Failed to load from the topology file {0}"
                             " with parser {1}.\n"
                             "Error: {2}".format(self.filename, parser, err))
+                        raise IOError(errmsg) from err
                 except (ValueError, NotImplementedError) as err:
                     raise ValueError(
                         "Failed to construct topology from file {0}"
                         " with parser {1}.\n"
-                        "Error: {2}".format(self.filename, parser, err))
+                        "Error: {2}".format(self.filename, parser, err)) from e
 
             # generate and populate Universe version of each class
             self._generate_from_topology()
@@ -508,8 +509,8 @@ class Universe(object):
         # created at the beginning of __init__.
         try:
             segment = self._instant_selectors[key]
-        except KeyError:
-            raise AttributeError('No attribute "{}".'.format(key))
+        except KeyError as e:
+            raise AttributeError('No attribute "{}".'.format(key)) from e
         else:
             warnings.warn("Instant selector Universe.<segid> "
                           "is deprecated and will be removed in 1.0. "
@@ -859,14 +860,15 @@ class Universe(object):
         if isinstance(topologyattr, six.string_types):
             try:
                 tcls = _TOPOLOGY_ATTRS[topologyattr]
-            except KeyError:
-                raise ValueError(
+            except KeyError as e:
+                errmsg = (
                     "Unrecognised topology attribute name: '{}'."
                     "  Possible values: '{}'\n"
                     "To raise an issue go to: http://issues.mdanalysis.org"
                     "".format(
                         topologyattr, ', '.join(sorted(_TOPOLOGY_ATTRS.keys())))
                 )
+                raise ValueError(errmsg) from e
             else:
                 topologyattr = tcls.from_blank(
                     n_atoms=self._topology.n_atoms,

--- a/package/MDAnalysis/lib/distances.py
+++ b/package/MDAnalysis/lib/distances.py
@@ -100,9 +100,11 @@ def _run(funcname, args=None, kwargs=None, backend="serial"):
     try:
         func = getattr(_distances[backend], funcname)
     except KeyError:
-        errmsg = ("Function {0} not available with backend {1}; try one "
-                  "of: {2}".format(funcname, backend, _distances.keys()))
-        raise_from(ValueError(errmsg), None)
+        raise_from(
+            ValueError(
+                "Function {0} not available with backend {1}; try one "
+                "of: {2}".format(funcname, backend, _distances.keys())),
+            None)
     return func(*args, **kwargs)
 
 # serial versions are always available (and are typically used within

--- a/package/MDAnalysis/lib/distances.py
+++ b/package/MDAnalysis/lib/distances.py
@@ -98,9 +98,10 @@ def _run(funcname, args=None, kwargs=None, backend="serial"):
     backend = backend.lower()
     try:
         func = getattr(_distances[backend], funcname)
-    except KeyError:
-        raise ValueError("Function {0} not available with backend {1}; try one "
-                         "of: {2}".format(funcname, backend, _distances.keys()))
+    except KeyError as e:
+        errmsg = ("Function {0} not available with backend {1}; try one "
+                  "of: {2}".format(funcname, backend, _distances.keys()))
+        raise ValueError(errmsg) from e
     return func(*args, **kwargs)
 
 # serial versions are always available (and are typically used within

--- a/package/MDAnalysis/lib/distances.py
+++ b/package/MDAnalysis/lib/distances.py
@@ -68,6 +68,7 @@ Functions
 """
 from __future__ import division, absolute_import
 from six.moves import range
+from six import raise_from
 
 import numpy as np
 from numpy.lib.utils import deprecate
@@ -98,10 +99,10 @@ def _run(funcname, args=None, kwargs=None, backend="serial"):
     backend = backend.lower()
     try:
         func = getattr(_distances[backend], funcname)
-    except KeyError as e:
+    except KeyError:
         errmsg = ("Function {0} not available with backend {1}; try one "
                   "of: {2}".format(funcname, backend, _distances.keys()))
-        raise ValueError(errmsg) from e
+        raise_from(ValueError(errmsg), None)
     return func(*args, **kwargs)
 
 # serial versions are always available (and are typically used within

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -1694,9 +1694,11 @@ class Namespace(dict):
     def __delattr__(self, key):
         try:
             dict.__delitem__(self, key)
-        except KeyError as e:
-            raise AttributeError('"{}" is not known in the namespace.'
-                                 .format(key)) from e
+        except KeyError:
+            six.raise_from(
+                AttributeError('"{}" is not known in the namespace.'
+                                 .format(key)),
+                None)
 
     def __eq__(self, other):
         try:

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -850,9 +850,9 @@ class NamedStream(io.IOBase, PathLike):
         """
         try:
             return self.stream.fileno()
-        except AttributeError:
+        except AttributeError as e:
             # IOBase.fileno does not raise IOError as advertised so we do this here
-            raise IOError("This NamedStream does not use a file descriptor.")
+            raise IOError("This NamedStream does not use a file descriptor.") from e
 
     def readline(self):
         try:
@@ -955,9 +955,9 @@ def check_compressed_format(root, ext):
     if ext.lower() in ("bz2", "gz"):
         try:
             root, ext = get_ext(root)
-        except:
+        except Exception as e:
             raise TypeError("Cannot determine coordinate format for '{0}.{1}'"
-                            "".format(root, ext))
+                            "".format(root, ext)) from e
 
     return ext.upper()
 
@@ -980,11 +980,11 @@ def format_from_filename_extension(filename):
     """
     try:
         root, ext = get_ext(filename)
-    except:
+    except Exception as e:
         raise TypeError(
             "Cannot determine file format for file '{0}'.\n"
             "           You can set the format explicitly with "
-            "'Universe(..., format=FORMAT)'.".format(filename))
+            "'Universe(..., format=FORMAT)'.".format(filename)) from e
     format = check_compressed_format(root, ext)
     return format
 
@@ -1020,10 +1020,10 @@ def guess_format(filename):
         # perhaps StringIO or open stream
         try:
             format = format_from_filename_extension(filename.name)
-        except AttributeError:
+        except AttributeError as e:
             # format is None so we need to complain:
             raise ValueError("guess_format requires an explicit format specifier "
-                             "for stream {0}".format(filename))
+                             "for stream {0}".format(filename)) from e
     else:
         # iterator, list, filename: simple extension checking... something more
         # complicated is left for the ambitious.
@@ -1109,8 +1109,9 @@ class FixedcolumnEntry(object):
         """Read the entry from `line` and convert to appropriate type."""
         try:
             return self.convertor(line[self.start:self.stop])
-        except ValueError:
-            raise ValueError("{0!r}: Failed to read&convert {1!r}".format(self, line[self.start:self.stop]))
+        except ValueError as e:
+            errmsg = "{0!r}: Failed to read&convert {1!r}".format(self, line[self.start:self.stop])
+            raise ValueError(errmsg) from e
 
     def __len__(self):
         """Length of the field in columns (stop - start)"""
@@ -1343,8 +1344,8 @@ def get_weights(atoms, weights):
     if not iterable(weights) and weights == "mass":
         try:
             weights = atoms.masses
-        except AttributeError:
-            raise TypeError("weights='mass' selected but atoms.masses is missing")
+        except AttributeError as e:
+            raise TypeError("weights='mass' selected but atoms.masses is missing") from e
 
     if iterable(weights):
         if len(np.asarray(weights).shape) != 1:
@@ -1423,8 +1424,9 @@ def convert_aa_code(x):
 
     try:
         return d[x.upper()]
-    except KeyError:
-        raise ValueError("No conversion for {0} found (1 letter -> 3 letter or 3/4 letter -> 1 letter)".format(x))
+    except KeyError as e:
+        errmsg = "No conversion for {0} found (1 letter -> 3 letter or 3/4 letter -> 1 letter)".format(x)
+        raise ValueError(errmsg) from e
 
 
 #: Regular expression to match and parse a residue-atom selection; will match
@@ -1673,9 +1675,9 @@ class Namespace(dict):
         # a.this causes a __getattr__ call for key = 'this'
         try:
             return dict.__getitem__(self, key)
-        except KeyError:
+        except KeyError as e:
             raise AttributeError('"{}" is not known in the namespace.'
-                                 .format(key))
+                                 .format(key)) from e
 
     def __setattr__(self, key, value):
         dict.__setitem__(self, key, value)
@@ -1683,9 +1685,9 @@ class Namespace(dict):
     def __delattr__(self, key):
         try:
             dict.__delitem__(self, key)
-        except KeyError:
+        except KeyError as e:
             raise AttributeError('"{}" is not known in the namespace.'
-                                 .format(key))
+                                 .format(key)) from e
 
     def __eq__(self, other):
         try:
@@ -1990,9 +1992,10 @@ def check_coords(*coord_names, **options):
                                      "".format(fname, argname, coords.shape))
             try:
                 coords = coords.astype(np.float32, order='C', copy=enforce_copy)
-            except ValueError:
-                raise TypeError("{}(): {}.dtype must be convertible to float32,"
-                                " got {}.".format(fname, argname, coords.dtype))
+            except ValueError as e:
+                errmsg = ("{}(): {}.dtype must be convertible to float32,"
+                          " got {}.".format(fname, argname, coords.dtype))
+                raise TypeError(errmsg) from e
             return coords, is_single
 
         @wraps(func)

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -1117,8 +1117,11 @@ class FixedcolumnEntry(object):
         try:
             return self.convertor(line[self.start:self.stop])
         except ValueError:
-            errmsg = "{0!r}: Failed to read&convert {1!r}".format(self, line[self.start:self.stop])
-            six.raise_from(ValueError(errmsg), None)
+            six.raise_from(
+                ValueError(
+                    "{0!r}: Failed to read&convert {1!r}".format(
+                        self, line[self.start:self.stop])),
+                None)
 
     def __len__(self):
         """Length of the field in columns (stop - start)"""
@@ -1434,8 +1437,11 @@ def convert_aa_code(x):
     try:
         return d[x.upper()]
     except KeyError:
-        errmsg = "No conversion for {0} found (1 letter -> 3 letter or 3/4 letter -> 1 letter)".format(x)
-        six.raise_from(ValueError(errmsg), None)
+        six.raise_from(
+            ValueError(
+                "No conversion for {0} found (1 letter -> 3 letter or 3/4 letter -> 1 letter)".format(x)
+                ),
+            None)
 
 
 #: Regular expression to match and parse a residue-atom selection; will match
@@ -2004,9 +2010,11 @@ def check_coords(*coord_names, **options):
             try:
                 coords = coords.astype(np.float32, order='C', copy=enforce_copy)
             except ValueError:
-                errmsg = ("{}(): {}.dtype must be convertible to float32,"
-                          " got {}.".format(fname, argname, coords.dtype))
-                six.raise_from(TypeError(errmsg), None)
+                six.raise_from(
+                    TypeError(
+                        "{}(): {}.dtype must be convertible to float32,"
+                        " got {}.".format(fname, argname, coords.dtype)),
+                    None)
             return coords, is_single
 
         @wraps(func)

--- a/package/MDAnalysis/selections/__init__.py
+++ b/package/MDAnalysis/selections/__init__.py
@@ -45,6 +45,7 @@ exception of `:func:get_writer`:
 .. autofunction:: get_writer
 """
 from __future__ import absolute_import
+from six import raise_from
 
 import os.path
 
@@ -84,7 +85,8 @@ def get_writer(filename, defaultformat):
     format = format.strip().upper()  # canonical for lookup
     try:
         return _SELECTION_WRITERS[format]
-    except KeyError as e:
-        raise NotImplementedError(
+    except KeyError:
+        raise_from(NotImplementedError(
             "Writing as {0!r} is not implemented;"
-            " only {1!r} will work.".format(format, _SELECTION_WRITERS.keys())) from e
+            " only {1!r} will work.".format(format, _SELECTION_WRITERS.keys())),
+            None)

--- a/package/MDAnalysis/selections/__init__.py
+++ b/package/MDAnalysis/selections/__init__.py
@@ -84,7 +84,7 @@ def get_writer(filename, defaultformat):
     format = format.strip().upper()  # canonical for lookup
     try:
         return _SELECTION_WRITERS[format]
-    except KeyError:
+    except KeyError as e:
         raise NotImplementedError(
             "Writing as {0!r} is not implemented;"
-            " only {1!r} will work.".format(format, _SELECTION_WRITERS.keys()))
+            " only {1!r} will work.".format(format, _SELECTION_WRITERS.keys())) from e

--- a/package/MDAnalysis/tests/datafiles.py
+++ b/package/MDAnalysis/tests/datafiles.py
@@ -37,10 +37,11 @@ Real MD simulation data, used for examples and the unit tests::
    http://pypi.python.org/pypi/MDAnalysisTests and installed.
 """
 from __future__ import print_function, absolute_import
+from six import raise_from
 
 try:
     from MDAnalysisTests.datafiles import *
-except ImportError as e:
+except ImportError:
     print("*** ERROR ***")
     print("In order to run the MDAnalysis test cases you must install the")
     print("MDAnalysisTestData package (which has been separated from the ")
@@ -50,4 +51,4 @@ except ImportError as e:
     print()
     print("and download and install the `MDAnalysisTests-x.y.z.tar.gz'")
     print("that matches your MDAnalysis release.")
-    raise ImportError("MDAnalysisTests package not installed.") from e
+    raise_from(ImportError("MDAnalysisTests package not installed."), None)

--- a/package/MDAnalysis/tests/datafiles.py
+++ b/package/MDAnalysis/tests/datafiles.py
@@ -40,7 +40,7 @@ from __future__ import print_function, absolute_import
 
 try:
     from MDAnalysisTests.datafiles import *
-except ImportError:
+except ImportError as e:
     print("*** ERROR ***")
     print("In order to run the MDAnalysis test cases you must install the")
     print("MDAnalysisTestData package (which has been separated from the ")
@@ -50,4 +50,4 @@ except ImportError:
     print()
     print("and download and install the `MDAnalysisTests-x.y.z.tar.gz'")
     print("that matches your MDAnalysis release.")
-    raise ImportError("MDAnalysisTests package not installed.")
+    raise ImportError("MDAnalysisTests package not installed.") from e

--- a/package/MDAnalysis/topology/CRDParser.py
+++ b/package/MDAnalysis/topology/CRDParser.py
@@ -46,6 +46,7 @@ Classes
 
 """
 from __future__ import absolute_import
+from six import raise_from
 
 import numpy as np
 
@@ -121,9 +122,10 @@ class CRDParser(TopologyReaderBase):
                 try:
                     (serial, resnum, resName, name,
                      x, y, z, segid, resid, tempFactor) = r.read(line)
-                except Exception as e:
-                    raise ValueError("Check CRD format at line {0}: {1}"
-                                     "".format(linenum + 1, line.rstrip())) from e
+                except Exception:
+                    raise_from(ValueError("Check CRD format at line {0}: {1}"
+                                     "".format(linenum + 1, line.rstrip())),
+                               None)
 
                 atomids.append(serial)
                 atomnames.append(name)

--- a/package/MDAnalysis/topology/CRDParser.py
+++ b/package/MDAnalysis/topology/CRDParser.py
@@ -121,9 +121,9 @@ class CRDParser(TopologyReaderBase):
                 try:
                     (serial, resnum, resName, name,
                      x, y, z, segid, resid, tempFactor) = r.read(line)
-                except:
+                except Exception as e:
                     raise ValueError("Check CRD format at line {0}: {1}"
-                                     "".format(linenum + 1, line.rstrip()))
+                                     "".format(linenum + 1, line.rstrip())) from e
 
                 atomids.append(serial)
                 atomnames.append(name)

--- a/package/MDAnalysis/topology/DMSParser.py
+++ b/package/MDAnalysis/topology/DMSParser.py
@@ -140,9 +140,9 @@ class DMSParser(TopologyReaderBase):
                     cur.execute('SELECT {} FROM particle'
                                 ''.format(attrname))
                     vals = cur.fetchall()
-                except sqlite3.DatabaseError:
-                    raise IOError(
-                        "Failed reading the atoms from DMS Database")
+                except sqlite3.DatabaseError as e:
+                    errmsg = "Failed reading the atoms from DMS Database"
+                    raise IOError(errmsg) from e
                 else:
                     attrs[attrname] = np.array(vals, dtype=dt)
 
@@ -150,8 +150,9 @@ class DMSParser(TopologyReaderBase):
                 cur.row_factory = dict_factory
                 cur.execute('SELECT * FROM bond')
                 bonds = cur.fetchall()
-            except sqlite3.DatabaseError:
-                raise IOError("Failed reading the bonds from DMS Database")
+            except sqlite3.DatabaseError as e:
+                errmsg = "Failed reading the bonds from DMS Database"
+                raise IOError(errmsg) from e
             else:
                 bondlist = []
                 bondorder = {}

--- a/package/MDAnalysis/topology/DMSParser.py
+++ b/package/MDAnalysis/topology/DMSParser.py
@@ -142,8 +142,9 @@ class DMSParser(TopologyReaderBase):
                                 ''.format(attrname))
                     vals = cur.fetchall()
                 except sqlite3.DatabaseError:
-                    errmsg = "Failed reading the atoms from DMS Database"
-                    raise_from(IOError(errmsg), None)
+                    raise_from(
+                        IOError("Failed reading the atoms from DMS Database"),
+                        None)
                 else:
                     attrs[attrname] = np.array(vals, dtype=dt)
 
@@ -152,8 +153,9 @@ class DMSParser(TopologyReaderBase):
                 cur.execute('SELECT * FROM bond')
                 bonds = cur.fetchall()
             except sqlite3.DatabaseError:
-                errmsg = "Failed reading the bonds from DMS Database"
-                raise_from(IOError(errmsg), None)
+                raise_from(
+                    IOError("Failed reading the bonds from DMS Database"),
+                    None)
             else:
                 bondlist = []
                 bondorder = {}

--- a/package/MDAnalysis/topology/DMSParser.py
+++ b/package/MDAnalysis/topology/DMSParser.py
@@ -41,6 +41,7 @@ Classes
 
 """
 from __future__ import absolute_import
+from six import raise_from
 
 import numpy as np
 import sqlite3
@@ -140,9 +141,9 @@ class DMSParser(TopologyReaderBase):
                     cur.execute('SELECT {} FROM particle'
                                 ''.format(attrname))
                     vals = cur.fetchall()
-                except sqlite3.DatabaseError as e:
+                except sqlite3.DatabaseError:
                     errmsg = "Failed reading the atoms from DMS Database"
-                    raise IOError(errmsg) from e
+                    raise_from(IOError(errmsg), None)
                 else:
                     attrs[attrname] = np.array(vals, dtype=dt)
 
@@ -150,9 +151,9 @@ class DMSParser(TopologyReaderBase):
                 cur.row_factory = dict_factory
                 cur.execute('SELECT * FROM bond')
                 bonds = cur.fetchall()
-            except sqlite3.DatabaseError as e:
+            except sqlite3.DatabaseError:
                 errmsg = "Failed reading the bonds from DMS Database"
-                raise IOError(errmsg) from e
+                raise_from(IOError(errmsg), None)
             else:
                 bondlist = []
                 bondorder = {}

--- a/package/MDAnalysis/topology/GROParser.py
+++ b/package/MDAnalysis/topology/GROParser.py
@@ -48,6 +48,7 @@ from __future__ import absolute_import
 
 import numpy as np
 from six.moves import range
+from six import raise_from
 
 from ..lib.util import openany
 from ..core.topologyattrs import (
@@ -102,12 +103,12 @@ class GROParser(TopologyReaderBase):
                     resnames[i] = line[5:10].strip()
                     names[i] = line[10:15].strip()
                     indices[i] = int(line[15:20])
-                except (ValueError, TypeError) as e:
+                except (ValueError, TypeError):
                     errmsg = (
                         "Couldn't read the following line of the .gro file:\n"
                         "{0}"
                         )
-                    raise IOError(errmsg.format(line)) from e
+                    raise_from(IOError(errmsg.format(line)), None)
         # Check all lines had names
         if not np.all(names):
             missing = np.where(names == '')

--- a/package/MDAnalysis/topology/GROParser.py
+++ b/package/MDAnalysis/topology/GROParser.py
@@ -104,11 +104,11 @@ class GROParser(TopologyReaderBase):
                     names[i] = line[10:15].strip()
                     indices[i] = int(line[15:20])
                 except (ValueError, TypeError):
-                    errmsg = (
+                    raise_from(
+                        IOError((
                         "Couldn't read the following line of the .gro file:\n"
-                        "{0}"
-                        )
-                    raise_from(IOError(errmsg.format(line)), None)
+                        "{0}").format(line)),
+                        None)
         # Check all lines had names
         if not np.all(names):
             missing = np.where(names == '')

--- a/package/MDAnalysis/topology/GROParser.py
+++ b/package/MDAnalysis/topology/GROParser.py
@@ -102,10 +102,12 @@ class GROParser(TopologyReaderBase):
                     resnames[i] = line[5:10].strip()
                     names[i] = line[10:15].strip()
                     indices[i] = int(line[15:20])
-                except (ValueError, TypeError):
-                    raise IOError(
+                except (ValueError, TypeError) as e:
+                    errmsg = (
                         "Couldn't read the following line of the .gro file:\n"
-                        "{0}".format(line))
+                        "{0}"
+                        )
+                    raise IOError(errmsg.format(line)) from e
         # Check all lines had names
         if not np.all(names):
             missing = np.where(names == '')

--- a/package/MDAnalysis/topology/LAMMPSParser.py
+++ b/package/MDAnalysis/topology/LAMMPSParser.py
@@ -338,8 +338,9 @@ class DATAParser(TopologyReaderBase):
         try:
             positions, ordering = self._parse_pos(sects['Atoms'])
         except KeyError as err:
-            errmsg = "Position information not found: {}".format(err)
-            raise_from(IOError(errmsg), None)
+            raise_from(
+                IOError("Position information not found: {}".format(err)),
+                None)
 
         if 'Velocities' in sects:
             velocities = self._parse_vel(sects['Velocities'], ordering)

--- a/package/MDAnalysis/topology/LAMMPSParser.py
+++ b/package/MDAnalysis/topology/LAMMPSParser.py
@@ -80,6 +80,7 @@ Deprecated classes
 from __future__ import absolute_import, print_function
 
 from six.moves import range
+from six import raise_from
 
 import numpy as np
 import logging
@@ -285,12 +286,13 @@ class DATAParser(TopologyReaderBase):
 
         try:
             top = self._parse_atoms(sects['Atoms'], masses)
-        except Exception as e:
-            raise ValueError(
+        except Exception:
+            raise_from(ValueError(
                 "Failed to parse atoms section.  You can supply a description "
                 "of the atom_style as a keyword argument, "
                 "eg mda.Universe(..., atom_style='id resid x y z')"
-            ) from e
+            ),
+            None)
 
         # create mapping of id to index (ie atom id 10 might be the 0th atom)
         mapping = {atom_id: i for i, atom_id in enumerate(top.ids.values)}
@@ -335,9 +337,9 @@ class DATAParser(TopologyReaderBase):
 
         try:
             positions, ordering = self._parse_pos(sects['Atoms'])
-        except KeyError as err:
+        except KeyError:
             errmsg = "Position information not found: {}".format(err)
-            raise IOError(errmsg) from err
+            raise_from(IOError(errmsg), None)
 
         if 'Velocities' in sects:
             velocities = self._parse_vel(sects['Velocities'], ordering)

--- a/package/MDAnalysis/topology/LAMMPSParser.py
+++ b/package/MDAnalysis/topology/LAMMPSParser.py
@@ -285,12 +285,12 @@ class DATAParser(TopologyReaderBase):
 
         try:
             top = self._parse_atoms(sects['Atoms'], masses)
-        except:
+        except Exception as e:
             raise ValueError(
                 "Failed to parse atoms section.  You can supply a description "
                 "of the atom_style as a keyword argument, "
                 "eg mda.Universe(..., atom_style='id resid x y z')"
-            )
+            ) from e
 
         # create mapping of id to index (ie atom id 10 might be the 0th atom)
         mapping = {atom_id: i for i, atom_id in enumerate(top.ids.values)}
@@ -336,7 +336,8 @@ class DATAParser(TopologyReaderBase):
         try:
             positions, ordering = self._parse_pos(sects['Atoms'])
         except KeyError as err:
-            raise IOError("Position information not found: {}".format(err))
+            errmsg = "Position information not found: {}".format(err)
+            raise IOError(errmsg) from err
 
         if 'Velocities' in sects:
             velocities = self._parse_vel(sects['Velocities'], ordering)

--- a/package/MDAnalysis/topology/LAMMPSParser.py
+++ b/package/MDAnalysis/topology/LAMMPSParser.py
@@ -337,7 +337,7 @@ class DATAParser(TopologyReaderBase):
 
         try:
             positions, ordering = self._parse_pos(sects['Atoms'])
-        except KeyError:
+        except KeyError as err:
             errmsg = "Position information not found: {}".format(err)
             raise_from(IOError(errmsg), None)
 

--- a/package/MDAnalysis/topology/PSFParser.py
+++ b/package/MDAnalysis/topology/PSFParser.py
@@ -45,6 +45,7 @@ Classes
 """
 from __future__ import absolute_import, division
 from six.moves import range
+from six import raise_from
 
 import logging
 import functools
@@ -276,11 +277,11 @@ class PSFParser(TopologyReaderBase):
         for i in range(numlines):
             try:
                 line = lines()
-            except StopIteration as e:
+            except StopIteration:
                 err = ("{0} is not valid PSF file"
                        "".format(self.filename))
                 logger.error(err)
-                raise ValueError(err) from e
+                raise_from(ValueError(err), None)
             try:
                 vals = set_type(atom_parser(line))
             except ValueError:

--- a/package/MDAnalysis/topology/PSFParser.py
+++ b/package/MDAnalysis/topology/PSFParser.py
@@ -276,11 +276,11 @@ class PSFParser(TopologyReaderBase):
         for i in range(numlines):
             try:
                 line = lines()
-            except StopIteration:
+            except StopIteration as e:
                 err = ("{0} is not valid PSF file"
                        "".format(self.filename))
                 logger.error(err)
-                raise ValueError(err)
+                raise ValueError(err) from e
             try:
                 vals = set_type(atom_parser(line))
             except ValueError:

--- a/package/MDAnalysis/topology/TOPParser.py
+++ b/package/MDAnalysis/topology/TOPParser.py
@@ -81,6 +81,7 @@ Classes
 from __future__ import absolute_import, division
 
 from six.moves import range, zip
+from six import raise_from
 import numpy as np
 import functools
 from math import ceil
@@ -233,10 +234,10 @@ class TOPParser(TopologyReaderBase):
                 else:
                     try:
                         next_section = line.split("%FLAG")[1].strip()
-                    except IndexError as e:
+                    except IndexError:
                         msg = ("%FLAG section not found, formatting error "
                                "for PARM7 file {0} ".format(self.filename))
-                        raise IndexError(msg) from e
+                        raise_from(IndexError(msg), None)
 
         # strip out a few values to play with them
         n_atoms = len(attrs['name'])

--- a/package/MDAnalysis/topology/TOPParser.py
+++ b/package/MDAnalysis/topology/TOPParser.py
@@ -233,10 +233,10 @@ class TOPParser(TopologyReaderBase):
                 else:
                     try:
                         next_section = line.split("%FLAG")[1].strip()
-                    except IndexError:
+                    except IndexError as e:
                         msg = ("%FLAG section not found, formatting error "
                                "for PARM7 file {0} ".format(self.filename))
-                        raise IndexError(msg)
+                        raise IndexError(msg) from e
 
         # strip out a few values to play with them
         n_atoms = len(attrs['name'])

--- a/package/MDAnalysis/topology/TOPParser.py
+++ b/package/MDAnalysis/topology/TOPParser.py
@@ -235,9 +235,11 @@ class TOPParser(TopologyReaderBase):
                     try:
                         next_section = line.split("%FLAG")[1].strip()
                     except IndexError:
-                        msg = ("%FLAG section not found, formatting error "
-                               "for PARM7 file {0} ".format(self.filename))
-                        raise_from(IndexError(msg), None)
+                        raise_from(
+                            IndexError((
+                                "%FLAG section not found, formatting error "
+                                "for PARM7 file {0} ").format(self.filename)),
+                                None)
 
         # strip out a few values to play with them
         n_atoms = len(attrs['name'])

--- a/package/MDAnalysis/transformations/fit.py
+++ b/package/MDAnalysis/transformations/fit.py
@@ -33,6 +33,7 @@ a given AtomGroup to a reference structure.
 
 """
 from __future__ import absolute_import
+from six import raise_from
 
 import numpy as np
 from functools import partial
@@ -89,19 +90,21 @@ def fit_translation(ag, reference, plane=None, weights=None):
         axes = {'yz' : 0, 'xz' : 1, 'xy' : 2}
         try:
             plane = axes[plane]
-        except (TypeError, KeyError) as e:
-            raise ValueError('{} is not a valid plane'.format(plane)) from e
+        except (TypeError, KeyError):
+            raise_from(ValueError('{} is not a valid plane'.format(plane)), None)
     try:
         if ag.atoms.n_residues != reference.atoms.n_residues:
             raise ValueError("{} and {} have mismatched number of residues".format(ag,reference))
-    except AttributeError as e:
-        raise AttributeError("{} or {} is not valid Universe/AtomGroup".format(ag,reference)) from e
+    except AttributeError:
+        raise_from(
+            AttributeError("{} or {} is not valid Universe/AtomGroup".format(ag,reference)),
+            None)
     ref, mobile = align.get_matching_atoms(reference.atoms, ag.atoms)
     try:
         weights = align.get_weights(ref.atoms, weights=weights)
-    except (ValueError, TypeError) as e:
-        raise ValueError("weights must be {'mass', None} or an iterable of the "
-                        "same size as the atomgroup.") from e
+    except (ValueError, TypeError):
+        raise_from(ValueError("weights must be {'mass', None} or an iterable of the "
+                        "same size as the atomgroup."), None)
     
     ref_com = np.asarray(ref.center(weights), np.float32)
 
@@ -168,19 +171,19 @@ def fit_rot_trans(ag, reference, plane=None, weights=None):
         axes = {'yz' : 0, 'xz' : 1, 'xy' : 2}
         try:
             plane = axes[plane]
-        except (TypeError, KeyError) as e:
-            raise ValueError('{} is not a valid plane'.format(plane)) from e
+        except (TypeError, KeyError):
+            raise_from(ValueError('{} is not a valid plane'.format(plane)), None)
     try:
         if ag.atoms.n_residues != reference.atoms.n_residues:
             raise ValueError("{} and {} have mismatched number of residues".format(ag,reference))
-    except AttributeError as e:
-        raise AttributeError("{} or {} is not valid Universe/AtomGroup".format(ag,reference)) from e
+    except AttributeError:
+        raise_from(AttributeError("{} or {} is not valid Universe/AtomGroup".format(ag,reference)), None)
     ref, mobile = align.get_matching_atoms(reference.atoms, ag.atoms)
     try:
         weights = align.get_weights(ref.atoms, weights=weights)
-    except (ValueError, TypeError) as e:
-        raise ValueError("weights must be {'mass', None} or an iterable of the "
-                        "same size as the atomgroup.") from e
+    except (ValueError, TypeError):
+        raise_from(ValueError("weights must be {'mass', None} or an iterable of the "
+                        "same size as the atomgroup."), None)
     ref_com = ref.center(weights)
     ref_coordinates = ref.atoms.positions - ref_com
     

--- a/package/MDAnalysis/transformations/fit.py
+++ b/package/MDAnalysis/transformations/fit.py
@@ -89,19 +89,19 @@ def fit_translation(ag, reference, plane=None, weights=None):
         axes = {'yz' : 0, 'xz' : 1, 'xy' : 2}
         try:
             plane = axes[plane]
-        except (TypeError, KeyError):
-            raise ValueError('{} is not a valid plane'.format(plane))
+        except (TypeError, KeyError) as e:
+            raise ValueError('{} is not a valid plane'.format(plane)) from e
     try:
         if ag.atoms.n_residues != reference.atoms.n_residues:
             raise ValueError("{} and {} have mismatched number of residues".format(ag,reference))
-    except AttributeError:
-        raise AttributeError("{} or {} is not valid Universe/AtomGroup".format(ag,reference))
+    except AttributeError as e:
+        raise AttributeError("{} or {} is not valid Universe/AtomGroup".format(ag,reference)) from e
     ref, mobile = align.get_matching_atoms(reference.atoms, ag.atoms)
     try:
         weights = align.get_weights(ref.atoms, weights=weights)
-    except (ValueError, TypeError):
+    except (ValueError, TypeError) as e:
         raise ValueError("weights must be {'mass', None} or an iterable of the "
-                        "same size as the atomgroup.")
+                        "same size as the atomgroup.") from e
     
     ref_com = np.asarray(ref.center(weights), np.float32)
 
@@ -168,19 +168,19 @@ def fit_rot_trans(ag, reference, plane=None, weights=None):
         axes = {'yz' : 0, 'xz' : 1, 'xy' : 2}
         try:
             plane = axes[plane]
-        except (TypeError, KeyError):
-            raise ValueError('{} is not a valid plane'.format(plane))
+        except (TypeError, KeyError) as e:
+            raise ValueError('{} is not a valid plane'.format(plane)) from e
     try:
         if ag.atoms.n_residues != reference.atoms.n_residues:
             raise ValueError("{} and {} have mismatched number of residues".format(ag,reference))
-    except AttributeError:
-        raise AttributeError("{} or {} is not valid Universe/AtomGroup".format(ag,reference))
+    except AttributeError as e:
+        raise AttributeError("{} or {} is not valid Universe/AtomGroup".format(ag,reference)) from e
     ref, mobile = align.get_matching_atoms(reference.atoms, ag.atoms)
     try:
         weights = align.get_weights(ref.atoms, weights=weights)
-    except (ValueError, TypeError):
+    except (ValueError, TypeError) as e:
         raise ValueError("weights must be {'mass', None} or an iterable of the "
-                        "same size as the atomgroup.")
+                        "same size as the atomgroup.") from e
     ref_com = ref.center(weights)
     ref_coordinates = ref.atoms.positions - ref_com
     

--- a/package/MDAnalysis/transformations/rotate.py
+++ b/package/MDAnalysis/transformations/rotate.py
@@ -32,6 +32,7 @@ point
 
 """
 from __future__ import absolute_import
+from six import raise_from
 
 import math
 import numpy as np
@@ -112,8 +113,10 @@ def rotateby(angle, direction, point=None, ag=None, weights=None, wrap=False):
         if direction.shape != (3, ) and direction.shape != (1, 3):
             raise ValueError('{} is not a valid direction'.format(direction))
         direction = direction.reshape(3, )
-    except ValueError as e:
-        raise ValueError('{} is not a valid direction'.format(direction)) from e
+    except ValueError:
+        raise_from(
+            ValueError('{} is not a valid direction'.format(direction)),
+            None)
     if point is not None:
         point = np.asarray(point, np.float32)
         if point.shape != (3, ) and point.shape != (1, 3):
@@ -122,14 +125,16 @@ def rotateby(angle, direction, point=None, ag=None, weights=None, wrap=False):
     elif ag:
         try:
             atoms = ag.atoms
-        except AttributeError as e:
-            raise ValueError('{} is not an AtomGroup object'.format(ag)) from e
+        except AttributeError:
+            raise_from(ValueError('{} is not an AtomGroup object'.format(ag)), None)
         else:
             try:
                 weights = get_weights(atoms, weights=weights)
-            except (ValueError, TypeError) as e:
-                raise TypeError("weights must be {'mass', None} or an iterable of the "
-                                "same size as the atomgroup.") from e
+            except (ValueError, TypeError):
+                raise_from(
+                    TypeError("weights must be {'mass', None} or an iterable of the "
+                              "same size as the atomgroup."),
+                    None)
         center_method = partial(atoms.center, weights, pbc=wrap)
     else:
         raise ValueError('A point or an AtomGroup must be specified')

--- a/package/MDAnalysis/transformations/rotate.py
+++ b/package/MDAnalysis/transformations/rotate.py
@@ -112,8 +112,8 @@ def rotateby(angle, direction, point=None, ag=None, weights=None, wrap=False):
         if direction.shape != (3, ) and direction.shape != (1, 3):
             raise ValueError('{} is not a valid direction'.format(direction))
         direction = direction.reshape(3, )
-    except ValueError:
-        raise ValueError('{} is not a valid direction'.format(direction))
+    except ValueError as e:
+        raise ValueError('{} is not a valid direction'.format(direction)) from e
     if point is not None:
         point = np.asarray(point, np.float32)
         if point.shape != (3, ) and point.shape != (1, 3):
@@ -122,14 +122,14 @@ def rotateby(angle, direction, point=None, ag=None, weights=None, wrap=False):
     elif ag:
         try:
             atoms = ag.atoms
-        except AttributeError:
-            raise ValueError('{} is not an AtomGroup object'.format(ag))
+        except AttributeError as e:
+            raise ValueError('{} is not an AtomGroup object'.format(ag)) from e
         else:
             try:
                 weights = get_weights(atoms, weights=weights)
-            except (ValueError, TypeError):
+            except (ValueError, TypeError) as e:
                 raise TypeError("weights must be {'mass', None} or an iterable of the "
-                                "same size as the atomgroup.")
+                                "same size as the atomgroup.") from e
         center_method = partial(atoms.center, weights, pbc=wrap)
     else:
         raise ValueError('A point or an AtomGroup must be specified')

--- a/package/MDAnalysis/transformations/translate.py
+++ b/package/MDAnalysis/transformations/translate.py
@@ -124,11 +124,11 @@ def center_in_box(ag, center='geometry', point=None, wrap=False):
             center_method = partial(ag.center_of_mass, pbc=pbc_arg)
         else:
             raise ValueError('{} is not a valid argument for center'.format(center))
-    except AttributeError:
+    except AttributeError as e:
         if center == 'mass':
-            raise AttributeError('{} is not an AtomGroup object with masses'.format(ag))
+            raise AttributeError('{} is not an AtomGroup object with masses'.format(ag)) from e
         else:
-            raise ValueError('{} is not an AtomGroup object'.format(ag))
+            raise ValueError('{} is not an AtomGroup object'.format(ag)) from e
 
     def wrapped(ts):
         if point is None:

--- a/package/MDAnalysis/transformations/translate.py
+++ b/package/MDAnalysis/transformations/translate.py
@@ -37,6 +37,7 @@ or defined by centering an AtomGroup in the unit cell using the function
 
 """
 from __future__ import absolute_import, division
+from six import raise_from
 
 import numpy as np
 from functools import partial
@@ -124,11 +125,13 @@ def center_in_box(ag, center='geometry', point=None, wrap=False):
             center_method = partial(ag.center_of_mass, pbc=pbc_arg)
         else:
             raise ValueError('{} is not a valid argument for center'.format(center))
-    except AttributeError as e:
+    except AttributeError:
         if center == 'mass':
-            raise AttributeError('{} is not an AtomGroup object with masses'.format(ag)) from e
+            raise_from(
+                AttributeError('{} is not an AtomGroup object with masses'.format(ag)),
+                None)
         else:
-            raise ValueError('{} is not an AtomGroup object'.format(ag)) from e
+            raise_from(ValueError('{} is not an AtomGroup object'.format(ag)), None)
 
     def wrapped(ts):
         if point is None:

--- a/package/MDAnalysis/units.py
+++ b/package/MDAnalysis/units.py
@@ -363,14 +363,18 @@ def convert(x, u1, u2):
     """
     try:
         ut1 = unit_types[u1]
-    except KeyError:
-        raise ValueError("unit '{0}' not recognized.\n"
-                          "It must be one of {1}.".format(u1, ", ".join(unit_types)))
+    except KeyError as e:
+        errmsg = ("unit '{0}' not recognized.\n"
+                  "It must be one of {1}.".format(u1, ", ".join(unit_types))
+                  )
+        raise ValueError(errmsg) from e
     try:
         ut2 = unit_types[u2]
-    except KeyError:
-        raise ValueError("unit '{0}' not recognized.\n"
-                          "It must be one of {1}.".format(u2, ", ".join(unit_types)))
+    except KeyError as e:
+        errmsg = ("unit '{0}' not recognized.\n"
+                  "It must be one of {1}.".format(u2, ", ".join(unit_types))
+                  )
+        raise ValueError(errmsg) from e
     if ut1 != ut2:
         raise ValueError("Cannot convert between unit types "
                          "{0} --> {1}".format(u1, u2))

--- a/package/MDAnalysis/units.py
+++ b/package/MDAnalysis/units.py
@@ -167,6 +167,7 @@ References and footnotes
 """
 
 from __future__ import unicode_literals, division
+from six import raise_from
 
 #: `Avogadro's constant`_ in mol**-1.
 #:
@@ -363,18 +364,18 @@ def convert(x, u1, u2):
     """
     try:
         ut1 = unit_types[u1]
-    except KeyError as e:
+    except KeyError:
         errmsg = ("unit '{0}' not recognized.\n"
                   "It must be one of {1}.".format(u1, ", ".join(unit_types))
                   )
-        raise ValueError(errmsg) from e
+        raise_from(ValueError(errmsg), None)
     try:
         ut2 = unit_types[u2]
-    except KeyError as e:
+    except KeyError:
         errmsg = ("unit '{0}' not recognized.\n"
                   "It must be one of {1}.".format(u2, ", ".join(unit_types))
                   )
-        raise ValueError(errmsg) from e
+        raise_from(ValueError(errmsg), None)
     if ut1 != ut2:
         raise ValueError("Cannot convert between unit types "
                          "{0} --> {1}".format(u1, u2))

--- a/package/MDAnalysis/units.py
+++ b/package/MDAnalysis/units.py
@@ -365,17 +365,22 @@ def convert(x, u1, u2):
     try:
         ut1 = unit_types[u1]
     except KeyError:
-        errmsg = ("unit '{0}' not recognized.\n"
-                  "It must be one of {1}.".format(u1, ", ".join(unit_types))
-                  )
-        raise_from(ValueError(errmsg), None)
+        raise_from(
+            ValueError(
+                ("unit '{0}' not recognized.\n"
+                 "It must be one of {1}.").format(u1, ", ".join(unit_types))
+                ),
+            None)
+                  
     try:
         ut2 = unit_types[u2]
     except KeyError:
-        errmsg = ("unit '{0}' not recognized.\n"
-                  "It must be one of {1}.".format(u2, ", ".join(unit_types))
-                  )
-        raise_from(ValueError(errmsg), None)
+        raise_from(
+            ValueError(
+                ("unit '{0}' not recognized.\n"
+                 "It must be one of {1}.").format(u2, ", ".join(unit_types))
+                ),
+            None)
     if ut1 != ut2:
         raise ValueError("Cannot convert between unit types "
                          "{0} --> {1}".format(u1, u2))

--- a/package/MDAnalysis/units.py
+++ b/package/MDAnalysis/units.py
@@ -166,7 +166,7 @@ References and footnotes
 
 """
 
-from __future__ import unicode_literals, division
+from __future__ import absolute_import, unicode_literals, division
 from six import raise_from
 
 #: `Avogadro's constant`_ in mol**-1.

--- a/package/MDAnalysis/visualization/streamlines.py
+++ b/package/MDAnalysis/visualization/streamlines.py
@@ -55,13 +55,14 @@ try:
     import matplotlib
     import matplotlib.path
 except ImportError:
-    errmsg = (
-        '2d streamplot module requires: matplotlib.path for its '
-        'path.Path.contains_points method. The installation '
-        'instructions for the matplotlib module can be found here: '
-        'http://matplotlib.org/faq/installing_faq.html?highlight=install'
-        )
-    raise_from(ImportError(errmsg), None)
+    raise_from(
+        ImportError((
+            '2d streamplot module requires: matplotlib.path for its '
+            'path.Path.contains_points method. The installation '
+            'instructions for the matplotlib module can be found here: '
+            'http://matplotlib.org/faq/installing_faq.html?highlight=install'
+            )),
+        None)
 
 import MDAnalysis
 

--- a/package/MDAnalysis/visualization/streamlines.py
+++ b/package/MDAnalysis/visualization/streamlines.py
@@ -44,6 +44,7 @@ MDAnalysis.visualization.streamlines_3D : streamplots in 3D
 """
 from __future__ import absolute_import
 from six.moves import zip
+from six import raise_from
 
 import multiprocessing
 
@@ -53,14 +54,14 @@ import scipy
 try:
     import matplotlib
     import matplotlib.path
-except ImportError as e:
-    errmsg = ( 
+except ImportError:
+    errmsg = (
         '2d streamplot module requires: matplotlib.path for its '
         'path.Path.contains_points method. The installation '
         'instructions for the matplotlib module can be found here: '
         'http://matplotlib.org/faq/installing_faq.html?highlight=install'
         )
-    raise ImportError(errmsg) from e
+    raise_from(ImportError(errmsg), None)
 
 import MDAnalysis
 

--- a/package/MDAnalysis/visualization/streamlines.py
+++ b/package/MDAnalysis/visualization/streamlines.py
@@ -53,11 +53,14 @@ import scipy
 try:
     import matplotlib
     import matplotlib.path
-except ImportError:
-    raise ImportError(
-        '2d streamplot module requires: matplotlib.path for its path.Path.contains_points method. The installation '
+except ImportError as e:
+    errmsg = ( 
+        '2d streamplot module requires: matplotlib.path for its '
+        'path.Path.contains_points method. The installation '
         'instructions for the matplotlib module can be found here: '
-        'http://matplotlib.org/faq/installing_faq.html?highlight=install')
+        'http://matplotlib.org/faq/installing_faq.html?highlight=install'
+        )
+    raise ImportError(errmsg) from e
 
 import MDAnalysis
 


### PR DESCRIPTION
I did not rise any issue previously to this  PR.

# Problem

Exceptions raised while handling previous caught exceptions were not raised from the caught exception nor from `None`, producing the output:

```
During handling of the above exception, another exception occurred:
```

Which in Python means *"failed to handle exception properly"* or that an *uncontrolled* exception occurred, which is not the case in MDAnalysis whatsoever.

# Solution

By capturing exception as `as e` and rising exceptions `from e` the correct output yields:

```
The above exception was the direct cause of the following exception:
```

Custom exceptions are raised `from None`, instead.

I did not entered into the detail of fine tuning `from e` and `from None` aside from using `from None` in custom exceptions because I considered such to be already changing MDAnalysis functionality/interface and I did not want to enter in such detail for this PR.

Thanks to @mariocj89 for his [talk at PyCon2019](https://www.youtube.com/watch?v=V2fGAv2R5j8) about correct exception handling.

# Tests

Tests run without failure (reds):

```
platform linux -- Python 3.7.4, pytest-5.1.3, py-1.8.0, pluggy-0.13.0
plugins: hypothesis-4.37.0
15402 passed, 84 skipped, 2 xfailed, 2 xpassed, 31871 warnings in 663.39s (0:11:03)
```

and pylint,

```
pylint 2.3.1
astroid 2.2.5
Python 3.7.3 (default, Mar 27 2019, 22:11:17) 
[GCC 7.3.0]

$ pylint --rcfile=package/.pylintrc package/MDAnalysis

------------------------------------
Your code has been rated at 10.00/10
```


PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [ ] Issue raised/referenced?
