### PR TITLE
Add Plotly plots to DiffusionMap

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,7 +10,7 @@ cache:
 environment:
     global:
         CONDA_CHANNELS: conda-forge
-        CONDA_DEPENDENCIES: pip setuptools wheel cython mock six biopython networkx joblib matplotlib scipy vs2015_runtime pytest mmtf-python GridDataFormats hypothesis pytest-cov codecov
+        CONDA_DEPENDENCIES: pip setuptools wheel cython mock six biopython networkx joblib matplotlib scipy vs2015_runtime pytest mmtf-python GridDataFormats hypothesis pytest-cov codecov plotly
         PIP_DEPENDENCIES: gsd==1.9.3 duecredit parmed
         DEBUG: "False"
         MINGW_64: C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ env:
     - SETUP_CMD="${PYTEST_FLAGS}"
     - BUILD_CMD="pip install -e package/ && (cd testsuite/ && python setup.py build)"
     - CONDA_MIN_DEPENDENCIES="mmtf-python mock six biopython networkx cython matplotlib scipy griddataformats hypothesis gsd codecov"
-    - CONDA_DEPENDENCIES="${CONDA_MIN_DEPENDENCIES} seaborn>=0.7.0 clustalw=2.1 netcdf4 scikit-learn joblib>=0.12"
+    - CONDA_DEPENDENCIES="${CONDA_MIN_DEPENDENCIES} seaborn>=0.7.0 clustalw=2.1 netcdf4 scikit-learn joblib>=0.12 plotly"
     - CONDA_CHANNELS='biobuilds conda-forge'
     - CONDA_CHANNEL_PRIORITY=True
     - PIP_DEPENDENCIES="duecredit parmed"

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -56,6 +56,7 @@ Fixes
   * Added parmed to setup.py
 
 Enhancements
