### PR TITLE
fix for gcc 9 (post 7 really)

### DIFF
--- a/package/setup.py
+++ b/package/setup.py
@@ -261,7 +261,8 @@ def extensions(config):
     use_cython = config.get('use_cython', default=not is_release)
     use_openmp = config.get('use_openmp', default=True)
 
-    extra_compile_args = ['-std=c99', '-ffast-math', '-O3', '-funroll-loops']
+    extra_compile_args = ['-std=c99', '-ffast-math', '-O3', '-funroll-loops',
+                          '-fsigned-zeros']  # see #2722
     define_macros = []
     if config.get('debug_cflags', default=False):
         extra_compile_args.extend(['-Wall', '-pedantic'])


### PR DESCRIPTION
fixes failing triclinic image test

Fixes #2722

Changes made in this Pull Request:
 - toned down optimisations to get tests passing

Longer term we'll need to take a closer look at handling of precision, but this fixes this failure.

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
