### PR TITLE
Fix Issue #2131: Lammps Dump Parser can't do variable columns

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -21,6 +21,7 @@ mm/dd/yy richardjgowers, kain88-de, lilyminium, p-j-smith, bdice, joaomcteixeira
   * 0.21.0
 
 Fixes
+  * Fixed Lammps Dump parser can't do variable columns (Issue #2131)
   * Fixes outdated :class:`TRJReader` documentation on random frame access
     (Issue #2398)
   * Fixed mda.Merge for Universes without coordinates (Issue #2470)(PR #2580)


### PR DESCRIPTION
Fixes #2131 Lammps Dump Parser can't do variable columns

Changes made in this Pull Request:
 - Added adaptive columns for the lammps dump parser, similar to the LAMMPS data parser.


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
