### PR TITLE
Convert atom types of TXYZ to strings

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -32,6 +32,7 @@ Fixes
   * PDB files no longer lose chainIDs when reading files without segIDs (Issue #2389)
   * The expected frames are made available when a trajectory slice is sliced itself
     with an incomplete slice and/or with a negative step (Issue #2413)
+  * TXYZ parser uses strings for the atom types like other parsers (Issue #2435)
 
 Enhancements
   * Enhanges exception message when trajectory output file has no extension assigned.

--- a/package/MDAnalysis/topology/TXYZParser.py
+++ b/package/MDAnalysis/topology/TXYZParser.py
@@ -90,7 +90,7 @@ class TXYZParser(TopologyReaderBase):
 
             atomids = np.zeros(natoms, dtype=np.int)
             names = np.zeros(natoms, dtype=object)
-            types = np.zeros(natoms, dtype=np.int)
+            types = np.zeros(natoms, dtype=object)
             bonds = []
             # Find first atom line, maybe there's box information
             fline = inf.readline()
@@ -110,7 +110,7 @@ class TXYZParser(TopologyReaderBase):
                 line = line.split()
                 atomids[i]= line[0]
                 names[i] = line[1]
-                types[i] = line[5]
+                types[i] = str(line[5])
                 bonded_atoms = line[6:]
                 for other_atom in bonded_atoms:
                     other_atom = int(other_atom) - 1

--- a/package/MDAnalysis/topology/TXYZParser.py
+++ b/package/MDAnalysis/topology/TXYZParser.py
@@ -110,7 +110,7 @@ class TXYZParser(TopologyReaderBase):
                 line = line.split()
                 atomids[i]= line[0]
                 names[i] = line[1]
-                types[i] = str(line[5])
+                types[i] = line[5]
                 bonded_atoms = line[6:]
                 for other_atom in bonded_atoms:
                     other_atom = int(other_atom) - 1

--- a/testsuite/MDAnalysisTests/topology/test_txyz.py
+++ b/testsuite/MDAnalysisTests/topology/test_txyz.py
@@ -31,8 +31,8 @@ from MDAnalysisTests.datafiles import TXYZ, ARC
 
 class TestTXYZParser(ParserBase):
     parser = mda.topology.TXYZParser.TXYZParser
-    guessed_attrs = [ 'masses']
-    expected_attrs = ['ids', 'names', 'bonds', 'types' ] 
+    guessed_attrs = ['masses']
+    expected_attrs = ['ids', 'names', 'bonds', 'types']
     expected_n_residues = 1
     expected_n_atoms = 9
     expected_n_segments = 1
@@ -43,3 +43,13 @@ class TestTXYZParser(ParserBase):
     @pytest.fixture(params=(TXYZ, ARC))
     def filename(self, request):
         return request.param
+
+    def test_atom_type_type(self, top):
+        """
+        ``u.atoms.types`` contains strings.
+
+        See `issue #2435 <https://github.com/MDAnalysis/mdanalysis/issues/2435>
+        """
+        types = top.types.values
+        type_is_str = [isinstance(atom_type, str) for atom_type in types]
+        assert all(type_is_str)


### PR DESCRIPTION
Fixes #2435

Changes made in this Pull Request:
 - Express the atom types in TXYZ as strings like in the other topology parsers.


PR Checklist
------------
 - [X] Tests?
 - ~[ ] Docs?~
 - [x] CHANGELOG updated?
 - [X] Issue raised/referenced?
