### PR TITLE
Move parmed to optional dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,10 +29,10 @@ env:
     - BUILD_CMD="pip install -e package/ && (cd testsuite/ && python setup.py build)"
     - CONDA_MIN_DEPENDENCIES="mmtf-python mock six biopython networkx cython matplotlib scipy griddataformats hypothesis gsd codecov"
     # Cap seaborn to 0.9 since 0.10 drops Python 2 support (temporarily solve #2495)
-    - CONDA_DEPENDENCIES="${CONDA_MIN_DEPENDENCIES} seaborn>=0.7.0,<=0.9 clustalw=2.1 netcdf4 scikit-learn joblib>=0.12 parmed"
+    - CONDA_DEPENDENCIES="${CONDA_MIN_DEPENDENCIES} seaborn>=0.7.0,<=0.9 clustalw=2.1 netcdf4 scikit-learn joblib>=0.12"
     - CONDA_CHANNELS='biobuilds conda-forge'
     - CONDA_CHANNEL_PRIORITY=True
-    - PIP_DEPENDENCIES="duecredit"
+    - PIP_DEPENDENCIES="duecredit parmed"
     - NUMPY_VERSION=stable
     - INSTALL_HOLE="true"
     - CYTHON_TRACE_NOGIL=1
@@ -86,6 +86,7 @@ matrix:
 #           SETUP_CMD="${PYTEST_FLAGS} --cov=MDAnalysis"
 
     - env: NAME='minimal'
+           PIP_DEPENDENCIES=""
            CONDA_DEPENDENCIES=${CONDA_MIN_DEPENDENCIES}
            INSTALL_HOLE="false"
            CODECOV="true" SETUP_CMD="${PYTEST_FLAGS} --cov=MDAnalysis"

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,10 +29,10 @@ env:
     - BUILD_CMD="pip install -e package/ && (cd testsuite/ && python setup.py build)"
     - CONDA_MIN_DEPENDENCIES="mmtf-python mock six biopython networkx cython matplotlib scipy griddataformats hypothesis gsd codecov"
     # Cap seaborn to 0.9 since 0.10 drops Python 2 support (temporarily solve #2495)
-    - CONDA_DEPENDENCIES="${CONDA_MIN_DEPENDENCIES} seaborn>=0.7.0,<=0.9 clustalw=2.1 netcdf4 scikit-learn joblib>=0.12"
+    - CONDA_DEPENDENCIES="${CONDA_MIN_DEPENDENCIES} seaborn>=0.7.0,<=0.9 clustalw=2.1 netcdf4 scikit-learn joblib>=0.12 parmed"
     - CONDA_CHANNELS='biobuilds conda-forge'
     - CONDA_CHANNEL_PRIORITY=True
-    - PIP_DEPENDENCIES="duecredit parmed"
+    - PIP_DEPENDENCIES="duecredit"
     - NUMPY_VERSION=stable
     - INSTALL_HOLE="true"
     - CYTHON_TRACE_NOGIL=1

--- a/package/MDAnalysis/coordinates/ParmEd.py
+++ b/package/MDAnalysis/coordinates/ParmEd.py
@@ -162,7 +162,7 @@ class ParmEdConverter(base.ConverterBase):
         """
         try:
             import parmed as pmd
-        except ModuleNotFoundError:
+        except ImportError:
             raise ImportError('ParmEd is required for ParmEdConverter but '
                               'is not installed. Try installing it with \n'
                               'pip install parmed')

--- a/package/MDAnalysis/coordinates/ParmEd.py
+++ b/package/MDAnalysis/coordinates/ParmEd.py
@@ -163,8 +163,9 @@ class ParmEdConverter(base.ConverterBase):
         try:
             import parmed as pmd
         except ModuleNotFoundError:
-            raise ValueError('Parmed is required for ParmEdConverter but '
-                             'is not installed.')
+            raise ImportError('ParmEd is required for ParmEdConverter but '
+                              'is not installed. Try installing it with \n'
+                              'pip install parmed')
         try:
             # make sure to use atoms (Issue 46)
             ag_or_ts = obj.atoms

--- a/package/MDAnalysis/core/_get_readers.py
+++ b/package/MDAnalysis/core/_get_readers.py
@@ -25,6 +25,7 @@ from six import raise_from
 import copy
 import inspect
 
+
 from .. import (_READERS, _READER_HINTS,
                 _PARSERS, _PARSER_HINTS,
                 _MULTIFRAME_WRITERS, _SINGLEFRAME_WRITERS, _CONVERTERS)

--- a/package/MDAnalysis/core/_get_readers.py
+++ b/package/MDAnalysis/core/_get_readers.py
@@ -32,6 +32,15 @@ from .. import (_READERS, _READER_HINTS,
 from ..lib import util
 
 
+def _is_parmed_object(thing):
+    module = inspect.getmodule(thing.__class__)
+
+    if module is None:
+        return False
+    else:
+        return module.__name__.startswith('parmed')
+
+
 def get_reader_for(filename, format=None):
     """Return the appropriate trajectory reader class for `filename`.
 
