### PR TITLE
Use unittest.mock instead of mock

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,7 +10,7 @@ cache:
 environment:
     global:
         CONDA_CHANNELS: conda-forge
-        CONDA_DEPENDENCIES: pip setuptools wheel cython mock six biopython networkx joblib matplotlib scipy vs2015_runtime pytest mmtf-python GridDataFormats hypothesis pytest-cov codecov chemfiles tqdm tidynamics>=1.0.0 rdkit
+        CONDA_DEPENDENCIES: pip setuptools wheel cython six biopython networkx joblib matplotlib scipy vs2015_runtime pytest mmtf-python GridDataFormats hypothesis pytest-cov codecov chemfiles tqdm tidynamics>=1.0.0 rdkit
         PIP_DEPENDENCIES: gsd==1.9.3 duecredit parmed
         DEBUG: "False"
         MINGW_64: C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ env:
     - MAIN_CMD="pytest ${PYTEST_LIST}"
     - SETUP_CMD="${PYTEST_FLAGS}"
     - BUILD_CMD="pip install -e package/ && (cd testsuite/ && python setup.py build)"
-    - CONDA_MIN_DEPENDENCIES="mmtf-python mock six biopython networkx cython matplotlib scipy griddataformats hypothesis gsd codecov"
+    - CONDA_MIN_DEPENDENCIES="mmtf-python six biopython networkx cython matplotlib scipy griddataformats hypothesis gsd codecov"
     - CONDA_DEPENDENCIES="${CONDA_MIN_DEPENDENCIES} seaborn>=0.7.0 clustalw=2.1 netcdf4 scikit-learn joblib>=0.12 chemfiles tqdm>=4.43.0 tidynamics>=1.0.0 rdkit"
     - CONDA_CHANNELS='biobuilds conda-forge'
     - CONDA_CHANNEL_PRIORITY=True

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -35,7 +35,6 @@
 	    "pytest": [],
 	    "nose": [],
 	    "psutil": [],
-	    "mock": [],
         "MDAnalysisTests": [],
     },
     // The directory (relative to the current directory) that benchmarks are

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -35,6 +35,7 @@
 	    "pytest": [],
 	    "nose": [],
 	    "psutil": [],
