### PR TITLE
Improved exception message for traj file without extension.

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -30,6 +30,7 @@ Fixes
     (Issue #2392)
 
 Enhancements
+  * Enhanges exception message when trajectory output file has no extension assigned.
   * Uniforms exception handling between Python 2.7 and Python 3: raised exceptions
     do not contain previous exceptions traceback. Uses six package to handle
     py27 and py3 compatibility (PR #2357)

--- a/package/MDAnalysis/core/_get_readers.py
+++ b/package/MDAnalysis/core/_get_readers.py
@@ -26,7 +26,6 @@ import copy
 import inspect
 import mmtf
 import numpy as np
-from MDAnalysis.exceptions import FileIOError
 from MDAnalysis.lib.util import isstream
 
 from .. import _READERS, _PARSERS, _MULTIFRAME_WRITERS, _SINGLEFRAME_WRITERS
@@ -163,10 +162,10 @@ def get_writer_for(filename, format=None, multiframe=None):
     """
     if filename is None:
         format = 'NULL'
-    elif format is None:
+    elif format in ('', None):
         try:
             root, ext = util.get_ext(filename)
-        except (TypeError, AttributeError):
+        except (TypeError, AttributeError, ValueError):
             # An AttributeError is raised if filename cannot
             # be manipulated as a string.
             # A TypeError is raised in py3.6
@@ -178,13 +177,6 @@ def get_writer_for(filename, format=None, multiframe=None):
         else:
             format = util.check_compressed_format(root, ext)
         
-    if format == '':
-        # Improves detail of error message when ext is not assigned in
-        # output file. Otherwise TypeError is raised when except the
-        # return statement
-        raise FileIOError((
-            "No extension assigned for trajectory output file '{}'."
-            ).format(filename))
     format = format.upper()
     if multiframe is None:
         # Multiframe takes priority, else use singleframe

--- a/package/MDAnalysis/core/_get_readers.py
+++ b/package/MDAnalysis/core/_get_readers.py
@@ -26,6 +26,7 @@ import copy
 import inspect
 import mmtf
 import numpy as np
+from MDAnalysis.exceptions import FileIOError
 from MDAnalysis.lib.util import isstream
 
 from .. import _READERS, _PARSERS, _MULTIFRAME_WRITERS, _SINGLEFRAME_WRITERS
@@ -176,6 +177,14 @@ def get_writer_for(filename, format=None, multiframe=None):
                 None)
         else:
             format = util.check_compressed_format(root, ext)
+        
+    if format == '':
+        # Improves detail of error message when ext is not assigned in
+        # output file. Otherwise TypeError is raised when except the
+        # return statement
+        raise FileIOError((
+            "No extension assigned for trajectory output file '{}'."
+            ).format(filename))
     format = format.upper()
     if multiframe is None:
         # Multiframe takes priority, else use singleframe

--- a/package/MDAnalysis/core/_get_readers.py
+++ b/package/MDAnalysis/core/_get_readers.py
@@ -162,10 +162,10 @@ def get_writer_for(filename, format=None, multiframe=None):
     """
     if filename is None:
         format = 'NULL'
-    elif format in ('', None):
+    elif format is None:
         try:
             root, ext = util.get_ext(filename)
-        except (TypeError, AttributeError, ValueError):
+        except (TypeError, AttributeError):
             # An AttributeError is raised if filename cannot
             # be manipulated as a string.
             # A TypeError is raised in py3.6
@@ -176,7 +176,14 @@ def get_writer_for(filename, format=None, multiframe=None):
                 None)
         else:
             format = util.check_compressed_format(root, ext)
-        
+    
+    if format == '':
+        raise ValueError((
+            'File format could not be guessed from {}, '
+            'resulting in empty string - '
+            'only None or valid formats are supported.'
+            ).format(filename))
+
     format = format.upper()
     if multiframe is None:
         # Multiframe takes priority, else use singleframe

--- a/package/MDAnalysis/exceptions.py
+++ b/package/MDAnalysis/exceptions.py
@@ -60,10 +60,6 @@ class FileFormatWarning(Warning):
     """Warning indicating possible problems with a file format."""
 
 
-class FileIOError(Exception):
-    """Exception indicating errors with I/O paths."""
-
-
 class StreamWarning(Warning):
     """Warning indicating a possible problem with a stream.
 

--- a/package/MDAnalysis/exceptions.py
+++ b/package/MDAnalysis/exceptions.py
@@ -60,6 +60,10 @@ class FileFormatWarning(Warning):
     """Warning indicating possible problems with a file format."""
 
 
+class FileIOError(Exception):
+    """Exception indicating errors with I/O paths."""
+
+
 class StreamWarning(Warning):
     """Warning indicating a possible problem with a stream.
 

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -925,8 +925,13 @@ def get_ext(filename):
     ext : str
     """
     root, ext = os.path.splitext(filename)
+    
+    if ext == '':
+        raise ValueError
+    
     if ext.startswith(os.extsep):
         ext = ext[1:]
+
     return root, ext.lower()
 
 

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -926,9 +926,6 @@ def get_ext(filename):
     """
     root, ext = os.path.splitext(filename)
     
-    if ext == '':
-        raise ValueError
-    
     if ext.startswith(os.extsep):
         ext = ext[1:]
 

--- a/testsuite/MDAnalysisTests/lib/test_util.py
+++ b/testsuite/MDAnalysisTests/lib/test_util.py
@@ -41,7 +41,7 @@ import MDAnalysis.lib.mdamath as mdamath
 from MDAnalysis.lib.util import (cached, static_variables, warn_if_not_unique,
                                  check_coords)
 from MDAnalysis.core.topologyattrs import Bonds
-from MDAnalysis.exceptions import NoDataError, DuplicateWarning
+from MDAnalysis.exceptions import NoDataError, DuplicateWarning, FileIOError
 
 
 from MDAnalysisTests.datafiles import (
@@ -1103,15 +1103,21 @@ class TestGetWriterFor(object):
     def test_missing_extension(self):
         # Make sure ``get_writer_for`` behave as expected if *filename*
         # has no extension
-        with pytest.raises(TypeError):
+        with pytest.raises(FileIOError):
             mda.coordinates.core.get_writer_for(filename='test', format=None)
+
+    def test_file_no_extension(self):
+        """No format given"""
+        with pytest.raises(FileIOError):
+            mda.coordinates.core.get_writer_for('outtraj')
+
 
     def test_wrong_format(self):
         # Make sure ``get_writer_for`` fails if the format is unknown
         with pytest.raises(TypeError):
             mda.coordinates.core.get_writer_for(filename="fail_me",
                                                 format='UNK')
-
+    
     def test_compressed_extension(self):
         for ext in ('.gz', '.bz2'):
             fn = 'test.gro' + ext

--- a/testsuite/MDAnalysisTests/lib/test_util.py
+++ b/testsuite/MDAnalysisTests/lib/test_util.py
@@ -41,7 +41,7 @@ import MDAnalysis.lib.mdamath as mdamath
 from MDAnalysis.lib.util import (cached, static_variables, warn_if_not_unique,
                                  check_coords)
 from MDAnalysis.core.topologyattrs import Bonds
-from MDAnalysis.exceptions import NoDataError, DuplicateWarning, FileIOError
+from MDAnalysis.exceptions import NoDataError, DuplicateWarning
 
 
 from MDAnalysisTests.datafiles import (
@@ -931,6 +931,10 @@ class TestGuessFormat(object):
 
         assert a == 'file'
         assert b == extention.lower()
+    
+    def test_get_extension_without_extension(self):
+        with pytest.raises(ValueError):
+            util.get_ext('file')
 
     @pytest.mark.parametrize('extention',
                              [format_tuple[0].upper() for format_tuple in
@@ -1103,12 +1107,17 @@ class TestGetWriterFor(object):
     def test_missing_extension(self):
         # Make sure ``get_writer_for`` behave as expected if *filename*
         # has no extension
-        with pytest.raises(FileIOError):
+        with pytest.raises(ValueError):
             mda.coordinates.core.get_writer_for(filename='test', format=None)
+
+    def test_extension_empty_string(self):
+        """Test format=''."""
+        with pytest.raises(ValueError):
+            mda.coordinates.core.get_writer_for(filename='test', format='')
 
     def test_file_no_extension(self):
         """No format given"""
-        with pytest.raises(FileIOError):
+        with pytest.raises(ValueError):
             mda.coordinates.core.get_writer_for('outtraj')
 
 

--- a/testsuite/MDAnalysisTests/lib/test_util.py
+++ b/testsuite/MDAnalysisTests/lib/test_util.py
@@ -932,10 +932,6 @@ class TestGuessFormat(object):
         assert a == 'file'
         assert b == extention.lower()
     
-    def test_get_extension_without_extension(self):
-        with pytest.raises(ValueError):
-            util.get_ext('file')
-
     @pytest.mark.parametrize('extention',
                              [format_tuple[0].upper() for format_tuple in
                               formats] +
@@ -1111,7 +1107,12 @@ class TestGetWriterFor(object):
             mda.coordinates.core.get_writer_for(filename='test', format=None)
 
     def test_extension_empty_string(self):
-        """Test format=''."""
+        """
+        Test format=''.
+        
+        Raises TypeError because format can be only None or
+        valid formats.
+        """
         with pytest.raises(ValueError):
             mda.coordinates.core.get_writer_for(filename='test', format='')
 


### PR DESCRIPTION
*This is a very small addition.*

**Improves Exception message when `format=None` or `filename` string has no extension.**

**Previous behavior:**
```python
with mda.Writer('output_traj', selection=selection.n_atoms) as W:
    for ts in u.trajectory:
        W.write(selection)
  File "/home/joao/GitHub/fork_mdanalysis/package/MDAnalysis/coordinates/core.py", line 134, in writer
    multiframe=kwargs.pop('multiframe', None))
  File "/home/joao/GitHub/fork_mdanalysis/package/MDAnalysis/core/_get_readers.py", line 199, in get_writer_for
    raise_from(TypeError(errmsg.format(format)), None)
  File "<string>", line 3, in raise_from
TypeError: No trajectory or frame writer for format ''
```

**PR behavior**:
```python
with mda.Writer('output_traj', selection=selection.n_atoms) as W:
    for ts in u.trajectory:
        W.write(selection)
  File "/home/joao/GitHub/fork_mdanalysis/package/MDAnalysis/coordinates/core.py", line 134, in writer
    multiframe=kwargs.pop('multiframe', None))
  File "/home/joao/GitHub/fork_mdanalysis/package/MDAnalysis/core/_get_readers.py", line 187, in get_writer_for
    ).format(filename))
MDAnalysis.exceptions.FileIOError: No extension assigned for trajectory output file 'output_traj'.
```

Enhances:
* raises custom Exception
* exception message is clearer

Tests pass on my computer.