### PR TITLE
added parmed to setup.py

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -44,6 +44,7 @@ Fixes
     substitutes #define variables both from the file and when passed in as a keyword 
     argument. The directives parsed into bonds, angles, impropers, and dihedrals now 
     match TPRParser. (PR #2408)
+  * Added parmed to setup.py
 
 Enhancements
   * Improved ClusterCollection and Cluster string representations (Issue #2464)

--- a/package/setup.py
+++ b/package/setup.py
@@ -558,6 +558,7 @@ if __name__ == '__main__':
           'scipy>=1.0.0',
           'matplotlib>=1.5.1',
           'mock',
+          'parmed',
     ]
     if not os.name == 'nt':
         install_requires.append('gsd>=1.4.0')
@@ -592,7 +593,7 @@ if __name__ == '__main__':
           ext_modules=exts,
           requires=['numpy (>=1.13.3)', 'biopython (>= 1.71)', 'mmtf (>=1.0.0)',
                     'networkx (>=1.0)', 'GridDataFormats (>=0.3.2)', 'joblib',
-                    'scipy (>=1.0.0)', 'matplotlib (>=1.5.1)'],
+                    'scipy (>=1.0.0)', 'matplotlib (>=1.5.1)', 'parmed'],
           # all standard requirements are available through PyPi and
           # typically can be installed without difficulties through setuptools
           setup_requires=[


### PR DESCRIPTION
I forgot to include parmed in `setup.py`. Without it, you can't import the current develop version of MDAnalysis.

Changes made in this Pull Request:
 - Added parmed to `setup.py`


PR Checklist
------------
 - [x] Tests? Tested installation in an empty python 3.6 environment
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [ ] Issue raised/referenced?
