### PR TITLE
disable pylint warning for some E1136(unsubscriptable-object)

### DIFF
--- a/package/MDAnalysis/analysis/encore/utils.py
+++ b/package/MDAnalysis/analysis/encore/utils.py
@@ -96,6 +96,7 @@ class TriangularMatrix(object):
 
     def as_array(self):
         """Return standard numpy array equivalent"""
+        # pylint: disable=unsubscriptable-object
         a = np.zeros((self.size, self.size))
         a[np.tril_indices(self.size)] = self._elements
         a[np.triu_indices(self.size)] = a.T[np.triu_indices(self.size)]

--- a/package/MDAnalysis/lib/transformations.py
+++ b/package/MDAnalysis/lib/transformations.py
@@ -760,6 +760,7 @@ def decompose_matrix(matrix):
     True
 
     """
+    # pylint: disable=unsubscriptable-object
     M = np.array(matrix, dtype=np.float64, copy=True).T
     if abs(M[3, 3]) < _EPS:
         raise ValueError("M[3, 3] is zero")


### PR DESCRIPTION
disable pylint warning for some E1136(unsubscriptable-object)

Recent updates of pylint now flag some constructs with E1136 which in fact are perfectably subscriptable. Apparently, some numpy  constructs are not recognized as producing arrays. The additions   in this PR disable the warning for the relevant code blocks.

Changes made in this Pull Request:
 - disable E1136 in parts of encore/util.py
 - disable E1136 in parts of lib/transformations.py

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
