### PR TITLE
Fix GSD Windows compatibility

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,7 +11,7 @@ environment:
     global:
         CONDA_CHANNELS: conda-forge
         CONDA_DEPENDENCIES: pip setuptools wheel cython mock six biopython networkx joblib matplotlib scipy vs2015_runtime pytest mmtf-python GridDataFormats hypothesis pytest-cov codecov
-        PIP_DEPENDENCIES: gsd==1.5.2 duecredit
+        PIP_DEPENDENCIES: gsd==1.9.3 duecredit
         DEBUG: "False"
         MINGW_64: C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin
         OPENBLAS_64: https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-5f998ef_gcc7_1_0_win64.zip

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,7 +13,7 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-mm/dd/yy richardjgowers, kain88-de, lilyminium, p-j-smith
+mm/dd/yy richardjgowers, kain88-de, lilyminium, p-j-smith, bdice
 
   * 0.21.0
 
@@ -30,6 +30,7 @@ Enhancements
   * New analysis.hydrogenbonds.HydrogenBondAnalysis class for the analysis of
     hydrogen bonds. Simpler interface, more extensible and better performance
     than analysis.hbonds.HydrogenBondAnalysis (PR #2237)
+  * GSD reader is now supported on Windows (Issue #1923, PR #2384)
 
 Deprecations
   * analysis.hbonds.HydrogenBondAnalysis will be deprecated in 1.0

--- a/package/MDAnalysis/coordinates/GSD.py
+++ b/package/MDAnalysis/coordinates/GSD.py
@@ -49,8 +49,7 @@ from __future__ import absolute_import, division
 
 import numpy as np
 import os
-if os.name != 'nt':
-    import gsd.hoomd
+import gsd.hoomd
 
 from . import base
 
@@ -73,9 +72,6 @@ class GSDReader(base.ReaderBase):
 
         .. versionadded:: 0.17.0
         """
-        if os.name == 'nt':
-            raise NotImplementedError("GSD format not supported on Windows")
-
         super(GSDReader, self).__init__(filename, **kwargs)
         self.filename = filename
         self.open_trajectory()

--- a/package/MDAnalysis/topology/GSDParser.py
+++ b/package/MDAnalysis/topology/GSDParser.py
@@ -34,7 +34,7 @@ with the case in which there is no variation. The trajectory data are read with
 the :class:`~MDAnalysis.coordinates.GSD.GSDReader` class.
 
 .. _HOOMD: http://codeblue.umich.edu/hoomd-blue/index.html
-.. _HOOMD GSD: https://bitbucket.org/glotzer/gsd
+.. _HOOMD GSD: https://github.com/glotzerlab/gsd
 
 
 To load a GSD HOOMD file::
@@ -54,9 +54,7 @@ Classes
 from __future__ import absolute_import
 
 import os
-if os.name != 'nt':
-    # not supported on windows
-    import gsd.hoomd
+import gsd.hoomd
 import numpy as np
 
 from . import guessers
@@ -110,9 +108,6 @@ class GSDParser(TopologyReaderBase):
 
         .. versionadded:: 0.17.0
         """
-        if os.name == 'nt':
-            raise NotImplementedError("GSD format not supported on Windows")
-
         attrs = {}
 
         with gsd.hoomd.open(self.filename,mode='rb') as t :

--- a/package/setup.py
+++ b/package/setup.py
@@ -561,6 +561,8 @@ if __name__ == '__main__':
     ]
     if not os.name == 'nt':
         install_requires.append('gsd>=1.4.0')
+    else:
+        install_requires.append('gsd>=1.9.3')
 
     setup(name='MDAnalysis',
           version=RELEASE,

--- a/testsuite/MDAnalysisTests/coordinates/test_gsd.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_gsd.py
@@ -35,8 +35,6 @@ import os
 def GSD_U():
     return mda.Universe(GSD)
 
-@pytest.mark.skipif(os.name == 'nt',
-                    reason="gsd not windows compatible")
 def test_gsd_positions(GSD_U):
     # first frame first particle
     ts = GSD_U.trajectory[0]
@@ -47,20 +45,14 @@ def test_gsd_positions(GSD_U):
     assert_almost_equal(GSD_U.atoms.positions[0],
                         [ -5.58348083,  -9.98546982, -10.17657185])
 
-@pytest.mark.skipif(os.name == 'nt',
-                    reason="gsd not windows compatible")
 def test_gsd_n_frames(GSD_U):
     assert len(GSD_U.trajectory) == 2
 
-@pytest.mark.skipif(os.name == 'nt',
-                    reason="gsd not windows compatible")
 def test_gsd_dimensions(GSD_U):
     ts = GSD_U.trajectory[0]
     assert_almost_equal(ts.dimensions,
                         [ 21.60000038,21.60000038,21.60000038,90.,90.,90.])
 
-@pytest.mark.skipif(os.name == 'nt',
-                    reason="gsd not windows compatible")
 def test_gsd_data_step(GSD_U):
     assert GSD_U.trajectory[0].data['step'] == 0
     assert GSD_U.trajectory[1].data['step'] == 500

--- a/testsuite/MDAnalysisTests/topology/test_gsd.py
+++ b/testsuite/MDAnalysisTests/topology/test_gsd.py
@@ -33,8 +33,6 @@ from numpy.testing import assert_equal
 import os
 
 
-@pytest.mark.skipif(os.name == 'nt',
-                    reason="gsd not windows compatible")
 class TestGSDParser(ParserBase):
     parser = mda.topology.GSDParser.GSDParser
     ref_filename = GSD
@@ -48,9 +46,7 @@ class TestGSDParser(ParserBase):
         assert len(top.names) == top.n_atoms
         assert len(top.resids) == top.n_residues
         assert len(top.resnames) == top.n_residues
-    
-@pytest.mark.skipif(os.name == 'nt',
-                    reason="gsd not windows compatible")
+
 class TestGSDParserBonds(ParserBase):
     parser = mda.topology.GSDParser.GSDParser
     ref_filename = GSD_bonds
@@ -67,10 +63,10 @@ class TestGSDParserBonds(ParserBase):
         assert len(top.names) == top.n_atoms
         assert len(top.resids) == top.n_residues
         assert len(top.resnames) == top.n_residues
-        
+
     def test_atoms(self, top):
         assert top.n_atoms == self.expected_n_atoms
-        
+
     def test_bonds(self, top):
         assert len(top.bonds.values) == self.expected_n_bonds
         assert isinstance(top.bonds.values[0], tuple)


### PR DESCRIPTION
Fixes #1923.

Changes made in this Pull Request:
 - Add installation requirement of `gsd>=1.9.3` on Windows.
 - Removed conditional failures when attempting to read GSD files on Windows.
 - Updated tests so they won't skip GSD on Windows.

Note that `gsd>=1.8.0` requires Python 3, so I was careful not to invalidate Python 2 compatibility on non-Windows platforms. This should be fine in terms of compatibility because Python 3 is already a requirement for MDAnalysis on Windows (citation: https://github.com/MDAnalysis/mdanalysis/issues/2116, https://github.com/MDAnalysis/mdanalysis/pull/2093#discussion_r227438117). The Appveyor tests were updated to version 1.9.3 for consistency.

As a new developer to MDAnalysis, I appreciate the effort put into making the development guide and style guides. However, it took me a while to find the development guide in the GitHub wiki. I would recommend including the [Guide for Developers](https://github.com/MDAnalysis/mdanalysis/wiki/Guide-for-Developers) in the CONTRIBUTING file (the Style Guide is already linked, but that's only a subset of the Developer Guide in my understanding) and/or as a link on the MDAnalysis website, with a heading like "Developer Guide."

PR Checklist
------------
 - [x] Tests? _(tests are no longer skipped)_
 - [x] Docs? _(no updates needed)_
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
