### PR TITLE
Removes deprecated MDAnalysis.units.N_Avogadro

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -23,9 +23,9 @@ Enhancements
 
 Changes
   * Removes deprecated MDAnalysis.units.N_Avogadro (PR #2737)
+  * Dropped Python 2 support
 
 Deprecations
-  * Dropped Python 2 support
 
 
 06/09/20 richardjgowers, kain88-de, lilyminium, p-j-smith, bdice, joaomcteixeira,

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,7 +13,7 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-??/??/?? richardjgowers
+??/??/?? richardjgowers, IAlibay
 
   * 2.0.0
 
@@ -21,8 +21,11 @@ Fixes
 
 Enhancements
 
+Changes
+  * Removes deprecated MDAnalysis.units.N_Avogadro (PR #2737)
+
 Deprecations
-* Dropped Python 2 support
+  * Dropped Python 2 support
 
 
 06/09/20 richardjgowers, kain88-de, lilyminium, p-j-smith, bdice, joaomcteixeira,

--- a/package/MDAnalysis/units.py
+++ b/package/MDAnalysis/units.py
@@ -134,7 +134,6 @@ Data
 
 .. autodata:: constants
 .. autodata:: lengthUnit_factor
-.. autodata:: N_Avogadro
 .. autodata:: water
 .. autodata:: densityUnit_factor
 .. autodata:: timeUnit_factor

--- a/package/MDAnalysis/units.py
+++ b/package/MDAnalysis/units.py
@@ -169,16 +169,6 @@ References and footnotes
 from __future__ import absolute_import, unicode_literals, division
 from six import raise_from
 
-#: `Avogadro's constant`_ in mol**-1.
-#:
-#: .. deprecated:: 0.9.0
-#:    Use *N_Avogadro* in dict :data:`constants` instead.
-#:
-#: .. versionchanged:: 0.9.0
-#:    Use CODATA 2010 value, which differs from the previously used value
-#:    6.02214179e+23 mol**-1 by -5.00000000e+16 mol**-1.
-N_Avogadro = 6.02214129e+23  # mol**-1
-
 #
 # NOTE: Whenever a constant is added to the constants dict, you also
 #       MUST add an appropriate entry to


### PR DESCRIPTION
Related to #2230 ?

Changes made in this Pull Request:
 - Removes MDAnalysis.units.N_Avogadro which was deprecated in 0.9


PR Checklist
------------
 - [ ] Tests? N/A
 - [ ] Docs? N/A
 - [x] CHANGELOG updated?
 - [ ] Issue raised/referenced? N/A?