### PR TITLE
WIP: create Universes with Merge in encore

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -20,6 +20,10 @@ mm/dd/yy richardjgowers, kain88-de, lilyminium, p-j-smith, bdice, joaomcteixeira
   * 0.21.0
 
 Fixes
+  * Utility functions in encore now use mda.Merge to create universes
+    instead of mda.Universe (Issue #2576). 
+  * prepare_ensembles_for_convergence_increasing_window() transfers 
+    universes to memory before calling timeseries (Issue #2578)
   * Correct args order of base.AnalysisFromFunction (Issue #2503)  
   * encore.dres() returns dimensionality reduction details instead of a
     reference to itself (Issue #2471)

--- a/package/MDAnalysis/analysis/encore/bootstrap.py
+++ b/package/MDAnalysis/analysis/encore/bootstrap.py
@@ -144,15 +144,12 @@ def get_ensemble_bootstrap_samples(ensemble,
     """
 
     ensemble.transfer_to_memory()
+    coords = ensemble.trajectory.timeseries(order='fac')
+    n_frames = coords.shape[0]
 
     ensembles = []
     for i in range(samples):
-        indices = np.random.randint(
-            low=0,
-            high=ensemble.trajectory.timeseries().shape[1],
-            size=ensemble.trajectory.timeseries().shape[1])
-        ensembles.append(
-            mda.Universe(ensemble.filename,
-                        ensemble.trajectory.timeseries(order='fac')[indices,:,:],
-                         format=mda.coordinates.memory.MemoryReader))
+        indices = np.random.randint(low=0, high=n_frames, size=n_frames)
+        ensembles.append(ensemble.copy().load_new(coords[indices]))
+
     return ensembles

--- a/package/MDAnalysis/analysis/encore/utils.py
+++ b/package/MDAnalysis/analysis/encore/utils.py
@@ -417,4 +417,6 @@ def merge_universes(universes, select='name CA'):
     except ValueError:
         err = 'atom selection "{}" results in mismatching AtomGroups'
         raise ValueError(err.format(select))
+
+    ag = universes[0].select_atoms(select)
     return mda.Merge(ag).load_new(coords)

--- a/testsuite/MDAnalysisTests/analysis/test_encore.py
+++ b/testsuite/MDAnalysisTests/analysis/test_encore.py
@@ -58,17 +58,13 @@ class TestEncore(object):
 
     @pytest.fixture()
     def ens1(self, ens1_template):
-        return mda.Universe(
-            ens1_template.filename,
-            ens1_template.trajectory.timeseries(order='fac'),
-            format=mda.coordinates.memory.MemoryReader)
+        coords = ens1_template.trajectory.timeseries(order='fac')
+        return mda.Merge(ens1_template.atoms).load_new(coords)
 
     @pytest.fixture()
     def ens2(self, ens2_template):
-        return mda.Universe(
-            ens2_template.filename,
-            ens2_template.trajectory.timeseries(order='fac'),
-            format=mda.coordinates.memory.MemoryReader)
+        coords = ens2_template.trajectory.timeseries(order='fac')
+        return mda.Merge(ens2_template.atoms).load_new(coords)
 
     def test_triangular_matrix(self):
         scalar = 2


### PR DESCRIPTION
Fixes #2578 
Fixes #2576 

Changes made in this Pull Request:
 - transfer Universes to memory before getting coordinates in ``encore``
 - create new Universes with `mda.Merge` instead of `mda.Universe` in ``encore``
 - pass ``select`` into ``merge_universe`` to avoid the ``create_subverse()`` shenanigans in #2576, which are necessary if you have Universes with different atoms
 - improved performance a bit

Tests to come...

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
