### PR TITLE
select_atoms accepts atomgroups

### DIFF
--- a/package/MDAnalysis/analysis/rms.py
+++ b/package/MDAnalysis/analysis/rms.py
@@ -475,7 +475,6 @@ class RMSD(AnalysisBase):
         self.reference = reference if reference is not None else self.atomgroup
 
         select = process_selection(select)
-        print("SELECT IS", select)
         self.groupselections = ([process_selection(s) for s in groupselections]
                                 if groupselections is not None else [])
         self.weights = weights

--- a/package/MDAnalysis/analysis/rms.py
+++ b/package/MDAnalysis/analysis/rms.py
@@ -148,6 +148,7 @@ from MDAnalysis.analysis.base import AnalysisBase
 from MDAnalysis.exceptions import SelectionError, NoDataError
 from MDAnalysis.lib.log import ProgressMeter
 from MDAnalysis.lib.util import asiterable, iterable, get_weights, deprecate
+from MDAnalysis.core.groups import AtomGroup
 
 
 logger = logging.getLogger('MDAnalysis.analysis.rmsd')
@@ -283,6 +284,8 @@ def process_selection(select):
 
     if isinstance(select, string_types):
         select = {'reference': str(select), 'mobile': str(select)}
+    elif isinstance(select, AtomGroup):
+        select = {'reference': select, 'mobile': select}
     elif type(select) is tuple:
         try:
             select = {'mobile': select[0], 'reference': select[1]}
@@ -301,6 +304,10 @@ def process_selection(select):
         raise TypeError("'select' must be either a string, 2-tuple, or dict")
     select['mobile'] = asiterable(select['mobile'])
     select['reference'] = asiterable(select['reference'])
+    if isinstance(select['mobile'], AtomGroup):
+        select['mobile'] = [select['mobile']]
+    if isinstance(select['reference'], AtomGroup):
+        select['reference'] = [select['reference']]
     return select
 
 
@@ -468,6 +475,7 @@ class RMSD(AnalysisBase):
         self.reference = reference if reference is not None else self.atomgroup
 
         select = process_selection(select)
+        print("SELECT IS", select)
         self.groupselections = ([process_selection(s) for s in groupselections]
                                 if groupselections is not None else [])
         self.weights = weights

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -2837,6 +2837,9 @@ class AtomGroup(GroupBase):
             warnings.warn("Empty string to select atoms, empty group returned.",
                           UserWarning)
             return self[[]]
+        
+        if isinstance(sel, AtomGroup):
+            return sel
 
         # once flags removed, replace with default=True
         periodic = selgroups.pop('periodic', flags['use_periodic_selections'])

--- a/testsuite/MDAnalysisTests/core/test_atomselections.py
+++ b/testsuite/MDAnalysisTests/core/test_atomselections.py
@@ -363,6 +363,15 @@ class TestSelectionsCHARMM(object):
             "resname LYS and name NZ and around 4 backbone")
         ag2 = ag.select_atoms("around 4 global backbone")
         assert_equal(ag2.indices, ag1.indices)
+    
+    @pytest.mark.parametrize('selstr',
+        ["resname LYS and name NZ",
+        "protein", "backbone", "resid 100",
+        "resid 100:105",
+        "around 4.0 bynum 1943"])
+    def test_accept_atomgroup(self, universe, selstr):
+        ag = universe.select_atoms(selstr)
+        assert ag is universe.select_atoms(ag)
 
 
 class TestSelectionsAMBER(object):

--- a/testsuite/MDAnalysisTests/core/test_atomselections.py
+++ b/testsuite/MDAnalysisTests/core/test_atomselections.py
@@ -364,21 +364,12 @@ class TestSelectionsCHARMM(object):
         ag2 = ag.select_atoms("around 4 global backbone")
         assert_equal(ag2.indices, ag1.indices)
     
-    @pytest.mark.parametrize('selstr',
-        ["resname LYS and name NZ",
-        "protein", "backbone", "resid 100",
-        "resid 100:105",
-        "around 4.0 bynum 1943"])
-    def test_accept_atomgroup(self, universe, selstr):
-        ag = universe.select_atoms(selstr)
+    def test_accept_AtomGroup(self, universe):
+        ag = universe.select_atoms('protein')
         assert ag is universe.select_atoms(ag)
     
