### PR TITLE
Add radius_cut_q as a method to contacts.Contacts

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -57,6 +57,7 @@ Enhancements
   * Added _add_TopologyObjects, _delete_TopologyObjects, and public convenience 
     methods to Universe. Added type and order checking to _Connection
     topologyattrs. (PR #2382)
+  * Added radius_cut_q as a method to contacts.Contacts (PR #2458)
 
 Changes
   * The fasta2select now always assumes that the gap character in a sequence

--- a/package/MDAnalysis/analysis/contacts.py
+++ b/package/MDAnalysis/analysis/contacts.py
@@ -438,8 +438,6 @@ class Contacts(AnalysisBase):
         # compute distance array for a frame
         d = distance_array(self.grA.positions, self.grB.positions)
 
-        y = np.empty(len(self.r0) + 1)
-        y[0] = self._ts.frame
         for i, (initial_contacts, r0) in enumerate(zip(self.initial_contacts,
                                                        self.r0), 1):
             # select only the contacts that were formed in the reference state

--- a/package/MDAnalysis/analysis/contacts.py
+++ b/package/MDAnalysis/analysis/contacts.py
@@ -503,6 +503,5 @@ def q1q2(u, selection='all', radius=4.5,
     last_frame_refs = _new_selections(u, selection, -1)
     return Contacts(u, selection,
                     (first_frame_refs, last_frame_refs),
-                    radius=radius, method=radius_cut_q,
-                    start=start, stop=stop, step=step,
-                    kwargs={'radius': radius})
+                    radius=radius, method='radius_cut',
+                    start=start, stop=stop, step=step)

--- a/package/MDAnalysis/analysis/contacts.py
+++ b/package/MDAnalysis/analysis/contacts.py
@@ -385,7 +385,7 @@ class Contacts(AnalysisBase):
         radius : float, optional (4.5 Angstroms)
             radius within which contacts exist in refgroup
         method : string | callable (optional)
-            Can either be one of ``['hard_cut' , 'soft_cut']`` or a callable
+            Can either be one of ``['hard_cut' , 'soft_cut', 'radius_cut']`` or a callable
             with call signature ``func(r, r0, **kwargs)`` (the "Contacts API").
         kwargs : dict, optional
             dictionary of additional kwargs passed to `method`. Check
@@ -397,10 +397,15 @@ class Contacts(AnalysisBase):
         self.u = u
         super(Contacts, self).__init__(self.u.trajectory, **basekwargs)
 
+        self.fraction_kwargs = kwargs if kwargs is not None else {}
+
         if method == 'hard_cut':
             self.fraction_contacts = hard_cut_q
         elif method == 'soft_cut':
             self.fraction_contacts = soft_cut_q
+        elif method == 'radius_cut':
+            self.fraction_contacts = radius_cut_q
+            self.fraction_kwargs['radius'] = radius
         else:
             if not callable(method):
                 raise ValueError("method has to be callable")
@@ -424,28 +429,25 @@ class Contacts(AnalysisBase):
                 self.initial_contacts.append(contact_matrix(self.r0[-1],
                                                             radius))
 
-        self.fraction_kwargs = kwargs if kwargs is not None else {}
-        self.timeseries = []
+    def _prepare(self):
+        self.timeseries = np.empty((self.n_frames, len(self.r0)+1))
 
     def _single_frame(self):
+        self.timeseries[self._frame_index][0] = self._ts.frame
+
         # compute distance array for a frame
         d = distance_array(self.grA.positions, self.grB.positions)
 
         y = np.empty(len(self.r0) + 1)
         y[0] = self._ts.frame
         for i, (initial_contacts, r0) in enumerate(zip(self.initial_contacts,
-                                                       self.r0)):
+                                                       self.r0), 1):
             # select only the contacts that were formed in the reference state
             r = d[initial_contacts]
             r0 = r0[initial_contacts]
-            y[i + 1] = self.fraction_contacts(r, r0, **self.fraction_kwargs)
+            q = self.fraction_contacts(r, r0, **self.fraction_kwargs)
+            self.timeseries[self._frame_index][i] = q
 
-        if len(y) == 1:
-            y = y[0]
-        self.timeseries.append(y)
-
-    def _conclude(self):
-        self.timeseries = np.array(self.timeseries, dtype=float)
 
     @deprecate(release="0.19.0", remove="1.0.0")
     def save(self, outfile):

--- a/package/MDAnalysis/analysis/contacts.py
+++ b/package/MDAnalysis/analysis/contacts.py
@@ -208,6 +208,7 @@ import os
 import errno
 import warnings
 import bz2
+import functools
 
 import numpy as np
 
@@ -404,8 +405,7 @@ class Contacts(AnalysisBase):
         elif method == 'soft_cut':
             self.fraction_contacts = soft_cut_q
         elif method == 'radius_cut':
-            self.fraction_contacts = radius_cut_q
-            self.fraction_kwargs['radius'] = radius
+            self.fraction_contacts = functools.partial(radius_cut_q, radius=radius)
         else:
             if not callable(method):
                 raise ValueError("method has to be callable")

--- a/testsuite/MDAnalysisTests/analysis/test_contacts.py
+++ b/testsuite/MDAnalysisTests/analysis/test_contacts.py
@@ -219,7 +219,6 @@ class TestContacts(object):
 
 
     def test_villin_unfolded(self):
-
         # both folded
         f = mda.Universe(contacts_villin_folded)
         u = mda.Universe(contacts_villin_folded)
@@ -260,6 +259,19 @@ class TestContacts(object):
                     0.45631068, 0.37864078, 0.42718447]
         assert len(ca.timeseries) == len(expected)
         assert_array_almost_equal(ca.timeseries[:, 1], expected)
+
+    def test_radius_cut_method(self, universe):
+        acidic = universe.select_atoms(self.sel_acidic)
+        basic = universe.select_atoms(self.sel_basic)
+        r = contacts.distance_array(acidic.positions, basic.positions)
+        initial_contacts = contacts.contact_matrix(r, 6.0)
+        expected = []
+        for ts in universe.trajectory:
+            r = contacts.distance_array(acidic.positions, basic.positions)
+            expected.append(contacts.radius_cut_q(r[initial_contacts], None, radius=6.0))
+
+        ca = self._run_Contacts(universe, method='radius_cut')
+        assert_array_equal(ca.timeseries[:, 1], expected)
 
     @staticmethod
     def _is_any_closer(r, r0, dist=2.5):


### PR DESCRIPTION
Changes made in this Pull Request:
 - adds `radius_cut_q` as a method to contacts.Contacts

It seems like this method was made for contacts.Contacts anyway.

PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [ ] Issue raised/referenced?
