### PR TITLE
Weights rework for #2429

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -84,6 +84,8 @@ Enhancements
   * Added ParmEdParser, ParmEdReader and ParmEdConverter to
     convert between a parmed.Structure and MDAnalysis Universe (PR #2404)
   * Improve the distance search in water bridge analysis with capped_distance (PR #2480)
+  * Added weights_groupselections option in RMSD for mapping custom weights 
+    to groupselections (PR #2610, Issue #2429)
 
 Changes
   * encore.hes() doesn't accept the details keyword anymore, it always returns

--- a/package/MDAnalysis/analysis/rms.py
+++ b/package/MDAnalysis/analysis/rms.py
@@ -574,7 +574,7 @@ class RMSD(AnalysisBase):
                 self.weights_groupselections = [None] * len(self.groupselections)
 
         for igroup, (weights, atoms) in enumerate(zip(self.weights_groupselections,
-                                                      self._groupselections_atoms), 0):
+                                                      self._groupselections_atoms)):
             if str(weights) == 'mass':
                 self.weights_groupselections[igroup] = atoms['mobile'].masses
             if weights is not None:

--- a/package/MDAnalysis/analysis/rms.py
+++ b/package/MDAnalysis/analysis/rms.py
@@ -317,7 +317,7 @@ def weight_type_check(weights,atoms,selection):
             raise ValueError("Length of provided weights {} do not match the number of atoms "
                 "in the selection {}: {}".format(weights, selection['mobile'], atoms.n_atoms))
         else:
-            tmp_weights = get_weights(atoms, weights) 
+            get_weights(atoms, weights) 
     elif not iterable(weights) and str(weights) != 'mass' and weights is not None:
         raise ValueError("Each groupselection can only be combined with "
                                "weights: None, 'mass' or 1D float array")

--- a/package/MDAnalysis/analysis/rms.py
+++ b/package/MDAnalysis/analysis/rms.py
@@ -551,12 +551,17 @@ class RMSD(AnalysisBase):
             if len(self.weights_groupselections) != len(self.groupselections):
                 raise ValueError("Length of weights_groupselections is not equal to "
                                  "length of groupselections ")
-            for weights, atoms in zip(self.weights_groupselections,
-                                      self._groupselections_atoms):
-                if not iterable(weights) and weights == "mass":
-                    pass
-                else:
-                    get_weights(atoms['mobile'], weights)
+            for weights, atoms, selection in zip(self.weights_groupselections,
+                                                 self._groupselections_atoms,
+                                                 self.groupselections):
+                try:
+                    if not iterable(weights) and weights == "mass":
+                        pass
+                    else:
+                        get_weights(atoms['mobile'], weights)
+                except Exception as e:
+                    raise type(e)(str(e) + ' happens in selection %s' % selection['mobile'])
+
 
     def _prepare(self):
         self._n_atoms = self.mobile_atoms.n_atoms

--- a/package/MDAnalysis/analysis/rms.py
+++ b/package/MDAnalysis/analysis/rms.py
@@ -310,7 +310,6 @@ def process_selection(select):
     return select
 
 
-
 class RMSD(AnalysisBase):
     r"""Class to perform RMSD analysis on a trajectory.
 
@@ -383,11 +382,11 @@ class RMSD(AnalysisBase):
                       implemented.
         weights : {"mass", ``None``} or array_like (optional)
              Choose weights. With ``"mass"`` uses masses as weights for both `select`
-             and `groupselections`; with ``None`` weigh each atom equally for both 
+             and `groupselections`; with ``None`` weigh each atom equally for both
              `select` and `groupselections`. If a float array of the same length as
              `atomgroup` is provided, use each element of the `array_like` as a
-             weight for the corresponding atom in `select`, and assume ``None`` 
-             for `groupselections`. 
+             weight for the corresponding atom in `select`, and assume ``None``
+             for `groupselections`.
         weights_groupselections : False or list of {"mass", ``None``} or array_like (optional)
             Default: ``False`` will apply imposed weights from ``weights`` option
              Or a list with length of `groupselections`, apply the weights correspondingly.
@@ -542,7 +541,6 @@ class RMSD(AnalysisBase):
                         igroup, sel['reference'], sel['mobile'],
                         len(atoms['reference']), len(atoms['mobile'])))
 
-
         # check weights type
         if not iterable(self.weights) and self.weights == "mass":
             pass
@@ -550,11 +548,11 @@ class RMSD(AnalysisBase):
             get_weights(self.mobile_atoms, self.weights)
 
         if self.weights_groupselections:
-            if len(self.weights_groupselections) != len(self.groupselections):   #length check
+            if len(self.weights_groupselections) != len(self.groupselections):
                 raise ValueError("Length of weights_groupselections is not equal to "
-                                       "length of groupselections ")
+                                 "length of groupselections ")
             for weights, atoms in zip(self.weights_groupselections,
-                    self._groupselections_atoms):
+                                      self._groupselections_atoms):
                 if not iterable(weights) and weights == "mass":
                     pass
                 else:
@@ -563,18 +561,18 @@ class RMSD(AnalysisBase):
     def _prepare(self):
         self._n_atoms = self.mobile_atoms.n_atoms
         if not self.weights_groupselections:
-            if not iterable(self.weights):         # apply 'mass' or 'None' weights for all selections
+            if not iterable(self.weights):         # apply 'mass' or 'None' to groupselections
                 self.weights_groupselections = [self.weights] * len(self.groupselections)
             else:
                 self.weights_groupselections = [None] * len(self.groupselections)
 
         for igroup, (weights, atoms) in enumerate(zip(self.weights_groupselections,
-                                        self._groupselections_atoms), 0):
+                                                      self._groupselections_atoms), 0):
             if weights == 'mass':
                 self.weights_groupselections[igroup] = atoms['mobile'].masses
             if weights is not None:
                 self.weights_groupselections[igroup] = np.asarray(self.weights_groupselections[igroup],
-                                                              dtype=np.float64) /  \
+                                                                  dtype=np.float64) /  \
                                              np.mean(self.weights_groupselections[igroup])
         # add the array of weights to weights_select
         if str(self.weights) == 'mass':
@@ -585,9 +583,9 @@ class RMSD(AnalysisBase):
             self.weights_ref = self.weights
         if self.weights_select is not None:
             self.weights_select = np.asarray(self.weights_select, dtype=np.float64) /  \
-                                             np.mean(self.weights_select)
-            self.weights_ref = np.asarray(self.weights_ref, dtype=np.float64) /  \
-                                             np.mean(self.weights_ref)
+                                  np.mean(self.weights_select)
+            self.weights_ref = np.asarray(self.weights_ref, dtype=np.float64) / \
+                               np.mean(self.weights_ref)
 
         current_frame = self.reference.universe.trajectory.ts.frame
 
@@ -601,9 +599,9 @@ class RMSD(AnalysisBase):
             self._ref_coordinates = self.ref_atoms.positions - self._ref_com
             if self._groupselections_atoms:
                 self._groupselections_ref_coords64 = [(self.reference.
-                    select_atoms(*s['reference']).
-                    positions.astype(np.float64)) for s in
-                    self.groupselections]
+                                                       select_atoms(*s['reference']).
+                                                       positions.astype(np.float64)) for s in
+                                                     self.groupselections]
         finally:
             # Move back to the original frame
             self.reference.universe.trajectory[current_frame]
@@ -663,7 +661,7 @@ class RMSD(AnalysisBase):
                         self._groupselections_atoms), 3):
                 self.rmsd[self._frame_index, igroup] = rmsd(
                     refpos, atoms['mobile'].positions,
-                    weights=self.weights_groupselections[igroup-3], # apply weights to each groupselection
+                    weights=self.weights_groupselections[igroup-3],
                     center=False, superposition=False)
         else:
             # only calculate RMSD by setting the Rmatrix to None (no need
@@ -673,7 +671,6 @@ class RMSD(AnalysisBase):
                 self._n_atoms, None, self.weights_select)
 
         self._pm.rmsd = self.rmsd[self._frame_index, 2]
-
 
 
 class RMSF(AnalysisBase):
@@ -822,8 +819,3 @@ class RMSF(AnalysisBase):
         if not (self.rmsf >= 0).all():
             raise ValueError("Some RMSF values negative; overflow " +
                              "or underflow occurred")
-
-
-
-
-

--- a/package/MDAnalysis/analysis/rms.py
+++ b/package/MDAnalysis/analysis/rms.py
@@ -391,10 +391,10 @@ class RMSD(AnalysisBase):
              corresponding atom in `select`, and assumes ``None`` for `groupselections`.
 
         weights_groupselections : False or list of {"mass", ``None`` or array_like} (optional)
-             1. ``False`` will apply imposed weights from ``weights`` option
+             1. ``False`` will apply imposed weights to `groupselections` from ``weights`` option.
 
-             2. a list of {"mass", ``None`` or array_like} with the length of `groupselections`,
-             apply the weights correspondingly.
+             2. A list of {"mass", ``None`` or array_like} with the length of `groupselections`
+             will apply the weights to `groupselections` correspondingly.
 
         tol_mass : float (optional)
              Reject match if the atomic masses for matched atoms differ by more

--- a/package/MDAnalysis/analysis/rms.py
+++ b/package/MDAnalysis/analysis/rms.py
@@ -575,12 +575,8 @@ class RMSD(AnalysisBase):
                                                                   dtype=np.float64) /  \
                                              np.mean(self.weights_groupselections[igroup])
         # add the array of weights to weights_select
-        if str(self.weights) == 'mass':
-            self.weights_select = self.mobile_atoms.masses
-            self.weights_ref = self.ref_atoms.masses
-        else:
-            self.weights_select = self.weights
-            self.weights_ref = self.weights
+        self.weights_select = get_weights(self.mobile_atoms, self.weights)
+        self.weights_ref = get_weights(self.ref_atoms, self.weights)
         if self.weights_select is not None:
             self.weights_select = np.asarray(self.weights_select, dtype=np.float64) /  \
                                   np.mean(self.weights_select)

--- a/package/MDAnalysis/analysis/rms.py
+++ b/package/MDAnalysis/analysis/rms.py
@@ -318,7 +318,7 @@ def weight_type_check(weights,atoms,selection):
                 "in the selection {}: {}".format(weights, selection['mobile'], atoms.n_atoms))
         else:
             tmp_weights = get_weights(atoms, weights) 
-    elif not iterable(weights) and str(weights) != 'mass' and str(weights) != 'None':
+    elif not iterable(weights) and str(weights) != 'mass' and weights is not None:
         raise ValueError("Each groupselection can only be combined with "
                                "weights: None, 'mass' or 1D float array")
 
@@ -494,9 +494,9 @@ class RMSD(AnalysisBase):
         self.weights = weights
         self.tol_mass = tol_mass
         self.ref_frame = ref_frame
-        self.weights_ref = []              # save weights for reference
-        self.weights_select = []           # save weights for select
-        self.weights_groupselection = []   # save weights for each groupselection
+        self.weights_ref = []              
+        self.weights_select = []          
+        self.weights_groupselection = []   
         self.ref_atoms = self.reference.select_atoms(*select['reference'])
         self.mobile_atoms = self.atomgroup.select_atoms(*select['mobile'])
 
@@ -557,7 +557,7 @@ class RMSD(AnalysisBase):
 
         # check weights type
         #print(self.mobile_atoms)
-        if str(self.weights) == 'None':
+        if self.weights is None:
             pass
         elif (type(self.weights) == str) or \
             (np.array(self.weights).ndim == 1) & (np.array(self.weights).dtype 
@@ -568,7 +568,7 @@ class RMSD(AnalysisBase):
                 raise ValueError("Length of array of weights is not equal to " 
                                        "length of groupselections + 1")
             weights_list = self.weights
-            if str(weights_list[0]) == 'None':
+            if weights_list[0] is None:
                 pass
             elif type(weights_list[0]) == str or \
                 ((np.array(weights_list[0]).ndim == 1) & (np.array(weights_list[0]).dtype 
@@ -582,11 +582,11 @@ class RMSD(AnalysisBase):
         self._n_atoms = self.mobile_atoms.n_atoms
         if str(self.weights) == 'mass':         # apply 'mass' weights for all selections
            self.weights = ['mass'] * (len(self.groupselections) + 1)
-        elif str(self.weights) == 'None':         # apply 'None' weights for all selections
+        elif self.weights is None:         # apply 'None' weights for all selections
            self.weights = [None] * (len(self.groupselections) + 1)  
         elif (np.array(self.weights).ndim == 1) & (np.array(self.weights).dtype 
                                              in (np.dtype('float64'),np.dtype('int64'))):
-           none_selection =[None] * len(self.groupselections)       # apply '1D array' weights to select
+           none_selection = [None] * len(self.groupselections)       # apply '1D array' weights to select
            none_selection.insert(0, self.weights)                   # & apply 'None' weights to groupselections
            self.weights = none_selection
 
@@ -596,7 +596,7 @@ class RMSD(AnalysisBase):
         if str(self.weights[0]) == 'mass':
             self.weights_select = self.mobile_atoms.masses
             self.weights_ref = self.ref_atoms.masses
-        elif str(self.weights[0]) == 'None':
+        elif self.weights[0] is None:
             self.weights_select = None
             self.weights_ref = None
         else:

--- a/package/MDAnalysis/analysis/rms.py
+++ b/package/MDAnalysis/analysis/rms.py
@@ -544,7 +544,11 @@ class RMSD(AnalysisBase):
                         len(atoms['reference']), len(atoms['mobile'])))
 
         # check weights type
-        if iterable(weights) or weights != "mass":
+        if iterable(self.weights) and (np.array(weights).dtype
+                                not in (np.dtype('float64'),np.dtype('int64'))):
+            raise TypeError("´´weight´´ should only be be 'mass', ´None´ or 1D float array "
+                                 "For groupselections, use ´´weight_groupselections´´ ")
+        if iterable(self.weights) or self.weights != "mass":
             get_weights(self.mobile_atoms, self.weights)
 
         if self.weights_groupselections:

--- a/package/MDAnalysis/analysis/rms.py
+++ b/package/MDAnalysis/analysis/rms.py
@@ -546,8 +546,8 @@ class RMSD(AnalysisBase):
         # check weights type
         if iterable(self.weights) and (np.array(weights).dtype
                                 not in (np.dtype('float64'),np.dtype('int64'))):
-            raise TypeError("´´weight´´ should only be be 'mass', ´None´ or 1D float array "
-                                 "For groupselections, use ´´weight_groupselections´´ ")
+            raise TypeError("weight should only be be 'mass', None or 1D float array."
+                                 "For weights on groupselections, use **weight_groupselections** ")
         if iterable(self.weights) or self.weights != "mass":
             get_weights(self.mobile_atoms, self.weights)
 

--- a/package/MDAnalysis/analysis/rms.py
+++ b/package/MDAnalysis/analysis/rms.py
@@ -575,20 +575,16 @@ class RMSD(AnalysisBase):
 
     def _prepare(self):
         self._n_atoms = self.mobile_atoms.n_atoms
-        # apply 'mass' weights for all selections
-        if self.weights == 'mass':
+        if self.weights == 'mass':         # apply 'mass' weights for all selections
            self.weights = ['mass'] * (len(self.groupselections) + 1)
-        # apply 'None' weights for all selections
-        elif self.weights is None:
-           self.weights = [None] * (len(self.groupselections) + 1)
-        # if weight is an 1D num array, apply it to select, and  apply 'None' weights to groupselections
+        elif self.weights is None:         # apply 'None' weights for all selections
+           self.weights = [None] * (len(self.groupselections) + 1)  
         elif (np.array(self.weights).ndim == 1) & (np.array(self.weights).dtype in (np.dtype('float64'),np.dtype('int64'))):
-           none_selection =[None] * len(self.groupselections)
-           none_selection.insert(0, self.weights)
+           none_selection =[None] * len(self.groupselections)       # if weight is an 1D num array, apply it to select, 
+           none_selection.insert(0, self.weights)                   # and apply 'None' weights to groupselections
            self.weights = none_selection
 
-        # add the array of weights to select
-        if not iterable(self.weights[0]) and self.weights[0] == 'mass':
+        if not iterable(self.weights[0]) and self.weights[0] == 'mass': # add the array of weights to weights_select
             self.weights_select = self.ref_atoms.masses
         elif self.weights[0] is None:
             self.weights_select = None
@@ -597,8 +593,7 @@ class RMSD(AnalysisBase):
         if self.weights_select is not None:
             self.weights_select = np.asarray(self.weights_select, dtype=np.float64) / np.mean(self.weights_select)
 
-       # add a list of arrays of weights for each groupselection
-        if self._groupselections_atoms:
+        if self._groupselections_atoms:                             # add the array of weights to select
             for igroup, atoms in enumerate(
                         self._groupselections_atoms, 3):
                 if not iterable(self.weights[igroup-2]) and self.weights[igroup-2] == 'mass':
@@ -687,7 +682,7 @@ class RMSD(AnalysisBase):
                         self._groupselections_atoms), 3):
                 self.rmsd[self._frame_index, igroup] = rmsd(
                     refpos, atoms['mobile'].positions,
-                    weights=self.weights_groupselection[igroup-3],
+                    weights=self.weights_groupselection[igroup-3],     #apply weights to each groupselection
                     center=False, superposition=False)
         else:
             # only calculate RMSD by setting the Rmatrix to None (no need

--- a/package/MDAnalysis/analysis/rms.py
+++ b/package/MDAnalysis/analysis/rms.py
@@ -544,11 +544,7 @@ class RMSD(AnalysisBase):
 
         # check weights type
 
-        if self.weights == 'mass':
-            pass
-        elif self.weights is None:
-            pass
-        elif (np.array(self.weights).ndim == 1) & (np.array(self.weights).dtype 
+        if (np.array(self.weights).ndim == 1) & (np.array(self.weights).dtype 
 						in (np.dtype('float64'),np.dtype('int64'))):
             self.weights = get_weights(self.mobile_atoms, self.weights)
         elif not iterable(self.weights):
@@ -559,11 +555,7 @@ class RMSD(AnalysisBase):
         else:
             weights_list = self.weights
             for weights in weights_list:
-                if weights == 'mass':
-                    pass
-                elif weights is None:
-                    pass
-                elif (np.array(weights).ndim == 1) & (np.array(weights).dtype 
+                if (np.array(weights).ndim == 1) & (np.array(weights).dtype 
 						in (np.dtype('float64'),np.dtype('int64'))):
                     # TODO:
                     # check each length of weights matches the length of each group selection?

--- a/package/MDAnalysis/analysis/rms.py
+++ b/package/MDAnalysis/analysis/rms.py
@@ -548,12 +548,14 @@ class RMSD(AnalysisBase):
             pass
         elif self.weights is None:
             pass
-        elif (np.array(self.weights).ndim == 1) & (np.array(self.weights).dtype in (np.dtype('float64'),np.dtype('int64'))):
+        elif (np.array(self.weights).ndim == 1) & (np.array(self.weights).dtype 
+						in (np.dtype('float64'),np.dtype('int64'))):
             self.weights = get_weights(self.mobile_atoms, self.weights)
         elif not iterable(self.weights):
             self.weights = get_weights(self.mobile_atoms, self.weights)
         elif len(self.weights) != len(self.groupselections) + 1:
-            raise ValueError("Length of array of weights is not equal to length of groupselections + 1")
+            raise ValueError("Length of array of weights is not equal to " 
+					"length of groupselections + 1")
         else:
             weights_list = self.weights
             for weights in weights_list:
@@ -561,7 +563,8 @@ class RMSD(AnalysisBase):
                     pass
                 elif weights is None:
                     pass
-                elif (np.array(weights).ndim == 1) & (np.array(weights).dtype in (np.dtype('float64'),np.dtype('int64'))):
+                elif (np.array(weights).ndim == 1) & (np.array(weights).dtype 
+						in (np.dtype('float64'),np.dtype('int64'))):
                     # TODO:
                     # check each length of weights matches the length of each group selection?
                     pass
@@ -579,34 +582,45 @@ class RMSD(AnalysisBase):
            self.weights = ['mass'] * (len(self.groupselections) + 1)
         elif self.weights is None:         # apply 'None' weights for all selections
            self.weights = [None] * (len(self.groupselections) + 1)  
-        elif (np.array(self.weights).ndim == 1) & (np.array(self.weights).dtype in (np.dtype('float64'),np.dtype('int64'))):
-           none_selection =[None] * len(self.groupselections)       # if weight is an 1D num array, apply it to select, 
-           none_selection.insert(0, self.weights)                   # and apply 'None' weights to groupselections
+        elif (np.array(self.weights).ndim == 1) & (np.array(self.weights).dtype 
+                                             in (np.dtype('float64'),np.dtype('int64'))):
+           none_selection =[None] * len(self.groupselections)       # apply '1D array' weights to select
+           none_selection.insert(0, self.weights)                   # & apply 'None' weights to groupselections
            self.weights = none_selection
 
-        if not iterable(self.weights[0]) and self.weights[0] == 'mass': # add the array of weights to weights_select
-            self.weights_select = self.ref_atoms.masses
-        elif self.weights[0] is None:
+
+
+        # add the array of weights to weights_select
+        print(self.weights)
+        if self.weights[0] == 'mass':
+            self.weights_select = self.mobile_atoms.masses
+        elif (self.weights[0] is None):
             self.weights_select = None
         else:
             self.weights_select = self.weights[0]
         if self.weights_select is not None:
-            self.weights_select = np.asarray(self.weights_select, dtype=np.float64) / np.mean(self.weights_select)
-
-        if self._groupselections_atoms:                             # add the array of weights to select
+            self.weights_select = np.asarray(self.weights_select, dtype=np.float64) /  \
+                                             np.mean(self.weights_select)
+        # add the array of weights to weight_groupselection
+        if self._groupselections_atoms:                            
             for igroup, atoms in enumerate(
                         self._groupselections_atoms, 3):
-                if not iterable(self.weights[igroup-2]) and self.weights[igroup-2] == 'mass':
+                if self.weights[igroup-2] == 'mass':
                     self.weights_groupselection.append(atoms['mobile'].masses)
                 elif iterable(self.weights[igroup-2]):
                     self.weights_groupselection.append(self.weights[igroup-2])
-                    self.weights_groupselection[igroup-3] = np.asarray(self.weights_groupselection[igroup-3], dtype=np.float64) / np.mean(self.weights_groupselection[igroup-3])                  
+                    self.weights_groupselection[igroup-3] =   \
+                                       np.asarray(self.weights_groupselection[igroup-3], 
+                                                                        dtype=np.float64) / \
+                                       np.mean(self.weights_groupselection[igroup-3])                  
                 else:
                     self.weights_groupselection.append(None)
 
                 if self.weights_groupselection[igroup-3] is not None:
-                    self.weights_groupselection[igroup-3] = np.asarray(self.weights_groupselection[igroup-3], dtype=np.float64) / np.mean(self.weights_groupselection[igroup-3])
-
+                    self.weights_groupselection[igroup-3] =   \
+                                       np.asarray(self.weights_groupselection[igroup-3], 
+                                                                        dtype=np.float64) / \
+                                       np.mean(self.weights_groupselection[igroup-3])
 
         current_frame = self.reference.universe.trajectory.ts.frame
 
@@ -682,7 +696,7 @@ class RMSD(AnalysisBase):
                         self._groupselections_atoms), 3):
                 self.rmsd[self._frame_index, igroup] = rmsd(
                     refpos, atoms['mobile'].positions,
-                    weights=self.weights_groupselection[igroup-3],     #apply weights to each groupselection
+                    weights=self.weights_groupselection[igroup-3], # apply weights to each groupselection
                     center=False, superposition=False)
         else:
             # only calculate RMSD by setting the Rmatrix to None (no need
@@ -709,7 +723,7 @@ class RMSF(AnalysisBase):
     Run the analysis with :meth:`RMSF.run`, which stores the results
     in the array :attr:`RMSF.rmsf`.
 
-    """
+c    """
     def __init__(self, atomgroup, **kwargs):
         r"""Parameters
         ----------

--- a/package/MDAnalysis/analysis/rms.py
+++ b/package/MDAnalysis/analysis/rms.py
@@ -480,10 +480,9 @@ class RMSD(AnalysisBase):
         self.weights = weights
         self.tol_mass = tol_mass
         self.ref_frame = ref_frame
-        # save weights for select
-        self.weights_select = []
-        # save weights for each groupselection
-        self.weights_groupselection = []
+        self.weights_ref = []              # save weights for reference
+        self.weights_select = []           # save weights for select
+        self.weights_groupselection = []   # save weights for each groupselection
         self.ref_atoms = self.reference.select_atoms(*select['reference'])
         self.mobile_atoms = self.atomgroup.select_atoms(*select['mobile'])
 
@@ -593,13 +592,18 @@ class RMSD(AnalysisBase):
         # add the array of weights to weights_select
         if str(self.weights[0]) == 'mass':
             self.weights_select = self.mobile_atoms.masses
+            self.weights_ref = self.ref_atoms.masses
         elif str(self.weights[0]) == 'None':
             self.weights_select = None
+            self.weights_ref = None
         else:
             self.weights_select = self.weights[0]
+            self.weights_ref = self.weights[0]
         if self.weights_select is not None:
             self.weights_select = np.asarray(self.weights_select, dtype=np.float64) /  \
                                              np.mean(self.weights_select)
+            self.weights_ref = np.asarray(self.weights_ref, dtype=np.float64) /  \
+                                             np.mean(self.weights_ref)
         # add the array of weights to weight_groupselection
         if self._groupselections_atoms:                            
             for igroup, atoms in enumerate(
@@ -628,7 +632,7 @@ class RMSD(AnalysisBase):
             # (coordinates MUST be stored in case the ref traj is advanced
             # elsewhere or if ref == mobile universe)
             self.reference.universe.trajectory[self.ref_frame]
-            self._ref_com = self.ref_atoms.center(self.weights_select)
+            self._ref_com = self.ref_atoms.center(self.weights_ref)
             # makes a copy
             self._ref_coordinates = self.ref_atoms.positions - self._ref_com
             if self._groupselections_atoms:

--- a/package/MDAnalysis/analysis/rms.py
+++ b/package/MDAnalysis/analysis/rms.py
@@ -543,7 +543,6 @@ class RMSD(AnalysisBase):
 
 
         # check weights type
-
         if (np.array(self.weights).ndim == 1) & (np.array(self.weights).dtype 
 						in (np.dtype('float64'),np.dtype('int64'))):
             self.weights = get_weights(self.mobile_atoms, self.weights)
@@ -552,13 +551,22 @@ class RMSD(AnalysisBase):
         elif len(self.weights) != len(self.groupselections) + 1:
             raise ValueError("Length of array of weights is not equal to " 
 					"length of groupselections + 1")
-        else:
+        else:       # list of weights conditions
             weights_list = self.weights
-            for weights in weights_list:
-                if (np.array(weights).ndim == 1) & (np.array(weights).dtype 
+            if (np.array(weights_list[0]).ndim == 1) & (np.array(weights_list[0]).dtype 
+                                                in (np.dtype('float64'),np.dtype('int64'))):
+                self.weights = get_weights(self.mobile_atoms, weights_list[0]) # check first one exclusively
+            for weights, atoms, selection in zip(weights_list[1:],
+                        self._groupselections_atoms,self.groupselections):
+                if weights == 'mass':
+                    pass
+                elif weights is None:
+                    pass
+                elif (np.array(weights).ndim == 1) & (np.array(weights).dtype 
 						in (np.dtype('float64'),np.dtype('int64'))):
-                    # TODO:
-                    # check each length of weights matches the length of each group selection?
+                    if len(weights) != atoms['mobile'].n_atoms:
+                        raise ValueError("Length of provided weights {} do not match the number of atoms "
+                      "in the selection {}: {}".format(weights, selection['mobile'], atoms['mobile'].n_atoms))
                     pass
 
                 elif not iterable(self.weights):
@@ -583,7 +591,6 @@ class RMSD(AnalysisBase):
 
 
         # add the array of weights to weights_select
-        print(self.weights)
         if self.weights[0] == 'mass':
             self.weights_select = self.mobile_atoms.masses
         elif (self.weights[0] is None):

--- a/package/MDAnalysis/analysis/rms.py
+++ b/package/MDAnalysis/analysis/rms.py
@@ -558,9 +558,9 @@ class RMSD(AnalysisBase):
                 self.weights = get_weights(self.mobile_atoms, weights_list[0]) # check first one exclusively
             for weights, atoms, selection in zip(weights_list[1:],
                         self._groupselections_atoms,self.groupselections):
-                if weights == 'mass':
+                if str(weights) == 'mass':
                     pass
-                elif weights is None:
+                elif str(weights) == 'None':
                     pass
                 elif (np.array(weights).ndim == 1) & (np.array(weights).dtype 
 						in (np.dtype('float64'),np.dtype('int64'))):
@@ -578,9 +578,9 @@ class RMSD(AnalysisBase):
 
     def _prepare(self):
         self._n_atoms = self.mobile_atoms.n_atoms
-        if self.weights == 'mass':         # apply 'mass' weights for all selections
+        if str(self.weights) == 'mass':         # apply 'mass' weights for all selections
            self.weights = ['mass'] * (len(self.groupselections) + 1)
-        elif self.weights is None:         # apply 'None' weights for all selections
+        elif str(self.weights) == 'None':         # apply 'None' weights for all selections
            self.weights = [None] * (len(self.groupselections) + 1)  
         elif (np.array(self.weights).ndim == 1) & (np.array(self.weights).dtype 
                                              in (np.dtype('float64'),np.dtype('int64'))):
@@ -591,9 +591,9 @@ class RMSD(AnalysisBase):
 
 
         # add the array of weights to weights_select
-        if self.weights[0] == 'mass':
+        if str(self.weights[0]) == 'mass':
             self.weights_select = self.mobile_atoms.masses
-        elif (self.weights[0] is None):
+        elif str(self.weights[0]) == 'None':
             self.weights_select = None
         else:
             self.weights_select = self.weights[0]
@@ -604,7 +604,7 @@ class RMSD(AnalysisBase):
         if self._groupselections_atoms:                            
             for igroup, atoms in enumerate(
                         self._groupselections_atoms, 3):
-                if self.weights[igroup-2] == 'mass':
+                if str(self.weights[igroup-2]) == 'mass':
                     self.weights_groupselection.append(atoms['mobile'].masses)
                 elif iterable(self.weights[igroup-2]):
                     self.weights_groupselection.append(self.weights[igroup-2])

--- a/testsuite/MDAnalysisTests/analysis/test_rms.py
+++ b/testsuite/MDAnalysisTests/analysis/test_rms.py
@@ -173,6 +173,10 @@ class TestRMSD(object):
         return [[0, 1, 0], [49, 50, 4.74920]]
 
     @pytest.fixture()
+    def correct_values_mass_add_ten(self):
+        return [[0, 1, 0.0632], [49, 50, 4.7710]]
+
+    @pytest.fixture()
     def correct_values_group(self):
         return [[0, 1, 0, 0, 0],
                 [49, 50, 4.7857, 4.7048, 4.6924]]
@@ -254,7 +258,7 @@ class TestRMSD(object):
                             err_msg="error: rmsd profile should match" +
                             "test values")
 
-    def test_custom_groupselection_weights_applied_1D_array(self, universe, correct_values_mass):
+    def test_custom_groupselection_weights_applied_1D_array(self, universe):
         RMSD = MDAnalysis.analysis.rms.RMSD(universe,
                                             select='backbone',
                                             groupselections=['name CA and resid 1-5', 'name CA and resid 1'],
@@ -346,16 +350,18 @@ class TestRMSD(object):
             RMSD = MDAnalysis.analysis.rms.RMSD(universe,
                                                 reference=reference)
 
-    def test_ref_mobile_mass_mismapped(self, universe):
+    def test_ref_mobile_mass_mismapped(self, universe,correct_values_mass_add_ten):
         reference = MDAnalysis.Universe(PSF, DCD)
-        universe.atoms.masses = np.zeros(len(universe.atoms.masses))
-        with pytest.raises(ZeroDivisionError):
-            RMSD = MDAnalysis.analysis.rms.RMSD(universe,
+        universe.atoms.masses = universe.atoms.masses + 10
+        RMSD = MDAnalysis.analysis.rms.RMSD(universe,
                                                 reference=reference,
                                                 select='all',
                                                 weights='mass',
                                                 tol_mass=100)
-            RMSD.run()
+        RMSD.run(step=49)
+        assert_almost_equal(RMSD.rmsd, correct_values_mass_add_ten, 4,
+                            err_msg="error: rmsd profile should match "
+                            "between true values and calculated values")
 
     def test_group_selections_unequal_len(self, universe):
         reference = MDAnalysis.Universe(PSF, DCD)

--- a/testsuite/MDAnalysisTests/analysis/test_rms.py
+++ b/testsuite/MDAnalysisTests/analysis/test_rms.py
@@ -175,13 +175,12 @@ class TestRMSD(object):
     @pytest.fixture()
     def correct_values_group(self):
         return [[0, 1, 0, 0, 0],
-                 [49, 50, 4.7857, 4.7048, 4.6924]]
+                [49, 50, 4.7857, 4.7048, 4.6924]]
 
     @pytest.fixture()
     def correct_values_backbone_group(self):
         return [[0, 1, 0, 0, 0],
                 [49, 50, 4.6997, 1.9154, 2.7139]]
-
 
     def test_progress_meter(self, capsys, universe):
         RMSD = MDAnalysis.analysis.rms.RMSD(universe, verbose=True)
@@ -202,8 +201,8 @@ class TestRMSD(object):
         RMSD = MDAnalysis.analysis.rms.RMSD(universe, select=u'name CA')
         RMSD.run(step=49)
         assert_almost_equal(RMSD.rmsd, correct_values, 4,
-                                  err_msg="error: rmsd profile should match" +
-                                  "test values")
+                            err_msg="error: rmsd profile should match" +
+                            "test values")
 
     def test_rmsd_atomgroup_selections(self, universe):
         # see Issue #1684
@@ -258,25 +257,25 @@ class TestRMSD(object):
     def test_custom_groupselection_weights_applied_1D_array(self, universe, correct_values_mass):
         RMSD = MDAnalysis.analysis.rms.RMSD(universe,
                                             select='backbone',
-                                            groupselections=['name CA and resid 1-5','name CA and resid 1'], 
+                                            groupselections=['name CA and resid 1-5', 'name CA and resid 1'],
                                             weights=None,
-                                            weights_groupselections=[[1,0,0,0,0], None]).run(step=49)
+                                            weights_groupselections=[[1, 0, 0, 0, 0], None]).run(step=49)
 
         assert_almost_equal(RMSD.rmsd.T[3], RMSD.rmsd.T[4], 4,
                             err_msg="error: rmsd profile should match "
                             "for applied weight array and selected resid")
 
     def test_custom_groupselection_weights_applied_mass(self, universe, correct_values_mass):
-        RMSD = MDAnalysis.analysis.rms.RMSD(universe, 
-                                            select='backbone', 
-                                            groupselections=['all','all'], 
+        RMSD = MDAnalysis.analysis.rms.RMSD(universe,
+                                            select='backbone',
+                                            groupselections=['all', 'all'],
                                             weights=None,
-                                            weights_groupselections=['mass',universe.atoms.masses ]).run(step=49)
+                                            weights_groupselections=['mass',
+                                                                     universe.atoms.masses]).run(step=49)
 
         assert_almost_equal(RMSD.rmsd.T[3], RMSD.rmsd.T[4], 4,
                             err_msg="error: rmsd profile should match "
                             "between applied mass and universe.atoms.masses")
-
 
     def test_rmsd_scalar_weights_raises_TypeError(self, universe):
         with pytest.raises(TypeError):
@@ -292,11 +291,13 @@ class TestRMSD(object):
         with pytest.raises(ValueError):
             RMSD = MDAnalysis.analysis.rms.RMSD(
                 universe, weights=universe.atoms.masses[:-1])
+
     def test_rmsd_mismatched_weights_in_groupselection_raises_ValueError(self, universe):
         with pytest.raises(ValueError):
             RMSD = MDAnalysis.analysis.rms.RMSD(
                 universe, groupselections=['all'],
-                weights=[universe.atoms.masses,universe.atoms.masses[:-1]])
+                weights=[universe.atoms.masses, universe.atoms.masses[:-1]])
+
     def test_rmsd_list_of_weights_wrong_length(self, universe):
         with pytest.raises(ValueError):
             RMSD = MDAnalysis.analysis.rms.RMSD(
@@ -337,6 +338,7 @@ class TestRMSD(object):
         with pytest.raises(SelectionError):
             RMSD = MDAnalysis.analysis.rms.RMSD(universe,
                                                 reference=reference)
+
     def test_ref_mobile_mass_mismapped(self, universe):
         reference = MDAnalysis.Universe(PSF, DCD)
         universe.atoms.masses = np.zeros(len(universe.atoms.masses))
@@ -347,14 +349,14 @@ class TestRMSD(object):
                                                 weights='mass',
                                                 tol_mass=100)
             RMSD.run()
