### PR TITLE
[WIP] PDB parser and writer use the "elements" topology attribute

### DIFF
--- a/package/MDAnalysis/coordinates/PDB.py
+++ b/package/MDAnalysis/coordinates/PDB.py
@@ -927,6 +927,13 @@ class PDBWriter(base.WriterBase):
         occupancies = get_attr('occupancies', 1.0)
         tempfactors = get_attr('tempfactors', 0.0)
         atomnames = get_attr('names', 'X')
+        try:
+            elements = getattr(atoms, 'elements')
+        except AttributeError:
+            elements = [
+                guess_atom_element(name.strip())
+                for name in atomnames
+            ]
 
         for i, atom in enumerate(atoms):
             vals = {}
@@ -941,7 +948,7 @@ class PDBWriter(base.WriterBase):
             vals['occupancy'] = occupancies[i]
             vals['tempFactor'] = tempfactors[i]
             vals['segID'] = segids[i][:4]
-            vals['element'] = guess_atom_element(atomnames[i].strip())[:2]
+            vals['element'] = elements[i][:2]
 
             # .. _ATOM: http://www.wwpdb.org/documentation/file-format-content/format32/sect9.html#ATOM
             self.pdbfile.write(self.fmt['ATOM'].format(**vals))

--- a/package/MDAnalysis/topology/PDBParser.py
+++ b/package/MDAnalysis/topology/PDBParser.py
@@ -303,7 +303,7 @@ class PDBParser(TopologyReaderBase):
             attrs.append(Atomtypes(np.array(atomtypes, dtype=object)))
             attrs.append(Elements(np.array(atomtypes, dtype=object)))
             if not all(atomtypes):
-                n_undefined = sum(not atom_type for atom_type in atomtypes)
+                n_undefined = not all(atomtypes)
                 warnings.warn("The element symbol for some but not all atoms "
                               "are missing, the symbol is missing for "
                               "{}/{} atoms."

--- a/package/MDAnalysis/topology/PDBParser.py
+++ b/package/MDAnalysis/topology/PDBParser.py
@@ -72,6 +72,7 @@ from ..core.topologyattrs import (
     Bonds,
     ChainIDs,
     Atomtypes,
+    Elements,
     ICodes,
     Masses,
     Occupancies,
@@ -93,6 +94,7 @@ DIGITS_UPPER = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 DIGITS_LOWER = DIGITS_UPPER.lower()
 DIGITS_UPPER_VALUES = dict([pair for pair in zip(DIGITS_UPPER, range(36))])
 DIGITS_LOWER_VALUES = dict([pair for pair in zip(DIGITS_LOWER, range(36))])
+
 
 def decode_pure(digits_values, s):
     """Decodes the string s using the digit, value associations for each
@@ -299,6 +301,13 @@ class PDBParser(TopologyReaderBase):
             attrs.append(Atomtypes(atomtypes, guessed=True))
         else:
             attrs.append(Atomtypes(np.array(atomtypes, dtype=object)))
+            attrs.append(Elements(np.array(atomtypes, dtype=object)))
+            if not all(atomtypes):
+                n_undefined = sum(not atom_type for atom_type in atomtypes)
+                warnings.warn("The element symbol for some but not all atoms "
+                              "are missing, the symbol is missing for "
+                              "{}/{} atoms."
+                              .format(n_undefined, len(atomtypes)))
 
         masses = guess_masses(atomtypes)
         attrs.append(Masses(masses, guessed=True))

--- a/testsuite/MDAnalysisTests/topology/test_pdb.py
+++ b/testsuite/MDAnalysisTests/topology/test_pdb.py
@@ -335,7 +335,7 @@ def test_read_no_atom_elements():
 
 def test_read_no_atom_elements_no_warning(recwarn):
     """
-    If no element symbols are provided, no waring is issued.
+    If no element symbols are provided, no warning is issued.
     """
     u = mda.Universe(PDB_small)
     warning_is_about_elements = [


### PR DESCRIPTION
Fixes #2422 #2423

Changes made in this Pull Request:
 - The PDB parser populates the `elements` topology attribute if the appropriate column is filled in the input. The content of `elements` is the same as `atomtypes`.
- The PDB reader uses the `elements` topology attribute if available.


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [X] Issue raised/referenced?
