### PR TITLE
FIX 2353: Chainreader not reporting correct errors

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -20,6 +20,8 @@ mm/dd/yy richardjgowers
 Fixes
   * AtomGroup.guess_bonds now uses periodic boundary information when available
     (Issue #2350)
+  * Chainreader and continuous option work correctly when readers work for more 
+    than one format (Issue #2353)
 
 Enhancements
 

--- a/testsuite/MDAnalysisTests/coordinates/test_chainreader.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_chainreader.py
@@ -359,6 +359,12 @@ class TestChainReaderContinuous(object):
     def test_unsupported_filetypes(self):
         with pytest.raises(NotImplementedError):
             mda.Universe(PSF, [DCD, DCD], continuous=True)
+        # see issue 2353. The PDB reader has multiple format endings. To ensure 
+        # the not implemented error is thrown  we  do a check here. A more  
+        # careful test in the future would be a dummy reader with multiple 
+        # formats, just in case PDB will allow continuous reading in the future.
+        with pytest.raises(ValueError):
+            mda.Universe(PDB, [PDB, XTC], continuous=True)
 
 
 @pytest.mark.parametrize('l, ref', ([((0, 3), (3, 3), (4, 7)), (0, 1, 2)],


### PR DESCRIPTION
Fixes #2353

Changes made in this Pull Request:
 - If using a chainreader with continuous=True and a reader like the PDB
reader report a correct error for usage to the reader.



PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