-    @pytest.mark.parametrize('selstr',
-        ["around 4.0 bynum 1943",
-        "around 10.0 bynum 1943"
-        ])
-    def test_accept_updatingatomgroup(self, universe, selstr):
-        ag = universe.select_atoms(selstr, updating=True)
+    def test_accept_UpdatingAtomGroup(self, universe):
+        ag = universe.select_atoms('resid 100', updating=True)
         assert ag is universe.select_atoms(ag)
 
 

--- a/testsuite/MDAnalysisTests/core/test_atomselections.py
+++ b/testsuite/MDAnalysisTests/core/test_atomselections.py
@@ -364,13 +364,35 @@ class TestSelectionsCHARMM(object):
         ag2 = ag.select_atoms("around 4 global backbone")
         assert_equal(ag2.indices, ag1.indices)
     
-    def test_accept_AtomGroup(self, universe):
+    def test_returns_equal_AtomGroup_copy(self, universe):
         ag = universe.select_atoms('protein')
-        assert ag is universe.select_atoms(ag)
+        assert ag == universe.select_atoms(ag)
+        assert ag is not universe.select_atoms(ag)
     
-    def test_accept_UpdatingAtomGroup(self, universe):
-        ag = universe.select_atoms('resid 100', updating=True)
-        assert ag is universe.select_atoms(ag)
+    def test_returns_equal_UpdatingAtomGroup_copy(self, universe):
+        ag = universe.select_atoms('resid 100')
+        uag = universe.select_atoms(ag, updating=True)
+        no_uag = universe.select_atoms(uag)
+        assert ag == uag
+        assert no_uag == uag
+        assert isinstance(uag, mda.core.groups.UpdatingAtomGroup)
+        assert isinstance(no_uag, mda.core.groups.AtomGroup)
+        assert not isinstance(no_uag, mda.core.groups.UpdatingAtomGroup)
+    
+    def test_returns_atomgroup_intersection(self, universe):
+        g1 = universe.select_atoms('resid 1:100')
+        g2 = universe.select_atoms('name CA')
+        g3 = universe.select_atoms('name O')
+
+        ag1 = g1.select_atoms(g2)
+        ag2 = g2.select_atoms(g1)
+        ag3 = g1.select_atoms(g2, g3)
+
+        assert ag1 == ag2
+        assert ag1 == (g1 & g2)
+        assert ag3 == ((g1 & g2) + (g1 & g3))
+
+
 
 
 class TestSelectionsAMBER(object):

--- a/testsuite/MDAnalysisTests/core/test_atomselections.py
+++ b/testsuite/MDAnalysisTests/core/test_atomselections.py
@@ -372,6 +372,14 @@ class TestSelectionsCHARMM(object):
     def test_accept_atomgroup(self, universe, selstr):
         ag = universe.select_atoms(selstr)
         assert ag is universe.select_atoms(ag)
+    
+    @pytest.mark.parametrize('selstr',
+        ["around 4.0 bynum 1943",
+        "around 10.0 bynum 1943"
+        ])
+    def test_accept_updatingatomgroup(self, universe, selstr):
+        ag = universe.select_atoms(selstr, updating=True)
+        assert ag is universe.select_atoms(ag)
 
 
 class TestSelectionsAMBER(object):


### PR DESCRIPTION
Implements #2369 

Changes made in this Pull Request:
 - If `u.select_atoms` is given an Updating/AtomGroup, it returns that Updating/AtomGroup

@orbeckst commented [on the need for careful testing](https://github.com/MDAnalysis/mdanalysis/pull/2237#discussion_r272883354):

> I thought the same. Raise a separate issue. It looks like a simple change but this is such a fundamental method that it will require some careful testing. If it works consistently then it would be great. I think there was an old issue related to the "use AG where strings are allowed".

There is a simple test to check that it does return an AtomGroup, but otherwise I haven't got many ideas for others. Suggestions are welcome.

PR Checklist
------------
 - [ ] Tests? Kind of
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?