+
     def test_group_selections_unequal_len(self, universe):
         reference = MDAnalysis.Universe(PSF, DCD)
-        reference.atoms[0].residue.resname='NOTMET'
+        reference.atoms[0].residue.resname = 'NOTMET'
         with pytest.raises(SelectionError):
             RMSD = MDAnalysis.analysis.rms.RMSD(universe,
                                                 reference=reference,
-                                                groupselections=
-                                                ['resname MET','type NH3'])
+                                                groupselections=['resname MET', 'type NH3'])
 
 
 class TestRMSF(object):

--- a/testsuite/MDAnalysisTests/analysis/test_rms.py
+++ b/testsuite/MDAnalysisTests/analysis/test_rms.py
@@ -292,11 +292,18 @@ class TestRMSD(object):
             RMSD = MDAnalysis.analysis.rms.RMSD(
                 universe, weights=universe.atoms.masses[:-1])
 
+    def test_rmsd_misuse_weights_for_groupselection_raises_TypeError(self, universe):
+        with pytest.raises(TypeError):
+            RMSD = MDAnalysis.analysis.rms.RMSD(
+                universe, groupselections=['all'],
+                weights=[universe.atoms.masses, universe.atoms.masses[:-1]])
+
     def test_rmsd_mismatched_weights_in_groupselection_raises_ValueError(self, universe):
         with pytest.raises(ValueError):
             RMSD = MDAnalysis.analysis.rms.RMSD(
                 universe, groupselections=['all'],
-                weights=[universe.atoms.masses, universe.atoms.masses[:-1]])
+                weights=universe.atoms.masses,
+                weights_groupselections = [universe.atoms.masses[:-1]])
 
     def test_rmsd_list_of_weights_wrong_length(self, universe):
         with pytest.raises(ValueError):

