### PR TITLE
Select dihedrals faster

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -135,6 +135,8 @@ Enhancements
     the capability to allow intermittent behaviour (PR #2256)
 
 Changes
+  * Refactored dihedral selections and Ramachandran.__init__ to speed up 
+    dihedral selections for faster tests (Issue #2671, PR #2706)
   * Removes the deprecated `t0`, `tf`, and `dtmax` from
     :class:Waterdynamics.SurvivalProbability. Instead the `start`, `stop` and
     `tau_max` keywords should be passed to

--- a/package/MDAnalysis/analysis/dihedrals.py
+++ b/package/MDAnalysis/analysis/dihedrals.py
@@ -254,39 +254,60 @@ class Ramachandran(AnalysisBase):
     :class:`~MDAnalysis.ResidueGroup` is generated from `atomgroup` which is
     compared to the protein to determine if it is a legitimate selection.
 
+    Parameters
+    ----------
+    atomgroup : AtomGroup or ResidueGroup
+        atoms for residues for which :math:`\phi` and :math:`\psi` are
+        calculated
+    c_name: str (optional)
+        name for the backbone C atom
+    n_name: str (optional)
+        name for the backbone N atom
+    ca_name: str (optional)
+        name for the alpha-carbon atom
+    check_protein: bool (optional)
+        whether to raise an error if the provided atomgroup is not a 
+        subset of protein atoms
+
+    Example
+    -------
+    For standard proteins, the default arguments will suffice to run a 
+    Ramachandran analysis::
+
+        r = Ramachandran(u.select_atoms('protein')).run()
+
+    For proteins with non-standard residues, or for calculating dihedral 
+    angles for other linear polymers, you can switch off the protein checking 
+    and provide your own atom names in place of the typical peptide backbone 
+    atoms::
+
+        r = Ramachandran(u.atoms, c_name='CX', n_name='NT', ca_name='S',
+                         check_protein=False).run()
+
+    The above analysis will calculate angles from a "phi" selection of 
+    CX'-NT-S-CX and "psi" selections of NT-S-CX-NT'.
+
+    Raises
+    ------
+    ValueError
+        If the selection of residues is not contained within the protein
+        and ``check_protein`` is ``True``
+
     Note
     ----
-    If the residue selection is beyond the scope of the protein, then an error
-    will be raised. If the residue selection includes the first or last residue,
+    If ``check_protein`` is ``True`` and the residue selection is beyond 
+    the scope of the protein and, then an error will be raised. 
+    If the residue selection includes the first or last residue,
     then a warning will be raised and they will be removed from the list of
     residues, but the analysis will still run. If a :math:`\phi` or :math:`\psi`
     selection cannot be made, that residue will be removed from the analysis.
 
+    .. versionchanged:: 1.0.0
+        added c_name, n_name, ca_name, and check_protein keyword arguments
     """
 
     def __init__(self, atomgroup, c_name='C', n_name='N', ca_name='CA',
                  check_protein=True, **kwargs):
-        """Parameters
-        ----------
-        atomgroup : AtomGroup or ResidueGroup
-            atoms for residues for which :math:`\phi` and :math:`\psi` are
-            calculated
-        c_name: str (optional)
-            name for the backbone C atom
-        n_name: str (optional)
-            name for the backbone N atom
-        ca_name: str (optional)
-            name for the alpha-carbon atom
-        check_protein: bool (optional)
-            whether to raise an error if the provided atomgroup is not a 
-            subset of protein atoms
-
-        Raises
-        ------
-        ValueError
-            If the selection of residues is not contained within the protein
-
-        """
         super(Ramachandran, self).__init__(
             atomgroup.universe.trajectory, **kwargs)
         self.atomgroup = atomgroup

--- a/testsuite/MDAnalysisTests/analysis/test_dihedrals.py
+++ b/testsuite/MDAnalysisTests/analysis/test_dihedrals.py
@@ -106,11 +106,18 @@ class TestRamachandran(object):
 
     def test_outside_protein_length(self, universe):
         with pytest.raises(ValueError):
-            rama = Ramachandran(universe.select_atoms("resid 220")).run()
+            rama = Ramachandran(universe.select_atoms("resid 220"),
+                                check_protein=True).run()
+    
+    def test_outside_protein_unchecked(self, universe):
+        rama = Ramachandran(universe.select_atoms("resid 220"),
+                            check_protein=False).run()
 
     def test_protein_ends(self, universe):
-        with pytest.warns(UserWarning):
-            rama = Ramachandran(universe.select_atoms("protein")).run()
+        with pytest.warns(UserWarning) as record:
+            rama = Ramachandran(universe.select_atoms("protein"),
+                                check_protein=True).run()
+        assert len(record) == 1
 
     def test_None_removal(self):
         with pytest.warns(UserWarning):

--- a/testsuite/MDAnalysisTests/core/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/core/test_atomgroup.py
@@ -746,48 +746,208 @@ class TestDihedralSelections(object):
 
     @staticmethod
     @pytest.fixture(scope='module')
+    def GRO():
+        return mda.Universe(GRO)
+
+    @staticmethod
+    @pytest.fixture(scope='module')
     def PSFDCD():
         return mda.Universe(PSF, DCD)
 
-    def test_phi_selection(self, PSFDCD):
-        phisel = PSFDCD.segments[0].residues[9].phi_selection()
+    @staticmethod
+    @pytest.fixture(scope='class')
+    def resgroup(GRO):
+        return GRO.segments[0].residues[8:10]
+
+    def test_phi_selection(self, GRO):
+        phisel = GRO.segments[0].residues[9].phi_selection()
         assert_equal(phisel.names, ['C', 'N', 'CA', 'C'])
         assert_equal(phisel.residues.resids, [9, 10])
         assert_equal(phisel.residues.resnames, ['PRO', 'GLY'])
 
-    def test_psi_selection(self, PSFDCD):
-        psisel = PSFDCD.segments[0].residues[9].psi_selection()
+    @pytest.mark.parametrize('kwargs,names', [
+        ({'c_name': 'O'}, ['O', 'N', 'CA', 'O']),
+        ({'n_name': 'O'}, ['C', 'O', 'CA', 'C']),
+        ({'ca_name': 'O'}, ['C', 'N', 'O', 'C'])
+    ])
+    def test_phi_selection_name(self, GRO, kwargs, names):
+        phisel = GRO.segments[0].residues[9].phi_selection(**kwargs)
+        assert_equal(phisel.names, names)
+        assert_equal(phisel.residues.resids, [9, 10])
+        assert_equal(phisel.residues.resnames, ['PRO', 'GLY'])
+
+    def test_phi_selections_single(self, GRO):
+        rgsel = GRO.segments[0].residues[[9]].phi_selections()
+        assert len(rgsel) == 1
+        phisel = rgsel[0]
+        assert_equal(phisel.names, ['C', 'N', 'CA', 'C'])
+        assert_equal(phisel.residues.resids, [9, 10])
+        assert_equal(phisel.residues.resnames, ['PRO', 'GLY'])
+
+    def test_phi_selections(self, resgroup):
+        rgsel = resgroup.phi_selections()
+        rssel = [r.phi_selection() for r in resgroup]
+        assert_equal(rgsel, rssel)
+
+    @pytest.mark.parametrize('kwargs,names', [
+        ({'c_name': 'O'}, ['O', 'N', 'CA', 'O']),
+        ({'n_name': 'O'}, ['C', 'O', 'CA', 'C']),
+        ({'ca_name': 'O'}, ['C', 'N', 'O', 'C'])
+    ])
+    def test_phi_selections_name(self, resgroup, kwargs, names):
+        rgsel = resgroup.phi_selections(**kwargs)
+        for ag in rgsel:
+            assert_equal(ag.names, names)
+
+    def test_psi_selection(self, GRO):
+        psisel = GRO.segments[0].residues[9].psi_selection()
         assert_equal(psisel.names, ['N', 'CA', 'C', 'N'])
         assert_equal(psisel.residues.resids, [10, 11])
         assert_equal(psisel.residues.resnames, ['GLY', 'ALA'])
 
-    def test_omega_selection(self, PSFDCD):
-        osel = PSFDCD.segments[0].residues[7].omega_selection()
+    @pytest.mark.parametrize('kwargs,names', [
+        ({'c_name': 'O'}, ['N', 'CA', 'O', 'N']),
+        ({'n_name': 'O'}, ['O', 'CA', 'C', 'O']),
+        ({'ca_name': 'O'}, ['N', 'O', 'C', 'N']),
+    ])
+    def test_psi_selection_name(self, GRO, kwargs, names):
+        psisel = GRO.segments[0].residues[9].psi_selection(**kwargs)
+        assert_equal(psisel.names, names)
+        assert_equal(psisel.residues.resids, [10, 11])
+        assert_equal(psisel.residues.resnames, ['GLY', 'ALA'])
+
+    def test_psi_selections_single(self, GRO):
+        rgsel = GRO.segments[0].residues[[9]].psi_selections()
+        assert len(rgsel) == 1
+        psisel = rgsel[0]
+        assert_equal(psisel.names, ['N', 'CA', 'C', 'N'])
+        assert_equal(psisel.residues.resids, [10, 11])
+        assert_equal(psisel.residues.resnames, ['GLY', 'ALA'])
+
+    def test_psi_selections(self, resgroup):
+        rgsel = resgroup.psi_selections()
+        rssel = [r.psi_selection() for r in resgroup]
+        assert_equal(rgsel, rssel)
+
+    @pytest.mark.parametrize('kwargs,names', [
+        ({'c_name': 'O'}, ['N', 'CA', 'O', 'N']),
+        ({'n_name': 'O'}, ['O', 'CA', 'C', 'O']),
+        ({'ca_name': 'O'}, ['N', 'O', 'C', 'N']),
+    ])
+    def test_psi_selections_name(self, resgroup, kwargs, names):
+        rgsel = resgroup.psi_selections(**kwargs)
+        for ag in rgsel:
+            assert_equal(ag.names, names)
+
+    def test_omega_selection(self, GRO):
+        osel = GRO.segments[0].residues[7].omega_selection()
         assert_equal(osel.names, ['CA', 'C', 'N', 'CA'])
         assert_equal(osel.residues.resids, [8, 9])
         assert_equal(osel.residues.resnames, ['ALA', 'PRO'])
 
-    def test_chi1_selection(self, PSFDCD):
-        sel = PSFDCD.segments[0].residues[12].chi1_selection()  # LYS
+    @pytest.mark.parametrize('kwargs,names', [
+        ({'c_name': 'O'}, ['CA', 'O', 'N', 'CA']),
+        ({'n_name': 'O'}, ['CA', 'C', 'O', 'CA']),
+        ({'ca_name': 'O'}, ['O', 'C', 'N', 'O']),
+    ])
+    def test_omega_selection_name(self, GRO, kwargs, names):
+        osel = GRO.segments[0].residues[7].omega_selection(**kwargs)
+        assert_equal(osel.names, names)
+        assert_equal(osel.residues.resids, [8, 9])
+        assert_equal(osel.residues.resnames, ['ALA', 'PRO'])
+
+    def test_omega_selections_single(self, GRO):
+        rgsel = GRO.segments[0].residues[[7]].omega_selections()
+        assert len(rgsel) == 1
+        osel = rgsel[0]
+        assert_equal(osel.names, ['CA', 'C', 'N', 'CA'])
+        assert_equal(osel.residues.resids, [8, 9])
+        assert_equal(osel.residues.resnames, ['ALA', 'PRO'])
+
+    def test_omega_selections(self, resgroup):
+        rgsel = resgroup.omega_selections()
+        rssel = [r.omega_selection() for r in resgroup]
+        assert_equal(rgsel, rssel)
+
+    @pytest.mark.parametrize('kwargs,names', [
+        ({'c_name': 'O'}, ['CA', 'O', 'N', 'CA']),
+        ({'n_name': 'O'}, ['CA', 'C', 'O', 'CA']),
+        ({'ca_name': 'O'}, ['O', 'C', 'N', 'O']),
+    ])
+    def test_omega_selections_name(self, resgroup, kwargs, names):
+        rgsel = resgroup.omega_selections(**kwargs)
+        for ag in rgsel:
+            assert_equal(ag.names, names)
+
+    def test_chi1_selection(self, GRO):
+        sel = GRO.segments[0].residues[12].chi1_selection()  # LYS
         assert_equal(sel.names, ['N', 'CA', 'CB', 'CG'])
         assert_equal(sel.residues.resids, [13])
         assert_equal(sel.residues.resnames, ['LYS'])
 
-    def test_phi_sel_fail(self, PSFDCD):
-        sel = PSFDCD.residues[0].phi_selection()
+    @pytest.mark.parametrize('kwargs,names', [
+        ({'n_name': 'O'}, ['O', 'CA', 'CB', 'CG']),
+        ({'ca_name': 'O'}, ['N', 'O', 'CB', 'CG']),
+        ({'cb_name': 'O'}, ['N', 'CA', 'O', 'CG']),
+        ({'cg_name': 'O'}, ['N', 'CA', 'CB', 'O']),
+    ])
+    def test_chi1_selection_name(self, GRO, kwargs, names):
+        sel = GRO.segments[0].residues[12].chi1_selection(**kwargs)  # LYS
+        assert_equal(sel.names, names)
+        assert_equal(sel.residues.resids, [13])
+        assert_equal(sel.residues.resnames, ['LYS'])
+
+    def test_chi1_selections_single(self, GRO):
+        rgsel = GRO.segments[0].residues[[12]].chi1_selections()
+        assert len(rgsel) == 1
+        sel = rgsel[0]
+        assert_equal(sel.names, ['N', 'CA', 'CB', 'CG'])
+        assert_equal(sel.residues.resids, [13])
+        assert_equal(sel.residues.resnames, ['LYS'])
+
+    def test_chi1_selections(self, resgroup):
+        rgsel = resgroup.chi1_selections()
+        rssel = [r.chi1_selection() for r in resgroup]
+        assert_equal(rgsel, rssel)
+
+    def test_phi_sel_fail(self, GRO):
+        sel = GRO.residues[0].phi_selection()
         assert sel is None
 
-    def test_psi_sel_fail(self, PSFDCD):
-        sel = PSFDCD.residues[-1].psi_selection()
+    def test_phi_sels_fail(self, GRO):
+        rgsel = GRO.residues[212:216].phi_selections()
+        assert rgsel[0] is not None
+        assert rgsel[1] is not None
+        assert_equal(rgsel[-2:], [None, None])
+
+    def test_psi_sel_fail(self, GRO):
+        sel = GRO.residues[-1].psi_selection()
         assert sel is None
 
-    def test_omega_sel_fail(self, PSFDCD):
-        sel = PSFDCD.residues[-1].omega_selection()
+    def test_psi_sels_fail(self, GRO):
+        rgsel = GRO.residues[211:215].psi_selections()
+        assert rgsel[0] is not None
+        assert rgsel[1] is not None
+        assert_equal(rgsel[-2:], [None, None])
+
+    def test_omega_sel_fail(self, GRO):
+        sel = GRO.residues[-1].omega_selection()
         assert sel is None
 
-    def test_ch1_sel_fail(self, PSFDCD):
-        sel = PSFDCD.segments[0].residues[7].chi1_selection()
+    def test_omega_sels_fail(self, GRO):
+        rgsel = GRO.residues[211:215].omega_selections()
+        assert rgsel[0] is not None
+        assert rgsel[1] is not None
+        assert_equal(rgsel[-2:], [None, None])
+
+    def test_ch1_sel_fail(self, GRO):
+        sel = GRO.segments[0].residues[7].chi1_selection()
         assert sel is None  # ALA
+
+    def test_chi1_sels_fail(self, GRO):
+        rgsel = GRO.residues[12:14].chi1_selections()
+        assert rgsel[0] is not None
+        assert rgsel[1] is None
 
     def test_dihedral_phi(self, PSFDCD):
         phisel = PSFDCD.segments[0].residues[9].phi_selection()
@@ -805,21 +965,21 @@ class TestDihedralSelections(object):
         sel = PSFDCD.segments[0].residues[12].chi1_selection()  # LYS
         assert_almost_equal(sel.dihedral.value(), -58.428127, self.dih_prec)
 
-    def test_phi_nodep(self, PSFDCD):
+    def test_phi_nodep(self, GRO):
         with no_deprecated_call():
-            phisel = PSFDCD.segments[0].residues[9].phi_selection()
+            phisel = GRO.segments[0].residues[9].phi_selection()
 
-    def test_psi_nodep(self, PSFDCD):
+    def test_psi_nodep(self, GRO):
         with no_deprecated_call():
-            psisel = PSFDCD.segments[0].residues[9].psi_selection()
+            psisel = GRO.segments[0].residues[9].psi_selection()
 
-    def test_omega_nodep(self, PSFDCD):
+    def test_omega_nodep(self, GRO):
         with no_deprecated_call():
-            osel = PSFDCD.segments[0].residues[7].omega_selection()
+            osel = GRO.segments[0].residues[7].omega_selection()
 
-    def test_chi1_nodep(self, PSFDCD):
+    def test_chi1_nodep(self, GRO):
         with no_deprecated_call():
-            sel = PSFDCD.segments[0].residues[12].chi1_selection()  # LYS
+            sel = GRO.segments[0].residues[12].chi1_selection()  # LYS
 
 
 class TestUnwrapFlag(object):

--- a/testsuite/MDAnalysisTests/core/test_residuegroup.py
+++ b/testsuite/MDAnalysisTests/core/test_residuegroup.py
@@ -267,8 +267,19 @@ class TestResidueGroup(object):
                      sorted(universe.residues.atoms.indices))
 
     def test_get_next_residue(self, rg):
-        unsorted_rep_res = rg[[0, 1, 8, 3, 4, 0, 3, 1]]
-        next_res = sum(unsorted_rep_res._get_next_residues_by_resid())
-        resids = unsorted_rep_res.resids+1
+        unsorted_rep_res = rg[[0, 1, 8, 3, 4, 0, 3, 1, -1]]
+        next_res = unsorted_rep_res._get_next_residues_by_resid()
+        resids = list(unsorted_rep_res.resids+1)
+        resids[-1] = None
+        next_resids = [r.resid if r is not None else None for r in next_res]
         assert_equal(len(next_res), len(unsorted_rep_res))
-        assert_equal(next_res.resids, resids)
+        assert_equal(next_resids, resids)
+
+    def test_get_prev_residue(self, rg):
+        unsorted_rep_res = rg[[0, 1, 8, 3, 4, 0, 3, 1, -1]]
+        prev_res = unsorted_rep_res._get_prev_residues_by_resid()
+        resids = list(unsorted_rep_res.resids-1)
+        resids[0] = resids[5] = None
+        prev_resids = [r.resid if r is not None else None for r in prev_res]
+        assert_equal(len(prev_res), len(unsorted_rep_res))
+        assert_equal(prev_resids, resids)

--- a/testsuite/MDAnalysisTests/core/test_residuegroup.py
+++ b/testsuite/MDAnalysisTests/core/test_residuegroup.py
@@ -265,3 +265,10 @@ class TestResidueGroup(object):
     def test_atom_order(self, universe):
         assert_equal(universe.residues.atoms.indices,
                      sorted(universe.residues.atoms.indices))
+
+    def test_get_next_residue(self, rg):
+        unsorted_rep_res = rg[[0, 1, 8, 3, 4, 0, 3, 1]]
+        next_res = sum(unsorted_rep_res._get_next_residues_by_resid())
+        resids = unsorted_rep_res.resids+1
+        assert_equal(len(next_res), len(unsorted_rep_res))
+        assert_equal(next_res.resids, resids)


### PR DESCRIPTION
Fixes (part of) #2671

Changes made in this Pull Request:
 - made phi/psi_selection longer, but faster with manual boolean array matching of atom names
 - made Ramachandran really long and ugly, but really faster with manual boolean array matching to atom names
 - no longer hardcodes phi/psi selection names in Ramachandran

The original ``Ramachandran.__init__`` with the GRO/XTC files was [180 s on my laptop.](https://github.com/MDAnalysis/mdanalysis/issues/2671#issuecomment-636708041) When I changed only the `phi_selection` code (not `psi_selection`), it dropped to 122 s. When I changed the Ramachandran code, it dropped to 0.25 s. Most of that is selecting the protein.

![Screenshot 2020-06-01 at 9 23 10 PM](https://user-images.githubusercontent.com/31115101/83404539-2dbd3380-a44e-11ea-9eb6-7a94047d5948.png)

~How much testing does this need?~ lots



PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?

To do
-----
- [x] update omega_selection and chi1_selection too
- [x] add `c_name`, `n_name` etc. as kwargs to those, it's annoying that the names are hard-coded in (edit: will *remove* pending *dis*approval from another dev)
- [x] add the group selection methods to `ResidueGroup`
- [x] update `Ramachandran.__init__` to use the group selection methods

Edit: Ramachandran is no longer in the slowest 50 tests.
```
========================== slowest 50 test durations ===========================

39.76s call     MDAnalysisTests/analysis/test_density.py::Test_density_from_Universe::test_notwithin

31.18s call     MDAnalysisTests/analysis/test_density.py::TestNotWithin::test_within

30.83s call     MDAnalysisTests/analysis/test_density.py::TestNotWithin::test_not_within

29.70s call     MDAnalysisTests/analysis/test_density.py::TestNotWithin::test_has_DeprecationWarning

29.58s call     MDAnalysisTests/analysis/test_hbonds.py::TestHydrogenBondAnalysis::test_true_traj

29.21s call     MDAnalysisTests/analysis/test_hbonds.py::TestHydrogenBondAnalysisPBC::test_true_traj

29.15s call     MDAnalysisTests/analysis/test_hbonds.py::TestHydrogenBondAnalysisHeuristic::test_true_traj

29.11s call     MDAnalysisTests/analysis/test_hbonds.py::TestHydrogenBondAnalysisHeavy::test_true_traj

29.11s call     MDAnalysisTests/analysis/test_hbonds.py::TestHydrogenBondAnalysisHeavyFail::test_true_traj

21.78s call     MDAnalysisTests/visualization/test_streamlines.py::test_streamplot_2D

14.44s call     MDAnalysisTests/analysis/test_hole2.py::TestHoleAnalysis::test_context_manager

12.24s call     MDAnalysisTests/coordinates/test_pdb.py::test_conect_bonds_all

10.71s call     MDAnalysisTests/analysis/test_density.py::Test_density_from_Universe::test_update_selection

9.67s call     MDAnalysisTests/analysis/test_density.py::TestDensityAnalysis::test_run[dynamic]

8.56s call     MDAnalysisTests/coordinates/test_gro.py::TestGROLargeWriter::test_writer_large

8.44s call     MDAnalysisTests/analysis/test_gnm.py::test_closeContactGNMAnalysis

8.34s call     MDAnalysisTests/analysis/test_gnm.py::test_closeContactGNMAnalysis_weights_None

7.49s call     MDAnalysisTests/analysis/test_encore.py::TestEncore::test_ces_error_estimation_ensemble_bootstrap
```
