### PR TITLE
[WIP] ITP topology Writer

### DIFF
--- a/package/MDAnalysis/coordinates/ITP.py
+++ b/package/MDAnalysis/coordinates/ITP.py
@@ -1,0 +1,30 @@
+# -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
+#
+# MDAnalysis --- https://www.mdanalysis.org
+# Copyright (c) 2006-2017 The MDAnalysis Development Team and contributors
+# (see the file AUTHORS for the full list of names)
+#
+# Released under the GNU Public Licence, v2 or any higher version
+#
+# Please cite your use of MDAnalysis in published work:
+#
+# R. J. Gowers, M. Linke, J. Barnoud, T. J. E. Reddy, M. N. Melo, S. L. Seyler,
+# D. L. Dotson, J. Domanski, S. Buchoux, I. M. Kenney, and O. Beckstein.
+# MDAnalysis: A Python package for the rapid analysis of molecular dynamics
+# simulations. In S. Benthall and S. Rostrup editors, Proceedings of the 15th
+# Python in Science Conference, pages 102-109, Austin, TX, 2016. SciPy.
+# doi: 10.25080/majora-629e541a-00e
+#
+# N. Michaud-Agrawal, E. J. Denning, T. B. Woolf, and O. Beckstein.
+# MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
+# J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
+#
+
+"""
+ITP file format --- :mod:`MDAnalysis.coordinates.ITP`
+======================================================
+
+Classes to write Gromacs_ ITP_ topology files.
+
+"""


### PR DESCRIPTION
Changes made in this Pull Request:
My project requires me to write an ITP writer. Thus, I'm thinking of creating a topology writer which will write the text-based itp file from the topology file read with ITPPraser. I haven't seen any open PR about this so I guess I will just go on and write it?

However, I'm not too sure about where the file should be. I cannot seem to find any topology writer in the folder topology.

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
