### PR TITLE
Remove py2 things from coordinates & topology

### DIFF
--- a/package/MDAnalysis/coordinates/DLPoly.py
+++ b/package/MDAnalysis/coordinates/DLPoly.py
@@ -28,11 +28,6 @@ Read DL Poly_ format coordinate files
 
 .. _Poly: http://www.stfc.ac.uk/SCD/research/app/ccg/software/DL_POLY/44516.aspx
 """
-from __future__ import (absolute_import, division,
-                        print_function, unicode_literals)
-
-from six.moves import range
-
 import numpy as np
 
 from . import base

--- a/package/MDAnalysis/coordinates/DMS.py
+++ b/package/MDAnalysis/coordinates/DMS.py
@@ -32,8 +32,6 @@ coordinate files (as used by the Desmond_ MD package).
 .. _Desmond: http://www.deshawresearch.com/resources_desmond.html
 .. _DMS: http://www.deshawresearch.com/Desmond_Users_Guide-0.7.pdf
 """
-from __future__ import absolute_import
-
 import numpy as np
 import sqlite3
 

--- a/package/MDAnalysis/coordinates/GMS.py
+++ b/package/MDAnalysis/coordinates/GMS.py
@@ -37,8 +37,6 @@ will need to tweak the :class:`GMSReader`.
    :members:
 
 """
-from __future__ import absolute_import
-
 import os
 import errno
 import re

--- a/package/MDAnalysis/coordinates/GSD.py
+++ b/package/MDAnalysis/coordinates/GSD.py
@@ -45,9 +45,6 @@ Classes
    :inherited-members:
 
 """
-from __future__ import absolute_import, division
-from six import raise_from
-
 import numpy as np
 import os
 import gsd.hoomd
@@ -103,7 +100,7 @@ class GSDReader(base.ReaderBase):
         try :
             myframe = self._file[frame]
         except IndexError:
-            raise_from(IOError, None)
+            raise IOError from None
 
         # set frame number
         self._frame = frame

--- a/package/MDAnalysis/coordinates/INPCRD.py
+++ b/package/MDAnalysis/coordinates/INPCRD.py
@@ -37,9 +37,6 @@ Classes
    :members:
 
 """
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six.moves import range
 
 from . import base
 

--- a/package/MDAnalysis/coordinates/LAMMPS.py
+++ b/package/MDAnalysis/coordinates/LAMMPS.py
@@ -121,10 +121,6 @@ Classes
    :inherited-members:
 
 """
-from __future__ import absolute_import
-
-from six.moves import zip, range, map
-from six import raise_from
 import os
 import numpy as np
 
@@ -161,9 +157,8 @@ class DCDWriter(DCD.DCDWriter):
                 if units.unit_types[unit] != unit_type:
                     raise TypeError("LAMMPS DCDWriter: wrong unit {0!r} for unit type {1!r}".format(unit, unit_type))
             except KeyError:
-                raise_from(
-                    ValueError("LAMMPS DCDWriter: unknown unit {0!r}".format(unit)),
-                    None)
+                errmsg = f"LAMMPS DCDWriter: unknown unit {unit}"
+                raise ValueError(errmsg) from None
         super(DCDWriter, self).__init__(*args, **kwargs)
 
 
@@ -343,10 +338,9 @@ class DATAWriter(base.WriterBase):
                 self.f.write('{:d} {:d} '.format(i, int(bond.type))+\
                         ' '.join((bond.atoms.indices + 1).astype(str))+'\n')
             except TypeError:
-                raise_from(TypeError('LAMMPS DATAWriter: Trying to write bond, '
-                                'but bond type {} is not '
-                                'numerical.'.format(bond.type)),
-                            None)
+                errmsg = (f"LAMMPS DATAWriter: Trying to write bond, but bond "
+                          f"type {bond.type} is not numerical.")
+                raise TypeError(errmsg) from None
 
     def _write_dimensions(self, dimensions):
         """Convert dimensions to triclinic vectors, convert lengths to native
@@ -405,11 +399,9 @@ class DATAWriter(base.WriterBase):
         try:
             atoms.types.astype(np.int32)
         except ValueError:
-            raise_from(
-                ValueError(
-                    'LAMMPS.DATAWriter: atom types must be '
-                    'convertible to integers'),
-                    None)
+            errmsg = ("LAMMPS.DATAWriter: atom types must be convertible to "
+                      "integers")
+            raise ValueError(errmsg) from None
 
         try:
             velocities = atoms.velocities

--- a/package/MDAnalysis/coordinates/MMTF.py
+++ b/package/MDAnalysis/coordinates/MMTF.py
@@ -41,8 +41,6 @@ Classes
 .. _MMTF: https://mmtf.rcsb.org/
 
 """
-from __future__ import absolute_import
-
 import mmtf
 
 from . import base

--- a/package/MDAnalysis/coordinates/MOL2.py
+++ b/package/MDAnalysis/coordinates/MOL2.py
@@ -111,9 +111,6 @@ MOL2 format notes
     1   BENZENE 1   PERM    0   ****    ****    0   ROOT
 
 """
-from __future__ import absolute_import
-from six import raise_from
-
 import numpy as np
 
 from . import base
@@ -219,9 +216,9 @@ class MOL2Reader(base.ReaderBase):
         try:
             block = self.frames[frame]
         except IndexError:
-            raise_from(IOError("Invalid frame {0} for trajectory with length {1}"
-                          "".format(frame, len(self))),
-                       None)
+            errmsg = (f"Invalid frame {frame} for trajectory with length "
+                      f"{len(self)}")
+            raise IOError(errmsg) from None
 
         sections, coords = self.parse_block(block)
 
@@ -319,9 +316,8 @@ class MOL2Writer(base.WriterBase):
         try:
             molecule = ts.data['molecule']
         except KeyError:
-            raise_from(NotImplementedError(
-                "MOL2Writer cannot currently write non MOL2 data"),
-                None)
+            errmsg = "MOL2Writer cannot currently write non MOL2 data"
+            raise NotImplementedError(errmsg) from None
 
         # Need to remap atom indices to 1 based in this selection
         mapping = {a: i for i, a in enumerate(obj.atoms, start=1)}

--- a/package/MDAnalysis/coordinates/PDB.py
+++ b/package/MDAnalysis/coordinates/PDB.py
@@ -140,11 +140,7 @@ Classes
     http://www.wwpdb.org/documentation/file-format-content/format32/v3.2.html
 
 """
