### PR TITLE
CI: add 32-bit Win to CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,49 @@
+trigger:
+  # start a new build for every push
+  batch: False
+  branches:
+    include:
+      - develop
+  paths:
+    include:
+      - '*'
+
+pr:
+  branches:
+    include:
+    - '*'  # must quote since "*" is a YAML reserved character; we want a string
+
+
+jobs:
+- job: Windows
+  condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))  # skip for PR merges
+  pool:
+    vmImage: 'VS2017-Win2016'
+  strategy:
+    maxParallel: 4
+    matrix:
+        Python37-32bit-full:
+          PYTHON_VERSION: '3.7'
+          PYTHON_ARCH: 'x86'
+          BITS: 32
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: $(PYTHON_VERSION)
+      addToPath: true
+      architecture: $(PYTHON_ARCH)
+  - script: python -m pip install --upgrade pip setuptools wheel
+    displayName: 'Install tools'
+  - script: python -m pip install numpy scipy cython pytest pytest-xdist matplotlib
+    displayName: 'Install dependencies'
+  - powershell: |
+      cd package
+      python setup.py install
+      cd ..\testsuite
+      python setup.py install
+      cd ..
+    displayName: 'Build MDAnalysis'
+  - powershell: |
+      cd testsuite
+      pytest .\MDAnalysisTests --disable-pytest-warnings -n 2
+    displayName: 'Run MDAnalysis Test Suite'

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -17,7 +17,8 @@ mm/dd/yy richardjgowers, kain88-de, lilyminium, p-j-smith, bdice, joaomcteixeira
          PicoCentauri, davidercruz, jbarnoud, RMeli, IAlibay, mtiberti, CCook96,
          Yuan-Yu, xiki-tempula, HTian1997, Iv-Hristov, hmacdope, AnshulAngaria,
          ss62171, Luthaf, yuxuanzhuang, abhishandy, mlnance, shfrz, orbeckst,
-         wvandertoorn, cbouy, AmeyaHarmalkar, Oscuro-Phoenix, andrrizzi, WG150
+         wvandertoorn, cbouy, AmeyaHarmalkar, Oscuro-Phoenix, andrrizzi, WG150,
+         tylerjereddy
 
   * 0.21.0
 