+	    "mock": [],
         "MDAnalysisTests": [],
     },
     // The directory (relative to the current directory) that benchmarks are

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -32,6 +32,7 @@ Enhancements
   * Added computation of Mean Squared Displacements (#2438, PR #2619)
 
 Changes
+  * Replaces use of mock in favour of unittest.mock (Issue #2777)
   * Removes support for passing `atoms` to XYZWriter. (Issue #2739, PR #2754)
   * Removes; deprecated support for using Writer.write(Timestep), deprecated
     Writer.write_next_timestep, use write() instead. (Issue #2739)

--- a/package/MDAnalysis/due.py
+++ b/package/MDAnalysis/due.py
@@ -60,19 +60,13 @@ try:
     if sys.version_info >= (3, 7):
         import duecredit
     else:
-        from mock import patch
-        if sys.version_info <= (2, ):
-            from contextlib import nested
-            with nested(patch('os.fork'), patch('os.popen')) \
-                 as (os_dot_fork, os_dot_popen):
+        from unittest.mock import patch
+        if not os.name == 'nt':
+            with patch('os.fork') as os_dot_fork, patch('os.popen') as os_dot_popen:
                 import duecredit
         else:
-            if not os.name == 'nt':
-                with patch('os.fork') as os_dot_fork, patch('os.popen') as os_dot_popen:
-                    import duecredit
-            else:
-                # Windows doesn't have os.fork
-                import duecredit
+            # Windows doesn't have os.fork
+            import duecredit
 
     from duecredit import due, BibTeX, Doi, Url
     if 'due' in locals() and not hasattr(due, 'cite'):

--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -7,7 +7,6 @@ hypothesis
 joblib>=0.12
 matplotlib
 mmtf-python
-mock
 msmb_theme==1.2.0
 netcdf4
 networkx

--- a/package/setup.py
+++ b/package/setup.py
@@ -564,7 +564,6 @@ if __name__ == '__main__':
           'joblib>=0.12',
           'scipy>=1.0.0',
           'matplotlib>=1.5.1',
-          'mock',
           'tidynamics>=1.0.0',
           'tqdm>=4.43.0',
     ]

--- a/testsuite/MDAnalysisTests/analysis/test_density.py
+++ b/testsuite/MDAnalysisTests/analysis/test_density.py
@@ -24,6 +24,7 @@ import numpy as np
 import pytest
 import sys
 import warnings
+from unittest.mock import Mock, patch
 
 from numpy.testing import assert_equal, assert_almost_equal
 
@@ -33,7 +34,6 @@ import MDAnalysis as mda
 from MDAnalysis.analysis import density
 
 from MDAnalysisTests.datafiles import TPR, XTC, GRO, PDB_full
-from mock import Mock, patch
 from MDAnalysisTests.util import block_import
 
 

--- a/testsuite/MDAnalysisTests/analysis/test_hydrogenbondautocorrel.py
+++ b/testsuite/MDAnalysisTests/analysis/test_hydrogenbondautocorrel.py
@@ -29,7 +29,7 @@ from MDAnalysisTests.datafiles import (
 )
 from numpy.testing import assert_almost_equal
 import numpy as np
-import mock
+import unittest import mock
 import os
 
 import MDAnalysis as mda

--- a/testsuite/MDAnalysisTests/analysis/test_hydrogenbondautocorrel.py
+++ b/testsuite/MDAnalysisTests/analysis/test_hydrogenbondautocorrel.py
@@ -29,7 +29,7 @@ from MDAnalysisTests.datafiles import (
 )
 from numpy.testing import assert_almost_equal
 import numpy as np
-import unittest import mock
+from unittest import mock
 import os
 
 import MDAnalysis as mda

--- a/testsuite/MDAnalysisTests/analysis/test_waterdynamics.py
+++ b/testsuite/MDAnalysisTests/analysis/test_waterdynamics.py
@@ -28,8 +28,7 @@ from MDAnalysisTests.datafiles import waterPSF, waterDCD
 
 import pytest
 import numpy as np
-from mock import patch
-from mock import Mock
+from unittest import patch, Mock
 from numpy.testing import assert_almost_equal, assert_equal
 
 SELECTION1 = "byres name OH2"

--- a/testsuite/MDAnalysisTests/analysis/test_waterdynamics.py
+++ b/testsuite/MDAnalysisTests/analysis/test_waterdynamics.py
@@ -28,7 +28,7 @@ from MDAnalysisTests.datafiles import waterPSF, waterDCD
 
 import pytest
 import numpy as np
-from unittest import patch, Mock
+from unittest.mock import patch, Mock
 from numpy.testing import assert_almost_equal, assert_equal
 
 SELECTION1 = "byres name OH2"

--- a/testsuite/MDAnalysisTests/coordinates/test_xdr.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_xdr.py
@@ -21,7 +21,7 @@
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
 import pytest
-from mock import patch
+from unittest.mock import patch
 
 import errno
 import numpy as np

--- a/testsuite/MDAnalysisTests/core/test_updating_atomgroup.py
+++ b/testsuite/MDAnalysisTests/core/test_updating_atomgroup.py
@@ -23,7 +23,7 @@
 import numpy as np
 import pytest
 from numpy.testing import assert_equal
-import mock
+from unittest import mock
 
 
 from MDAnalysisTests.datafiles import PSF, GRO, XTC

--- a/testsuite/MDAnalysisTests/import/fork_called.py
+++ b/testsuite/MDAnalysisTests/import/fork_called.py
@@ -21,7 +21,7 @@
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
 import os
-import mock
+from unittest import mock
 
 """Tests whether os.fork() is called as a side effect when importing MDAnalysis.
 See PR #1794 for details."""

--- a/testsuite/MDAnalysisTests/lib/test_util.py
+++ b/testsuite/MDAnalysisTests/lib/test_util.py
@@ -26,7 +26,7 @@ import os
 import warnings
 import re
 import textwrap
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 import sys
 
 import numpy as np

--- a/testsuite/MDAnalysisTests/topology/test_mmtf.py
+++ b/testsuite/MDAnalysisTests/topology/test_mmtf.py
@@ -1,7 +1,7 @@
 import pytest
 from numpy.testing import assert_equal
 import mmtf
-import mock
+from unittest import mock
 
 import MDAnalysis as mda
 from MDAnalysis.core.groups import AtomGroup

--- a/testsuite/MDAnalysisTests/util.py
+++ b/testsuite/MDAnalysisTests/util.py
@@ -37,7 +37,7 @@ except ImportError:
 from contextlib import contextmanager
 from functools import wraps
 import importlib
-import mock
+from unittest import mock
 import os
 import warnings
 import pytest

--- a/testsuite/setup.py
+++ b/testsuite/setup.py
@@ -184,7 +184,6 @@ if __name__ == '__main__':
               'pytest>=3.3.0', # Raised to 3.3.0 due to Issue 2329
               'hypothesis',
               'psutil>=4.0.2',
-              'mock>=2.0.0',  # replace with unittest.mock in python 3 only version
               'tidynamics>=1.0.0'
           ],
           # had 'KeyError' as zipped egg (2MB savings are not worth the


### PR DESCRIPTION
Fixes #2777 

Changes made in this Pull Request:
 - Removes dependency on mock and uses unittest.mock instead.


PR Checklist
------------
 - [x] Tests?
 - [ ] Docs? N/A
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
