### PR TITLE
Read XDR offsets from trajectory if file read-in fails

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -135,6 +135,7 @@ Chronological list of authors
   - Hugo MacDermott-Opeskin
   - Anshul Angaria
   - Shubham Sharma
+  - Morgan L. Nance
 
 
 External code

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -16,11 +16,13 @@ The rules for this file:
 mm/dd/yy richardjgowers, kain88-de, lilyminium, p-j-smith, bdice, joaomcteixeira,
          PicoCentauri, davidercruz, jbarnoud, RMeli, IAlibay, mtiberti, CCook96,
          Yuan-Yu, xiki-tempula, HTian1997, Iv-Hristov, hmacdope, AnshulAngaria,
-         ss62171, Luthaf
+         ss62171, Luthaf, mlnance
 
   * 0.21.0
 
 Fixes
+  * XDR offsets now read from trajectory if offsets file read-in fails on
+    IOError. Added relevant tests (Issue #1893, PR #2611)
   * Fixed test for the `save_paths` and `load` methods of :class:`PSAnalysis`
     (Issue #2593)
   * Fixes outdated :class:`TRJReader` documentation on random frame access

--- a/package/MDAnalysis/coordinates/XDR.py
+++ b/package/MDAnalysis/coordinates/XDR.py
@@ -113,6 +113,9 @@ class XDRBaseReader(base.ReaderBase):
     Reader. However, the  next time the trajectory is opened,  the offsets will
     have to be rebuilt again.
 
+    .. versionchanged:: 0.21.0
+       XDR offsets read from trajectory if offsets file read-in fails
+
     """
     def __init__(self, filename, convert_units=True, sub=None,
                  refresh_offsets=False, **kwargs):

--- a/package/MDAnalysis/coordinates/XDR.py
+++ b/package/MDAnalysis/coordinates/XDR.py
@@ -192,9 +192,10 @@ class XDRBaseReader(base.ReaderBase):
         # refer to Issue #1893
         data = read_numpy_offsets(fname)
         if not data:
-            warnings.warn("Reading frame offsets from trajectory\n"
+            warnings.warn("Reading offsets from {} failed, "
+                          "reading offsets from trajectory instead\n"
                           "Consider setting 'refresh_offsets=True' "
-                          "when loading your Universe".format(filename))
+                          "when loading your Universe".format(fname))
             self._read_offsets(store=True)
             return
 


### PR DESCRIPTION
Fixes #1893 

Changes made in this Pull Request:
 - Wrapped `read_numpy_offsets` in a try/except that allows for handling `IOError`
 - Added a check for if read-in failed and to `_read_offsets` instead
 - Provided user with warning if file read-in failed and defaulting to reading from trajectory
 - Added necessary tests to `test_xdr.py`
   - Add assertion to all tests that call `read_numpy_offsets` that return value is a `dict`
   - Test that an `IOError` returns `False` for `read_numpy_offsets`
   - Test that even with `IOError`, `_load_offsets` still returns expected value


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
