### PR TITLE
bugfix for issue #2687

### DIFF
--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -2258,7 +2258,7 @@ class AtomGroup(GroupBase):
         """A sorted :class:`ResidueGroup` of the unique
         :class:`Residues<Residue>` present in the :class:`AtomGroup`.
         """
-        rg = self.universe.residues[unique_int_1d(self.resindices)]
+        rg = self.universe.residues[unique_int_1d(np.array((self.resindices),dtype='int64'))]
         rg._cache['isunique'] = True
         rg._cache['unique'] = rg
         return rg


### PR DESCRIPTION
Fixes #2687

Changes made in this Pull Request:
 - The 'self.resindices' was not being passed as a numpy array of int64 type in the argument of AtomGroup 's residues' function which is relayed to _cutil.pyx whose unique_int_1d function requires a numpy array of int64 datatype . The commit intends to solve the particular issue.

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?
