### PR TITLE
restrict pip package versions to Python 2.7 compatible ones

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,6 +13,15 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
+??/>>/20 orbeckst
+
+  * 1.0.1
+
+Fixes
+  * pip installation only requests Python 2.7-compatible packages (#2736)
+
+
+
 06/09/20 richardjgowers, kain88-de, lilyminium, p-j-smith, bdice, joaomcteixeira,
          PicoCentauri, davidercruz, jbarnoud, RMeli, IAlibay, mtiberti, CCook96,
          Yuan-Yu, xiki-tempula, HTian1997, Iv-Hristov, hmacdope, AnshulAngaria,

--- a/package/setup.py
+++ b/package/setup.py
@@ -549,13 +549,13 @@ if __name__ == '__main__':
     exts, cythonfiles = extensions(config)
 
     install_requires = [
-          'numpy>=1.13.3',
-          'biopython>=1.71',
+          'numpy>=1.13.3,<1.17',
+          'biopython>=1.71,<1.77', # to support Py 2
           'networkx>=1.0',
           'GridDataFormats>=0.4.0',
           'six>=1.4.0',
           'mmtf-python>=1.0.0',
-          'joblib>=0.12',
+          'joblib>=0.12,<0.15.0',  # to support Py 2
           'scipy>=1.0.0',
           'matplotlib>=1.5.1',
           'mock',
@@ -592,13 +592,11 @@ if __name__ == '__main__':
                         ],
           },
           ext_modules=exts,
-          requires=['numpy (>=1.13.3)', 'biopython (>= 1.71)', 'mmtf (>=1.0.0)',
-                    'networkx (>=1.0)', 'GridDataFormats (>=0.3.2)', 'joblib',
-                    'scipy (>=1.0.0)', 'matplotlib (>=1.5.1)', 'tqdm (>=4.43.0)'],
+          python_requires=">=2.7,!=3.0,!=3.1,!=3.2,!=3.3,!=3.4,!=3.5",
           # all standard requirements are available through PyPi and
           # typically can be installed without difficulties through setuptools
           setup_requires=[
-              'numpy>=1.13.3',
+              'numpy>=1.13.3,<1.17',
           ],
           install_requires=install_requires,
           # extras can be difficult to install through setuptools and/or


### PR DESCRIPTION
Fixes #2736

Changes made in this Pull Request:
- restrict numpy, biopython, joblib to versions that support
  python 2.7
- removed deprecated 'requires' in setup.py (see
  https://setuptools.readthedocs.io/en/latest/setuptools.html#developer-s-guide)
- added python_requires (2.7 and >= 3.6)



PR Checklist
------------
 - [ ] Tests? – manually checked that it cleanly installs in a fresh Py 2.7 env
 - n/a Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
