### PR TITLE
print message if C extension not installed

### DIFF
--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -207,7 +207,11 @@ from numpy.testing import assert_equal
 import inspect
 
 from ..exceptions import StreamWarning, DuplicateWarning
-from ._cutil import unique_int_1d
+try:
+    from ._cutil import unique_int_1d
+except ImportError:
+    print("MDAnalysis not installed properly.")
+    raise
 
 # Python 3.0, 3.1 do not have the builtin callable()
 try:

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -207,8 +207,11 @@ from numpy.testing import assert_equal
 import inspect
 
 from ..exceptions import StreamWarning, DuplicateWarning
-from ._cutil import unique_int_1d
-
+try:
+    from ._cutil import unique_int_1d
+except ImportError:
+    print('MDAnalysis not installed properly')
+    sys.exit(-1)
 
 # Python 3.0, 3.1 do not have the builtin callable()
 try:

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -211,7 +211,7 @@ try:
     from ._cutil import unique_int_1d
 except ImportError:
     print("MDAnalysis not installed properly.")
-    raise
+    raise ImportError
 
 # Python 3.0, 3.1 do not have the builtin callable()
 try:

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -207,11 +207,7 @@ from numpy.testing import assert_equal
 import inspect
 
 from ..exceptions import StreamWarning, DuplicateWarning
-try:
-    from ._cutil import unique_int_1d
-except ImportError:
-    print('MDAnalysis not installed properly')
-    sys.exit(-1)
+from ._cutil import unique_int_1d
 
 # Python 3.0, 3.1 do not have the builtin callable()
 try:

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -210,8 +210,9 @@ from ..exceptions import StreamWarning, DuplicateWarning
 try:
     from ._cutil import unique_int_1d
 except ImportError:
-    print("MDAnalysis not installed properly.")
-    raise ImportError
+    raise ImportError("MDAnalysis not installed properly. "
+                      "This can happen if your C extensions "
+                      "have not been built.")
 
 # Python 3.0, 3.1 do not have the builtin callable()
 try:

--- a/testsuite/MDAnalysisTests/lib/test_util.py
+++ b/testsuite/MDAnalysisTests/lib/test_util.py
@@ -52,7 +52,8 @@ from MDAnalysisTests.datafiles import (
 
 def test_absence_cutil():
     with patch.dict('sys.modules', {'MDAnalysis.lib._cutil':None}):
-        if sys.version_info[:2] <= (3, 3):
+        #http://docs.python.org/library/sys.html#sys.hexversion
+        if sys.hexversion <= 0x03030000:
             import imp
             with pytest.raises(ImportError):
                 imp.reload(sys.modules['MDAnalysis.lib.util'])

--- a/testsuite/MDAnalysisTests/lib/test_util.py
+++ b/testsuite/MDAnalysisTests/lib/test_util.py
@@ -54,11 +54,11 @@ def test_absence_cutil():
     with patch.dict('sys.modules', {'MDAnalysis.lib._cutil':None}):
         if sys.version_info[:2] <= (3, 3):
             import imp
-            with pytest.raises(ModuleNotFoundError):
+            with pytest.raises(ImportError):
                 imp.reload(sys.modules['MDAnalysis.lib.util'])
         else:
             import importlib
-            with pytest.raises(ModuleNotFoundError):
+            with pytest.raises(ImportError):
                 importlib.reload(sys.modules['MDAnalysis.lib.util'])
 
 def test_presence_cutil():

--- a/testsuite/MDAnalysisTests/lib/test_util.py
+++ b/testsuite/MDAnalysisTests/lib/test_util.py
@@ -29,6 +29,8 @@ import os
 import warnings
 import re
 import textwrap
+from mock import Mock, patch
+import sys
 
 import numpy as np
 from numpy.testing import (assert_equal, assert_almost_equal,
@@ -48,6 +50,19 @@ from MDAnalysisTests.datafiles import (
     Make_Whole, TPR, GRO, fullerene, two_water_gro,
 )
 
+def test_absence_cutil():
+    with patch.dict('sys.modules', {'MDAnalysis.lib._cutil':None}):
+        with pytest.raises(ImportError):
+            import MDAnalysis.lib._cutil
+
+def test_presence_cutil():
+    mock = Mock()
+    with patch.dict('sys.modules', {'MDAnalysis.lib._cutil':mock}):
+        try:
+            import MDAnalysis.lib._cutil
+        except ImportError:
+            pytest.fail(msg='''MDAnalysis.lib._cutil should not raise
+                         an ImportError if cutil is available.''')
 
 def convert_aa_code_long_data():
     aa = [

--- a/testsuite/MDAnalysisTests/lib/test_util.py
+++ b/testsuite/MDAnalysisTests/lib/test_util.py
@@ -52,8 +52,14 @@ from MDAnalysisTests.datafiles import (
 
 def test_absence_cutil():
     with patch.dict('sys.modules', {'MDAnalysis.lib._cutil':None}):
-        with pytest.raises(ImportError):
-            import MDAnalysis.lib._cutil
+        if sys.version_info[:2] <= (3, 3):
+            import imp
+            with pytest.raises(ModuleNotFoundError):
+                imp.reload(sys.modules['MDAnalysis.lib.util'])
+        else:
+            import importlib
+            with pytest.raises(ModuleNotFoundError):
+                importlib.reload(sys.modules['MDAnalysis.lib.util'])
 
 def test_presence_cutil():
     mock = Mock()


### PR DESCRIPTION
Fixes #2550 

Changes made in this Pull Request:
 - Issued an error message if C extensions are not installed properly.
- Added test for the same


PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
