### PR TITLE
CI: add codecov to Azure CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,6 +42,7 @@ jobs:
       matplotlib
       numpy
       pytest
+      pytest-cov
       pytest-xdist
       scikit-learn
       scipy
@@ -55,5 +56,12 @@ jobs:
     displayName: 'Build MDAnalysis'
   - powershell: |
       cd testsuite
-      pytest .\MDAnalysisTests --disable-pytest-warnings -n 2 -rsx
+      pytest .\MDAnalysisTests --disable-pytest-warnings -n 2 -rsx --cov=MDAnalysis
     displayName: 'Run MDAnalysis Test Suite'
+  - script: |
+      curl -s https://codecov.io/bash | bash
+      echo %CODECOV_TOKEN%
+    condition: succeeded()
+    displayName: 'Codecov Coverage Data Upload'
+    env:
+      CODECOV_TOKEN: $(CODECOV_TOKEN)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,5 +63,3 @@ jobs:
       echo %CODECOV_TOKEN%
     condition: succeeded()
     displayName: 'Codecov Coverage Data Upload'
-    env:
-      CODECOV_TOKEN: $(CODECOV_TOKEN)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,6 +60,5 @@ jobs:
     displayName: 'Run MDAnalysis Test Suite'
   - script: |
       curl -s https://codecov.io/bash | bash
-      echo %CODECOV_TOKEN%
     condition: succeeded()
     displayName: 'Codecov Coverage Data Upload'


### PR DESCRIPTION
* add a codecov upload to Azure CI (32-bit
Windows)

* I was a bit surprised that we don't
seem to have a `yaml` file for codecov
settings (?), so I didn't add a lint
stage for our codecov config

* reviewers should check carefully that the upload actually happens because the job passed without uploading on my fork (i.e., the upload utility ran, but then exited with `Commit sha does not match Azure build. Please upload with the Codecov repository upload token to resolve issue.
`,  hopefully just because it was on my fork...)

Changes made in this Pull Request:
 - 


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
