### PR TITLE
BUG: fix segfault with 0.0 around sels

### DIFF
--- a/package/MDAnalysis/core/selection.py
+++ b/package/MDAnalysis/core/selection.py
@@ -260,6 +260,10 @@ class AroundSelection(DistanceSelection):
         sel = self.sel.apply(group)
         # All atoms in group that aren't in sel
         sys = group[~np.in1d(group.indices, sel.indices)]
+        # all "around" selections with a zero
+        # distance will produce an empty atomgroup
+        if self.cutoff == 0.0:
+            return sys[0:0]
 
         if not sys or not sel:
             return sys[[]]

--- a/package/MDAnalysis/core/selection.py
+++ b/package/MDAnalysis/core/selection.py
@@ -268,6 +268,7 @@ class AroundSelection(DistanceSelection):
             # check for entries with the same position
             result = cdist(sel.positions, sys.positions)
             indices = np.where(result == 0)[1]
+            warnings.warn("No support for 'around 0.0' with wrapping")
             if result.size > 0:
                 return sys[np.asarray(indices, dtype=np.int64)].unique
             else:

--- a/testsuite/MDAnalysisTests/core/test_atomselections.py
+++ b/testsuite/MDAnalysisTests/core/test_atomselections.py
@@ -178,13 +178,14 @@ class TestSelectionsCHARMM(object):
         sel = universe.select_atoms('not backbone')
         assert_equal(len(sel), 2486)
 
