### PR TITLE
Removes skip and format from DCD reader

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -78,6 +78,8 @@ Enhancements
     convert between a parmed.Structure and MDAnalysis Universe (PR #2404)
 
 Changes
+  * Removes the `format` and `skip` keywords from :meth:`DCDReader.timeseries`
+    (Issue #2443)
   * AlignTraj `save()` method has been removed and the `filename` variable now
     defaults to the current working directory (Issues #2099, #1745, #2443)
   * Removed `MDAnalysis.migration` (Issue #2490, PR #2496)

--- a/package/MDAnalysis/coordinates/DCD.py
+++ b/package/MDAnalysis/coordinates/DCD.py
@@ -62,7 +62,6 @@ from six.moves import range
 import os
 import errno
 import numpy as np
-from numpy.lib.utils import deprecate
 import struct
 import types
 import warnings
@@ -299,12 +298,6 @@ class DCDReader(base.ReaderBase):
             where the shape is (frame, number of atoms,
             coordinates)
 
-
-        .. deprecated:: 0.16.0
-           `skip` has been deprecated in favor of the standard keyword `step`.
-
-        .. deprecated:: 0.17.0
-           `format` has been deprecated in favor of the standard keyword `order`.
 
         .. versionchanged:: 1.0.0
            `skip` and `format` keywords have been removed.

--- a/package/MDAnalysis/coordinates/DCD.py
+++ b/package/MDAnalysis/coordinates/DCD.py
@@ -272,9 +272,7 @@ class DCDReader(base.ReaderBase):
                    start=None,
                    stop=None,
                    step=None,
-                   skip=None,
-                   order='afc',
-                   format=None):
+                   order='afc'):
         """Return a subset of coordinate data for an AtomGroup
 
         Parameters
@@ -300,8 +298,6 @@ class DCDReader(base.ReaderBase):
             of 'a', 'f', 'c' are allowed ie "fac" - return array
             where the shape is (frame, number of atoms,
             coordinates)
-        format : str (optional)
-            deprecated, equivalent to `order`
 
 
         .. deprecated:: 0.16.0
@@ -309,13 +305,10 @@ class DCDReader(base.ReaderBase):
 
         .. deprecated:: 0.17.0
            `format` has been deprecated in favor of the standard keyword `order`.
+
+        .. versionchanged:: 1.0.0
+           `skip` and `format` keywords have been removed.
         """
-        if skip is not None:
-            step = skip
-            warnings.warn(
-                "Skip is deprecated and will be removed in"
-                "in 1.0. Use step instead.",
-                category=DeprecationWarning)
 
         start, stop, step = self.check_slice_indices(start, stop, step)
 
@@ -326,12 +319,6 @@ class DCDReader(base.ReaderBase):
             atom_numbers = list(asel.indices)
         else:
             atom_numbers = list(range(self.n_atoms))
-
-        if format is not None:
-            warnings.warn(
-                "'format' is deprecated and will be removed in 1.0. Use 'order' instead",
-                category=DeprecationWarning)
-            order = format
 
         frames = self._file.readframes(
             start, stop, step, order=order, indices=atom_numbers)

--- a/testsuite/MDAnalysisTests/coordinates/test_dcd.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_dcd.py
@@ -199,11 +199,6 @@ def test_timeseries_slices(slice, length, universe_dcd):
     assert_array_almost_equal(xyz, allframes[start:stop:step])
 
 
-def test_timeseries_deprecation(universe_dcd):
-    with pytest.warns(DeprecationWarning):
-        universe_dcd.trajectory.timeseries(format='fac')
-
-
 @pytest.mark.parametrize("order, shape", (
     ('fac', (98, 3341, 3)),
     ('fca', (98, 3, 3341)),
@@ -230,12 +225,6 @@ def test_timeseries_empty_selection(universe_dcd):
     with pytest.raises(NoDataError):
         asel = universe_dcd.select_atoms('name FOO')
         universe_dcd.trajectory.timeseries(asel=asel)
-
-
-def test_timeseries_skip(universe_dcd):
-    with pytest.warns(DeprecationWarning):
-        xyz = universe_dcd.trajectory.timeseries(skip=2, order='fac')
-    assert len(xyz) == universe_dcd.trajectory.n_frames / 2
 
 
 def test_reader_set_dt():


### PR DESCRIPTION
Towards #2443 

Changes made in this Pull Request:
 - Removes `skip` and `format` keywords from :meth:`DCDReader.timeseries`.


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