--- a/testsuite/MDAnalysisTests/analysis/test_rms.py
+++ b/testsuite/MDAnalysisTests/analysis/test_rms.py
@@ -259,7 +259,8 @@ class TestRMSD(object):
         RMSD = MDAnalysis.analysis.rms.RMSD(universe,
                                             select='backbone',
                                             groupselections=['name CA and resid 1-5','name CA and resid 1'], 
-                                            weights=[None, [1,0,0,0,0], None]).run(step=49)
+                                            weights=None,
+                                            weights_groupselections=[[1,0,0,0,0], None]).run(step=49)
 
         assert_almost_equal(RMSD.rmsd.T[3], RMSD.rmsd.T[4], 4,
                             err_msg="error: rmsd profile should match "
@@ -269,7 +270,8 @@ class TestRMSD(object):
         RMSD = MDAnalysis.analysis.rms.RMSD(universe, 
                                             select='backbone', 
                                             groupselections=['all','all'], 
-                                            weights=[None, 'mass',universe.atoms.masses ]).run(step=49)
+                                            weights=None,
+                                            weights_groupselections=['mass',universe.atoms.masses ]).run(step=49)
 
         assert_almost_equal(RMSD.rmsd.T[3], RMSD.rmsd.T[4], 4,
                             err_msg="error: rmsd profile should match "
@@ -282,7 +284,7 @@ class TestRMSD(object):
                 universe, weights=42)
 
     def test_rmsd_string_weights_raises_TypeError(self, universe):
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             RMSD = MDAnalysis.analysis.rms.RMSD(
                 universe, weights="Jabberwock")
 
