### PR TITLE
Removes PersistenceLength.perform_fit

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -96,6 +96,7 @@ Enhancements
   * Improve the distance search in water bridge analysis with capped_distance (PR #2480)
 
 Changes
+  * Removed deprecated :meth:`PersistenceLength.perform_fit` (Issue #2596)
   * Removed `format` keyword from :meth:`MemoryReader.timeseries` (Issue #1453,
     #2443)
   * Deprecated :class:`LAMMPSDataConverter` has now been removed (Issue #2564)

--- a/package/MDAnalysis/analysis/polymer.py
+++ b/package/MDAnalysis/analysis/polymer.py
@@ -189,6 +189,8 @@ class PersistenceLength(AnalysisBase):
     .. versionadded:: 0.13.0
     .. versionchanged:: 0.20.0
        The run method now automatically performs the exponential fit
+    .. versionchanged:: 1.0.0
+       Deprecated :meth:`PersistenceLength.perform_fit` has now been removed.
     """
     def __init__(self, atomgroups, **kwargs):
         super(PersistenceLength, self).__init__(
@@ -239,10 +241,6 @@ class PersistenceLength(AnalysisBase):
             b = calc_bonds(pos[:-1], pos[1:]).mean()
             bs.append(b)
         self.lb = np.mean(bs)
-
-    def perform_fit(self):
-        warnings.warn("perform_fit is now called automatically from run",
-                      DeprecationWarning)
 
     def _perform_fit(self):
         """Fit the results to an exponential decay"""

--- a/testsuite/MDAnalysisTests/analysis/test_persistencelength.py
+++ b/testsuite/MDAnalysisTests/analysis/test_persistencelength.py
@@ -93,9 +93,6 @@ class TestPersistenceLength(object):
 
         assert ax2 is ax
 
-    def test_perform_fit_warn(self, p_run):
-        with pytest.warns(DeprecationWarning):
-            p_run.perform_fit()
 
 class TestFitExponential(object):
     x = np.linspace(0, 250, 251)


### PR DESCRIPTION
Fixes #2596 
Towards #2443 

Opening PR in advance of agreement on this removal. Please ignore until then.

Changes made in this Pull Request:
 - Removes deprecated :meth:`PersistenceLength.perform_fit`.

PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
