### PR TITLE
added READER_HINTS

### DIFF
--- a/package/MDAnalysis/__init__.py
+++ b/package/MDAnalysis/__init__.py
@@ -169,9 +169,11 @@ except ImportError:
 # Registry of Readers, Parsers and Writers known to MDAnalysis
 # Metaclass magic fills these as classes are declared.
 _READERS = {}
+_READER_HINTS = {}
 _SINGLEFRAME_WRITERS = {}
 _MULTIFRAME_WRITERS = {}
 _PARSERS = {}
+_PARSER_HINTS = {}
 _SELECTION_WRITERS = {}
 _CONVERTERS = {}
 # Registry of TopologyAttributes

--- a/package/MDAnalysis/coordinates/MMTF.py
+++ b/package/MDAnalysis/coordinates/MMTF.py
@@ -62,7 +62,7 @@ class MMTFReader(base.SingleFrameReaderBase):
     format = 'MMTF'
 
     @staticmethod
-    def format_test(thing):
+    def _format_hint(thing):
         return isinstance(thing, mmtf.MMTFDecoder)
 
     @due.dcite(

--- a/package/MDAnalysis/coordinates/MMTF.py
+++ b/package/MDAnalysis/coordinates/MMTF.py
@@ -61,6 +61,10 @@ class MMTFReader(base.SingleFrameReaderBase):
     """Coordinate reader for the Macromolecular Transmission Format format (MMTF_)."""
     format = 'MMTF'
 
+    @staticmethod
+    def format_test(thing):
+        return isinstance(thing, mmtf.MMTFDecoder)
+
     @due.dcite(
         Doi('10.1371/journal.pcbi.1005575'),
         description="MMTF Reader",

--- a/package/MDAnalysis/coordinates/MMTF.py
+++ b/package/MDAnalysis/coordinates/MMTF.py
@@ -63,6 +63,10 @@ class MMTFReader(base.SingleFrameReaderBase):
 
     @staticmethod
     def _format_hint(thing):
+        """Can this Reader read *thing*?
+
+        .. versionadded:: 1.0.0
+        """
         return isinstance(thing, mmtf.MMTFDecoder)
 
     @due.dcite(

--- a/package/MDAnalysis/coordinates/ParmEd.py
+++ b/package/MDAnalysis/coordinates/ParmEd.py
@@ -87,6 +87,15 @@ class ParmEdReader(base.SingleFrameReaderBase):
     # Structure.coordinates always in Angstrom
     units = {'time': None, 'length': 'Angstrom'}
 
+    @staticmethod
+    def format_test(thing):
+        try:
+            import parmed as pmd
+        except ImportError:
+            return False
+        else:
+            return isinstance(thing, pmd.Structure)
+
     def _read_first_frame(self):
         self.n_atoms = len(self.filename.atoms)
 

--- a/package/MDAnalysis/coordinates/ParmEd.py
+++ b/package/MDAnalysis/coordinates/ParmEd.py
@@ -88,7 +88,7 @@ class ParmEdReader(base.SingleFrameReaderBase):
     units = {'time': None, 'length': 'Angstrom'}
 
     @staticmethod
-    def format_test(thing):
+    def _format_hint(thing):
         try:
             import parmed as pmd
         except ImportError:

--- a/package/MDAnalysis/coordinates/ParmEd.py
+++ b/package/MDAnalysis/coordinates/ParmEd.py
@@ -89,9 +89,14 @@ class ParmEdReader(base.SingleFrameReaderBase):
 
     @staticmethod
     def _format_hint(thing):
+        """Can this reader read *thing*?
+
+        .. versionadded:: 1.0.0
+        """
         try:
             import parmed as pmd
         except ImportError:
+            # if we can't import parmed, it's probably not parmed
             return False
         else:
             return isinstance(thing, pmd.Structure)

--- a/package/MDAnalysis/coordinates/__init__.py
+++ b/package/MDAnalysis/coordinates/__init__.py
@@ -472,6 +472,8 @@ The following methods must be implemented in a Reader class.
  ``__exit__()``
      exit method of a `Context Manager`_, should call ``close()``.
 
+.. _Context Manager: http://docs.python.org/2/reference/datamodel.html#context-managers
+
 .. Note::
    a ``__del__()`` method should also be present to ensure that the
    trajectory is properly closed. However, certain types of Reader can ignore

--- a/package/MDAnalysis/coordinates/__init__.py
+++ b/package/MDAnalysis/coordinates/__init__.py
@@ -279,30 +279,6 @@ Reader and Writer classes are derived from base classes in
 :mod:`MDAnalysis.coordinates.base`.
 
 
-History
-~~~~~~~
-
-- 2010-04-30 Draft [orbeckst]
-- 2010-08-20 added single frame writers to API [orbeckst]
-- 2010-10-09 added write() method to Writers [orbeckst]
-- 2010-10-19 use close() instead of close_trajectory() [orbeckst]
-- 2010-10-30 clarified Writer write() methods (see also `Issue 49`_)
-- 2011-02-01 extended call signature of Reader class
-- 2011-03-30 optional Writer() method for Readers
-- 2011-04-18 added time and frame managed attributes to Reader
-- 2011-04-20 added volume to Timestep
-- 2012-02-11 added _velocities to Timestep
-- 2012-05-24 multiframe keyword to distinguish trajectory from single frame writers
-- 2012-06-04 missing implementations of Reader.__getitem__ should raise :exc:`TypeError`
-- 2013-08-02 Readers/Writers must conform to the Python `Context Manager`_ API
-- 2015-01-15 Timestep._init_unitcell() method added
-- 2015-06-11 Reworked Timestep init.  Base Timestep now does Vels & Forces
-- 2015-07-21 Major changes to Timestep and Reader API (release 0.11.0)
-- 2016-04-03 Removed references to Strict Readers for PDBS [jdetle]
-
-.. _Issue 49: https://github.com/MDAnalysis/mdanalysis/issues/49
-.. _Context Manager: http://docs.python.org/2/reference/datamodel.html#context-managers
-
 Registry
 ~~~~~~~~
 
@@ -315,6 +291,13 @@ or :class:`MDAnalysis.coordinates.base.WriterBase` and set the
 :attr:`~MDAnalysis.coordinates.base.ProtoReader.format` attribute with a string
 defining the expected suffix.  To assign multiple suffixes to an I/O class, a
 list of suffixes can be given.
+
+In addition to this, a Reader may define a ``_format_hint`` staticmethod, which
+returns a boolean of if it can process a given object. E.g. the
+:class:`MDAnalysis.coordinates.memory.MemoryReader` identifies itself as
+capable of reading numpy arrays.  This functionality is used in
+:func:`MDAnalysis.core._get_readers.get_reader_for` when figuring out how to
+read an object (which was usually supplied to mda.Universe).
 
 To define that a Writer can write multiple trajectory frames, set the
 `multiframe` attribute to ``True``.  The default is ``False``.

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -210,7 +210,7 @@ import weakref
 from . import core
 from .. import NoDataError
 from .. import (
-    _READERS,
+    _READERS, _READER_HINTS,
     _SINGLEFRAME_WRITERS,
     _MULTIFRAME_WRITERS,
     _CONVERTERS
@@ -1373,6 +1373,10 @@ class _Readermeta(type):
             for f in fmt:
                 f = f.upper()
                 _READERS[f] = cls
+
+                if 'format_test' in classdict:
+                    # isn't bound yet, so access __func__
+                    _READER_HINTS[f] = classdict['format_test'].__func__
 
 
 class ProtoReader(six.with_metaclass(_Readermeta, IOBase)):

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -1362,6 +1362,11 @@ class IOBase(object):
 
 
 class _Readermeta(type):
+    """Automatic Reader registration metaclass
+
+    .. versionchanged:: 1.0.0
+       Added _format_hint functionality
+    """
     # Auto register upon class creation
     def __init__(cls, name, bases, classdict):
         type.__init__(type, name, bases, classdict)

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -1370,13 +1370,13 @@ class _Readermeta(type):
         except KeyError:
             pass
         else:
-            for f in fmt:
-                f = f.upper()
-                _READERS[f] = cls
+            for fmt_name in fmt:
+                fmt_name = fmt_name.upper()
+                _READERS[fmt_name] = cls
 
-                if 'format_test' in classdict:
+                if '_format_hint' in classdict:
                     # isn't bound yet, so access __func__
-                    _READER_HINTS[f] = classdict['format_test'].__func__
+                    _READER_HINTS[fmt_name] = classdict['_format_hint'].__func__
 
 
 class ProtoReader(six.with_metaclass(_Readermeta, IOBase)):

--- a/package/MDAnalysis/coordinates/chain.py
+++ b/package/MDAnalysis/coordinates/chain.py
@@ -52,6 +52,7 @@ import copy
 
 import numpy as np
 
+from ..lib import util
 from ..lib.util import asiterable
 from . import base
 from . import core
@@ -366,6 +367,13 @@ class ChainReader(base.ProtoReader):
         # rewind() also sets self.ts
         self.ts = None
         self.rewind()
+
+    @staticmethod
+    def format_test(thing):
+        """Can ChainReader read the object *thing*"""
+        return (not isinstance(thing, np.ndarray) and
+                util.iterable(thing) and
+                not util.isstream(thing))
 
     def _get_local_frame(self, k):
         """Find trajectory index and trajectory frame for chained frame `k`.

--- a/package/MDAnalysis/coordinates/chain.py
+++ b/package/MDAnalysis/coordinates/chain.py
@@ -369,7 +369,7 @@ class ChainReader(base.ProtoReader):
         self.rewind()
 
     @staticmethod
-    def format_test(thing):
+    def _format_hint(thing):
         """Can ChainReader read the object *thing*"""
         return (not isinstance(thing, np.ndarray) and
                 util.iterable(thing) and

--- a/package/MDAnalysis/coordinates/chain.py
+++ b/package/MDAnalysis/coordinates/chain.py
@@ -370,7 +370,10 @@ class ChainReader(base.ProtoReader):
 
     @staticmethod
     def _format_hint(thing):
-        """Can ChainReader read the object *thing*"""
+        """Can ChainReader read the object *thing*
+
+        .. versionadded:: 1.0.0
+        """
         return (not isinstance(thing, np.ndarray) and
                 util.iterable(thing) and
                 not util.isstream(thing))

--- a/package/MDAnalysis/coordinates/memory.py
+++ b/package/MDAnalysis/coordinates/memory.py
@@ -401,7 +401,7 @@ class MemoryReader(base.ProtoReader):
         self._read_next_timestep()
 
     @staticmethod
-    def format_test(thing):
+    def _format_hint(thing):
         """For internal use: Check if MemoryReader can operate on *thing*"""
         return isinstance(thing, np.ndarray)
 

--- a/package/MDAnalysis/coordinates/memory.py
+++ b/package/MDAnalysis/coordinates/memory.py
@@ -401,6 +401,11 @@ class MemoryReader(base.ProtoReader):
         self._read_next_timestep()
 
     @staticmethod
+    def format_test(thing):
+        """For internal use: Check if MemoryReader can operate on *thing*"""
+        return isinstance(thing, np.ndarray)
+
+    @staticmethod
     def parse_n_atoms(filename, order='fac', **kwargs):
         """Deduce number of atoms in a given array of coordinates
 

--- a/package/MDAnalysis/coordinates/memory.py
+++ b/package/MDAnalysis/coordinates/memory.py
@@ -402,7 +402,10 @@ class MemoryReader(base.ProtoReader):
 
     @staticmethod
     def _format_hint(thing):
-        """For internal use: Check if MemoryReader can operate on *thing*"""
+        """For internal use: Check if MemoryReader can operate on *thing*
+
+        .. versionadded:: 1.0.0
+        """
         return isinstance(thing, np.ndarray)
 
     @staticmethod

--- a/package/MDAnalysis/core/_get_readers.py
+++ b/package/MDAnalysis/core/_get_readers.py
@@ -24,9 +24,6 @@ from six import raise_from
 
 import copy
 import inspect
-import mmtf
-import parmed as pmd
-import numpy as np
 
 from .. import (_READERS, _READER_HINTS,
                 _PARSERS, _PARSER_HINTS,
@@ -91,7 +88,7 @@ def get_reader_for(filename, format=None):
         for f, test in _READER_HINTS.items():
             if test(filename):
                 format = f
-                break;
+                break
         else:  # hits else if for loop completes
             # else let the guessing begin!
             format = util.guess_format(filename)
@@ -233,10 +230,10 @@ def get_parser_for(filename, format=None):
 
     # Only guess if format is not provided
     if format is None:
-        if isinstance(filename, mmtf.MMTFDecoder):
-            format = 'mmtf'
-        elif isinstance(filename, pmd.Structure):
-            format = 'PARMED'
+        for f, test in _PARSER_HINTS.items():
+            if test(filename):
+                format = f
+                break
         else:
             format = util.guess_format(filename)
     format = format.upper()

--- a/package/MDAnalysis/core/_get_readers.py
+++ b/package/MDAnalysis/core/_get_readers.py
@@ -85,9 +85,9 @@ def get_reader_for(filename, format=None):
         format = 'CHAIN'
     # Only guess if format is not specified
     if format is None:
-        for f, test in _READER_HINTS.items():
+        for fmt_name, test in _READER_HINTS.items():
             if test(filename):
-                format = f
+                format = fmt_name
                 break
         else:  # hits else if for loop completes
             # else let the guessing begin!
@@ -230,9 +230,9 @@ def get_parser_for(filename, format=None):
 
     # Only guess if format is not provided
     if format is None:
-        for f, test in _PARSER_HINTS.items():
+        for fmt_name, test in _PARSER_HINTS.items():
             if test(filename):
-                format = f
+                format = fmt_name
                 break
         else:
             format = util.guess_format(filename)

--- a/package/MDAnalysis/core/_get_readers.py
+++ b/package/MDAnalysis/core/_get_readers.py
@@ -75,6 +75,8 @@ def get_reader_for(filename, format=None):
     :class:`~MDAnalysis.coordinates.chain.ChainReader` is returned and `format`
     passed to the :class:`~MDAnalysis.coordinates.chain.ChainReader`.
 
+    .. versionchanged:: 1.0.0
+       Added format_hint functionalityx
     """
     # check if format is actually a Reader
     if inspect.isclass(format):
@@ -224,6 +226,8 @@ def get_parser_for(filename, format=None):
     ValueError
         If no appropriate parser could be found.
 
+    .. versionchanged:: 1.0.0
+       Added format_hint functionality
     """
     if inspect.isclass(format):
         return format

--- a/package/MDAnalysis/topology/MMTFParser.py
+++ b/package/MDAnalysis/topology/MMTFParser.py
@@ -152,6 +152,10 @@ class ModelSelection(RangeSelection):
 class MMTFParser(base.TopologyReaderBase):
     format = 'MMTF'
 
+    @staticmethod
+    def _format_hint(thing):
+        return isinstance(thing, mmtf.MMTFDecoder)
+
     @due.dcite(
         Doi('10.1371/journal.pcbi.1005575'),
         description="MMTF Parser",

--- a/package/MDAnalysis/topology/MMTFParser.py
+++ b/package/MDAnalysis/topology/MMTFParser.py
@@ -154,6 +154,10 @@ class MMTFParser(base.TopologyReaderBase):
 
     @staticmethod
     def _format_hint(thing):
+        """Can parser read *thing*?
+
+        .. versionadded:: 1.0.0
+        """
         return isinstance(thing, mmtf.MMTFDecoder)
 
     @due.dcite(

--- a/package/MDAnalysis/topology/ParmEdParser.py
+++ b/package/MDAnalysis/topology/ParmEdParser.py
@@ -138,6 +138,15 @@ class ParmEdParser(TopologyReaderBase):
     """
     format = 'PARMED'
 
+    @staticmethod
+    def _format_hint(thing):
+        try:
+            import parmed as pmd
+        except ImportError:
+            return False
+        else:
+            return isinstance(thing, pmd.Structure)
+
     def parse(self, **kwargs):
         """Parse PARMED into Topology
 

--- a/package/MDAnalysis/topology/ParmEdParser.py
+++ b/package/MDAnalysis/topology/ParmEdParser.py
@@ -140,9 +140,13 @@ class ParmEdParser(TopologyReaderBase):
 
     @staticmethod
     def _format_hint(thing):
+        """Can this Parser read object *thing*?
+
+        .. versionadded:: 1.0.0
+        """
         try:
             import parmed as pmd
-        except ImportError:
+        except ImportError:  # if no parmed, probably not parmed
             return False
         else:
             return isinstance(thing, pmd.Structure)

--- a/package/MDAnalysis/topology/base.py
+++ b/package/MDAnalysis/topology/base.py
@@ -46,7 +46,7 @@ import itertools
 import numpy as np
 import warnings
 
-from .. import _PARSERS
+from .. import _PARSERS, _PARSER_HINTS
 from ..coordinates.base import IOBase
 from ..lib import util
 
@@ -59,10 +59,12 @@ class _Topologymeta(type):
         except KeyError:
             pass
         else:
-            for f in fmt:
-                f = f.upper()
-                _PARSERS[f] = cls
+            for fmt_name in fmt:
+                fmt_name = fmt_name.upper()
+                _PARSERS[fmt_name] = cls
 
+                if '_format_hint' in classdict:
+                    _PARSER_HINTS[fmt_name] = classdict['_format_hint'].__func__
 
 class TopologyReaderBase(six.with_metaclass(_Topologymeta, IOBase)):
     """Base class for topology readers

--- a/package/MDAnalysis/topology/base.py
+++ b/package/MDAnalysis/topology/base.py
@@ -52,6 +52,31 @@ from ..lib import util
 
 
 class _Topologymeta(type):
+    """Internal: Topology Parser registration voodoo
+
+    When classes which inherit from TopologyReaderBase are *defined*
+    this metaclass makes it known to MDAnalysis.  The optional `format`
+    attribute and `_format_hint` staticmethod are read:
+     - `format` defines the file extension this Parser targets.
+     - `_format_hint` defines a function which returns a boolean if the
+       Parser can process a particular object
+
+    Eg::
+
+      class Thing(TopologyReaderBase):
+          format = ['foo', 'bar']
+
+          @staticmethod
+          _format_hint(thing):
+              try:
+                  import WeirdPackage
+              except ImportError:
+                  return False
+              return isinstance(thing, Weirdpackage.Thing)
+
+    .. versionchanged:: 1.0.0
+       Added format_hint functionality
+    """
     def __init__(cls, name, bases, classdict):
         type.__init__(type, name, bases, classdict)
         try:

--- a/package/MDAnalysis/topology/base.py
+++ b/package/MDAnalysis/topology/base.py
@@ -63,7 +63,7 @@ class _Topologymeta(type):
 
     Eg::
 
-      class Thing(TopologyReaderBase):
+      class ThingParser(TopologyReaderBase):
           format = ['foo', 'bar']
 
           @staticmethod
@@ -72,7 +72,11 @@ class _Topologymeta(type):
                   import WeirdPackage
               except ImportError:
                   return False
-              return isinstance(thing, Weirdpackage.Thing)
+              return isinstance(thing, WeirdPackage.Thing)
+
+    This way there is no strict dependency on "WeirdPackage", but if
+    a user supplies a WeirdPackage.Thing the "ThingParser' will be able
+    to step up and read it.
 
     .. versionchanged:: 1.0.0
        Added format_hint functionality


### PR DESCRIPTION
I think this is maybe a more elegant way to deal with optional dependencies.

Readers can define a `format_test` staticmethod, which when provided a "filename" (which is the thing provided to `Universe`, so can be eg numpy array) returns a bool of if they reckon they can read it.  `MemoryReader` is an example of a Reader that would implement this.  The `ParmedReader` is another example, which then means that only this Reader module needs to import Parmed, the rest of MDA is oblivious.

Then things like `get_reader_for` are simplified, as they just rely on information provided by Readers during the metaclass magic that happens. (ie `_READERS` and the new `_READER_HINTS`)

This would also be how the Chemfiles PR (and other converter type readers) would be resolved, you would load the system with chemfiles, then pass this to Universe.

TODO: identical treatment for parsers

Possible problem: race conditions in `format_test` (though is also currently a problem)

Thoughts? @MDAnalysis/coredevs 
