### PR TITLE
guess zinc properly

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -24,6 +24,7 @@ Fixes
   * Chainreader and continuous option work correctly when readers work for more 
     than one format (Issue #2353)
   * PDBQTParser now gives icode TopologyAttrs (Issue #2361)
+  * Guess atom element with uppercase name
 
 Enhancements
   * Uniforms exception handling between Python 2.7 and Python 3: raised exceptions

--- a/package/MDAnalysis/topology/guessers.py
+++ b/package/MDAnalysis/topology/guessers.py
@@ -134,11 +134,16 @@ def guess_atom_element(atomname):
     if atomname == '':
         return ''
     try:
-        return tables.atomelements[atomname]
+        return tables.atomelements[atomname.upper()]
     except KeyError:
         # strip symbols and numbers
         no_symbols = re.sub(SYMBOLS, '', atomname)
         name = re.sub(NUMBERS, '', no_symbols).upper()
+
+        # just in case
+        if name in tables.atomelements:
+            return tables.atomelements[name]
+
         while name:
             if name in tables.elements:
                 return name

--- a/testsuite/MDAnalysisTests/topology/test_guessers.py
+++ b/testsuite/MDAnalysisTests/topology/test_guessers.py
@@ -89,7 +89,9 @@ class TestGuessTypes(object):
         ('3hg2', 'H'),
         ('OH-', 'O'),
         ('HO', 'H'),
-        ('he', 'H')
+        ('he', 'H'), 
+        ('zn', 'ZN'),
+        ('Ca2+', 'CA'),
     ))
     def test_guess_element_from_name(self, name, element):
         assert guessers.guess_atom_element(name) == element

--- a/testsuite/MDAnalysisTests/topology/test_guessers.py
+++ b/testsuite/MDAnalysisTests/topology/test_guessers.py
@@ -92,6 +92,7 @@ class TestGuessTypes(object):
         ('he', 'H'), 
         ('zn', 'ZN'),
         ('Ca2+', 'CA'),
+        ('CA', 'C'),
     ))
     def test_guess_element_from_name(self, name, element):
         assert guessers.guess_atom_element(name) == element


### PR DESCRIPTION
https://github.com/MDAnalysis/mdanalysis/issues/2348#issuecomment-532644903

Changes made in this Pull Request:
 - Guess the upper case of name

Until [a more longterm solution](https://github.com/MDAnalysis/mdanalysis/issues/2348#issuecomment-532647413) is implemented, it would be nice if zinc atoms weren't interpreted as nitrogen.

PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [ ] Issue raised/referenced?