### PR TITLE
Fix #2582: polymer persistence length example fix

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -133,6 +133,7 @@ Chronological list of authors
   - Hao Tian
   - Hugo MacDermott-Opeskin
   - Anshul Angaria
+  - Shubham Sharma
 
 
 

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -15,7 +15,8 @@ The rules for this file:
 ------------------------------------------------------------------------------
 mm/dd/yy richardjgowers, kain88-de, lilyminium, p-j-smith, bdice, joaomcteixeira,
          PicoCentauri, davidercruz, jbarnoud, RMeli, IAlibay, mtiberti, CCook96,
-         Yuan-Yu, xiki-tempula, HTian1997, Iv-Hristov, hmacdope, AnshulAngaria
+         Yuan-Yu, xiki-tempula, HTian1997, Iv-Hristov, hmacdope, AnshulAngaria,
+         ss62171
 
   * 0.21.0
 

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -58,6 +58,7 @@ Fixes
     argument. The directives parsed into bonds, angles, impropers, and dihedrals now
     match TPRParser. (PR #2408)
   * Added parmed to setup.py
+  * Fixed example docs for polymer persistence length (#2582)
 
 Enhancements
   * New analysis.hole2 module for HOLE interfacing. Contains a function (hole) 

--- a/package/MDAnalysis/analysis/polymer.py
+++ b/package/MDAnalysis/analysis/polymer.py
@@ -48,16 +48,16 @@ using MDAnalysis.
   # so we can select the chains by using the .fragments attribute
   chains = u.atoms.fragments
   # select only the backbone atoms for each chain
-  backbones = [chain.select_atoms('not name O* H') for chain in chains]
+  backbones = [chain.select_atoms('not name O* H*') for chain in chains]
   # sort the chains, removing any non-backbone atoms
   sorted_backbones = [polymer.sort_backbone(bb) for bb in backbones]
-  lp = polymer.PersistenceLength(sorted_backbones)
+  persistence_length = polymer.PersistenceLength(sorted_backbones)
   # Run the analysis, this will average over all polymer chains
   # and all timesteps in trajectory
-  lp = lp.run()
-  print('The persistence length is: {}'.format(lp.pl))
+  persistence_length = persistence_length.run()
+  print('The persistence length is: {}'.format(persistence_length.lp))
   # always check the visualisation of this:
-  lp.plot()
+  persistence_length.plot()
 
 """
 from __future__ import division, absolute_import


### PR DESCRIPTION
Fixes #2582 

Changes made in this Pull Request:
 - 
lp variable is renamed to persistence length and missing * is added after H ``` 'not name O* H' ```.

![pl](https://user-images.githubusercontent.com/32260593/76127951-1a562400-6029-11ea-9474-bdc22d487078.png)

PR Checklist
------------
 - [ ] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