-from __future__ import absolute_import
-
-from six.moves import range, zip
-from six import raise_from, StringIO, BytesIO
-
+from io import StringIO, BytesIO
 import os
 import errno
 import itertools
@@ -394,7 +390,7 @@ class PDBReader(base.ReaderBase):
             start = self._start_offsets[frame]
             stop = self._stop_offsets[frame]
         except IndexError:  # out of range of known frames
-            raise_from(IOError, None)
+            raise IOError from None
 
         pos = 0
         occupancy = np.ones(self.n_atoms)
@@ -940,12 +936,9 @@ class PDBWriter(base.WriterBase):
             try:
                 ts = self.ts
             except AttributeError:
-                raise_from(
-                    NoDataError(
-                        "PBDWriter: no coordinate data to write to "
-                        "trajectory file"
-                        ),
-                    None)
+                errmsg = ("PBDWriter: no coordinate data to write to "
+                          "trajectory file")
+                raise NoDataError(errmsg) from None
         self._check_pdb_coordinates()
         self._write_timestep(ts, **kwargs)
 

--- a/package/MDAnalysis/coordinates/PDBQT.py
+++ b/package/MDAnalysis/coordinates/PDBQT.py
@@ -38,7 +38,6 @@ available in this case).
    http://autodock.scripps.edu/
 """
 
-from __future__ import absolute_import
 import os
 import errno
 import itertools

--- a/package/MDAnalysis/coordinates/ParmEd.py
+++ b/package/MDAnalysis/coordinates/ParmEd.py
@@ -72,7 +72,6 @@ Classes
 
 
 """
-from __future__ import absolute_import
 import functools
 
 from . import base

--- a/package/MDAnalysis/coordinates/TXYZ.py
+++ b/package/MDAnalysis/coordinates/TXYZ.py
@@ -45,10 +45,6 @@ Classes
    :inherited-members:
 
 """
-from __future__ import absolute_import, division
-from six.moves import range
-from six import raise_from
-
 import numpy as np
 import os
 import errno
@@ -155,7 +151,7 @@ class TXYZReader(base.ReaderBase):
             ts.frame += 1
             return ts
         except (ValueError, IndexError) as err:
-            raise_from(EOFError(err), None)
+            raise EOFError(err) from None
 
     def _reopen(self):
         self.close()

--- a/package/MDAnalysis/coordinates/XDR.py
+++ b/package/MDAnalysis/coordinates/XDR.py
@@ -33,8 +33,6 @@ MDAnalysis.coordinates.XTC: Read and write GROMACS XTC trajectory files.
 MDAnalysis.coordinates.TRR: Read and write GROMACS TRR trajectory files.
 MDAnalysis.lib.formats.libmdaxdr: Low level xdr format reader
 """
-from __future__ import absolute_import
-import six
 
 import errno
 import numpy as np
@@ -83,7 +81,7 @@ def read_numpy_offsets(filename):
 
     """
     try:
-        return {k: v for k, v in six.iteritems(np.load(filename))}
+        return {k: v for k, v in np.load(filename).items()}
     except IOError:
         warnings.warn("Failed to load offsets file {}\n".format(filename))
         return False

--- a/package/MDAnalysis/coordinates/__init__.py
+++ b/package/MDAnalysis/coordinates/__init__.py
@@ -707,10 +707,7 @@ Methods
    raw :class:`~MDAnalysis.coordinates.base.Timestep` objects.
 
 """
-from __future__ import absolute_import
 __all__ = ['reader', 'writer']
-
-import six
 
 from . import base
 from .core import reader, writer

--- a/package/MDAnalysis/coordinates/chain.py
+++ b/package/MDAnalysis/coordinates/chain.py
@@ -41,8 +41,6 @@ interest to developers.
    .. automethod:: _chained_iterator
 
 """
-from __future__ import absolute_import
-
 import warnings
 
 import os.path

--- a/package/MDAnalysis/coordinates/core.py
+++ b/package/MDAnalysis/coordinates/core.py
@@ -37,9 +37,6 @@ Helper functions:
 .. autofunction:: get_writer_for
 
 """
-from __future__ import absolute_import
-
-import six
 
 from ..lib import util
 from ..lib.mdamath import triclinic_box, triclinic_vectors, box_volume
@@ -84,14 +81,8 @@ def reader(filename, format=None, **kwargs):
     try:
         return Reader(filename, **kwargs)
     except ValueError:
-        six.raise_from(
-            TypeError(
-                'Unable to read {fn} with {r}.'.format(
-                    fn=filename,
-                    r=Reader
-                    )
-                ),
-            None)
+        errmsg = f'Unable to read {filename} with {Reader}.'
+        raise TypeError(errmsg) from None
 
 
 def writer(filename, n_atoms=None, **kwargs):

