### PR TITLE
Remove py2 things from aux, vis, transform, and others

### DIFF
--- a/benchmarks/benchmarks/GRO.py
+++ b/benchmarks/benchmarks/GRO.py
@@ -1,5 +1,3 @@
-from __future__ import division, absolute_import, print_function
-
 import numpy as np
 from MDAnalysis.coordinates.GRO import GROReader
 from MDAnalysis.topology.GROParser import GROParser

--- a/benchmarks/benchmarks/ag_methods.py
+++ b/benchmarks/benchmarks/ag_methods.py
@@ -1,5 +1,3 @@
-from __future__ import division, absolute_import, print_function
-
 import MDAnalysis
 import numpy as np
 

--- a/benchmarks/benchmarks/analysis/distances.py
+++ b/benchmarks/benchmarks/analysis/distances.py
@@ -1,5 +1,3 @@
-from __future__ import division, absolute_import, print_function
-
 import MDAnalysis
 import numpy as np
 

--- a/benchmarks/benchmarks/analysis/leaflet.py
+++ b/benchmarks/benchmarks/analysis/leaflet.py
@@ -1,5 +1,3 @@
-from __future__ import division, absolute_import, print_function
-
 import MDAnalysis
 
 # use a lipid bilayer system for leaflet testing

--- a/benchmarks/benchmarks/analysis/psa.py
+++ b/benchmarks/benchmarks/analysis/psa.py
@@ -1,5 +1,3 @@
-from __future__ import division, absolute_import, print_function
-
 import MDAnalysis
 import numpy as np
 

--- a/benchmarks/benchmarks/analysis/rdf.py
+++ b/benchmarks/benchmarks/analysis/rdf.py
@@ -1,5 +1,3 @@
-from __future__ import division, absolute_import, print_function
-
 import MDAnalysis
 
 try:

--- a/benchmarks/benchmarks/analysis/rms.py
+++ b/benchmarks/benchmarks/analysis/rms.py
@@ -1,5 +1,3 @@
-from __future__ import division, absolute_import, print_function
-
 import MDAnalysis
 
 try:

--- a/benchmarks/benchmarks/selections.py
+++ b/benchmarks/benchmarks/selections.py
@@ -1,5 +1,3 @@
-from __future__ import division, absolute_import, print_function
-
 import MDAnalysis
 
 try:

--- a/benchmarks/benchmarks/traj_reader.py
+++ b/benchmarks/benchmarks/traj_reader.py
@@ -1,4 +1,3 @@
-from __future__ import division, absolute_import, print_function
 
 try:
     from MDAnalysis.coordinates.DCD import DCDReader

--- a/maintainer/adapt_sitemap.py
+++ b/maintainer/adapt_sitemap.py
@@ -3,8 +3,6 @@
 #
 # Adjust path in sitemap.xml
 
-from __future__ import print_function
-
 from xml.etree import ElementTree
 import argparse
 

--- a/package/MDAnalysis/__init__.py
+++ b/package/MDAnalysis/__init__.py
@@ -149,7 +149,6 @@ the OPLS/AA force field.
    doi:10.1016/j.jmb.2009.09.009
 
 """
-from __future__ import absolute_import
 
 __all__ = ['Universe', 'as_Universe', 'Writer', 'fetch_mmtf',
            'AtomGroup', 'ResidueGroup', 'SegmentGroup']

--- a/package/MDAnalysis/auxiliary/XVG.py
+++ b/package/MDAnalysis/auxiliary/XVG.py
@@ -66,10 +66,6 @@ supported (the readers will stop at the first line starting '&').
 .. autofunction:: uncomment
 
 """
-from __future__ import absolute_import
-
-from six import raise_from
-
 import numbers
 import os
 import numpy as np
@@ -150,13 +146,9 @@ class XVGStep(base.AuxStep):
             try:
                 return self._data[key]
             except IndexError:
-                raise_from(
-                    ValueError(
-                        '{} not a valid index for data with {} '
-                        'columns'.format(key, len(self._data))
-                        ),
-                    None
-                    )
+                errmsg = (f'{key} not a valid index for data with '
+                          f'{len(self._data)} columns')
+                raise ValueError(errmsg) from None
         else:
             return np.array([self._select_data(i) for i in key])
 

--- a/package/MDAnalysis/auxiliary/__init__.py
+++ b/package/MDAnalysis/auxiliary/__init__.py
@@ -517,8 +517,6 @@ following (these may be overwritten by subclasses as appropriate):
 
 """
 
-from __future__ import absolute_import
-
 # registry of auxiliary readers
 _AUXREADERS = {}
 

--- a/package/MDAnalysis/auxiliary/base.py
+++ b/package/MDAnalysis/auxiliary/base.py
@@ -39,10 +39,6 @@ Base classes for deriving all auxiliary data readers. See the API in :mod:`MDAna
 
 """
 
-from __future__ import division, absolute_import
-import six
-from six.moves import range
-
 import os
 import numbers
 import math
@@ -235,7 +231,7 @@ class AuxStep(object):
         return np.full_like(self.data, np.nan)
 
 