@@ -66,7 +75,7 @@ def get_reader_for(filename, format=None):
       :class:`~MDAnalysis.coordinates.memory.MemoryReader` is returned.
     - If `filename` is an MMTF object,
       :class:`~MDAnalysis.coordinates.MMTF.MMTFReader` is returned.
-    - If `filename` is a ParmEd Structure, 
+    - If `filename` is a ParmEd Structure,
       :class:`~MDAnalysis.coordinates.ParmEd.ParmEdReader` is returned.
     - If `filename` is an iterable of filenames,
       :class:`~MDAnalysis.coordinates.chain.ChainReader` is returned.
@@ -177,7 +186,7 @@ def get_writer_for(filename, format=None, multiframe=None):
                 None)
         else:
             format = util.check_compressed_format(root, ext)
-    
+
     if format == '':
         raise ValueError((
             'File format could not be guessed from {}, '
@@ -276,7 +285,7 @@ def get_converter_for(format):
     TypeError
         If no appropriate parser could be found.
 
-    
+
     .. versionadded:: 0.21.0
     """
     try:

--- a/package/MDAnalysis/core/_get_readers.py
+++ b/package/MDAnalysis/core/_get_readers.py
@@ -25,20 +25,10 @@ from six import raise_from
 import copy
 import inspect
 
-
 from .. import (_READERS, _READER_HINTS,
                 _PARSERS, _PARSER_HINTS,
                 _MULTIFRAME_WRITERS, _SINGLEFRAME_WRITERS, _CONVERTERS)
 from ..lib import util
-
-
-def _is_parmed_object(thing):
-    module = inspect.getmodule(thing.__class__)
-
-    if module is None:
-        return False
-    else:
-        return module.__name__.startswith('parmed')
 
 
 def get_reader_for(filename, format=None):

--- a/package/setup.py
+++ b/package/setup.py
@@ -558,7 +558,6 @@ if __name__ == '__main__':
           'scipy>=1.0.0',
           'matplotlib>=1.5.1',
           'mock',
-          'parmed',
     ]
     if not os.name == 'nt':
         install_requires.append('gsd>=1.4.0')
@@ -593,7 +592,7 @@ if __name__ == '__main__':
           ext_modules=exts,
           requires=['numpy (>=1.13.3)', 'biopython (>= 1.71)', 'mmtf (>=1.0.0)',
                     'networkx (>=1.0)', 'GridDataFormats (>=0.3.2)', 'joblib',
-                    'scipy (>=1.0.0)', 'matplotlib (>=1.5.1)', 'parmed'],
+                    'scipy (>=1.0.0)', 'matplotlib (>=1.5.1)'],
           # all standard requirements are available through PyPi and
           # typically can be installed without difficulties through setuptools
           setup_requires=[

--- a/testsuite/MDAnalysisTests/coordinates/test_parmed.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_parmed.py
@@ -46,18 +46,6 @@ from MDAnalysisTests.datafiles import (
 
 pmd = pytest.importorskip('parmed')
 
-from MDAnalysis.core._get_readers import _is_parmed_object
-
-
-@pytest.mark.parametrize('thing,reference', [
-    ('foo', False),
-    ([1,2,3], False),
-    (pmd.load_file(GRO), True),
-])
-def test_is_parmed_object(thing, reference):
-    assert _is_parmed_object(thing) == reference
-
-
 
 class TestParmEdReaderGRO:
     ref_filename = GRO

--- a/testsuite/MDAnalysisTests/coordinates/test_parmed.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_parmed.py
@@ -46,10 +46,23 @@ from MDAnalysisTests.datafiles import (
 
 pmd = pytest.importorskip('parmed')
 
+from MDAnalysis.core._get_readers import _is_parmed_object
+
+
+@pytest.mark.parametrize('thing,reference', [
+    ('foo', False),
+    ([1,2,3], False),
+    (pmd.load_file(GRO), True),
+])
+def test_is_parmed_object(thing, reference):
+    assert _is_parmed_object(thing) == reference
+
+
+
 class TestParmEdReaderGRO:
     ref_filename = GRO
 
-    universe = mda.Universe(pmd.load_file(GRO), format='parmed')
+    universe = mda.Universe(pmd.load_file(GRO))
     ref = mda.Universe(GRO)
     prec = 3
 
@@ -68,10 +81,8 @@ class TestParmEdReaderGRO:
 
 
 class BaseTestParmEdReader(_SingleFrameReader):
-
     def setUp(self):
-        self.universe = mda.Universe(pmd.load_file(self.ref_filename),
-                                     format='parmed')
+        self.universe = mda.Universe(pmd.load_file(self.ref_filename))
         self.ref = mda.Universe(self.ref_filename)
         self.prec = 3
 
@@ -135,7 +146,7 @@ class BaseTestParmEdConverter:
 
     @pytest.fixture(scope='class')
     def roundtrip(self, ref):
-        u = mda.Universe(ref, format='parmed')
+        u = mda.Universe(ref)
         return u.atoms.convert_to('PARMED')
 
     def test_equivalent_connectivity_counts(self, universe, output):
@@ -232,7 +243,7 @@ class BaseTestParmEdConverterFromParmed(BaseTestParmEdConverter):
 
     @pytest.fixture(scope='class')
     def universe(self, ref):
-        return mda.Universe(ref, format='parmed')
+        return mda.Universe(ref)
 
     def test_equivalent_connectivity_counts(self, ref, output):
         for attr in ('atoms', 'bonds', 'angles', 'dihedrals', 'impropers',

--- a/testsuite/MDAnalysisTests/coordinates/test_parmed.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_parmed.py
@@ -23,7 +23,6 @@
 from __future__ import absolute_import
 
 import pytest
-import parmed as pmd
 import MDAnalysis as mda
 
 from numpy.testing import (assert_equal,
@@ -45,10 +44,12 @@ from MDAnalysisTests.datafiles import (
     PRM_UreyBradley,
 )
 
+pmd = pytest.importorskip('parmed')
+
 class TestParmEdReaderGRO:
     ref_filename = GRO
 
-    universe = mda.Universe(pmd.load_file(GRO))
+    universe = mda.Universe(pmd.load_file(GRO), format='parmed')
     ref = mda.Universe(GRO)
     prec = 3
 
@@ -69,7 +70,8 @@ class TestParmEdReaderGRO:
 class BaseTestParmEdReader(_SingleFrameReader):
 
     def setUp(self):
-        self.universe = mda.Universe(pmd.load_file(self.ref_filename))
+        self.universe = mda.Universe(pmd.load_file(self.ref_filename),
+                                     format='parmed')
         self.ref = mda.Universe(self.ref_filename)
         self.prec = 3
 
@@ -133,7 +135,7 @@ class BaseTestParmEdConverter:
 
     @pytest.fixture(scope='class')
     def roundtrip(self, ref):
-        u = mda.Universe(ref)
+        u = mda.Universe(ref, format='parmed')
         return u.atoms.convert_to('PARMED')
 
     def test_equivalent_connectivity_counts(self, universe, output):
@@ -230,7 +232,7 @@ class BaseTestParmEdConverterFromParmed(BaseTestParmEdConverter):
 
     @pytest.fixture(scope='class')
     def universe(self, ref):
-        return mda.Universe(ref)
+        return mda.Universe(ref, format='parmed')
 
     def test_equivalent_connectivity_counts(self, ref, output):
         for attr in ('atoms', 'bonds', 'angles', 'dihedrals', 'impropers',

--- a/testsuite/MDAnalysisTests/topology/test_parmed.py
+++ b/testsuite/MDAnalysisTests/topology/test_parmed.py
@@ -23,7 +23,6 @@
 from __future__ import absolute_import
 
 import pytest
-import parmed as pmd
 import MDAnalysis as mda
 
 from MDAnalysisTests.topology.base import ParserBase
@@ -31,6 +30,8 @@ from MDAnalysisTests.datafiles import (
     PSF_NAMD_GBIS,
     PRM
 )
+
+pmd = pytest.importorskip('parmed')
 
 class BaseTestParmedParser(ParserBase):
     parser = mda.topology.ParmEdParser.ParmEdParser
@@ -60,7 +61,11 @@ class BaseTestParmedParser(ParserBase):
 
     @pytest.fixture
     def universe(self, filename):
-        return mda.Universe(filename)
+        return mda.Universe(filename, format='parmed')
+
+    def test_creates_universe(self, filename):
+        u = mda.Universe(filename, format='parmed')
+        assert isinstance(u, mda.Universe)
 
     def test_bonds_total_counts(self, top, filename):
         unique = set([(a.atom1.idx, a.atom2.idx)

--- a/testsuite/MDAnalysisTests/topology/test_parmed.py
+++ b/testsuite/MDAnalysisTests/topology/test_parmed.py
@@ -61,10 +61,10 @@ class BaseTestParmedParser(ParserBase):
 
     @pytest.fixture
     def universe(self, filename):
-        return mda.Universe(filename, format='parmed')
+        return mda.Universe(filename)
 
     def test_creates_universe(self, filename):
-        u = mda.Universe(filename, format='parmed')
+        u = mda.Universe(filename)
         assert isinstance(u, mda.Universe)
 
     def test_bonds_total_counts(self, top, filename):
@@ -241,4 +241,3 @@ class TestParmedParserPRM(BaseTestParmedParser):
         )):
             assert dih.type[i].type.phi_k == phi_k
             assert dih.type[i].type.per == per
-                                            


### PR DESCRIPTION
Changes made in this Pull Request:
 - Made ParmEd an optional dependency

If MDAnalysis is going to expand its interoperability with #2468 and more, it seems best to not make users install every library under the sun.
 
PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