--- a/package/MDAnalysis/coordinates/memory.py
+++ b/package/MDAnalysis/coordinates/memory.py
@@ -184,8 +184,6 @@ Classes
    :inherited-members:
 
 """
-from __future__ import absolute_import
-from six import raise_from
 import logging
 import errno
 import numpy as np
@@ -319,10 +317,9 @@ class MemoryReader(base.ProtoReader):
             if coordinate_array.ndim == 2 and coordinate_array.shape[1] == 3:
                 coordinate_array = coordinate_array[np.newaxis, :, :]
         except AttributeError:
-            raise_from(TypeError("The input has to be a numpy.ndarray that "
-                            "corresponds to the layout specified by the "
-                            "'order' keyword."),
-                        None)
+            errmsg = ("The input has to be a numpy.ndarray that corresponds "
+                      "to the layout specified by the 'order' keyword.")
+            raise TypeError(errmsg) from None
 
         self.set_array(coordinate_array, order)
         self.n_frames = \
@@ -334,10 +331,9 @@ class MemoryReader(base.ProtoReader):
             try:
                 velocities = np.asarray(velocities, dtype=np.float32)
             except ValueError:
-                raise_from(
-                    TypeError("'velocities' must be array-like got {}"
-                              "".format(type(velocities))),
-                    None)
+                errmsg = (f"'velocities' must be array-like got "
+                          f"{type(velocities)}")
+                raise TypeError(errmsg) from None
             # if single frame, make into array of 1 frame
             if velocities.ndim == 2:
                 velocities = velocities[np.newaxis, :, :]
@@ -354,9 +350,8 @@ class MemoryReader(base.ProtoReader):
             try:
                 forces = np.asarray(forces, dtype=np.float32)
             except ValueError:
-                raise_from(TypeError("'forces' must be array like got {}"
-                                     "".format(type(forces))),
-                           None)
+                errmsg = f"'forces' must be array like got {type(forces)}"
+                raise TypeError(errmsg) from None
             if forces.ndim == 2:
                 forces = forces[np.newaxis, :, :]
             if not forces.shape == self.coordinate_array.shape:
@@ -386,9 +381,9 @@ class MemoryReader(base.ProtoReader):
             try:
                 dimensions = np.asarray(dimensions, dtype=np.float32)
             except ValueError:
-                raise_from(TypeError("'dimensions' must be array-like got {}"
-                                     "".format(type(dimensions))),
-                           None)
+                errmsg = (f"'dimensions' must be array-like got "
+                          f"{type(dimensions)}")
+                raise TypeError(errmsg) from None
             if dimensions.shape == (6,):
                 # single box, tile this to trajectory length
                 # allows modifying the box of some frames

--- a/package/MDAnalysis/coordinates/null.py
+++ b/package/MDAnalysis/coordinates/null.py
@@ -37,8 +37,6 @@ Classes
    :members:
 
 """
-from __future__ import absolute_import
-
 from . import base
 
 

--- a/package/MDAnalysis/topology/CRDParser.py
+++ b/package/MDAnalysis/topology/CRDParser.py
@@ -45,9 +45,6 @@ Classes
    :inherited-members:
 
 """
-from __future__ import absolute_import
-from six import raise_from
-
 import numpy as np
 
 from ..lib.util import openany, FORTRANReader
@@ -123,9 +120,9 @@ class CRDParser(TopologyReaderBase):
                     (serial, resnum, resName, name,
                      x, y, z, segid, resid, tempFactor) = r.read(line)
                 except Exception:
-                    raise_from(ValueError("Check CRD format at line {0}: {1}"
-                                     "".format(linenum + 1, line.rstrip())),
-                               None)
+                    errmsg = (f"Check CRD format at line {linenum + 1}: "
+                              f"{line.rstrip()}")
+                    raise ValueError(errmsg) from None
 
                 atomids.append(serial)
                 atomnames.append(name)

--- a/package/MDAnalysis/topology/DLPolyParser.py
+++ b/package/MDAnalysis/topology/DLPolyParser.py
@@ -35,9 +35,6 @@ Guesses the following attributes:
 
 .. _Poly: http://www.stfc.ac.uk/SCD/research/app/ccg/software/DL_POLY/44516.aspx
 """
-from __future__ import (absolute_import, division,
-                        print_function, unicode_literals)
-
 import numpy as np
 
 from . import guessers

--- a/package/MDAnalysis/topology/DMSParser.py
+++ b/package/MDAnalysis/topology/DMSParser.py
@@ -40,9 +40,6 @@ Classes
    :inherited-members:
 
 """
-from __future__ import absolute_import
-from six import raise_from
-
 import numpy as np
 import sqlite3
 import os
@@ -142,9 +139,8 @@ class DMSParser(TopologyReaderBase):
                                 ''.format(attrname))
                     vals = cur.fetchall()
                 except sqlite3.DatabaseError:
-                    raise_from(
-                        IOError("Failed reading the atoms from DMS Database"),
-                        None)
+                    errmsg = "Failed reading the atoms from DMS Database"
+                    raise IOError(errmsg) from None
                 else:
                     attrs[attrname] = np.array(vals, dtype=dt)
 
@@ -153,9 +149,8 @@ class DMSParser(TopologyReaderBase):
                 cur.execute('SELECT * FROM bond')
                 bonds = cur.fetchall()
             except sqlite3.DatabaseError:
-                raise_from(
-                    IOError("Failed reading the bonds from DMS Database"),
-                    None)
+                errmsg = "Failed reading the bonds from DMS Database"
+                raise IOError(errmsg) from None
             else:
                 bondlist = []
                 bondorder = {}

--- a/package/MDAnalysis/topology/ExtendedPDBParser.py
+++ b/package/MDAnalysis/topology/ExtendedPDBParser.py
@@ -53,7 +53,6 @@ Classes
    :inherited-members:
 
 """