@@ -87,6 +88,7 @@ Fixes
   * Contact Analysis class respects PBC (Issue #2368)
 
 Enhancements
+  * vastly improved support for 32-bit Windows (PR #2696)
   * Added methods to compute the root-mean-square-inner-product of subspaces 
     and the cumulative overlap of a vector in a subspace for PCA (PR #2613)
   * Added .frames and .times arrays to AnalysisBase (Issue #2661)

--- a/package/MDAnalysis/core/selection.py
+++ b/package/MDAnalysis/core/selection.py
@@ -226,7 +226,7 @@ class ByResSelection(UnarySelection):
 
     def apply(self, group):
         res = self.sel.apply(group)
-        unique_res = unique_int_1d(res.resindices.astype(np.int64))
+        unique_res = unique_int_1d(res.resindices.astype(np.intp))
         mask = np.in1d(group.resindices, unique_res)
 
         return group[mask].unique

--- a/package/MDAnalysis/core/selection.py
+++ b/package/MDAnalysis/core/selection.py
@@ -226,7 +226,7 @@ class ByResSelection(UnarySelection):
 
     def apply(self, group):
         res = self.sel.apply(group)
-        unique_res = unique_int_1d(res.resindices.astype(np.intp))
+        unique_res = unique_int_1d(res.resindices)
         mask = np.in1d(group.resindices, unique_res)
 
         return group[mask].unique

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -1474,7 +1474,7 @@ class Molnums(ResidueAttr):
     attrname = 'molnums'
     singular = 'molnum'
     target_classes = [AtomGroup, ResidueGroup, Atom, Residue]
-    dtype = np.int64
+    dtype = np.intp
 
 # segment attributes
 
@@ -1730,7 +1730,7 @@ class Bonds(_Connection):
         .. versionadded:: 0.20.0
         """
         fragdict = self.universe._fragdict
-        return np.array([fragdict[aix].ix for aix in self.ix], dtype=np.int64)
+        return np.array([fragdict[aix].ix for aix in self.ix], dtype=np.intp)
 
     def fragment(self):
         """An :class:`~MDAnalysis.core.groups.AtomGroup` representing the

--- a/package/MDAnalysis/lib/NeighborSearch.py
+++ b/package/MDAnalysis/lib/NeighborSearch.py
@@ -93,7 +93,7 @@ class AtomNeighborSearch(object):
                                 radius, box=self._box, return_distances=False)
 
         if pairs.size > 0:
-            unique_idx = unique_int_1d(np.asarray(pairs[:, 1], dtype=np.int64))
+            unique_idx = unique_int_1d(np.asarray(pairs[:, 1], dtype=np.intp))
         return self._index2level(unique_idx, level)
 
     def _index2level(self, indices, level):

--- a/package/MDAnalysis/lib/_augment.pyx
+++ b/package/MDAnalysis/lib/_augment.pyx
@@ -294,12 +294,12 @@ def augment_coordinates(float[:, ::1] coordinates, float[:] box, float r):
                 output.push_back(coord[j] - shiftZ[j])
             indices.push_back(i)
     n = indices.size()
-    return np.asarray(output, dtype=np.float32).reshape(n, 3), np.asarray(indices, dtype=np.int64)
+    return np.asarray(output, dtype=np.float32).reshape(n, 3), np.asarray(indices, dtype=np.intp)
 
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def undo_augment(np.int64_t[:] results, np.int64_t[:] translation, int nreal):
+def undo_augment(np.intp_t[:] results, np.intp_t[:] translation, int nreal):
     """Translate augmented indices back to original indices.
 
     Parameters
@@ -339,4 +339,4 @@ def undo_augment(np.int64_t[:] results, np.int64_t[:] translation, int nreal):
     for i in range(N):
         if results[i] >= nreal:
             results[i] = translation[results[i] - nreal]
-    return np.asarray(results, dtype=np.int64)
+    return np.asarray(results, dtype=np.intp)

--- a/package/MDAnalysis/lib/_cutil.pyx
+++ b/package/MDAnalysis/lib/_cutil.pyx
@@ -49,7 +49,7 @@ ctypedef cmap[int, intset] intmap
 
 @cython.boundscheck(False) # turn off bounds-checking for entire function
 @cython.wraparound(False)  # turn off negative index wrapping for entire function
-def unique_int_1d(np.int64_t[:] values):
+def unique_int_1d(np.intp_t[:] values):
     """Find the unique elements of a 1D array of integers.
 
     This function is optimal on sorted arrays.
@@ -71,7 +71,7 @@ def unique_int_1d(np.int64_t[:] values):
     cdef int i = 0
     cdef int j = 0
     cdef int n_values = values.shape[0]
-    cdef np.int64_t[:] result = np.empty(n_values, dtype=np.int64)
+    cdef np.intp_t[:] result = np.empty(n_values, dtype=np.intp)
 
     if n_values == 0:
         return np.array(result)

--- a/package/MDAnalysis/lib/distances.py
+++ b/package/MDAnalysis/lib/distances.py
@@ -526,7 +526,7 @@ def _bruteforce_capped(reference, configuration, max_cutoff, min_cutoff=None,
         ``configuration[pairs[k, 1]]``.
     """
     # Default return values (will be overwritten only if pairs are found):
-    pairs = np.empty((0, 2), dtype=np.int64)
+    pairs = np.empty((0, 2), dtype=np.intp)
     distances = np.empty((0,), dtype=np.float64)
 
     if len(reference) > 0 and len(configuration) > 0:
@@ -605,7 +605,7 @@ def _pkdtree_capped(reference, configuration, max_cutoff, min_cutoff=None,
     from .pkdtree import PeriodicKDTree  # must be here to avoid circular import
 
     # Default return values (will be overwritten only if pairs are found):
-    pairs = np.empty((0, 2), dtype=np.int64)
+    pairs = np.empty((0, 2), dtype=np.intp)
     distances = np.empty((0,), dtype=np.float64)
 
     if len(reference) > 0 and len(configuration) > 0:
@@ -685,7 +685,7 @@ def _nsgrid_capped(reference, configuration, max_cutoff, min_cutoff=None,
         ``configuration[pairs[k, 1]]``.
     """
     # Default return values (will be overwritten only if pairs are found):
-    pairs = np.empty((0, 2), dtype=np.int64)
+    pairs = np.empty((0, 2), dtype=np.intp)
     distances = np.empty((0,), dtype=np.float64)
 
     if len(reference) > 0 and len(configuration) > 0:
@@ -919,7 +919,7 @@ def _bruteforce_capped_self(reference, max_cutoff, min_cutoff=None, box=None,
        Added `return_distances` keyword.
     """
     # Default return values (will be overwritten only if pairs are found):
-    pairs = np.empty((0, 2), dtype=np.int64)
+    pairs = np.empty((0, 2), dtype=np.intp)
     distances = np.empty((0,), dtype=np.float64)
 
     N = len(reference)
@@ -996,7 +996,7 @@ def _pkdtree_capped_self(reference, max_cutoff, min_cutoff=None, box=None,
     from .pkdtree import PeriodicKDTree  # must be here to avoid circular import
 
     # Default return values (will be overwritten only if pairs are found):
-    pairs = np.empty((0, 2), dtype=np.int64)
+    pairs = np.empty((0, 2), dtype=np.intp)
     distances = np.empty((0,), dtype=np.float64)
 
     # We're searching within a single coordinate set, so we need at least two
@@ -1068,7 +1068,7 @@ def _nsgrid_capped_self(reference, max_cutoff, min_cutoff=None, box=None,
        Added `return_distances` keyword.
     """
     # Default return values (will be overwritten only if pairs are found):
-    pairs = np.empty((0, 2), dtype=np.int64)
+    pairs = np.empty((0, 2), dtype=np.intp)
     distances = np.empty((0,), dtype=np.float64)
 
     # We're searching within a single coordinate set, so we need at least two

--- a/package/MDAnalysis/lib/nsgrid.pyx
+++ b/package/MDAnalysis/lib/nsgrid.pyx
@@ -385,7 +385,7 @@ cdef class NSResults(object):
             and initial atom coordinates of shape ``(N, 2)``
         """
 
-        return np.asarray(self.pairs_buffer, dtype=np.int64).reshape(self.npairs, 2)
+        return np.asarray(self.pairs_buffer, dtype=np.intp).reshape(self.npairs, 2)
 
     def get_pair_distances(self):
         """Returns all the distances corresponding to each pair of neighbors

--- a/package/MDAnalysis/lib/pkdtree.py
+++ b/package/MDAnalysis/lib/pkdtree.py
@@ -189,7 +189,7 @@ class PeriodicKDTree(object):
                                                       radius))
             self._indices = np.array(list(
                                      itertools.chain.from_iterable(indices)),
-                                     dtype=np.int64)
+                                     dtype=np.intp)
             if self._indices.size > 0:
                 self._indices = undo_augment(self._indices,
                                              self.mapping,
@@ -200,7 +200,7 @@ class PeriodicKDTree(object):
                                                       radius))
             self._indices = np.array(list(
                                      itertools.chain.from_iterable(indices)),
-                                     dtype=np.int64)
+                                     dtype=np.intp)
         self._indices = np.asarray(unique_int_1d(self._indices))
         return self._indices
 
