### PR TITLE
TST: pin NumPy version for Travis MacOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,7 @@ matrix:
 
     - os: osx
       env: PYTHON_VERSION=3.6
+           NUMPY_VERSION=1.17.3
 
 # macOS Python 2.7 works in principle but times out on Travis CI:
 # Disabled so that the tests can pass.


### PR DESCRIPTION
Fixes #2434, if I'm lucky

* try pinning the NumPy version used for
the Travis CI MacOS matrix entry, which
is currently failing on develop branch

* at the time of writing, the most
recent NumPy version available from
conda-forge in `1.17.3`, despite
the newer version on PyPI

The exact cause of the CI failure seems hard to dissect from the messy log. CI helpers is maybe to blame for that, but anyway..