-from __future__ import absolute_import
 
 from . import PDBParser
 

--- a/package/MDAnalysis/topology/FHIAIMSParser.py
+++ b/package/MDAnalysis/topology/FHIAIMSParser.py
@@ -45,9 +45,6 @@ Classes
    :inherited-members:
 
 """
-from __future__ import absolute_import
-
-from six.moves import range
 import numpy as np
 
 from . import guessers

--- a/package/MDAnalysis/topology/GMSParser.py
+++ b/package/MDAnalysis/topology/GMSParser.py
@@ -45,8 +45,6 @@ Classes
    :inherited-members:
 
 """
-from __future__ import absolute_import
-
 import re
 import numpy as np
 

--- a/package/MDAnalysis/topology/GROParser.py
+++ b/package/MDAnalysis/topology/GROParser.py
@@ -44,11 +44,7 @@ Classes
    :inherited-members:
 
 """
-from __future__ import absolute_import
-
 import numpy as np
-from six.moves import range
-from six import raise_from
 
 from ..lib.util import openany
 from ..core.topologyattrs import (
@@ -104,11 +100,10 @@ class GROParser(TopologyReaderBase):
                     names[i] = line[10:15].strip()
                     indices[i] = int(line[15:20])
                 except (ValueError, TypeError):
-                    raise_from(
-                        IOError((
-                        "Couldn't read the following line of the .gro file:\n"
-                        "{0}").format(line)),
-                        None)
+                    errmsg = (
+                    f"Couldn't read the following line of the .gro file:\n"
+                    f"{line}")
+                    raise IOError(errmsg) from None
         # Check all lines had names
         if not np.all(names):
             missing = np.where(names == '')

--- a/package/MDAnalysis/topology/GSDParser.py
+++ b/package/MDAnalysis/topology/GSDParser.py
@@ -51,8 +51,6 @@ Classes
    :inherited-members:
 
 """
-from __future__ import absolute_import
-
 import os
 import gsd.hoomd
 import numpy as np

--- a/package/MDAnalysis/topology/HoomdXMLParser.py
+++ b/package/MDAnalysis/topology/HoomdXMLParser.py
@@ -46,8 +46,6 @@ Classes
    :inherited-members:
 
 """
-from __future__ import absolute_import
-
 import xml.etree.ElementTree as ET
 import numpy as np
 

--- a/package/MDAnalysis/topology/ITPParser.py
+++ b/package/MDAnalysis/topology/ITPParser.py
@@ -122,7 +122,6 @@ Classes
    :inherited-members:
 
 """
-from __future__ import absolute_import
 from collections import defaultdict
 import os
 

--- a/package/MDAnalysis/topology/LAMMPSParser.py
+++ b/package/MDAnalysis/topology/LAMMPSParser.py
@@ -75,11 +75,6 @@ Classes
 
 
 """
-from __future__ import absolute_import, print_function
-
-from six.moves import range
-from six import raise_from
-
 import numpy as np
 import logging
 import string
@@ -285,12 +280,11 @@ class DATAParser(TopologyReaderBase):
         try:
             top = self._parse_atoms(sects['Atoms'], masses)
         except Exception:
-            raise_from(ValueError(
+            errmsg = (
                 "Failed to parse atoms section.  You can supply a description "
                 "of the atom_style as a keyword argument, "
-                "eg mda.Universe(..., atom_style='id resid x y z')"
-            ),
-            None)
+                "eg mda.Universe(..., atom_style='id resid x y z')")
+            raise ValueError(errmsg) from None
 
         # create mapping of id to index (ie atom id 10 might be the 0th atom)
         mapping = {atom_id: i for i, atom_id in enumerate(top.ids.values)}
@@ -336,9 +330,8 @@ class DATAParser(TopologyReaderBase):
         try:
             positions, ordering = self._parse_pos(sects['Atoms'])
         except KeyError as err:
-            raise_from(
-                IOError("Position information not found: {}".format(err)),
-                None)
+            errmsg = f"Position information not found: {err}"
+            raise IOError(errmsg) from None
 
         if 'Velocities' in sects:
             velocities = self._parse_vel(sects['Velocities'], ordering)

--- a/package/MDAnalysis/topology/MMTFParser.py
+++ b/package/MDAnalysis/topology/MMTFParser.py
@@ -66,9 +66,6 @@ Classes
 
 .. _Macromolecular Transmission Format (MMTF) format: https://mmtf.rcsb.org/
 """
-from __future__ import absolute_import
-from six.moves import zip
-
 from collections import defaultdict
 import mmtf
 import numpy as np

--- a/package/MDAnalysis/topology/MOL2Parser.py
+++ b/package/MDAnalysis/topology/MOL2Parser.py
@@ -41,8 +41,6 @@ Classes
    :inherited-members:
 
 """
-from __future__ import absolute_import
-
 import os
 import numpy as np
 

--- a/package/MDAnalysis/topology/MinimalParser.py
+++ b/package/MDAnalysis/topology/MinimalParser.py
@@ -39,7 +39,6 @@ Classes
    :inherited-members:
 
 """
-from __future__ import absolute_import
 
 from ..core._get_readers import get_reader_for
 from ..core.topology import Topology

--- a/package/MDAnalysis/topology/PDBParser.py
+++ b/package/MDAnalysis/topology/PDBParser.py
@@ -60,12 +60,9 @@ Classes
    :inherited-members:
 
 """
-from __future__ import absolute_import, print_function
-
 import numpy as np
 import warnings
 
-from six.moves import range
 from .guessers import guess_masses, guess_types
 from .tables import SYMB2Z
 from ..lib import util

--- a/package/MDAnalysis/topology/PDBQTParser.py
+++ b/package/MDAnalysis/topology/PDBQTParser.py
@@ -55,8 +55,6 @@ Classes
 .. _AutoDock:
    http://autodock.scripps.edu/
 """
