### PR TITLE
TST: pin setuptools in Python 2.7 CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,7 @@ matrix:
            CODECOV="true"
            NUMPY_VERSION=1.16
            SETUP_CMD="${PYTEST_FLAGS} --cov=MDAnalysis"
+           PIP_DEPENDENCIES="${PIP_DEPENDENCIES} setuptools<45.0.0"
 
     - os: osx
       env: PYTHON_VERSION=3.6


### PR DESCRIPTION
Fixes #2444, I hope

* pin `setuptools` to a version < `45.0.0`
in Travis CI Python 2.7 matrix entry to
prevent pulling in newer/unsupported versions

Incidentally, there are solutions like [dependabot](https://dependabot.com/) for
pinning & gradually raising/adjusting CI deps versions with automatic PRs for review, but I
think we don't have the bandwidth to set this up right now (I know NumPy was trying this,
SciPy hasn't so far). Not sure if it handles the reverse case of suggesting a pin
when forward-bumps cause breaks.