### PR TITLE
BUG: allow repeated mol2 writes

### DIFF
--- a/package/MDAnalysis/coordinates/MOL2.py
+++ b/package/MDAnalysis/coordinates/MOL2.py
@@ -357,10 +357,21 @@ class MOL2Writer(base.WriterBase):
 
         check_sums = molecule[1].split()
         check_sums[0], check_sums[1] = str(len(obj.atoms)), str(len(bondgroup))
+
+        # prevent behavior change between repeated calls
+        # see gh-2678
+        molecule_0_store = molecule[0]
+        molecule_1_store = molecule[1]
+
         molecule[1] = "{0}\n".format(" ".join(check_sums))
         molecule.insert(0, "@<TRIPOS>MOLECULE\n")
 
-        return "".join(molecule) + atom_lines + bond_lines + "".join(substructure)
+        return_val = ("".join(molecule) + atom_lines +
+                      bond_lines + "".join(substructure))
+
+        molecule[0] = molecule_0_store
+        molecule[1] = molecule_1_store
+        return return_val
 
     def write(self, obj):
         """Write a new frame to the MOL2 file.

--- a/testsuite/MDAnalysisTests/coordinates/test_mol2.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_mol2.py
@@ -184,3 +184,10 @@ def test_mol2_write_NIE():
     u = make_Universe(trajectory=True)
     with pytest.raises(NotImplementedError):
         u.atoms.write(outfile)
+
+def test_mol2_multi_write(tmpdir):
+    # see: gh-2678
+    with tmpdir.as_cwd():
+        u = mda.Universe(mol2_molecules)
+        u.atoms[:4].write('group1.mol2')
+        u.atoms[:4].write('group1.mol2')


### PR DESCRIPTION
Fixes #2678

Changes made in this Pull Request:
---------------------------------------

* add a unit test reproduce gh-2678

* the `encode_block` method of `MOL2Writer` now
restores mutated properties of `molecule` to prevent
the issue



PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?