-class AuxReader(six.with_metaclass(_AuxReaderMeta)):
+class AuxReader(metaclass=_AuxReaderMeta):
     """ Base class for auxiliary readers.
 
     Allows iteration over a set of data from a trajectory, additional

--- a/package/MDAnalysis/auxiliary/core.py
+++ b/package/MDAnalysis/auxiliary/core.py
@@ -28,12 +28,9 @@ Common functions for auxiliary reading --- :mod:`MDAnalysis.auxiliary.core`
 .. autofunction:: get_auxreader_for
 .. autofunction:: auxreader
 """
-from __future__ import absolute_import
-
-from six import raise_from, string_types
-
 from . import _AUXREADERS
 from ..lib import util
+
 
 def get_auxreader_for(auxdata=None, format=None):
     """Return the appropriate auxiliary reader class for *auxdata*/*format*.
@@ -65,7 +62,7 @@ def get_auxreader_for(auxdata=None, format=None):
         raise ValueError('Must provide either auxdata or format')
 
     if format is None:
-        if isinstance(auxdata, string_types):
+        if isinstance(auxdata, str):
             ## assume it's a filename?
             format = util.guess_format(auxdata)
         else:
@@ -75,19 +72,14 @@ def get_auxreader_for(auxdata=None, format=None):
         try:
             return _AUXREADERS[format]
         except KeyError:
-            raise_from(
-                ValueError(
-                    "Unknown auxiliary data format for auxdata: "
-                    "{0}".format(auxdata)),
-                None
-                )
+            errmsg = f"Unknown auxiliary data format for auxdata: {auxdata}"
+            raise ValueError(errmsg) from None
     else:
         try:
             return _AUXREADERS[format]
         except KeyError:
-            raise_from(
-                ValueError("Unknown auxiliary data format {0}".format(format)),
-                None)
+            errmsg = f"Unknown auxiliary data format {format}"
+            raise ValueError(errmsg) from None
 
 def auxreader(auxdata, format=None, **kwargs):
     """ Return an auxiliary reader instance for *auxdata*.

