### PR TITLE
Changed menu navigation level in docs theme

### DIFF
--- a/package/doc/sphinx/source/conf.py
+++ b/package/doc/sphinx/source/conf.py
@@ -151,7 +151,7 @@ html_theme_options = {
     # Toc options
     'collapse_navigation': True,
     'sticky_navigation': True,
-    'navigation_depth': 5,
+    'navigation_depth': 4,
     'includehidden': True,
     'titles_only': False,
 }


### PR DESCRIPTION
Sphinx RTD theme does not support menu levels beyond 4, and sub[x5]-headings end up looking like this:

![Screenshot 2020-01-23 at 12 58 45 PM](https://user-images.githubusercontent.com/31115101/72950918-cd075580-3de0-11ea-8562-bf6206386e0f.png)

We can hide sub-headings beyond the fourth level by changing `navigation_depth` in `conf.py`.

The changed version looks like this:

![Screenshot 2020-01-23 at 12 58 56 PM](https://user-images.githubusercontent.com/31115101/72950952-e6a89d00-3de0-11ea-97df-71694b82bf6e.png)


Changes made in this Pull Request:

```diff

  -  'navigation_depth': 5,
  +  'navigation_depth': 4,

```


PR Checklist
------------
 - [ ] Tests?
 - [x] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