@@ -234,7 +234,7 @@ class PeriodicKDTree(object):
             if self.cutoff < radius:
                 raise RuntimeError('Set cutoff greater or equal to the radius.')
 
-        pairs = np.array(list(self.ckdt.query_pairs(radius)), dtype=np.int64)
+        pairs = np.array(list(self.ckdt.query_pairs(radius)), dtype=np.intp)
         if self.pbc:
             if len(pairs) > 1:
                 pairs[:, 0] = undo_augment(pairs[:, 0], self.mapping,
@@ -294,7 +294,7 @@ class PeriodicKDTree(object):
             other_tree = cKDTree(wrapped_centers, leafsize=self.leafsize)
             pairs = other_tree.query_ball_tree(self.ckdt, radius)
             pairs = np.array([[i, j] for i, lst in enumerate(pairs) for j in lst],
-                                   dtype=np.int64)
+                                   dtype=np.intp)
             if pairs.size > 0:
                 pairs[:, 1] = undo_augment(pairs[:, 1],
                                              self.mapping,
@@ -303,7 +303,7 @@ class PeriodicKDTree(object):
             other_tree = cKDTree(centers, leafsize=self.leafsize)
             pairs = other_tree.query_ball_tree(self.ckdt, radius)
             pairs = np.array([[i, j] for i, lst in enumerate(pairs) for j in lst],
-                                   dtype=np.int64)
+                                   dtype=np.intp)
         if pairs.size > 0:
             pairs = unique_rows(pairs)
         return pairs