-    @pytest.mark.parametrize('selstr', [
-        'around 4.0 bynum 1943', 
-        'around 4.0 index 1942'
+    @pytest.mark.parametrize('selstr, size', [
+        ('around 4.0 bynum 1943', 32),
+        ('around 4.0 index 1942', 32),
+        ('around 0.0 resid 1', 0),  # gh-2656
     ])
-    def test_around(self, universe, selstr):
+    def test_around(self, universe, selstr, size):
         sel = universe.select_atoms(selstr)
-        assert_equal(len(sel), 32)
+        assert_equal(len(sel), size)
 
     @pytest.mark.parametrize('selstr', [
         'sphlayer 4.0 6.0 bynum 1281',

--- a/testsuite/MDAnalysisTests/core/test_atomselections.py
+++ b/testsuite/MDAnalysisTests/core/test_atomselections.py
@@ -188,14 +188,10 @@ class TestSelectionsCHARMM(object):
     @pytest.mark.parametrize('selstr, size', [
         ('around 4.0 bynum 1943', 32),
         ('around 4.0 index 1942', 32),
-        # ('around 0.0 resid 1', 0),  # gh-2656
+        ('around 0.0 resid 1', 0),  # gh-2656
     ])
     def test_around(self, universe, selstr, size):
-        if 'around 0.0' in selstr:
-            with pytest.warns(UserWarning):
-                sel = universe.select_atoms(selstr)
-        else:
-            sel = universe.select_atoms(selstr)
+        sel = universe.select_atoms(selstr)
         assert_equal(len(sel), size)
 
     @pytest.mark.xfail(reason="passes in develop, fails in gh-2657, len(res)==7")
@@ -210,8 +206,6 @@ class TestSelectionsCHARMM(object):
             'around 0.0 resid 3')
         assert len(ag) == 1
 
-    @pytest.mark.xfail(reason="nsgrid broken, see gh-2345, finds 10 atoms")
-    # https://github.com/MDAnalysis/mdanalysis/issues/2345#issuecomment-529888097
     def test_around_triclinic_nsgrid(self, u_pbc_triclinic,
                                      cutoff=1.5e-4):
         u_small = u_pbc_triclinic.atoms[:50]
@@ -249,8 +243,7 @@ class TestSelectionsCHARMM(object):
         for i in range(n_dup):
             new_ag[i + 1].position = reference_pos
 
-        with pytest.warns(UserWarning):
-            sel = new_ag.select_atoms(selstr)
+        sel = new_ag.select_atoms(selstr)
         assert_equal(len(sel), size)
 
     @pytest.mark.xfail(reason="see gh-2657")
@@ -258,8 +251,7 @@ class TestSelectionsCHARMM(object):
         # around 0.0 with wrapping
         u = mda.Universe(PDB)
         u.dimensions = [1e-2, 1e-2, 1e-2, 90, 90, 90]
-        with pytest.warns(UserWarning):
-            ag = u.select_atoms('around 0.0 resid 1')
+        ag = u.select_atoms('around 0.0 resid 1')
         assert len(ag) == len(u.atoms) - len(u.residues[0].atoms)
 
     @pytest.mark.parametrize('selstr', [

--- a/testsuite/MDAnalysisTests/core/test_atomselections.py
+++ b/testsuite/MDAnalysisTests/core/test_atomselections.py
@@ -187,6 +187,30 @@ class TestSelectionsCHARMM(object):
         sel = universe.select_atoms(selstr)
         assert_equal(len(sel), size)
 
+    @pytest.mark.parametrize('selstr, n_dup, size', [
+        # no duplicate atom positions means no matches
+        ('around 0.0 bynum 1', 0, 0),
+        # 1 duplicate atom position means 1 match
+        ('around 0.0 bynum 1', 1, 1),
+        # 5 duplicate atom positions means 5 matches
+        ('around 0.0 bynum 1', 5, 5),
+        # the first residue will encompass the duplications
+        # so no non-self entities are selected
+        ('around 0.0 resid 1', 5, 0),
+    ])
+    def test_around_degenerate(self, universe, selstr, n_dup, size):
+        # for cases with duplicate (spatially identical)
+        # atoms separated by 0.0 distance
+        new_ag = universe.atoms
+        reference_pos = new_ag[0].position
+        # produce atoms with unique ids but
+        # the same position
+        for i in range(n_dup):
+            new_ag[i + 1].position = reference_pos
+
+        sel = new_ag.select_atoms(selstr)
+        assert_equal(len(sel), size)
+
     @pytest.mark.parametrize('selstr', [
         'sphlayer 4.0 6.0 bynum 1281',
         'sphlayer 4.0 6.0 index 1280'

--- a/testsuite/MDAnalysisTests/core/test_atomselections.py
+++ b/testsuite/MDAnalysisTests/core/test_atomselections.py
@@ -188,7 +188,7 @@ class TestSelectionsCHARMM(object):
     @pytest.mark.parametrize('selstr, size', [
         ('around 4.0 bynum 1943', 32),
         ('around 4.0 index 1942', 32),
-        ('around 0.0 resid 1', 0),  # gh-2656
+        # ('around 0.0 resid 1', 0),  # gh-2656
     ])
     def test_around(self, universe, selstr, size):
         if 'around 0.0' in selstr:
@@ -200,35 +200,33 @@ class TestSelectionsCHARMM(object):
 
     @pytest.mark.xfail(reason="passes in develop, fails in gh-2657, len(res)==7")
     def test_around_superposed_small_res(self, u_pbc_triclinic):
-        ag = u_pbc_triclinic.select_atoms('around 0.0 resid 10')
+        ag = u_pbc_triclinic.atoms[6550:6600].select_atoms(
+            'around 0.0 resid 10')
         assert len(ag) == 1
 
     @pytest.mark.xfail(reason="segfaults in develop, fails in gh-2657, len(res)==19")
     def test_around_superposed_large_res(self, u_pbc_triclinic):
-        ag = u_pbc_triclinic.select_atoms('around 0.0 resid 3')
+        ag = u_pbc_triclinic.atoms[46800:46900].select_atoms(
+            'around 0.0 resid 3')
         assert len(ag) == 1
 
-    @pytest.mark.xfail(reason="nsgrid broken, see gh-2345, finds 14486 atoms")
+    @pytest.mark.xfail(reason="nsgrid broken, see gh-2345, finds 10 atoms")
     # https://github.com/MDAnalysis/mdanalysis/issues/2345#issuecomment-529888097
     def test_around_triclinic_nsgrid(self, u_pbc_triclinic,
                                      cutoff=1.5e-4):
-        r1 = u_pbc_triclinic.residues[0].atoms
-        notr1 = u_pbc_triclinic.residues[1:].atoms
-        dist_arr = distance_array(r1.positions, notr1.positions,
-                                  box=u_pbc_triclinic.dimensions)
-        n_in_cutoff = np.count_nonzero(np.any(dist_arr <= cutoff, axis=0))
-        ag = u_pbc_triclinic.select_atoms('around {} resid 1'.format(cutoff))
-        assert len(ag) == n_in_cutoff == 28838
+        u_small = u_pbc_triclinic.atoms[:50]
+        r1 = u_small.residues[0].atoms
+        notr1 = u_small.atoms[len(r1):]
+        ag = u_small.select_atoms('around {} resid 1'.format(cutoff))
+        assert len(ag) == 18
 
     def test_around_triclinic_bruteforce(self, u_pbc_triclinic,
                                          cutoff=1.500001e-4):
-        r1 = u_pbc_triclinic.residues[0].atoms
-        notr1 = u_pbc_triclinic.residues[1:].atoms
-        dist_arr = distance_array(r1.positions, notr1.positions,
-                                  box=u_pbc_triclinic.dimensions)
-        n_in_cutoff = np.count_nonzero(np.any(dist_arr <= cutoff, axis=0))
-        ag = u_pbc_triclinic.select_atoms('around {} resid 1'.format(cutoff))
-        assert len(ag) == n_in_cutoff == 28838
+        u_small = u_pbc_triclinic.atoms[:50]
+        r1 = u_small.residues[0].atoms
+        notr1 = u_small.atoms[len(r1):]
+        ag = u_small.select_atoms('around {} resid 1'.format(cutoff))
+        assert len(ag) == 18
 
     @pytest.mark.parametrize('selstr, n_dup, size', [
         # no duplicate atom positions means no matches


### PR DESCRIPTION
Fixes #2656 

* atomgroup selections with `around 0.0` were
segfaulting; fix this by returning an empty
slice of the query atomgroup

* add a regression test for the fix