-from __future__ import absolute_import
-
 import numpy as np
 
 from . import guessers

--- a/package/MDAnalysis/topology/PQRParser.py
+++ b/package/MDAnalysis/topology/PQRParser.py
@@ -47,8 +47,6 @@ Classes
 .. _PDB:     http://www.wwpdb.org/documentation/file-format
 
 """
-from __future__ import absolute_import
-
 import numpy as np
 
 from . import guessers

--- a/package/MDAnalysis/topology/PSFParser.py
+++ b/package/MDAnalysis/topology/PSFParser.py
@@ -43,10 +43,6 @@ Classes
    :inherited-members:
 
 """
-from __future__ import absolute_import, division
-from six.moves import range
-from six import raise_from
-
 import logging
 import functools
 from math import ceil
@@ -280,10 +276,9 @@ class PSFParser(TopologyReaderBase):
             try:
                 line = lines()
             except StopIteration:
-                err = ("{0} is not valid PSF file"
-                       "".format(self.filename))
+                err = f"{self.filename} is not valid PSF file"
                 logger.error(err)
-                raise_from(ValueError(err), None)
+                raise ValueError(err) from None
             try:
                 vals = set_type(atom_parser(line))
             except ValueError:

--- a/package/MDAnalysis/topology/ParmEdParser.py
+++ b/package/MDAnalysis/topology/ParmEdParser.py
@@ -80,10 +80,6 @@ Classes
    :inherited-members:
 
 """
-from __future__ import absolute_import, division
-from six.moves import range
-from six import raise_from
-
 import logging
 import functools
 from math import ceil

--- a/package/MDAnalysis/topology/TOPParser.py
+++ b/package/MDAnalysis/topology/TOPParser.py
@@ -88,10 +88,6 @@ Classes
    :inherited-members:
 
 """
-from __future__ import absolute_import, division
-
-from six.moves import range, zip
-from six import raise_from
 import numpy as np
 import itertools
 
@@ -258,11 +254,9 @@ class TOPParser(TopologyReaderBase):
                     try:
                         next_section = line.split("%FLAG")[1].strip()
                     except IndexError:
-                        raise_from(
-                            IndexError((
-                                "%FLAG section not found, formatting error "
-                                "for PARM7 file {0} ").format(self.filename)),
-                                None)
+                        errmsg = (f"%FLAG section not found, formatting error "
+                                  f"for PARM7 file {self.filename} ")
+                        raise IndexError(errmsg) from None
 
         # strip out a few values to play with them
         n_atoms = len(attrs['name'])

--- a/package/MDAnalysis/topology/TPRParser.py
+++ b/package/MDAnalysis/topology/TPRParser.py
@@ -146,7 +146,6 @@ has not been solved. Versions prior to Gromacs 4.0.x are not supported.
 .. _`Issue 2428`: https://github.com/MDAnalysis/mdanalysis/issues/2428
 
 """
-from __future__ import absolute_import
 __author__ = "Zhuyi Xue"
 __copyright__ = "GNU Public Licence, v2"
 

--- a/package/MDAnalysis/topology/TXYZParser.py
+++ b/package/MDAnalysis/topology/TXYZParser.py
@@ -43,11 +43,8 @@ Classes
 
 """
 
-from __future__ import absolute_import
-
 import itertools
 import numpy as np
-from six.moves import zip
 
 from . import guessers
 from ..lib.util import openany

--- a/package/MDAnalysis/topology/XYZParser.py
+++ b/package/MDAnalysis/topology/XYZParser.py
@@ -38,9 +38,6 @@ Classes
    :members:
 
 """
-from __future__ import absolute_import
-
-from six.moves import range
 import numpy as np
 
 from . import guessers

--- a/package/MDAnalysis/topology/__init__.py
+++ b/package/MDAnalysis/topology/__init__.py
@@ -302,7 +302,6 @@ four atoms need not be sequentially bonded, and are instead often all bonded
 to the second atom.
 
 """