+  * Added subsetting to DiffusionMap and plotting functions (PR #2548)
   * Added coordinate reader and writer for NAMD binary coordinate format (PR #2485)
   * Improved ClusterCollection and Cluster string representations (Issue #2464)
   * XYZ parser store elements attribute (#2420) and XYZ write uses the elements

--- a/package/MDAnalysis/analysis/diffusionmap.py
+++ b/package/MDAnalysis/analysis/diffusionmap.py
@@ -522,15 +522,15 @@ class DiffusionMap(object):
             embeds the data at integer ``time`` scales from 0 to ``n_frame``, 
             exclusive.  If ``None``, uses the number of frames in the analysis.
         colorscale: str, optional
-            Plotly colorscale for coloring. Default: 'Viridis'
+            Plotly colorscale for coloring.
         marker_size: float, optional
-            Marker size for plot. Default: 3
+            Marker size for plot.
         x: int, optional
-            Eigenvector to plot on x-axis. Default: 1
+            Eigenvector to plot on x-axis.
         y: int, optional
-            Eigenvector to plot on y-axis. Default: 2
+            Eigenvector to plot on y-axis.
         z: int, optional
-            Eigenvector to plot on z-axis. Default: 3
+            Eigenvector to plot on z-axis.
 
         Returns
         -------

--- a/package/MDAnalysis/analysis/diffusionmap.py
+++ b/package/MDAnalysis/analysis/diffusionmap.py
@@ -418,8 +418,11 @@ class DiffusionMap(object):
         diffusion_space : array (n_frames, n_eigenvectors)
             The diffusion map embedding as defined by [Ferguson1]_.
         """
-        return (self._eigenvectors[1:n_eigenvectors+1, ].T *
-                (self.eigenvalues[1:n_eigenvectors+1]**time))
+        try:
+            return (self._eigenvectors[1:n_eigenvectors+1, ].T *
+                    (self.eigenvalues[1:n_eigenvectors+1]**time))
+        except AttributeError:
+            raise ValueError('Call run() on DiffusionMap before using transform')
 
     def plot_animated_transform(self, n_frames=None, colorscale='Viridis', marker_size=3,
                                 x=1, y=2):

--- a/package/MDAnalysis/analysis/diffusionmap.py
+++ b/package/MDAnalysis/analysis/diffusionmap.py
@@ -161,7 +161,8 @@ module in published work please cite [Theobald2005]_.
              map. J. Chem. Phys. 134, 124116 (2011).
 
 .. [Ferguson1] Ferguson, A. L.; Panagiotopoulos, A. Z.; Kevrekidis, I. G.
-             Debenedetti, P. G.  Chem. Phys. Lett. 509, 1−11
+             Debenedetti, P. G. Nonlinear dimensionality reduction in molecular
+             simulation: The diffusion map approach Chem. Phys. Lett. 509, 1−11
              (2011)
 
 """

--- a/package/MDAnalysis/analysis/diffusionmap.py
+++ b/package/MDAnalysis/analysis/diffusionmap.py
@@ -421,15 +421,15 @@ class DiffusionMap(object):
         return (self._eigenvectors[1:n_eigenvectors+1, ].T *
                 (self.eigenvalues[1:n_eigenvectors+1]**time))
 
-    def plot_animated_transform(self, n_frame=None, colorscale='Viridis', marker_size=3,
+    def plot_animated_transform(self, n_frames=None, colorscale='Viridis', marker_size=3,
                                 x=1, y=2):
         """ Plots an interactive 2D plot of chosen eigenvectors at different timescales.
 
         Parameters
         ----------
-        n_frame: int, optional
+        n_frames: int, optional
             number of ``time`` values for ``transform()``. The animated graph 
-            embeds the data at integer ``time`` scales from 0 to ``n_frame``, 
+            embeds the data at integer ``time`` scales from 0 to ``n_frames``, 
             exclusive.  If ``None``, uses the number of frames in the analysis.
         colorscale: str, optional
             Plotly colorscale for coloring.
@@ -452,14 +452,14 @@ class DiffusionMap(object):
         except ImportError:
             raise ImportError('Plotly is required for this animated graph')
 
-        if n_frame is None:
-            n_frame = self._n_frames
+        if n_frames is None:
+            n_frames = self._n_frames
 
         eig = np.array([x, y]) - 1
         n_eig = max(eig) + 1
 
         data = np.array([self.transform(n_eig, time=i)
-                         for i in range(n_frame)])
+                         for i in range(n_frames)])
         order = np.arange(self._n_frames)
         n_data = len(data)
 
@@ -510,16 +510,16 @@ class DiffusionMap(object):
         fig.update_layout(sliders=sliders)
         return fig
 
-    def plot_animated_transform3D(self, n_frame=None, colorscale='Viridis', marker_size=3,
+    def plot_animated_transform3D(self, n_frames=None, colorscale='Viridis', marker_size=3,
                                   x=1, y=2, z=3):
         """
         Plots an interactive 3D plot of chosen eigenvectors at different timescales.
 
         Parameters
         ----------
-        n_frame: int, optional
+        n_frames: int, optional
             number of ``time`` values for ``transform()``. The animated graph 
-            embeds the data at integer ``time`` scales from 0 to ``n_frame``, 
+            embeds the data at integer ``time`` scales from 0 to ``n_frames``, 
             exclusive.  If ``None``, uses the number of frames in the analysis.
         colorscale: str, optional
             Plotly colorscale for coloring.
@@ -547,10 +547,10 @@ class DiffusionMap(object):
         eig = np.array([x, y, z]) - 1
         n_eig = max(eig) + 1
 
-        if n_frame is None:
-            n_frame = self._n_frames
+        if n_frames is None:
+            n_frames = self._n_frames
         data = np.array([self.transform(n_eig, time=i)
-                         for i in range(n_frame)])
+                         for i in range(n_frames)])
         order = np.arange(self._n_frames)
         n_data = len(data)
 

--- a/testsuite/MDAnalysisTests/analysis/test_diffusionmap.py
+++ b/testsuite/MDAnalysisTests/analysis/test_diffusionmap.py
@@ -137,9 +137,9 @@ def not_square_array_error():
 
 def test_get_plotly_graphs(dmap):
     plotly = pytest.importorskip("plotly")
-    n_frame = 5
-    fig = dmap.plot_animated_transform(n_frame=n_frame, x=3, y=4)
+    n_frames = 5
+    fig = dmap.plot_animated_transform(n_frames=n_frames, x=3, y=4)
     assert isinstance(fig, plotly.graph_objects.Figure)
-    assert len(fig.layout['sliders'][0]['steps']) == n_frame
+    assert len(fig.layout['sliders'][0]['steps']) == n_frames
     assert fig.layout['xaxis']['title']['text'] == 'DC 3'
     assert fig.layout['yaxis']['title']['text'] == 'DC 4'


### PR DESCRIPTION
Is MDAnalysis interested in supporting optional Plotly graphics in DiffusionMap? [(e.g. in this notebook, some scrolling required)](https://lilyminium.github.io/UserGuide/examples/analysis/reduced_dimensions/diffusion_map.html#Passing-your-own-distance-metric-to-DiffusionMap) It's convenient for quickly looking through the mapping at different time scales. 

Changes made in this Pull Request:
 - Added 2D and 3D animated plots
 - Added frame checking/subsetting to `DiffusionMap.run()`. It's not clear that if the user `run()`s `DistanceMatrix` themselves, that they cannot alter the frames of the analysis in `DiffusionMap.run()`
 - Added NumPy arrays to `DiffusionMap`. `DiffusionMap` doesn't actually operate on a universe or trajectory, just the distance matrix thereof. If I have my own distance matrix, I would like to use `DiffusionMap` on it instead of writing my own analysis.


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [ ] Issue raised/referenced?
