### PR TITLE
Fix #2606: moving local function to the top

### DIFF
--- a/testsuite/MDAnalysisTests/analysis/test_encore.py
+++ b/testsuite/MDAnalysisTests/analysis/test_encore.py
@@ -47,7 +47,6 @@ def function(x):
     return x**2
 
 class TestEncore(object):
-
     @pytest.fixture(scope='class')
     def ens1_template(self):
         template = mda.Universe(PSF, DCD)

--- a/testsuite/MDAnalysisTests/analysis/test_encore.py
+++ b/testsuite/MDAnalysisTests/analysis/test_encore.py
@@ -43,7 +43,11 @@ import MDAnalysis.analysis.align as align
 import MDAnalysis.analysis.encore.confdistmatrix as confdistmatrix
 
 
+def function(x):
+    return x**2
+
 class TestEncore(object):
+
     @pytest.fixture(scope='class')
     def ens1_template(self):
         template = mda.Universe(PSF, DCD)
@@ -120,9 +124,6 @@ inconsistent results")
                        strict=True,
                        reason="Not yet supported on Windows.")
     def test_parallel_calculation(self):
-
-        def function(x):
-            return x**2
 
         arguments = [tuple([i]) for i in np.arange(0,100)]
 

--- a/testsuite/MDAnalysisTests/analysis/test_encore.py
+++ b/testsuite/MDAnalysisTests/analysis/test_encore.py
@@ -120,7 +120,6 @@ class TestEncore(object):
 inconsistent results")
 
     @pytest.mark.xfail(os.name == 'nt',
-                       strict=True,
                        reason="Not yet supported on Windows.")
     def test_parallel_calculation(self):
 


### PR DESCRIPTION
Fixes #2606 

Pytest and/or multiprocessing fails to pickle local functions. Found a workaround here: https://bugs.python.org/issue33884

Basically, moving the local function to the top level.

Changes made in this Pull Request:
 - the function which is being evaluated in parallel is global now

PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?