@@ -299,7 +301,8 @@ class TestRMSD(object):
         with pytest.raises(ValueError):
             RMSD = MDAnalysis.analysis.rms.RMSD(
                 universe, groupselections=['backbone', 'name CA'],
-                weights=['mass',None])
+                weights='mass',
+                weights_groupselections=[None])
 
     def test_rmsd_group_selections(self, universe, correct_values_group):
         RMSD = MDAnalysis.analysis.rms.RMSD(universe,

--- a/testsuite/MDAnalysisTests/analysis/test_rms.py
+++ b/testsuite/MDAnalysisTests/analysis/test_rms.py
@@ -282,7 +282,7 @@ class TestRMSD(object):
                 universe, weights=42)
 
     def test_rmsd_string_weights_raises_TypeError(self, universe):
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             RMSD = MDAnalysis.analysis.rms.RMSD(
                 universe, weights="Jabberwock")
 

--- a/testsuite/MDAnalysisTests/analysis/test_rms.py
+++ b/testsuite/MDAnalysisTests/analysis/test_rms.py
@@ -270,11 +270,11 @@ class TestRMSD(object):
             RMSD = MDAnalysis.analysis.rms.RMSD(
                 universe, weights=universe.atoms.masses[:-1])
 
-    def test_rmsd_group_selections_wrong_weights(self, universe):
+    def test_rmsd_list_of_weights_wrong_length(self, universe):
         with pytest.raises(ValueError):
             RMSD = MDAnalysis.analysis.rms.RMSD(
                 universe, groupselections=['backbone', 'name CA'],
-                weights=universe.atoms.masses)
+                weights=['mass',None])
 
     def test_rmsd_group_selections(self, universe, correct_values_group):
         RMSD = MDAnalysis.analysis.rms.RMSD(universe,

--- a/testsuite/MDAnalysisTests/analysis/test_rms.py
+++ b/testsuite/MDAnalysisTests/analysis/test_rms.py
@@ -255,6 +255,27 @@ class TestRMSD(object):
                             err_msg="error: rmsd profile should match" +
                             "test values")
 
