### PR TITLE
Pylint checks for Python 3 only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ matrix:
 
     - env: NAME="Lint"
            PYLINTRC="${TRAVIS_BUILD_DIR}/package/.pylintrc"
-           MAIN_CMD="pylint package/MDAnalysis && pylint testsuite/MDAnalysisTests"
+           MAIN_CMD="pylint --py3k package/MDAnalysis && pylint --py3k testsuite/MDAnalysisTests"
            SETUP_CMD=""
            BUILD_CMD=""
            CONDA_DEPENDENCIES=""

--- a/package/MDAnalysis/analysis/align.py
+++ b/package/MDAnalysis/analysis/align.py
@@ -183,14 +183,9 @@ normal users.
 .. autofunction:: get_matching_atoms
 
 """
-from __future__ import division, absolute_import
-
 import os.path
 import warnings
 import logging
-
-from six.moves import range, zip, zip_longest
-from six import raise_from, string_types
 
 import numpy as np
 
@@ -508,20 +503,18 @@ def alignto(mobile, reference, select=None, weights=None,
     if subselection is None:
         # mobile_atoms is Universe
         mobile_atoms = mobile.universe.atoms
-    elif isinstance(subselection, string_types):
+    elif isinstance(subselection, str):
         # select mobile_atoms from string
         mobile_atoms = mobile.select_atoms(subselection)
     else:
         try:
             # treat subselection as AtomGroup
             mobile_atoms = subselection.atoms
-        except AttributeError:
-            raise_from(
-                TypeError(
-                    "subselection must be a selection string, an"
-                    " AtomGroup or Universe or None"
-                    ),
-                None)
+        except AttributeError as exc:
+            err = ("subselection must be a selection string, an"
+                   " AtomGroup or Universe or None")
+            raise TypeError(err) from exc
+
 
     # _fit_to DOES subtract center of mass, will provide proper min_rmsd
     mobile_atoms, new_rmsd = _fit_to(mobile_coordinates, ref_coordinates,
@@ -1348,12 +1341,12 @@ def get_matching_atoms(ag1, ag2, tol_mass=0.1, strict=False, match_atoms=True):
         else:
             try:
                 mass_mismatches = (np.absolute(ag1.masses - ag2.masses) > tol_mass)
-            except ValueError:
+            except ValueError as exc:
                 errmsg = ("Failed to find matching atoms: len(reference) = {}, len(mobile) = {} "
                           "Try to improve your selections for mobile and reference.").format(
                             ag1.n_atoms, ag2.n_atoms)
                 logger.error(errmsg)
-                raise_from(SelectionError(errmsg), None)
+                raise SelectionError(errmsg) from exc
 
             if np.any(mass_mismatches):
                 # Test 2 failed.


### PR DESCRIPTION
Fixes #2744

Changes made in this Pull Request:
 - get the linter check to error on Python 3 things only


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?