--- a/package/MDAnalysis/due.py
+++ b/package/MDAnalysis/due.py
@@ -26,7 +26,6 @@ warning under MPI(see PR #1794 for rationale)
 
 """
 
-from __future__ import absolute_import
 __version__ = '0.0.5'
 
 

--- a/package/MDAnalysis/selections/__init__.py
+++ b/package/MDAnalysis/selections/__init__.py
@@ -44,9 +44,6 @@ exception of `:func:get_writer`:
 
 .. autofunction:: get_writer
 """
-from __future__ import absolute_import
-from six import raise_from
-
 import os.path
 
 from .. import _SELECTION_WRITERS
@@ -86,7 +83,6 @@ def get_writer(filename, defaultformat):
     try:
         return _SELECTION_WRITERS[format]
     except KeyError:
-        raise_from(NotImplementedError(
-            "Writing as {0!r} is not implemented;"
-            " only {1!r} will work.".format(format, _SELECTION_WRITERS.keys())),
-            None)
+        errmsg = (f"Writing as {format} is not implemented; only "
+                  f"{ _SELECTION_WRITERS.keys()} will work.")
+        raise NotImplementedError(errmsg) from None

--- a/package/MDAnalysis/selections/base.py
+++ b/package/MDAnalysis/selections/base.py
@@ -37,15 +37,11 @@ methods.
 .. autofunction:: join
 
 """
-from __future__ import absolute_import
-
-import six
-from six.moves import range
-
 import os.path
 
 from ..lib import util
 from . import _SELECTION_WRITERS
+
 
 def join(seq, string="", func=None):
     """Create a list from sequence.
@@ -75,7 +71,7 @@ class _Selectionmeta(type):
                 _SELECTION_WRITERS[f] = cls
 
 
-class SelectionWriterBase(six.with_metaclass(_Selectionmeta)):
+class SelectionWriterBase(metaclass=_Selectionmeta):
     """Export a selection in MDAnalysis to a format usable in an external package.
 
     The :class:`SelectionWriterBase` writes a selection string to a file

--- a/package/MDAnalysis/selections/charmm.py
+++ b/package/MDAnalysis/selections/charmm.py
@@ -39,9 +39,8 @@ The selection is named *mdanalysis001*.
 .. _CHARMM: http://www.charmm.org
 .. _CHARMM selection: http://www.charmm.org/documentation/c34b1/select.html
 """
-from __future__ import absolute_import
-
 from . import base
+
 
 class SelectionWriter(base.SelectionWriterBase):
     format = ["CHARMM", "str"]

--- a/package/MDAnalysis/selections/gromacs.py
+++ b/package/MDAnalysis/selections/gromacs.py
@@ -39,9 +39,8 @@ The index groups are named *mdanalysis001*, *mdanalysis002*, etc.
 .. autoclass:: SelectionWriter
    :inherited-members:
 """
-from __future__ import absolute_import
-
 from . import base
+
 
 class SelectionWriter(base.SelectionWriterBase):
     format = ["Gromacs", "ndx"]

--- a/package/MDAnalysis/selections/jmol.py
+++ b/package/MDAnalysis/selections/jmol.py
@@ -39,9 +39,8 @@ The selection is named *mdanalysis001*.TODO
 .. _Jmol: http://wiki.jmol.org/index.php/Main_Page
 .. _Jmol selection: http://chemapps.stolaf.edu/jmol/docs/#define
 """
-from __future__ import absolute_import
-
 from . import base
+
 
 class SelectionWriter(base.SelectionWriterBase):
     format = ["Jmol", "spt"]

--- a/package/MDAnalysis/selections/pymol.py
+++ b/package/MDAnalysis/selections/pymol.py
@@ -40,9 +40,8 @@ The selections should appear in the user interface.
 .. autoclass:: SelectionWriter
    :inherited-members:
 """
-from __future__ import absolute_import
-
 from . import base
+
 
 class SelectionWriter(base.SelectionWriterBase):
     format = ["PyMol", "pml"]

--- a/package/MDAnalysis/selections/vmd.py
+++ b/package/MDAnalysis/selections/vmd.py
@@ -47,9 +47,8 @@ In the VMD_ GUI the macro "mdanalysis001" appears in the
    :inherited-members:
 
 """
-from __future__ import absolute_import
-
 from . import base
+
 
 class SelectionWriter(base.SelectionWriterBase):
     format = "VMD"

--- a/package/MDAnalysis/tests/datafiles.py
+++ b/package/MDAnalysis/tests/datafiles.py
@@ -36,8 +36,6 @@ Real MD simulation data, used for examples and the unit tests::
    :mod:`MDAnalysisTests` package which must be downloaded from
    http://pypi.python.org/pypi/MDAnalysisTests and installed.
 """
-from __future__ import print_function, absolute_import
-from six import raise_from
 
 try:
     from MDAnalysisTests.datafiles import *
@@ -51,4 +49,4 @@ except ImportError:
     print()
     print("and download and install the `MDAnalysisTests-x.y.z.tar.gz'")
     print("that matches your MDAnalysis release.")
-    raise_from(ImportError("MDAnalysisTests package not installed."), None)
+    raise ImportError("MDAnalysisTests package not installed.") from None

--- a/package/MDAnalysis/transformations/__init__.py
+++ b/package/MDAnalysis/transformations/__init__.py
@@ -56,8 +56,6 @@ See `MDAnalysis.transformations.translate` for a simple example.
 
 """
 
-from __future__ import absolute_import
-
 from .translate import translate, center_in_box
 from .rotate import rotateby
 from .positionaveraging import PositionAverager

--- a/package/MDAnalysis/transformations/fit.py
+++ b/package/MDAnalysis/transformations/fit.py
@@ -32,9 +32,6 @@ a given AtomGroup to a reference structure.
 .. autofunction:: fit_rot_trans
 
 """
-from __future__ import absolute_import
-from six import raise_from
-
 import numpy as np
 from functools import partial
 
@@ -91,14 +88,14 @@ def fit_translation(ag, reference, plane=None, weights=None):
         try:
             plane = axes[plane]
         except (TypeError, KeyError):
-            raise_from(ValueError('{} is not a valid plane'.format(plane)), None)
+            raise ValueError(f'{plane} is not a valid plane') from None
     try:
         if ag.atoms.n_residues != reference.atoms.n_residues:
-            raise ValueError("{} and {} have mismatched number of residues".format(ag,reference))
+            errmsg = f"{ag} and {reference} have mismatched number of residues"
+            raise ValueError(errmsg)
     except AttributeError:
-        raise_from(
-            AttributeError("{} or {} is not valid Universe/AtomGroup".format(ag,reference)),
-            None)
+        errmsg = f"{ag} or {reference} is not valid Universe/AtomGroup"
+        raise AttributeError(errmsg) from None
     ref, mobile = align.get_matching_atoms(reference.atoms, ag.atoms)
     weights = align.get_weights(ref.atoms, weights=weights)
     ref_com = ref.center(weights)
@@ -168,12 +165,14 @@ def fit_rot_trans(ag, reference, plane=None, weights=None):
         try:
             plane = axes[plane]
         except (TypeError, KeyError):
-            raise_from(ValueError('{} is not a valid plane'.format(plane)), None)
+            raise ValueError(f'{plane} is not a valid plane') from None
     try:
         if ag.atoms.n_residues != reference.atoms.n_residues:
-            raise ValueError("{} and {} have mismatched number of residues".format(ag,reference))
+            errmsg = f"{ag} and {reference} have mismatched number of residues"
+            raise ValueError(errmsg)
     except AttributeError:
-        raise_from(AttributeError("{} or {} is not valid Universe/AtomGroup".format(ag,reference)), None)
+        errmsg = f"{ag} or {reference} is not valid Universe/AtomGroup"
+        raise AttributeError(errmsg) from None
     ref, mobile = align.get_matching_atoms(reference.atoms, ag.atoms)
     weights = align.get_weights(ref.atoms, weights=weights)
     ref_com = ref.center(weights)

--- a/package/MDAnalysis/transformations/positionaveraging.py
+++ b/package/MDAnalysis/transformations/positionaveraging.py
@@ -32,11 +32,8 @@ returned.
 .. autoclass:: PositionAverager
 
 """
-from __future__ import absolute_import
-
 import numpy as np
 import warnings
-
 
 
 class PositionAverager(object):  

--- a/package/MDAnalysis/transformations/rotate.py
+++ b/package/MDAnalysis/transformations/rotate.py
@@ -31,9 +31,6 @@ point
 .. autofunction:: rotateby
 
 """
-from __future__ import absolute_import
-from six import raise_from
-
 import math
 import numpy as np
 from functools import partial
@@ -114,9 +111,7 @@ def rotateby(angle, direction, point=None, ag=None, weights=None, wrap=False):
             raise ValueError('{} is not a valid direction'.format(direction))
         direction = direction.reshape(3, )
     except ValueError:
-        raise_from(
-            ValueError('{} is not a valid direction'.format(direction)),
-            None)
+        raise ValueError(f'{direction} is not a valid direction') from None
     if point is not None:
         point = np.asarray(point, np.float32)
         if point.shape != (3, ) and point.shape != (1, 3):
@@ -126,15 +121,14 @@ def rotateby(angle, direction, point=None, ag=None, weights=None, wrap=False):
         try:
             atoms = ag.atoms
         except AttributeError:
-            raise_from(ValueError('{} is not an AtomGroup object'.format(ag)), None)
+            raise ValueError(f'{ag} is not an AtomGroup object') from None
         else:
             try:
                 weights = get_weights(atoms, weights=weights)
             except (ValueError, TypeError):
-                raise_from(
-                    TypeError("weights must be {'mass', None} or an iterable of the "
-                              "same size as the atomgroup."),
-                    None)
+                errmsg = ("weights must be {'mass', None} or an iterable of "
+                          "the same size as the atomgroup.")
+                raise TypeError(errmsg) from None
         center_method = partial(atoms.center, weights, pbc=wrap)
     else:
         raise ValueError('A point or an AtomGroup must be specified')

--- a/package/MDAnalysis/transformations/translate.py
+++ b/package/MDAnalysis/transformations/translate.py
@@ -36,9 +36,6 @@ or defined by centering an AtomGroup in the unit cell using the function
 
 
 """
-from __future__ import absolute_import, division
-from six import raise_from
-
 import numpy as np
 from functools import partial
 
@@ -127,11 +124,10 @@ def center_in_box(ag, center='geometry', point=None, wrap=False):
             raise ValueError('{} is not a valid argument for center'.format(center))
     except AttributeError:
         if center == 'mass':
-            raise_from(
-                AttributeError('{} is not an AtomGroup object with masses'.format(ag)),
-                None)
+            errmsg = f'{ag} is not an AtomGroup object with masses'
+            raise AttributeError(errmsg) from None
         else:
-            raise_from(ValueError('{} is not an AtomGroup object'.format(ag)), None)
+            raise ValueError(f'{ag} is not an AtomGroup object') from None
 
     def wrapped(ts):
         if point is None:

--- a/package/MDAnalysis/transformations/wrap.py
+++ b/package/MDAnalysis/transformations/wrap.py
@@ -34,9 +34,8 @@ atoms of each molecule so that bons don't split over images.
 
 """
 
-from __future__ import absolute_import
-
 from ..lib._cutil import make_whole
+
 
 def wrap(ag, compound='atoms'):
     """

--- a/package/MDAnalysis/units.py
+++ b/package/MDAnalysis/units.py
@@ -165,9 +165,6 @@ References and footnotes
 
 """
 
-from __future__ import absolute_import, unicode_literals, division
-from six import raise_from
-
 #
 # NOTE: Whenever a constant is added to the constants dict, you also
 #       MUST add an appropriate entry to
@@ -354,22 +351,16 @@ def convert(x, u1, u2):
     try:
         ut1 = unit_types[u1]
     except KeyError:
-        raise_from(
-            ValueError(
-                ("unit '{0}' not recognized.\n"
-                 "It must be one of {1}.").format(u1, ", ".join(unit_types))
-                ),
-            None)
+        errmsg = (f"unit '{u1}' not recognized.\n"
+                  f"It must be one of {', '.join(unit_types)}.")
+        raise ValueError(errmsg) from None
                   
     try:
         ut2 = unit_types[u2]
     except KeyError:
-        raise_from(
-            ValueError(
-                ("unit '{0}' not recognized.\n"
-                 "It must be one of {1}.").format(u2, ", ".join(unit_types))
-                ),
-            None)
+        errsmg = (f"unit '{u2}' not recognized.\n"
+                  f"It must be one of {', '.join(unit_types)}.")
+        raise ValueError(errmsg) from None
     if ut1 != ut2:
         raise ValueError("Cannot convert between unit types "
                          "{0} --> {1}".format(u1, u2))

--- a/package/MDAnalysis/units.py
+++ b/package/MDAnalysis/units.py
@@ -358,7 +358,7 @@ def convert(x, u1, u2):
     try:
         ut2 = unit_types[u2]
     except KeyError:
-        errsmg = (f"unit '{u2}' not recognized.\n"
+        errmsg = (f"unit '{u2}' not recognized.\n"
                   f"It must be one of {', '.join(unit_types)}.")
         raise ValueError(errmsg) from None
     if ut1 != ut2:

--- a/package/MDAnalysis/visualization/__init__.py
+++ b/package/MDAnalysis/visualization/__init__.py
@@ -21,7 +21,6 @@
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
 
-from __future__ import absolute_import
 from . import streamlines
 from . import streamlines_3D
 

--- a/package/MDAnalysis/visualization/streamlines.py
+++ b/package/MDAnalysis/visualization/streamlines.py
@@ -42,10 +42,6 @@ MDAnalysis.visualization.streamlines_3D : streamplots in 3D
 .. autofunction:: generate_streamlines
 
 """
-from __future__ import absolute_import
-from six.moves import zip
-from six import raise_from
-
 import multiprocessing
 
 import numpy as np
@@ -55,14 +51,12 @@ try:
     import matplotlib
     import matplotlib.path
 except ImportError:
-    raise_from(
-        ImportError((
+    raise ImportError(
             '2d streamplot module requires: matplotlib.path for its '
             'path.Path.contains_points method. The installation '
             'instructions for the matplotlib module can be found here: '
             'http://matplotlib.org/faq/installing_faq.html?highlight=install'
-            )),
-        None)
+            ) from None
 
 import MDAnalysis
 

--- a/package/MDAnalysis/visualization/streamlines_3D.py
+++ b/package/MDAnalysis/visualization/streamlines_3D.py
@@ -43,10 +43,6 @@ MDAnalysis.visualization.streamlines : streamplots in 2D
 .. autofunction:: generate_streamlines_3d
 
 """
-from __future__ import division, absolute_import
-import six
-from six.moves import range, zip
-
 import multiprocessing
 
 import numpy as np
@@ -267,7 +263,7 @@ def per_core_work(start_frame_coord_array, end_frame_coord_array, dictionary_cub
         corresponding to the indices of the relevant particles that fall within a given cube. Also, for a given cube,
         store a key/value pair for the centroid of the particles that fall within the cube."""
         cube_counter = 0
-        for key, cube in six.iteritems(dictionary_cube_data_this_core):
+        for key, cube in dictionary_cube_data_this_core.items():
             index_list_in_cube = point_in_cube(array_simulation_particle_coordinates, cube['vertex_list'],
                                                cube['centroid'])
             cube['start_frame_index_list_in_cube'] = index_list_in_cube
@@ -282,7 +278,7 @@ def per_core_work(start_frame_coord_array, end_frame_coord_array, dictionary_cub
     def update_dictionary_end_frame(array_simulation_particle_coordinates, dictionary_cube_data_this_core):
         """Update the cube dictionary objects again as appropriate for the second and final frame."""
         cube_counter = 0
-        for key, cube in six.iteritems(dictionary_cube_data_this_core):
+        for key, cube in dictionary_cube_data_this_core.items():
             # if there were no particles in the cube in the first frame, then set dx,dy,dz each to 0
             if cube['centroid_of_particles_first_frame'] == 'empty':
                 cube['dx'] = 0

--- a/testsuite/MDAnalysisTests/__init__.py
+++ b/testsuite/MDAnalysisTests/__init__.py
@@ -90,7 +90,6 @@ especially as we are directly using this framework (imported from numpy).
 .. _Gromacs: http://www.gromacs.org
 
 """
-from __future__ import absolute_import
 import logging
 
 import pytest

--- a/testsuite/MDAnalysisTests/auxiliary/base.py
+++ b/testsuite/MDAnalysisTests/auxiliary/base.py
@@ -20,14 +20,11 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
-
 import MDAnalysis as mda
 import numpy as np
 import pytest
 from MDAnalysisTests.datafiles import (COORDINATES_XTC, COORDINATES_TOPOLOGY)
 from numpy.testing import assert_almost_equal, assert_equal
-from six.moves import range
 
 
 def test_get_bad_auxreader_format_raises_ValueError():

--- a/testsuite/MDAnalysisTests/auxiliary/test_core.py
+++ b/testsuite/MDAnalysisTests/auxiliary/test_core.py
@@ -21,8 +21,6 @@
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
 
-from __future__ import absolute_import
-
 import MDAnalysis as mda
 
 import pytest

--- a/testsuite/MDAnalysisTests/auxiliary/test_xvg.py
+++ b/testsuite/MDAnalysisTests/auxiliary/test_xvg.py
@@ -20,9 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
-
-from six.moves import range
 import pytest
 from numpy.testing import assert_array_equal
 import numpy as np

--- a/testsuite/MDAnalysisTests/data/coordinates/create_data.py
+++ b/testsuite/MDAnalysisTests/data/coordinates/create_data.py
@@ -1,6 +1,5 @@
 import MDAnalysis as mda
 import numpy as np
-from six.moves import range
 
 
 def create_test_trj(uni, fname):

--- a/testsuite/MDAnalysisTests/datafiles.py
+++ b/testsuite/MDAnalysisTests/datafiles.py
@@ -35,7 +35,6 @@ Note that the files are actually located in a separate package,
 
  from MDAnalysisTestData.datafiles import *
 """
-from __future__ import absolute_import
 
 __all__ = [
     "PSF", "DCD", "CRD",  # CHARMM (AdK example, DIMS trajectory from JMB 2009 paper)

--- a/testsuite/MDAnalysisTests/dummy.py
+++ b/testsuite/MDAnalysisTests/dummy.py
@@ -23,9 +23,6 @@
 """Mock Universe and Topology generated from scratch with default values
 
 """
-from __future__ import absolute_import, division
-
-from six.moves import range
 
 import numpy as np
 import string

--- a/testsuite/MDAnalysisTests/formats/test_libdcd.py
+++ b/testsuite/MDAnalysisTests/formats/test_libdcd.py
@@ -13,9 +13,7 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import, print_function
-from six.moves import zip
-from six.moves import cPickle as pickle
+import pickle
 
 from collections import namedtuple
 import os

--- a/testsuite/MDAnalysisTests/formats/test_libmdaxdr.py
+++ b/testsuite/MDAnalysisTests/formats/test_libmdaxdr.py
@@ -20,8 +20,7 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import print_function, absolute_import
-from six.moves import cPickle as pickle
+import pickle
 
 import numpy as np
 

--- a/testsuite/MDAnalysisTests/import/fork_called.py
+++ b/testsuite/MDAnalysisTests/import/fork_called.py
@@ -20,7 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import, print_function
 import os
 import mock
 

--- a/testsuite/MDAnalysisTests/import/test_import.py
+++ b/testsuite/MDAnalysisTests/import/test_import.py
@@ -20,7 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import, print_function
 import sys
 import os
 import subprocess

--- a/testsuite/MDAnalysisTests/test_api.py
+++ b/testsuite/MDAnalysisTests/test_api.py
@@ -24,8 +24,6 @@
 Test the user facing API is as we expect...
 """
 
-from __future__ import absolute_import
-
 import MDAnalysis as mda
 
 def test_Universe():

--- a/testsuite/MDAnalysisTests/transformations/test_fit.py
+++ b/testsuite/MDAnalysisTests/transformations/test_fit.py
@@ -19,8 +19,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import division, print_function, absolute_import
-
 import numpy as np
 import pytest
 from numpy.testing import assert_array_almost_equal

--- a/testsuite/MDAnalysisTests/transformations/test_positionaveraging.py
+++ b/testsuite/MDAnalysisTests/transformations/test_positionaveraging.py
@@ -1,7 +1,5 @@
 ###
 
-from __future__ import absolute_import
-
 import numpy as np
 import pytest
 from numpy.testing import assert_array_almost_equal

--- a/testsuite/MDAnalysisTests/transformations/test_rotate.py
+++ b/testsuite/MDAnalysisTests/transformations/test_rotate.py
@@ -21,8 +21,6 @@
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
 
-from __future__ import absolute_import
-
 import numpy as np
 import pytest
 from numpy.testing import assert_array_almost_equal

--- a/testsuite/MDAnalysisTests/transformations/test_translate.py
+++ b/testsuite/MDAnalysisTests/transformations/test_translate.py
@@ -21,8 +21,6 @@
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
 
-from __future__ import absolute_import
-
 import numpy as np
 import pytest
 from numpy.testing import assert_array_almost_equal

--- a/testsuite/MDAnalysisTests/transformations/test_wrap.py
+++ b/testsuite/MDAnalysisTests/transformations/test_wrap.py
@@ -20,8 +20,6 @@
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
 
-from __future__ import absolute_import
-
 import numpy as np
 import pytest
 from numpy.testing import assert_array_almost_equal

--- a/testsuite/MDAnalysisTests/util.py
+++ b/testsuite/MDAnalysisTests/util.py
@@ -24,7 +24,6 @@
 Useful functions for running tests
 
 """
-from __future__ import absolute_import
 
 try:
     import __builtin__
@@ -44,6 +43,7 @@ import warnings
 import pytest
 
 from numpy.testing import assert_warns
+
 
 def block_import(package):
     """Block import of a given package

--- a/testsuite/MDAnalysisTests/utils/test_altloc.py
+++ b/testsuite/MDAnalysisTests/utils/test_altloc.py
@@ -20,8 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
-
 import pytest
 from MDAnalysis import Universe
 from numpy.testing import assert_equal

--- a/testsuite/MDAnalysisTests/utils/test_authors.py
+++ b/testsuite/MDAnalysisTests/utils/test_authors.py
@@ -20,7 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
 from numpy.testing import assert_
 
 import MDAnalysis

--- a/testsuite/MDAnalysisTests/utils/test_datafiles.py
+++ b/testsuite/MDAnalysisTests/utils/test_datafiles.py
@@ -20,8 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
-
 import pytest
 from numpy.testing import assert_equal
 

--- a/testsuite/MDAnalysisTests/utils/test_duecredit.py
+++ b/testsuite/MDAnalysisTests/utils/test_duecredit.py
@@ -20,7 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
 import os
 import pytest
 

--- a/testsuite/MDAnalysisTests/utils/test_failure.py
+++ b/testsuite/MDAnalysisTests/utils/test_failure.py
@@ -20,8 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
-
 import os
 
 

--- a/testsuite/MDAnalysisTests/utils/test_imports.py
+++ b/testsuite/MDAnalysisTests/utils/test_imports.py
@@ -20,8 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
-
 import os
 
 import MDAnalysisTests

--- a/testsuite/MDAnalysisTests/utils/test_log.py
+++ b/testsuite/MDAnalysisTests/utils/test_log.py
@@ -20,9 +20,7 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import division, absolute_import
-
-from six.moves import StringIO, range
+from io import StringIO
 
 import logging
 import sys

--- a/testsuite/MDAnalysisTests/utils/test_meta.py
+++ b/testsuite/MDAnalysisTests/utils/test_meta.py
@@ -20,8 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
-
 import re
 
 import MDAnalysisTests

--- a/testsuite/MDAnalysisTests/utils/test_modelling.py
+++ b/testsuite/MDAnalysisTests/utils/test_modelling.py
@@ -20,8 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import, print_function
-
 import os
 import MDAnalysis
 import pytest

--- a/testsuite/MDAnalysisTests/utils/test_persistence.py
+++ b/testsuite/MDAnalysisTests/utils/test_persistence.py
@@ -20,10 +20,8 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import
-
 import pytest
-from six.moves import cPickle
+import pickle
 
 import MDAnalysis as mda
 from numpy.testing import (
@@ -64,23 +62,23 @@ class TestAtomGroupPickle(object):
     @staticmethod
     @pytest.fixture()
     def pickle_str(ag):
-        return cPickle.dumps(ag, protocol=cPickle.HIGHEST_PROTOCOL)
+        return pickle.dumps(ag, protocol=pickle.HIGHEST_PROTOCOL)
 
     @staticmethod
     @pytest.fixture()
     def pickle_str_n(ag_n):
-        return cPickle.dumps(ag_n, protocol=cPickle.HIGHEST_PROTOCOL)
+        return pickle.dumps(ag_n, protocol=pickle.HIGHEST_PROTOCOL)
 
     def test_unpickle(self, pickle_str, ag, universe):
         """Test that an AtomGroup can be unpickled (Issue 293)"""
-        newag = cPickle.loads(pickle_str)
+        newag = pickle.loads(pickle_str)
         # Can unpickle
         assert_equal(ag.indices, newag.indices)
         assert newag.universe is universe, "Unpickled AtomGroup on wrong Universe."
 
     def test_unpickle_named(self, pickle_str_n, ag_n, universe_n):
         """Test that an AtomGroup can be unpickled (Issue 293)"""
-        newag = cPickle.loads(pickle_str_n)
+        newag = pickle.loads(pickle_str_n)
         # Can unpickle
         assert_equal(ag_n.indices, newag.indices)
         assert newag.universe is universe_n, "Unpickled AtomGroup on wrong Universe."
@@ -91,16 +89,16 @@ class TestAtomGroupPickle(object):
                                   anchor_name="test1")
         ag = universe.atoms[:20]  # prototypical AtomGroup
         ag_n = universe_n.atoms[:10]
-        pickle_str_n = cPickle.dumps(ag_n, protocol=cPickle.HIGHEST_PROTOCOL)
+        pickle_str_n = pickle.dumps(ag_n, protocol=pickle.HIGHEST_PROTOCOL)
         # Kill AtomGroup and Universe
         del ag_n
         del universe_n
         # and make sure they're very dead
         gc.collect()
         # we shouldn't be able to unpickle
-        # assert_raises(RuntimeError, cPickle.loads, pickle_str_n)
+        # assert_raises(RuntimeError, pickle.loads, pickle_str_n)
         with pytest.raises(RuntimeError):
-            cPickle.loads(pickle_str_n)
+            pickle.loads(pickle_str_n)
 
     def test_unpickle_noanchor(self, universe, pickle_str):
         # Shouldn't unpickle if the universe is removed from the anchors
@@ -108,9 +106,9 @@ class TestAtomGroupPickle(object):
         # In the complex (parallel) testing environment there's the risk of
         # other compatible Universes being available for anchoring even after
         # this one is expressly removed.
-        # assert_raises(RuntimeError, cPickle.loads, pickle_str)
+        # assert_raises(RuntimeError, pickle.loads, pickle_str)
         with pytest.raises(RuntimeError):
-            cPickle.loads(pickle_str)
+            pickle.loads(pickle_str)
         # If this fails to raise an exception either:
         # 1-the anchoring Universe failed to remove_anchor or 2-another
         # Universe with the same characteristics was created for testing and is
@@ -121,7 +119,7 @@ class TestAtomGroupPickle(object):
         universe.remove_anchor()
         # now it goes back into the anchor list again
         universe.make_anchor()
-        newag = cPickle.loads(pickle_str)
+        newag = pickle.loads(pickle_str)
         assert_equal(ag.indices, newag.indices)
         assert newag.universe is universe, "Unpickled AtomGroup on wrong Universe."
 
@@ -131,22 +129,22 @@ class TestAtomGroupPickle(object):
         # shouldn't unpickle if no name matches, even if there's a compatible
         # universe in the unnamed anchor list.
         with pytest.raises(RuntimeError):
-            cPickle.loads(pickle_str_n)
+            pickle.loads(pickle_str_n)
 
     def test_unpickle_rename(self, universe_n, universe, pickle_str_n, ag_n):
         # we change universe_n's anchor_name
         universe_n.anchor_name = "test2"
         # and make universe a named anchor
         universe.anchor_name = "test1"
-        newag = cPickle.loads(pickle_str_n)
+        newag = pickle.loads(pickle_str_n)
         assert_equal(ag_n.indices, newag.indices)
         assert newag.universe is universe, "Unpickled AtomGroup on wrong Universe."
 
     def test_pickle_unpickle_empty(self, universe):
         """Test that an empty AtomGroup can be pickled/unpickled (Issue 293)"""
         ag = universe.atoms[[]]
-        pickle_str = cPickle.dumps(ag, protocol=cPickle.HIGHEST_PROTOCOL)
-        newag = cPickle.loads(pickle_str)
+        pickle_str = pickle.dumps(ag, protocol=pickle.HIGHEST_PROTOCOL)
+        newag = pickle.loads(pickle_str)
         assert len(newag) == 0
 
 
@@ -160,15 +158,15 @@ class TestPicklingUpdatingAtomGroups(object):
     def test_pickling_uag(self, u):
         ag = u.atoms[:100]
         uag = ag.select_atoms('name C', updating=True)
-        pickle_str = cPickle.dumps(uag, protocol=cPickle.HIGHEST_PROTOCOL)
-        new_uag = cPickle.loads(pickle_str)
+        pickle_str = pickle.dumps(uag, protocol=pickle.HIGHEST_PROTOCOL)
+        new_uag = pickle.loads(pickle_str)
 
         assert_equal(uag.indices, new_uag.indices)
 
     def test_pickling_uag_of_uag(self, u):
         uag1 = u.select_atoms('name C or name H', updating=True)
         uag2 = uag1.select_atoms('name C', updating=True)
-        pickle_str = cPickle.dumps(uag2, protocol=cPickle.HIGHEST_PROTOCOL)
-        new_uag2 = cPickle.loads(pickle_str)
+        pickle_str = pickle.dumps(uag2, protocol=pickle.HIGHEST_PROTOCOL)
+        new_uag2 = pickle.loads(pickle_str)
 
         assert_equal(uag2.indices, new_uag2.indices)

--- a/testsuite/MDAnalysisTests/utils/test_qcprot.py
+++ b/testsuite/MDAnalysisTests/utils/test_qcprot.py
@@ -36,8 +36,6 @@ For the example provided below, the minimum least-squares RMSD for the two
      [-0.0271479  -0.67963547  0.73304748]]
 
 """
-from __future__ import division, absolute_import
-
 import numpy as np
 
 import MDAnalysis.lib.qcprot as qcp

--- a/testsuite/MDAnalysisTests/utils/test_selections.py
+++ b/testsuite/MDAnalysisTests/utils/test_selections.py
@@ -22,10 +22,9 @@
 #
 
 # Test the selection exporters in MDAnalysis.selections
-from __future__ import absolute_import
 # use StringIO and NamedStream to write to memory instead to temp files
 import pytest
-from six.moves import StringIO
+from io import StringIO
 
 import re
 

--- a/testsuite/MDAnalysisTests/utils/test_transformations.py
+++ b/testsuite/MDAnalysisTests/utils/test_transformations.py
@@ -20,9 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import division, absolute_import
-
-from six.moves import range
 from itertools import permutations
 
 import numpy as np

--- a/testsuite/MDAnalysisTests/utils/test_units.py
+++ b/testsuite/MDAnalysisTests/utils/test_units.py
@@ -20,8 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import unicode_literals, absolute_import
-import six
 import pytest
 
 import numpy as np

--- a/testsuite/MDAnalysisTests/visualization/test_streamlines.py
+++ b/testsuite/MDAnalysisTests/visualization/test_streamlines.py
@@ -20,7 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import, print_function, division
 import numpy as np
 from numpy.testing import assert_almost_equal
 import MDAnalysis


### PR DESCRIPTION
Towards #2451 

Changes made in this Pull Request:
 - Removes py2 things (six/future) from aux, selections, tests, transformations, visualization, and misc files.

Notes:
 - setup files will be changed in a separate PR, once everything has been merged.


PR Checklist
------------
 - [x] Tests?
 - [ ] Docs? N/A
 - [ ] CHANGELOG updated? N/A
 - [x] Issue raised/referenced?
