### PR TITLE
CI: enable more win32 Azure tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,7 +34,15 @@ jobs:
       architecture: $(PYTHON_ARCH)
   - script: python -m pip install --upgrade pip setuptools wheel
     displayName: 'Install tools'
-  - script: python -m pip install numpy scipy cython pytest pytest-xdist matplotlib
+  - script: >-
+      python -m pip install
+      cython
+      matplotlib
+      numpy
+      pytest
+      pytest-xdist
+      scikit-learn
+      scipy
     displayName: 'Install dependencies'
   - powershell: |
       cd package
@@ -45,5 +53,5 @@ jobs:
     displayName: 'Build MDAnalysis'
   - powershell: |
       cd testsuite
-      pytest .\MDAnalysisTests --disable-pytest-warnings -n 2
+      pytest .\MDAnalysisTests --disable-pytest-warnings -n 2 -rsx
     displayName: 'Run MDAnalysis Test Suite'


### PR DESCRIPTION
* add `pip` install of `scikit-learn` for Azure
32-bit Windows testing, so that a few more
tests are probed there (+11 more tests pass
instead of skip; approx. 45 seconds added
to test suite in testing on my fork)

* clean up the `pip install` line in Azure CI
to span several alphabetically-sorted lines
for readability (achieved using yaml multiline
folding: https://yaml-multiline.info/ ); this
is similar to the approach suggested for i.e.,
`Dockerfile`s that have long `apt-get` dependency
install lines

* use `rsx` pytest flag to report some details
on the test skips (etc.) in Azure CI Windows
32-bit

Other Notes
-------------

Let's deal with other deps separately. I found no evidence of a Windows port for `HOLE`, which is the cause of many other test skips, but we should be able to add the right version of `seaborn` in the future, and possibly 1 or 2 other deps.

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
