### PR TITLE
FullGroup selection keyword removal

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -78,6 +78,7 @@ Enhancements
     convert between a parmed.Structure and MDAnalysis Universe (PR #2404)
 
 Changes
+  * `fullgroup` selection has now been removed (#268)
   * AlignTraj `save()` method has been removed and the `filename` variable now
     defaults to the current working directory (Issues #2099, #1745, #2443)
   * Removed `MDAnalysis.migration` (Issue #2490, PR #2496)

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -2847,6 +2847,8 @@ class AtomGroup(GroupBase):
            Added periodic kwarg (default True)
         .. versionchanged:: 0.19.2
            Empty sel string now returns an empty Atom group.
+        .. versionchanged:: 1.0.0
+           The ``fullgroup`` selection has now been removed.
         """
 
         if not sel:

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -2834,8 +2834,6 @@ class AtomGroup(GroupBase):
 
         .. versionchanged:: 0.7.4 Added *resnum* selection.
         .. versionchanged:: 0.8.1 Added *group* and *fullgroup* selections.
-        .. deprecated:: 0.11 The use of *fullgroup* has been deprecated in favor
-            of the equivalent *global group* selections.
         .. versionchanged:: 0.13.0 Added *bonded* selection.
         .. versionchanged:: 0.16.0 Resid selection now takes icodes into account
             where present.
@@ -2848,7 +2846,8 @@ class AtomGroup(GroupBase):
         .. versionchanged:: 0.19.2
            Empty sel string now returns an empty Atom group.
         .. versionchanged:: 1.0.0
-           The ``fullgroup`` selection has now been removed.
+           The ``fullgroup`` selection has now been removed in favor of the
+           equivalent ``global group`` selection.
         """
 
         if not sel:

--- a/package/MDAnalysis/core/selection.py
+++ b/package/MDAnalysis/core/selection.py
@@ -48,7 +48,6 @@ import functools
 import warnings
 
 import numpy as np
-from numpy.lib.utils import deprecate
 
 
 from MDAnalysis.lib.util import unique_int_1d
@@ -496,24 +495,6 @@ class SelgroupSelection(Selection):
     def apply(self, group):
         mask = np.in1d(group.indices, self.grp.indices)
         return group[mask]
-
-# TODO: remove in 1.0 (should have been removed in 0.15.0)
-class FullSelgroupSelection(Selection):
-    token = 'fullgroup'
-
-    def __init__(self, parser, tokens):
-        grpname = tokens.popleft()
-        try:
-            self.grp = parser.selgroups[grpname]
-        except KeyError:
-            six.raise_from(
-                ValueError("Failed to find group: {0}".format(grpname)),
-                None)
-
-    @deprecate(old_name='fullgroup', new_name='global group',
-               message=' This will be removed in v0.15.0')
-    def apply(self, group):
-        return self.grp.unique
 
 
 class StringSelection(Selection):

--- a/package/doc/sphinx/source/documentation_pages/selections.rst
+++ b/package/doc/sphinx/source/documentation_pages/selections.rst
@@ -255,6 +255,9 @@ global *selection*
    The use of ``fullgroup`` has been deprecated in favor of the equivalent
    ``global group``.
 
+.. versionchanged:: 1.0.0
+   The ``fullgroup`` selection has now been removed.
+
 Dynamic selections
 ==================
 

--- a/package/doc/sphinx/source/documentation_pages/selections.rst
+++ b/package/doc/sphinx/source/documentation_pages/selections.rst
@@ -251,12 +251,9 @@ global *selection*
     :meth:`~MDAnalysis.core.groups.AtomGroup.select_atoms` from a
     :class:`~MDAnalysis.core.universe.Universe`, ``global`` is ignored.
 
-.. deprecated:: 0.11
-   The use of ``fullgroup`` has been deprecated in favor of the equivalent
-   ``global group``.
-
 .. versionchanged:: 1.0.0
-   The ``fullgroup`` selection has now been removed.
+   The ``fullgroup`` selection has now been removed. Please use the equivalent
+   ``global group`` selection.
 
 Dynamic selections
 ==================

--- a/testsuite/MDAnalysisTests/core/test_atomselections.py
+++ b/testsuite/MDAnalysisTests/core/test_atomselections.py
@@ -927,7 +927,6 @@ class TestSelectionErrors(object):
         'index or protein',
         'prop mass < 4.0 hello',  # unused token
         'prop mass > 10. and group this',  # missing group
-        'prop mass > 10. and fullgroup this',  # missing fullgroup
         'resname E*Y*Z',  # >1 wildcards
     ])
     def test_selection_fail(self, selstr, universe):


### PR DESCRIPTION
Completes #268

Changes made in this Pull Request:
 - Removes the `fullgroup` keyword from selections (and related test).

PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