+    def test_custom_groupselection_weights_applied_1D_array(self, universe, correct_values_mass):
+        RMSD = MDAnalysis.analysis.rms.RMSD(universe,
+                                            select='backbone',
+                                            groupselections=['name CA and resid 1-5','name CA and resid 1'], 
+                                            weights=[None, [1,0,0,0,0], None]).run(step=49)
+
+        assert_almost_equal(RMSD.rmsd.T[3], RMSD.rmsd.T[4], 4,
+                            err_msg="error: rmsd profile should match "
+                            "for applied weight array and selected resid")
+
+    def test_custom_groupselection_weights_applied_mass(self, universe, correct_values_mass):
+        RMSD = MDAnalysis.analysis.rms.RMSD(universe, 
+                                            select='backbone', 
+                                            groupselections=['all','all'], 
+                                            weights=[None, 'mass',universe.atoms.masses ]).run(step=49)
+
+        assert_almost_equal(RMSD.rmsd.T[3], RMSD.rmsd.T[4], 4,
+                            err_msg="error: rmsd profile should match "
+                            "between applied mass and universe.atoms.masses")
+
+
     def test_rmsd_scalar_weights_raises_TypeError(self, universe):
         with pytest.raises(TypeError):
             RMSD = MDAnalysis.analysis.rms.RMSD(

--- a/testsuite/MDAnalysisTests/analysis/test_rms.py
+++ b/testsuite/MDAnalysisTests/analysis/test_rms.py
@@ -313,7 +313,16 @@ class TestRMSD(object):
         with pytest.raises(SelectionError):
             RMSD = MDAnalysis.analysis.rms.RMSD(universe,
                                                 reference=reference)
-
+    def test_ref_mobile_mass_mismapped(self, universe):
+        reference = MDAnalysis.Universe(PSF, DCD)
+        universe.atoms.masses = np.zeros(len(universe.atoms.masses))
+        with pytest.raises(ZeroDivisionError):
+            RMSD = MDAnalysis.analysis.rms.RMSD(universe,
+                                                reference=reference,
+                                                select='all',
+                                                weights='mass',
+                                                tol_mass=100)
+            RMSD.run()
     def test_group_selections_unequal_len(self, universe):
         reference = MDAnalysis.Universe(PSF, DCD)
         reference.atoms[0].residue.resname='NOTMET'

--- a/testsuite/MDAnalysisTests/analysis/test_rms.py
+++ b/testsuite/MDAnalysisTests/analysis/test_rms.py
@@ -269,7 +269,11 @@ class TestRMSD(object):
         with pytest.raises(ValueError):
             RMSD = MDAnalysis.analysis.rms.RMSD(
                 universe, weights=universe.atoms.masses[:-1])
-
+    def test_rmsd_mismatched_weights_in_groupselection_raises_ValueError(self, universe):
+        with pytest.raises(ValueError):
+            RMSD = MDAnalysis.analysis.rms.RMSD(
+                universe, groupselections=['all'],
+                weights=[universe.atoms.masses,universe.atoms.masses[:-1]])
     def test_rmsd_list_of_weights_wrong_length(self, universe):
         with pytest.raises(ValueError):
             RMSD = MDAnalysis.analysis.rms.RMSD(


### PR DESCRIPTION
Fixes #2429

Changes made in this Pull Request:

- Weights now accept *mass*, *None*, 1D float array or a list of them.
  - None and *mass* applies to all selections.
  - 1D float array applies only to select.
  - a list of them with length 1 + len(groupselection) applies to each
  selection correspondingly.

- Length mismatch between each groupselection and each weight is not yet checked.

Code fixed:

```python3
import MDAnalysis as mda
from MDAnalysis.tests.datafiles import PSF, DCD, CRD
import MDAnalysis.analysis.rms as rms
u = mda.Universe(PSF, DCD)  # closed AdK (PDB ID: 1AKE)
R = rms.RMSD(u,  # universe to align
            u,  # reference universe or atomgroup
            select='backbone',  # group to superimpose and calculate RMSD
            groupselections=["all"],  # groups for RMSD
            weights='mass')  # weights for each atom
R.run()
```

PR Checklist
------------
- [x] Tests?
- [x] Docs?
- [x] CHANGELOG updated?
- [x] Issue raised/referenced?