--- a/testsuite/MDAnalysisTests/analysis/test_density.py
+++ b/testsuite/MDAnalysisTests/analysis/test_density.py
@@ -398,6 +398,8 @@ class TestNotWithin(object):
     def u():
         return mda.Universe(GRO)
 
+    @pytest.mark.skipif(sys.maxsize <= 2**32,
+                        reason="non-kdtree density too large for 32-bit")
     def test_within(self, u):
         vers1 = density.notwithin_coordinates_factory(u, 'resname SOL',
                                                       'protein', 2,
@@ -410,6 +412,8 @@ class TestNotWithin(object):
 
         assert_equal(vers1, vers2)
 
+    @pytest.mark.skipif(sys.maxsize <= 2**32,
+                        reason="non-kdtree density too large for 32-bit")
     def test_not_within(self, u):
         vers1 = density.notwithin_coordinates_factory(u, 'resname SOL',
                                                      'protein', 2,

--- a/testsuite/MDAnalysisTests/analysis/test_hole2.py
+++ b/testsuite/MDAnalysisTests/analysis/test_hole2.py
@@ -73,6 +73,8 @@ class TestCheckAndFixLongFilename(object):
             fixed = check_and_fix_long_filename(abspath)
             assert fixed == self.filename
     
+    @pytest.mark.skipif(os.name == 'nt' and sys.maxsize <= 2**32,
+                        reason="FileNotFoundError on Win 32-bit")
     def test_symlink_dir(self, tmpdir):
         dirname = 'really_'*20 +'long_name'
         short_name = self.filename[-20:]
@@ -86,6 +88,8 @@ class TestCheckAndFixLongFilename(object):
             assert os.path.islink(fixed)
             assert fixed.endswith(short_name)
     
+    @pytest.mark.skipif(os.name == 'nt' and sys.maxsize <= 2**32,
+                        reason="OSError: symbolic link privilege not held")
     def test_symlink_file(self, tmpdir):
         long_name = 'a'*10 + self.filename
 

--- a/testsuite/MDAnalysisTests/core/test_fragments.py
+++ b/testsuite/MDAnalysisTests/core/test_fragments.py
@@ -129,7 +129,7 @@ class TestFragments(object):
         # number of unique fragindices must correspond to number of fragments:
         assert len(np.unique(fragindices)) == len(fragments)
         # check fragindices dtype:
-        assert fragindices.dtype == np.int64
+        assert fragindices.dtype == np.intp
         #check n_fragments
         assert u.atoms.n_fragments == len(fragments)
 

--- a/testsuite/MDAnalysisTests/formats/test_libdcd.py
+++ b/testsuite/MDAnalysisTests/formats/test_libdcd.py
@@ -19,6 +19,7 @@ from six.moves import cPickle as pickle
 
 from collections import namedtuple
 import os
+import sys
 import string
 import struct
 
@@ -316,6 +317,8 @@ def write_dcd(in_name, out_name, remarks='testing', header=None):
             f_out.write(xyz=frame.xyz, box=frame.unitcell)
 
 
+@pytest.mark.xfail(os.name == 'nt' and sys.maxsize <= 2**32,
+                   reason="occasional fail on 32-bit windows")
 @given(remarks=strategies.text(
     alphabet=string.printable, min_size=0,
     max_size=239))  # handle the printable ASCII strings

--- a/testsuite/MDAnalysisTests/lib/test_augment.py
+++ b/testsuite/MDAnalysisTests/lib/test_augment.py
@@ -105,5 +105,5 @@ def test_undoaugment(b, qres):
     q = apply_PBC(q, b)
     aug, mapping = augment_coordinates(q, b, radius)
     for idx, val in enumerate(aug):
-        imageid = np.asarray([len(q) + idx], dtype=np.int64)
+        imageid = np.asarray([len(q) + idx], dtype=np.intp)
         assert_equal(mapping[idx], undo_augment(imageid, mapping, len(q))[0])

--- a/testsuite/MDAnalysisTests/lib/test_cutil.py
+++ b/testsuite/MDAnalysisTests/lib/test_cutil.py
@@ -38,7 +38,7 @@ from MDAnalysis.lib._cutil import unique_int_1d, find_fragments
     [1, 2, 2, 6, 4, 4, ],  # duplicates, non-monotonic
 ))
 def test_unique_int_1d(values):