-from __future__ import absolute_import
 
 __all__ = ['core', 'PSFParser', 'PDBParser', 'PQRParser', 'GROParser',
            'CRDParser', 'TOPParser', 'PDBQTParser', 'TPRParser',

--- a/package/MDAnalysis/topology/base.py
+++ b/package/MDAnalysis/topology/base.py
@@ -36,10 +36,6 @@ Classes
    :inherited-members:
 
 """
-from __future__ import absolute_import
-import six
-from six.moves import zip
-# While reduce is a built-in in python 2, it is not in python 3
 from functools import reduce
 
 import itertools
@@ -95,7 +91,7 @@ class _Topologymeta(type):
                 if '_format_hint' in classdict:
                     _PARSER_HINTS[fmt_name] = classdict['_format_hint'].__func__
 
-class TopologyReaderBase(six.with_metaclass(_Topologymeta, IOBase)):
+class TopologyReaderBase(IOBase, metaclass=_Topologymeta):
     """Base class for topology readers
 
     Parameters

--- a/package/MDAnalysis/topology/core.py
+++ b/package/MDAnalysis/topology/core.py
@@ -34,9 +34,6 @@ See Also
 
 """
 
-from __future__ import print_function, absolute_import
-import six
-
 # Global imports
 import os.path
 import numpy as np

--- a/package/MDAnalysis/topology/guessers.py
+++ b/package/MDAnalysis/topology/guessers.py
@@ -96,8 +96,6 @@ More information on adding topology attributes can found in the `user guide`_.
 .. _user guide: https://www.mdanalysis.org/UserGuide/examples/constructing_universe.html#Adding-topology-attributes
 
 """
-from __future__ import absolute_import
-
 import numpy as np
 import warnings
 import re

--- a/package/MDAnalysis/topology/tables.py
+++ b/package/MDAnalysis/topology/tables.py
@@ -45,7 +45,6 @@ The raw tables are stored in the strings
 .. autodata:: TABLE_MASSES
 .. autodata:: TABLE_VDWRADII
 """
-from __future__ import absolute_import
 
 
 def kv2dict(s, convertor=str):

--- a/package/MDAnalysis/topology/tpr/__init__.py
+++ b/package/MDAnalysis/topology/tpr/__init__.py
@@ -38,8 +38,6 @@ The :mod:`MDAnalysis.topology.tpr` module is required for the
 * :mod:`MDAnalysis.topology.tpr.utils`
 
 """
-from __future__ import absolute_import
-
 from .setting import SUPPORTED_VERSIONS
 
 __all__ = ["obj", "setting", "utils"]

--- a/package/MDAnalysis/topology/tpr/obj.py
+++ b/package/MDAnalysis/topology/tpr/obj.py
@@ -31,10 +31,6 @@ Class definitions for the TPRParser
 ===================================
 
 """
-from __future__ import absolute_import
-
-from six.moves import range
-
 from collections import namedtuple
 
 TpxHeader = namedtuple(

--- a/package/MDAnalysis/topology/tpr/setting.py
+++ b/package/MDAnalysis/topology/tpr/setting.py
@@ -36,9 +36,6 @@ The currently read file format versions are defined in
 :data:`SUPPORTED_VERSIONS`.
 
 """
-from __future__ import absolute_import
-
-from six.moves import range
 
 #: Gromacs TPR file format versions that can be read by the TPRParser.
 SUPPORTED_VERSIONS = (58, 73, 83, 100, 103, 110, 112, 116, 119)

--- a/package/MDAnalysis/topology/tpr/utils.py
+++ b/package/MDAnalysis/topology/tpr/utils.py
@@ -46,9 +46,6 @@ Then compose the stuffs in the format :class:`MDAnalysis.Universe` reads in.
 
 The module also contains the :func:`do_inputrec` to read the TPR header with.
 """
-from __future__ import absolute_import
-
-from six.moves import range
 import numpy as np
 import xdrlib
 import struct

--- a/testsuite/MDAnalysisTests/coordinates/base.py
+++ b/testsuite/MDAnalysisTests/coordinates/base.py
@@ -20,11 +20,9 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
 import itertools
 import numpy as np
 import pytest
-from six.moves import zip, range
 from unittest import TestCase
 from numpy.testing import (assert_equal, assert_almost_equal,
                            assert_array_almost_equal, assert_allclose)

--- a/testsuite/MDAnalysisTests/coordinates/reference.py
+++ b/testsuite/MDAnalysisTests/coordinates/reference.py
@@ -20,7 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
 import numpy as np
 
 from MDAnalysisTests import datafiles

--- a/testsuite/MDAnalysisTests/coordinates/test_amber_inpcrd.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_amber_inpcrd.py
@@ -20,10 +20,7 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
-
 import numpy as np
-from six.moves import zip
 
 from numpy.testing import (assert_allclose, assert_equal)
 

--- a/testsuite/MDAnalysisTests/coordinates/test_chemfiles.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_chemfiles.py
@@ -19,8 +19,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
-
 import numpy as np
 import pytest
 

--- a/testsuite/MDAnalysisTests/coordinates/test_copying.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_copying.py
@@ -20,8 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
-
 import numpy as np
 try:
     from numpy import shares_memory

--- a/testsuite/MDAnalysisTests/coordinates/test_crd.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_crd.py
@@ -20,9 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
-
-from six.moves import zip
 from collections import OrderedDict
 
 import pytest

--- a/testsuite/MDAnalysisTests/coordinates/test_dlpoly.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_dlpoly.py
@@ -20,11 +20,9 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
 import MDAnalysis as mda
 import numpy as np
 import pytest
-from six.moves import zip
 
 from numpy.testing import (assert_equal, assert_allclose)
 

--- a/testsuite/MDAnalysisTests/coordinates/test_dms.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_dms.py
@@ -20,7 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
 import MDAnalysis as mda
 import numpy as np
 import pytest

--- a/testsuite/MDAnalysisTests/coordinates/test_fhiaims.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_fhiaims.py
@@ -20,11 +20,8 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
-
 import pytest
-from six import StringIO
-from six.moves import zip
+from io import StringIO
 import os
 
 import MDAnalysis as mda
@@ -36,8 +33,6 @@ from MDAnalysisTests.datafiles import FHIAIMS
 from numpy.testing import (assert_equal,
                            assert_array_almost_equal,
                            assert_almost_equal)
-
-from six import StringIO
 
 
 @pytest.fixture(scope='module')

--- a/testsuite/MDAnalysisTests/coordinates/test_gms.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_gms.py
@@ -20,10 +20,7 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
-
 import pytest
-from six.moves import range
 
 import MDAnalysis as mda
 import numpy as np

--- a/testsuite/MDAnalysisTests/coordinates/test_gro.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_gro.py
@@ -20,7 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
 import MDAnalysis as mda
 import numpy as np
 from MDAnalysis.coordinates.GRO import GROReader, GROWriter
@@ -44,7 +43,7 @@ from numpy.testing import (
     assert_equal,
 )
 import pytest
-from six import StringIO
+from io import StringIO
 
 
 class TestGROReaderOld(RefAdK):

--- a/testsuite/MDAnalysisTests/coordinates/test_gsd.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_gsd.py
@@ -20,8 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
-
 import pytest
 from numpy.testing import assert_almost_equal
 

--- a/testsuite/MDAnalysisTests/coordinates/test_memory.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_memory.py
@@ -20,7 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
 import numpy as np
 
 import MDAnalysis as mda

--- a/testsuite/MDAnalysisTests/coordinates/test_mmtf.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_mmtf.py
@@ -20,8 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import division, absolute_import
-
 import pytest
 import numpy as np
 from numpy.testing import (

--- a/testsuite/MDAnalysisTests/coordinates/test_mol2.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_mol2.py
@@ -20,10 +20,7 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
-
 import pytest
-from six.moves import range
 
 import os
 from numpy.testing import (

--- a/testsuite/MDAnalysisTests/coordinates/test_namdbin.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_namdbin.py
@@ -20,10 +20,7 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
-
 import numpy as np
-from six.moves import zip
 import os
 
 import pytest

--- a/testsuite/MDAnalysisTests/coordinates/test_null.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_null.py
@@ -20,8 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
-
 import MDAnalysis as mda
 import pytest
 

--- a/testsuite/MDAnalysisTests/coordinates/test_parmed.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_parmed.py
@@ -20,8 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
-
 import pytest
 import MDAnalysis as mda
 

--- a/testsuite/MDAnalysisTests/coordinates/test_pdb.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_pdb.py
@@ -20,11 +20,8 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
-
 import pytest
-from six import StringIO
-from six.moves import zip
+from io import StringIO
 import os
 
 import MDAnalysis as mda

--- a/testsuite/MDAnalysisTests/coordinates/test_pdbqt.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_pdbqt.py
@@ -20,8 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
-
 import MDAnalysis as mda
 from MDAnalysisTests.datafiles import PDBQT_input, PDBQT_querypdb
 from MDAnalysis.lib.NeighborSearch import AtomNeighborSearch

--- a/testsuite/MDAnalysisTests/coordinates/test_pqr.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_pqr.py
@@ -20,7 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
 import MDAnalysis as mda
 import os
 import pytest

--- a/testsuite/MDAnalysisTests/coordinates/test_reader_api.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_reader_api.py
@@ -20,8 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
-
 import numpy as np
 from collections import OrderedDict
 from MDAnalysis.coordinates.base import (

--- a/testsuite/MDAnalysisTests/coordinates/test_timestep_api.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_timestep_api.py
@@ -26,8 +26,6 @@
 
 _TestTimestepInterface tests the Readers are correctly using Timesteps
 """
-from __future__ import absolute_import
-
 import numpy as np
 from numpy.testing import assert_equal
 

--- a/testsuite/MDAnalysisTests/coordinates/test_trj.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_trj.py
@@ -20,7 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
 import MDAnalysis as mda
 import numpy as np
 import pytest

--- a/testsuite/MDAnalysisTests/coordinates/test_txyz.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_txyz.py
@@ -20,11 +20,8 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
-
 import pytest
 from numpy.testing import assert_almost_equal
-from six.moves import zip
 
 from MDAnalysisTests.datafiles import TXYZ, ARC, ARC_PBC
 

--- a/testsuite/MDAnalysisTests/coordinates/test_windows.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_windows.py
@@ -30,8 +30,6 @@ These tests are just basic repeats of the tests from elsewhere, but on these DOS
 line ending files.
 """
 
-from __future__ import absolute_import
-
 import numpy as np
 import pytest
 from numpy.testing import assert_almost_equal, assert_equal

--- a/testsuite/MDAnalysisTests/coordinates/test_writer_registration.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_writer_registration.py
@@ -20,8 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
-
 import pytest
 
 import MDAnalysis as mda

--- a/testsuite/MDAnalysisTests/topology/base.py
+++ b/testsuite/MDAnalysisTests/topology/base.py
@@ -20,8 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
-
 import pytest
 
 import MDAnalysis as mda

--- a/testsuite/MDAnalysisTests/topology/test_crd.py
+++ b/testsuite/MDAnalysisTests/topology/test_crd.py
@@ -20,8 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
-
 import MDAnalysis as mda
 
 from MDAnalysisTests.topology.base import ParserBase

--- a/testsuite/MDAnalysisTests/topology/test_dlpoly.py
+++ b/testsuite/MDAnalysisTests/topology/test_dlpoly.py
@@ -20,7 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
 from numpy.testing import assert_equal
 
 import MDAnalysis as mda

--- a/testsuite/MDAnalysisTests/topology/test_dms.py
+++ b/testsuite/MDAnalysisTests/topology/test_dms.py
@@ -20,8 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
-
 import MDAnalysis as mda
 
 from MDAnalysisTests.topology.base import ParserBase

--- a/testsuite/MDAnalysisTests/topology/test_fhiaims.py
+++ b/testsuite/MDAnalysisTests/topology/test_fhiaims.py
@@ -20,8 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
-
 from numpy.testing import assert_equal, assert_almost_equal
 
 import MDAnalysis as mda

--- a/testsuite/MDAnalysisTests/topology/test_gms.py
+++ b/testsuite/MDAnalysisTests/topology/test_gms.py
@@ -20,8 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
-
 from numpy.testing import assert_equal
 
 import MDAnalysis as mda

--- a/testsuite/MDAnalysisTests/topology/test_gro.py
+++ b/testsuite/MDAnalysisTests/topology/test_gro.py
@@ -20,8 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
-
 import pytest
 
 import MDAnalysis as mda

--- a/testsuite/MDAnalysisTests/topology/test_gsd.py
+++ b/testsuite/MDAnalysisTests/topology/test_gsd.py
@@ -20,8 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
-
 import pytest
 
 import MDAnalysis as mda

--- a/testsuite/MDAnalysisTests/topology/test_guessers.py
+++ b/testsuite/MDAnalysisTests/topology/test_guessers.py
@@ -20,8 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
-
 import pytest
 from numpy.testing import assert_equal
 import numpy as np

--- a/testsuite/MDAnalysisTests/topology/test_hoomdxml.py
+++ b/testsuite/MDAnalysisTests/topology/test_hoomdxml.py
@@ -20,8 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
-
 import MDAnalysis as mda
 
 from MDAnalysisTests.topology.base import ParserBase

--- a/testsuite/MDAnalysisTests/topology/test_itp.py
+++ b/testsuite/MDAnalysisTests/topology/test_itp.py
@@ -20,7 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
 import pytest
 
 import MDAnalysis as mda

--- a/testsuite/MDAnalysisTests/topology/test_lammpsdata.py
+++ b/testsuite/MDAnalysisTests/topology/test_lammpsdata.py
@@ -20,12 +20,10 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
-
 import pytest
 from numpy.testing import assert_equal
 import numpy as np
-from six import StringIO
+from io import StringIO
 
 import MDAnalysis as mda
 from MDAnalysisTests.topology.base import ParserBase

--- a/testsuite/MDAnalysisTests/topology/test_minimal.py
+++ b/testsuite/MDAnalysisTests/topology/test_minimal.py
@@ -20,8 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
-
 import itertools
 import numpy as np
 import pytest

--- a/testsuite/MDAnalysisTests/topology/test_mmtf.py
+++ b/testsuite/MDAnalysisTests/topology/test_mmtf.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import pytest
 from numpy.testing import assert_equal
 import mmtf

--- a/testsuite/MDAnalysisTests/topology/test_mol2.py
+++ b/testsuite/MDAnalysisTests/topology/test_mol2.py
@@ -20,8 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
-
 import pytest
 from numpy.testing import assert_equal
 

--- a/testsuite/MDAnalysisTests/topology/test_parmed.py
+++ b/testsuite/MDAnalysisTests/topology/test_parmed.py
@@ -20,8 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
-
 import pytest
 import MDAnalysis as mda
 

--- a/testsuite/MDAnalysisTests/topology/test_pdb.py
+++ b/testsuite/MDAnalysisTests/topology/test_pdb.py
@@ -20,9 +20,7 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
-
-from six.moves import StringIO
+from io import StringIO
 
 import pytest
 import warnings

--- a/testsuite/MDAnalysisTests/topology/test_pdbqt.py
+++ b/testsuite/MDAnalysisTests/topology/test_pdbqt.py
@@ -20,8 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
-
 import MDAnalysis as mda
 
 from MDAnalysisTests.topology.base import ParserBase

--- a/testsuite/MDAnalysisTests/topology/test_pqr.py
+++ b/testsuite/MDAnalysisTests/topology/test_pqr.py
@@ -20,9 +20,7 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
-
-from six.moves import StringIO
+from io import StringIO
 from numpy.testing import assert_equal, assert_almost_equal
 import pytest
 import MDAnalysis as mda

--- a/testsuite/MDAnalysisTests/topology/test_psf.py
+++ b/testsuite/MDAnalysisTests/topology/test_psf.py
@@ -20,7 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
 from numpy.testing import assert_equal
 
 import pytest

--- a/testsuite/MDAnalysisTests/topology/test_top.py
+++ b/testsuite/MDAnalysisTests/topology/test_top.py
@@ -20,7 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
 import MDAnalysis as mda
 import pytest
 import numpy as np

--- a/testsuite/MDAnalysisTests/topology/test_topology_base.py
+++ b/testsuite/MDAnalysisTests/topology/test_topology_base.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import numpy as np
 from numpy.testing import assert_equal
 

--- a/testsuite/MDAnalysisTests/topology/test_topology_str_types.py
+++ b/testsuite/MDAnalysisTests/topology/test_topology_str_types.py
@@ -20,10 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import division, absolute_import
-
-
-from six import string_types
 import MDAnalysis
 import pytest
 
@@ -86,4 +82,4 @@ def test_str_types(top_format, top, prop):
     # Related to Issue #1336
     u = MDAnalysis.Universe(top, format=top_format)
     if hasattr(u.atoms[0], prop):
-        assert isinstance(getattr(u.atoms[0], prop), string_types)
+        assert isinstance(getattr(u.atoms[0], prop), str)

--- a/testsuite/MDAnalysisTests/topology/test_tprparser.py
+++ b/testsuite/MDAnalysisTests/topology/test_tprparser.py
@@ -20,8 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
-
 import pytest
 from numpy.testing import assert_equal
 import functools

--- a/testsuite/MDAnalysisTests/topology/test_txyz.py
+++ b/testsuite/MDAnalysisTests/topology/test_txyz.py
@@ -20,8 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
-
 import MDAnalysis as mda
 import pytest
 

--- a/testsuite/MDAnalysisTests/topology/test_xpdb.py
+++ b/testsuite/MDAnalysisTests/topology/test_xpdb.py
@@ -20,7 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
 import MDAnalysis as mda
 
 from MDAnalysisTests.topology.base import ParserBase

--- a/testsuite/MDAnalysisTests/topology/test_xyz.py
+++ b/testsuite/MDAnalysisTests/topology/test_xyz.py
@@ -20,8 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
-
 import MDAnalysis as mda
 import pytest
 


### PR DESCRIPTION
Towards #2541 

Changes made in this Pull Request:
 - Removes py2 things (six/future) from coordinates and topology


PR Checklist
------------
 - [x] Tests?
 - [ ] Docs? N/A
 - [ ] CHANGELOG updated? N/A
 - [x] Issue raised/referenced?
