### PR TITLE
unreshape topologygroup attributes

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -26,6 +26,8 @@ Fixes
   * PDBQTParser now gives icode TopologyAttrs (Issue #2361)
   * GROReader and GROWriter now can handle boxes with box vectors >1000nm
   * Guess atom element with uppercase name
+  * TopologyGroup no longer reshapes the type, guessed, and order properties
+    (Issue #2392)
 
 Enhancements
   * Uniforms exception handling between Python 2.7 and Python 3: raised exceptions

--- a/package/MDAnalysis/core/topologyobjects.py
+++ b/package/MDAnalysis/core/topologyobjects.py
@@ -542,15 +542,15 @@ class TopologyGroup(object):
         nbonds = len(bondidx)
         # remove duplicate bonds
         if type is None:
-            type = np.repeat(None, nbonds).reshape(nbonds, 1)
+            type = np.repeat(None, nbonds)
         if guessed is None:
-            guessed = np.repeat(True, nbonds).reshape(nbonds, 1)
+            guessed = np.repeat(True, nbonds)
         elif guessed is True or guessed is False:
-            guessed = np.repeat(guessed, nbonds).reshape(nbonds, 1)
+            guessed = np.repeat(guessed, nbonds)
         else:
-            guessed = np.asarray(guessed, dtype=np.bool).reshape(nbonds, 1)
+            guessed = np.asarray(guessed, dtype=np.bool)
         if order is None:
-            order = np.repeat(None, nbonds).reshape(nbonds, 1)
+            order = np.repeat(None, nbonds)
 
         if nbonds > 0:
             uniq, uniq_idx = util.unique_rows(bondidx, return_index=True)
@@ -736,7 +736,7 @@ class TopologyGroup(object):
                     type=np.concatenate([self._bondtypes,
                                          np.array([other._bondtype])]),
                     guessed=np.concatenate([self._guessed,
-                                            np.array([[other.is_guessed]])]),
+                                            np.array([other.is_guessed])]),
                     order=np.concatenate([self._order,
                                           np.array([other.order])]),
                 )

--- a/package/MDAnalysis/core/topologyobjects.py
+++ b/package/MDAnalysis/core/topologyobjects.py
@@ -523,6 +523,9 @@ class TopologyGroup(object):
     .. versionchanged:: 0.19.0
        Empty TopologyGroup now returns correctly shaped empty array via
        indices property and to_indices()
+    .. versionchanged::0.21.0
+       ``type``, ``guessed``, and ``order`` are no longer reshaped to arrays
+       with an extra dimension
     """
     def __init__(self, bondidx, universe, btype=None, type=None, guessed=None,
                  order=None):

--- a/testsuite/MDAnalysisTests/core/test_topologyobjects.py
+++ b/testsuite/MDAnalysisTests/core/test_topologyobjects.py
@@ -361,13 +361,13 @@ class TestTopologyGroup(object):
         vals = np.array([[0, 10], [5, 15]])
         tg = TopologyGroup(vals, PSFDCD, guessed=True)
 
-        assert_equal(tg._guessed, np.array([[True], [True]]))
+        assert_equal(tg._guessed, np.array([True, True]))
 
     def test_create_guessed_tg_2(self, PSFDCD):
         vals = np.array([[0, 10], [5, 15]])
         tg = TopologyGroup(vals, PSFDCD, guessed=False)
 
-        assert_equal(tg._guessed, np.array([[False], [False]]))
+        assert_equal(tg._guessed, np.array([False, False]))
 
     def test_TG_equality(self, PSFDCD):
         """Make two identical TGs,


### PR DESCRIPTION
Fixes #2392

Changes made in this Pull Request:
 - Don't reshape TopologyGroup attributes when creating them directly


PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