-    array = np.array(values, dtype=np.int64)
+    array = np.array(values, dtype=np.intp)
     ref = np.unique(array)
     res = unique_int_1d(array)
     assert_equal(res, ref)

--- a/testsuite/MDAnalysisTests/lib/test_distances.py
+++ b/testsuite/MDAnalysisTests/lib/test_distances.py
@@ -1245,7 +1245,7 @@ class TestOutputTypes(object):
         else:
             pairs = res
         assert type(pairs) == np.ndarray
-        assert pairs.dtype.type == np.int64
+        assert pairs.dtype.type == np.intp
         assert pairs.ndim == 2
         assert pairs.shape[1] == 2
         if ret_dist:
@@ -1270,7 +1270,7 @@ class TestOutputTypes(object):
         else:
             pairs = res
         assert type(pairs) == np.ndarray
-        assert pairs.dtype.type == np.int64
+        assert pairs.dtype.type == np.intp
         assert pairs.ndim == 2
         assert pairs.shape[1] == 2
         if ret_dist:

--- a/testsuite/MDAnalysisTests/topology/test_tprparser.py
+++ b/testsuite/MDAnalysisTests/topology/test_tprparser.py
@@ -55,7 +55,7 @@ class TPRAttrs(ParserBase):
     def test_molnums(self, top):
         molnums = top.molnums.values
         assert_equal(molnums, self.ref_molnums)
-        assert molnums.dtype == np.int64
+        assert molnums.dtype == np.intp
 
 
 class TestTPR(TPRAttrs):


### PR DESCRIPTION
Supersedes #2695

Add 32-bit Windows testing via Azure CI (not Appveyor because of the lack of parallel jobs there)

It is up to the team if we want to just place fixes in this PR before merging, switch to "allowed failure" somehow, or just merge in when ready and have "red CI" for a bit until the issues are fixed/skipped/xfailed, etc.

this is a pared-down version of the 32-bit Windows testing I set up for NumPy/SciPy--probably could pare it down even more, but seems to catch the test failures we'd expect

Related to:
#2693
#2687
#2689
#2346