### PR TITLE
decorate Selection.apply to ignore empty atomgroups

### DIFF
--- a/package/MDAnalysis/core/selection.py
+++ b/package/MDAnalysis/core/selection.py
@@ -156,6 +156,16 @@ class OrOperation(LogicOperation):
 
         return group.universe.atoms[idx]
 
+def return_empty_on_apply(func):
+    """
+    Decorator to return empty AtomGroups from the apply() function
+    without evaluating it
+    """
+    def apply(self, group):
+        if len(group) == 0:
+            return group
+        return func(self, group)
+    return apply
 
 class _Selectionmeta(type):
     def __init__(cls, name, bases, classdict):
@@ -163,6 +173,11 @@ class _Selectionmeta(type):
         try:
             _SELECTIONDICT[classdict['token']] = cls
         except KeyError:
+            pass
+        
+        try:
+            cls.apply = return_empty_on_apply(cls.apply)
+        except AttributeError:
             pass
 
 

--- a/package/MDAnalysis/core/selection.py
+++ b/package/MDAnalysis/core/selection.py
@@ -176,13 +176,6 @@ class _Selectionmeta(type):
         except KeyError:
             pass
 
-        # GlobalSelections can return something even if empty AG
-        if not cls.__name__ == 'GlobalSelection':
-            try:
-                cls.apply = return_empty_on_apply(cls.apply)
-            except AttributeError:
-                pass
-
 
 class Selection(object, metaclass=_Selectionmeta):
     pass
@@ -276,6 +269,7 @@ class AroundSelection(DistanceSelection):
         self.cutoff = float(tokens.popleft())
         self.sel = parser.parse_expression(self.precedence)
 
+    @return_empty_on_apply
     def apply(self, group):
         indices = []
         sel = self.sel.apply(group)
@@ -304,6 +298,7 @@ class SphericalLayerSelection(DistanceSelection):
         self.exRadius = float(tokens.popleft())
         self.sel = parser.parse_expression(self.precedence)
     
+    @return_empty_on_apply
     def apply(self, group):
         indices = []
         sel = self.sel.apply(group)
@@ -329,6 +324,7 @@ class SphericalZoneSelection(DistanceSelection):
         self.cutoff = float(tokens.popleft())
         self.sel = parser.parse_expression(self.precedence)
 
+    @return_empty_on_apply
     def apply(self, group):
         indices = []
         sel = self.sel.apply(group)
@@ -345,6 +341,7 @@ class SphericalZoneSelection(DistanceSelection):
 
 
 class CylindricalSelection(Selection):
+    @return_empty_on_apply
     def apply(self, group):
         sel = self.sel.apply(group)
 
@@ -438,6 +435,7 @@ class PointSelection(DistanceSelection):
         self.ref = np.array([x, y, z], dtype=np.float32)
         self.cutoff = float(tokens.popleft())
 
+    @return_empty_on_apply
     def apply(self, group):
         indices = []
         box = self.validate_dimensions(group.dimensions)
@@ -530,6 +528,7 @@ class StringSelection(Selection):
 
         self.values = vals
 
+    @return_empty_on_apply
     def apply(self, group):
         mask = np.zeros(len(group), dtype=np.bool)
         for val in self.values:

--- a/package/MDAnalysis/core/selection.py
+++ b/package/MDAnalysis/core/selection.py
@@ -161,6 +161,7 @@ def return_empty_on_apply(func):
     Decorator to return empty AtomGroups from the apply() function
     without evaluating it
     """
+    @functools.wraps(func)
     def apply(self, group):
         if len(group) == 0:
             return group
@@ -174,11 +175,13 @@ class _Selectionmeta(type):
             _SELECTIONDICT[classdict['token']] = cls
         except KeyError:
             pass
-        
-        try:
-            cls.apply = return_empty_on_apply(cls.apply)
-        except AttributeError:
-            pass
+
+        # GlobalSelections can return something even if empty AG
+        if not cls.__name__ == 'GlobalSelection':
+            try:
+                cls.apply = return_empty_on_apply(cls.apply)
+            except AttributeError:
+                pass
 
 
 class Selection(object, metaclass=_Selectionmeta):

--- a/testsuite/MDAnalysisTests/core/test_atomselections.py
+++ b/testsuite/MDAnalysisTests/core/test_atomselections.py
@@ -1140,6 +1140,12 @@ def test_selections_on_empty_group(u_pdb_icodes, selection):
     ag = u_pdb_icodes.atoms[[]].select_atoms(selection)
     assert len(ag) == 0
 
+def test_empty_yet_global(u_pdb_icodes):
+    # slight exception to above test, an empty AG can return something if 'global' used
+    ag = u_pdb_icodes.atoms[[]].select_atoms('global name O')
+
+    assert len(ag) == 185  # len(u_pdb_icodes.select_atoms('name O'))
+
 def test_arbitrary_atom_group_raises_error():
     u = make_Universe(trajectory=True)
     with pytest.raises(TypeError):

--- a/testsuite/MDAnalysisTests/core/test_atomselections.py
+++ b/testsuite/MDAnalysisTests/core/test_atomselections.py
@@ -1126,6 +1126,19 @@ def test_similarity_selection_icodes(u_pdb_icodes, selection, n_atoms):
 
     assert len(sel.atoms) == n_atoms
 
+@pytest.mark.parametrize('selection', [
+    'all', 'protein', 'backbone', 'nucleic', 'nucleicbackbone',
+    'name O', 'name N*', 'resname stuff', 'resname ALA', 'type O',
+    'index 0', 'index 1', 'bynum 1-10',
+    'segid SYSTEM', 'resid 163', 'resid 1-10', 'resnum 2',
+    'around 10 resid 1', 'point 0 0 0 10', 'sphzone 10 resid 1',
+    'sphlayer 0 10 index 1', 'cyzone 15 4 -8 index 0',
+    'cylayer 5 10 10 -8 index 1', 'prop abs z <= 100',
+    'byres index 0', 'same resid as index 0',
+])
+def test_selections_on_empty_group(u_pdb_icodes, selection):
+    ag = u_pdb_icodes.atoms[[]].select_atoms(selection)
+    assert len(ag) == 0
 
 def test_arbitrary_atom_group_raises_error():
     u = make_Universe(trajectory=True)


### PR DESCRIPTION
Fixes #2765 

Changes made in this Pull Request:
 - if an empty AtomGroup is passed to Selection.apply, just return it

I decorated `Selection.apply` in `_Selectionmeta.__init__`, which I baselessly feel is a bit iffy. Any opinions on if I should move it somewhere else?

Edit: alternately it could be expensive to have so many ifs, I could just do the `StringSelection` and sphzone/layer ones individually

PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?
