### PR TITLE
Removing deprecated reader code for v1.0

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -19,6 +19,8 @@ mm/dd/yy richardjgowers, kain88-de, lilyminium, p-j-smith, bdice, joaomcteixeira
   * 0.21.0
 
 Fixes
+  * Removes support for reading AMBER NetCDF files with `cell_angle` units set
+    to `degrees` instead of the convention agreed `degree` (Issue #2327). 
   * Removes the MassWeight option from gnm (PR #2479).
   * AtomGroup.guess_bonds now uses periodic boundary information when available
     (Issue #2350)

--- a/package/MDAnalysis/coordinates/TRJ.py
+++ b/package/MDAnalysis/coordinates/TRJ.py
@@ -458,10 +458,9 @@ class NCDFReader(base.ReaderBase):
        kJ/(mol*Angstrom). It is noted that with 0.19.2 and earlier versions,
        velocities would have often been reported in values of angstrom/AKMA
        time units instead (Issue #2323).
-
-    .. TODO:
-       * Remove support for `degrees` units in MDAnalysis version > 1.0
-         (Issue #2327, PR #2326).
+    .. versionchanged:: 1.0.0
+       Support for reading `degrees` units for `cell_angles` has now been
+       removed (Issue #2327)
 
     """
 
@@ -621,21 +620,9 @@ class NCDFReader(base.ReaderBase):
         if self.periodic:
             self._verify_units(self.trjfile.variables['cell_lengths'].units,
                                'angstrom')
-            # Currently the MDA writer outputs 'degrees' rather than the
-            # singular form 'degree' agreed in the conventions. As discussed
-            # in PR #2326 from MDA 1.0 only and 'degree' will be accepted.
+            # As of v1.0.0 only `degree` is accepted as a unit
             cell_angle_units = self.trjfile.variables['cell_angles'].units
-            if (cell_angle_units.decode('utf-8') == 'degrees'):
-                wmsg = ("DEPRECATED (1.0): NCDF trajectory {0} uses units of "
-                        "`degrees` for the `cell_angles` variable instead of "
-                        "`degree`. Support for non-AMBER convention units is "
-                        "now deprecated and will end in MDAnalysis version "
-                        "1.0. Afterwards, reading this file will raise an "
-                        "error.")
-                warnings.warn(wmsg, category=DeprecationWarning)
-                logger.warning(wmsg)
-            else:
-                self._verify_units(cell_angle_units, 'degree')
+            self._verify_units(cell_angle_units, 'degree')
 
         self._current_frame = 0
 

--- a/testsuite/MDAnalysisTests/coordinates/test_netcdf.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_netcdf.py
@@ -596,24 +596,6 @@ class TestNCDFReaderExceptionsWarnings(_NCDFGenerator):
                     "attributes are missing")
             assert str(record[0].message.args[0]) == wmsg
 
-    def test_degrees_warn(self, tmpdir):
-        """Checks that plural degrees throws an user deprecation warning
-        TODO: remove in MDAnalysis version 1.0 (Issue #2327)"""
-        mutation = {'cell_angles': 'degrees'}
-        params = self.gen_params(keypair=mutation, restart=False)
-        with tmpdir.as_cwd():
-            self.create_ncdf(params)
-            with pytest.warns(DeprecationWarning) as record:
-                NCDFReader(params['filename'])
-
-            assert len(record) == 1
-            wmsg = ("DEPRECATED (1.0): NCDF trajectory {0} uses units of "
-                    "`degrees` for the `cell_angles` variable instead of "
-                    "`degree`. Support for non-AMBER convention units is "
-                    "now deprecated and will end in MDAnalysis version 1.0. "
-                    "Afterwards, reading this file will raise an error.")
-            assert str(record[0].message.args[0]) == wmsg
-
 
 class _NCDFWriterTest(object):
     prec = 5


### PR DESCRIPTION
Partly addresses #2327 and #2443 

As far as I am aware, the NetCDF writer is the only part of the reader/writers that has code set for removal by v1.0.0, please let me know if this isn't the case.

Changes made in this Pull Request:
 - Removes support for the `degrees` unit for `cell_angles` in the AMBER NetCDF reader.

Note: this does not completely fix the NetCDF reader/writer (`scale_factor` writer support is needed, and we really should switch the writing of velocities from unscaled to the same factor used by the AMBER MD engines use [see #2327]). However, assuming a non API complete v1.0.0, further fixes can probably be done by the next release.

PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
