### PR TITLE
removed matplotlib.use('agg') from tests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,7 +21,8 @@ environment:
         # Temporarily fall back to default MINICONDA_VERSION in ci-helpers until https://github.com/MDAnalysis/mdanalysis/issues/2311
         # is fixed in ci-helpers https://github.com/astropy/ci-helpers/issues/406
         # MINICONDA_VERSION: "latest"
-
+        MPLBACKEND: "agg"
+        
     matrix:
         - PYTHON_VERSION: 3.6
           PYTHON_ARCH: 64

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ env:
     - NUMPY_VERSION=stable
     - INSTALL_HOLE="true"
     - CYTHON_TRACE_NOGIL=1
+    - MPLBACKEND=agg
 
   matrix:
     # Run a coverage test for most versions

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,6 +19,8 @@ jobs:
   condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))  # skip for PR merges
   pool:
     vmImage: 'VS2017-Win2016'
+  variables:
+    MPLBACKEND: agg    
   strategy:
     maxParallel: 4
     matrix:

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,13 +13,14 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-??/??/?? richardjgowers, IAlibay, hmacdope
+??/??/?? richardjgowers, IAlibay, hmacdope, orbeckst
 
   * 2.0.0
 
 Fixes
   * TOPParser no longer guesses elements when missing atomic number records
     (Issues #2449, #2651)
+  * Testsuite does not any more matplotlib.use('agg') (#2191)
 
 Enhancements
   * Added computation of Mean Squared Displacements (#2438, PR #2619)

--- a/testsuite/MDAnalysisTests/__init__.py
+++ b/testsuite/MDAnalysisTests/__init__.py
@@ -118,14 +118,10 @@ import sys
 os.environ['DUECREDIT_ENABLE'] = 'yes'
 
 # Any tests that plot with matplotlib need to run with the simple agg backend
-# because on Travis there is no DISPLAY set. This doesn't warn if we import
-# files from the tests after loading matplotlib. This will remove unnecessary
-# user warnings. 
-try:
-    import matplotlib
-    matplotlib.use('agg', warn=False)
-except ImportError:
-    pass
+# because on Travis there is no DISPLAY set.
+#
+# Instead of using matplotlib.use() we set MPLBACKEND=agg in the CI environment.
+# See https://matplotlib.org/3.2.1/tutorials/introductory/usage.html#backends
 
 from MDAnalysisTests.util import (
     block_import,

--- a/testsuite/MDAnalysisTests/visualization/test_streamlines.py
+++ b/testsuite/MDAnalysisTests/visualization/test_streamlines.py
@@ -29,8 +29,6 @@ from MDAnalysis.visualization import (streamlines,
 from MDAnalysis.coordinates.XTC import XTCWriter
 from MDAnalysisTests.datafiles import Martini_membrane_gro
 import pytest
-import matplotlib
-matplotlib.use('agg')
 import matplotlib.pyplot as plt
 import os
 


### PR DESCRIPTION
Fixes #2191

Changes made in this Pull Request:
- removed `matplotlib.use('agg')` from tests
- use MPLBACKEND=agg in the CI environments
  - Travis
  - appveyor
  - Azure pipelines

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
