### PR TITLE
BENCH: fix benchmark suite

### DIFF
--- a/benchmarks/benchmarks/ag_methods.py
+++ b/benchmarks/benchmarks/ag_methods.py
@@ -328,13 +328,24 @@ class AtomGroupAttrsBench(object):
 
 class FragmentFinding(object):
     """Test how quickly we find fragments (distinct molecules from bonds)"""
-    params = [(TPR, XTC),  # single large fragment, many small solvents
-              (PSF, DCD),  # single large fragment
-              (TRZ_psf, TRZ)]  # 20ish polymer chains
-    param_names = ['universe']
+    # if we try to parametrize over topology &
+    # trajectory formats asv will use all
+    # possible combinations, so instead handle
+    # this in setup()
+    params = ('large_fragment_small_solvents',
+              'large_fragment',
+              'polymer_chains', # 20ish polymer chains
+              )
+    param_names = ['universe_type']
 
-    def setup(self, universe):
-        self.u = MDAnalysis.Universe(*universe)
+    def setup(self, universe_type):
+        if universe_type == 'large_fragment_small_solvents':
+            univ = (TPR, XTC) 
+        elif universe_type == 'large_fragment':
+            univ = (PSF, DCD)
+        else:
+            univ = (TRZ_psf, TRZ) 
+        self.u = MDAnalysis.Universe(*univ)
 
-    def time_find_fragments(self, universe):
+    def time_find_fragments(self, universe_type):
         frags = self.u.atoms.fragments

--- a/benchmarks/benchmarks/analysis/rdf.py
+++ b/benchmarks/benchmarks/analysis/rdf.py
@@ -43,7 +43,7 @@ class SimpleRdfBench(object):
                             nbins=nbins,
                             range=range_val)
 
-    def time_interrdf(self, nbins, range_val):
+    def time_interrdf(self, nbins, range_val, natoms):
         """Benchmark a full trajectory parse
         by MDAnalysis.analysis.rdf.InterRDF
         """


### PR DESCRIPTION
Fixes #2489 
Fixes #2488

* there were two basic errors in the `asv`
benchmark suite; the errors were first
reproduced then confirmed fixed using
`asv check`, which does a sort of
syntax/lint check on the benchmarks
without actually running them

I suggest adding `asv check` to our CI runs, but I'll open
a separate issue for that as we may need to check
how long it takes. I'm pretty sure SciPy/NumPy do that
in CI as well.