### PR TITLE
Makes tidynamics a non required install

### DIFF
--- a/package/setup.py
+++ b/package/setup.py
@@ -564,7 +564,6 @@ if __name__ == '__main__':
           'joblib>=0.12',
           'scipy>=1.0.0',
           'matplotlib>=1.5.1',
-          'tidynamics>=1.0.0',
           'tqdm>=4.43.0',
     ]
     if not os.name == 'nt':
@@ -619,6 +618,7 @@ if __name__ == '__main__':
                               # plotting in PSA
                   'sklearn',  # For clustering and dimensionality reduction
                               # functionality in encore
+                  'tidynamics>=1.0.0', # For MSD analysis method
               ],
           },
           test_suite="MDAnalysisTests",

--- a/testsuite/MDAnalysisTests/analysis/test_msd.py
+++ b/testsuite/MDAnalysisTests/analysis/test_msd.py
@@ -91,16 +91,6 @@ def step_traj_arr(NSTEP):  # constant velocity
     return traj
 
 
-def random_walk_3d(NSTEP):
-    np.random.seed(1)
-    steps = -1 + 2*np.random.randint(0, 2, size=(NSTEP, 3))
-    traj = np.cumsum(steps, axis=0)
-    traj_reshape = traj.reshape([NSTEP, 1, 3])
-    u = mda.Universe.empty(1)
-    u.load_new(traj_reshape)
-    return u, traj
-
-
 def characteristic_poly(n, d):  # polynomial that describes unit step traj MSD
     x = np.arange(0, n)
     y = d*x*x

--- a/testsuite/MDAnalysisTests/analysis/test_msd.py
+++ b/testsuite/MDAnalysisTests/analysis/test_msd.py
@@ -103,6 +103,12 @@ class TestMSDSimple(object):
         # test some basic size and shape things
         assert_equal(msd.n_particles, 10)
 
+    @pytest.mark.parametrize('msdtype', ['foo', 'bar', 'yx', 'zyx'])
+    def test_msdtype_error(self, u, SELECTION, msdtype):
+        errmsg = f"invalid msd_type: {msdtype}"
+        with pytest.raises(ValueError, match=errmsg):
+            m = MSD(u, SELECTION, msd_type=msdtype)
+
     @pytest.mark.parametrize("dim, dim_factor", [
         ('xyz', 3), ('xy', 2), ('xz', 2), ('yz', 2), ('x', 1), ('y', 1),
         ('z', 1)

--- a/testsuite/MDAnalysisTests/analysis/test_msd.py
+++ b/testsuite/MDAnalysisTests/analysis/test_msd.py
@@ -31,7 +31,8 @@ import numpy as np
 from MDAnalysisTests.datafiles import PSF, DCD, RANDOM_WALK, RANDOM_WALK_TOPO
 
 import pytest
-import tidynamics
+
+pytest.importorskip('tidynamics')
 
 
 @pytest.fixture(scope='module')

--- a/testsuite/MDAnalysisTests/analysis/test_msd.py
+++ b/testsuite/MDAnalysisTests/analysis/test_msd.py
@@ -32,6 +32,8 @@ from MDAnalysisTests.datafiles import PSF, DCD, RANDOM_WALK, RANDOM_WALK_TOPO
 
 import pytest
 
+pytest.importorskip('tidynamics')
+
 
 @pytest.fixture(scope='module')
 def SELECTION():
@@ -158,7 +160,6 @@ def test_simple_step_traj_all_dims(step_traj, NSTEP, dim, dim_factor):
     poly = characteristic_poly(NSTEP, dim_factor)
     assert_almost_equal(m_simple.timeseries, poly, decimal=4)
 
-
 @pytest.mark.parametrize("dim, dim_factor", \
 [('xyz', 3), ('xy', 2), ('xz', 2), ('yz', 2), ('x', 1), ('y', 1), ('z', 1)])
 def test_simple_start_stop_step_all_dims(step_traj, NSTEP, dim, dim_factor):
@@ -184,7 +185,6 @@ def test_fft_step_traj_all_dims(step_traj, NSTEP, dim, dim_factor):
     poly = characteristic_poly(NSTEP, dim_factor)
     # this was relaxed from decimal=4 for numpy=1.13 test
     assert_almost_equal(m_simple.timeseries, poly, decimal=3)
-
 
 @pytest.mark.parametrize("dim, dim_factor", \
 [('xyz', 3), ('xy', 2), ('xz', 2), ('yz', 2), ('x', 1), ('y', 1), ('z', 1)])

--- a/testsuite/MDAnalysisTests/analysis/test_msd.py
+++ b/testsuite/MDAnalysisTests/analysis/test_msd.py
@@ -32,8 +32,6 @@ from MDAnalysisTests.datafiles import PSF, DCD, RANDOM_WALK, RANDOM_WALK_TOPO
 
 import pytest
 
-pytest.importorskip('tidynamics')
-
 
 @pytest.fixture(scope='module')
 def SELECTION():
@@ -160,6 +158,7 @@ def test_simple_step_traj_all_dims(step_traj, NSTEP, dim, dim_factor):
     poly = characteristic_poly(NSTEP, dim_factor)
     assert_almost_equal(m_simple.timeseries, poly, decimal=4)
 
+
 @pytest.mark.parametrize("dim, dim_factor", \
 [('xyz', 3), ('xy', 2), ('xz', 2), ('yz', 2), ('x', 1), ('y', 1), ('z', 1)])
 def test_simple_start_stop_step_all_dims(step_traj, NSTEP, dim, dim_factor):
@@ -185,6 +184,7 @@ def test_fft_step_traj_all_dims(step_traj, NSTEP, dim, dim_factor):
     poly = characteristic_poly(NSTEP, dim_factor)
     # this was relaxed from decimal=4 for numpy=1.13 test
     assert_almost_equal(m_simple.timeseries, poly, decimal=3)
+
 
 @pytest.mark.parametrize("dim, dim_factor", \
 [('xyz', 3), ('xy', 2), ('xz', 2), ('yz', 2), ('x', 1), ('y', 1), ('z', 1)])

--- a/testsuite/MDAnalysisTests/analysis/test_msd.py
+++ b/testsuite/MDAnalysisTests/analysis/test_msd.py
@@ -23,16 +23,15 @@
 
 
 import MDAnalysis as mda
-from MDAnalysis.analysis.msd import EinsteinMSD as MSD
 
 from numpy.testing import (assert_almost_equal, assert_equal)
 import numpy as np
 
 from MDAnalysisTests.datafiles import PSF, DCD, RANDOM_WALK, RANDOM_WALK_TOPO
+from MDAnalysisTests.util import block_import
 
 import pytest
-
-pytest.importorskip('tidynamics')
+from importlib import import_module
 
 
 @pytest.fixture(scope='module')
@@ -42,14 +41,29 @@ def SELECTION():
 
 
 @pytest.fixture(scope='module')
-def NSTEP():
-    nstep = 5000
-    return nstep
+def u():
+    return mda.Universe(PSF, DCD)
+
+
+@block_import('tidynamics')
+def test_notidynamics(u, SELECTION):
+    # Have to avoid importing until here as otherwise tidynamics will already
+    # be imported
+    from MDAnalysis.analysis.msd import EinsteinMSD as MSD
+
+    with pytest.raises(ImportError, match="tidynamics was not found"):
+        u = mda.Universe(PSF, DCD)
+        msd = MSD(u, SELECTION)
+        msd.run()
+
+
+from MDAnalysis.analysis.msd import EinsteinMSD as MSD
 
 
 @pytest.fixture(scope='module')
-def u():
-    return mda.Universe(PSF, DCD)
+def NSTEP():
+    nstep = 5000
+    return nstep
 
 
 @pytest.fixture(scope='module')
@@ -67,14 +81,6 @@ def msd(u, SELECTION):
 
 
 @pytest.fixture(scope='module')
-def msd_fft(u, SELECTION):
-    # fft msd
-    m = MSD(u, SELECTION, msd_type='xyz', fft=True)
-    m.run()
-    return m
-
-
-@pytest.fixture(scope='module')
 def step_traj(NSTEP):  # constant velocity
     x = np.arange(NSTEP)
     traj = np.vstack([x, x, x]).T
@@ -84,123 +90,138 @@ def step_traj(NSTEP):  # constant velocity
     return u
 
 
-@pytest.fixture(scope='module')
-def step_traj_arr(NSTEP):  # constant velocity
-    x = np.arange(NSTEP)
-    traj = np.vstack([x, x, x]).T
-    return traj
-
-
-def characteristic_poly(n, d):  # polynomial that describes unit step traj MSD
+def characteristic_poly(n, d):
+    # polynomial that describes unit step traj MSD
     x = np.arange(0, n)
     y = d*x*x
     return y
 
 
-def test_selection_works(msd):
-    # test some basic size and shape things
-    assert_equal(msd.n_particles, 10)
+class TestMSDSimple(object):
+
+    def test_selection_works(self, msd):
+        # test some basic size and shape things
+        assert_equal(msd.n_particles, 10)
+
+    @pytest.mark.parametrize("dim, dim_factor", [
+        ('xyz', 3), ('xy', 2), ('xz', 2), ('yz', 2), ('x', 1), ('y', 1),
+        ('z', 1)
+    ])
+    def test_simple_step_traj_all_dims(self, step_traj, NSTEP, dim,
+                                       dim_factor):
+        # testing the "simple" algorithm on constant velocity trajectory
+        # should fit the polynomial y=dim_factor*x**2
+        m_simple = MSD(step_traj, 'all', msd_type=dim, fft=False)
+        m_simple.run()
+        poly = characteristic_poly(NSTEP, dim_factor)
+        assert_almost_equal(m_simple.timeseries, poly, decimal=4)
+
+    @pytest.mark.parametrize("dim, dim_factor", [
+        ('xyz', 3), ('xy', 2), ('xz', 2), ('yz', 2), ('x', 1), ('y', 1),
+        ('z', 1)
+    ])
+    def test_simple_start_stop_step_all_dims(self, step_traj, NSTEP, dim,
+                                             dim_factor):
+        # testing the "simple" algorithm on constant velocity trajectory
+        # test start stop step is working correctly
+        m_simple = MSD(step_traj, 'all', msd_type=dim, fft=False)
+        m_simple.run(start=10, stop=1000, step=10)
+        poly = characteristic_poly(NSTEP, dim_factor)
+        # polynomial must take offset start into account
+        assert_almost_equal(m_simple.timeseries, poly[0:990:10], decimal=4)
+
+    def test_random_walk_u_simple(self, random_walk_u):
+        # regress against random_walk test data
+        msd_rw = MSD(random_walk_u, 'all', msd_type='xyz', fft=False)
+        msd_rw.run()
+        norm = np.linalg.norm(msd_rw.timeseries)
+        val = 3932.39927487146
+        assert_almost_equal(norm, val, decimal=5)
 
 
-def test_fft_vs_simple_default(msd, msd_fft):
-    # testing on the  PSF, DCD trajectory
-    timeseries_simple = msd.timeseries
-    timeseries_fft = msd_fft.timeseries
-    assert_almost_equal(timeseries_simple, timeseries_fft, decimal=4)
+def import_check(module):
+    try:
+        test = import_module(module)
+    except ImportError:
+        return True
+    else:
+        return False
 
 
-def test_fft_vs_simple_default_per_particle(msd, msd_fft):
-    # check fft and simple give same result per particle
-    per_particle_simple = msd.msds_by_particle
-    per_particle_fft = msd_fft.msds_by_particle
-    assert_almost_equal(per_particle_simple, per_particle_fft, decimal=4)
+@pytest.mark.skipif(import_check("tidynamics"),
+                    reason="Test skipped because tidynamics not found")
+class TestMSDFFT(object):
 
+    @pytest.fixture(scope='class')
+    def msd_fft(self, u, SELECTION):
+        # fft msd
+        m = MSD(u, SELECTION, msd_type='xyz', fft=True)
+        m.run()
+        return m
 
-@pytest.mark.parametrize("dim", ['xyz', 'xy', 'xz', 'yz', 'x', 'y', 'z'])
-def test_fft_vs_simple_all_dims(u, SELECTION, dim):
-    # check fft and simple give same result for each dimensionality
-    m_simple = MSD(u, SELECTION, msd_type=dim, fft=False)
-    m_simple.run()
-    timeseries_simple = m_simple.timeseries
-    m_fft = MSD(u, SELECTION, msd_type=dim, fft=True)
-    m_fft.run()
-    timeseries_fft = m_fft.timeseries
-    assert_almost_equal(timeseries_simple, timeseries_fft, decimal=4)
+    def test_fft_vs_simple_default(self, msd, msd_fft):
+        # testing on the  PSF, DCD trajectory
+        timeseries_simple = msd.timeseries
+        timeseries_fft = msd_fft.timeseries
+        assert_almost_equal(timeseries_simple, timeseries_fft, decimal=4)
 
+    def test_fft_vs_simple_default_per_particle(self, msd, msd_fft):
+        # check fft and simple give same result per particle
+        per_particle_simple = msd.msds_by_particle
+        per_particle_fft = msd_fft.msds_by_particle
+        assert_almost_equal(per_particle_simple, per_particle_fft, decimal=4)
 
-@pytest.mark.parametrize("dim", ['xyz', 'xy', 'xz', 'yz', 'x', 'y', 'z'])
-def test_fft_vs_simple_all_dims_per_particle(u, SELECTION, dim):
-    # check fft and simple give same result for each particle in each dimension
-    m_simple = MSD(u, SELECTION, msd_type=dim, fft=False)
-    m_simple.run()
-    per_particle_simple = m_simple.msds_by_particle
-    m_fft = MSD(u, SELECTION, msd_type=dim, fft=True)
-    m_fft.run()
-    per_particle_fft = m_fft.msds_by_particle
-    assert_almost_equal(per_particle_simple, per_particle_fft, decimal=4)
+    @pytest.mark.parametrize("dim", ['xyz', 'xy', 'xz', 'yz', 'x', 'y', 'z'])
+    def test_fft_vs_simple_all_dims(self, u, SELECTION, dim):
+        # check fft and simple give same result for each dimensionality
+        m_simple = MSD(u, SELECTION, msd_type=dim, fft=False)
+        m_simple.run()
+        timeseries_simple = m_simple.timeseries
+        m_fft = MSD(u, SELECTION, msd_type=dim, fft=True)
+        m_fft.run()
+        timeseries_fft = m_fft.timeseries
+        assert_almost_equal(timeseries_simple, timeseries_fft, decimal=4)
 
+    @pytest.mark.parametrize("dim", ['xyz', 'xy', 'xz', 'yz', 'x', 'y', 'z'])
+    def test_fft_vs_simple_all_dims_per_particle(self, u, SELECTION, dim):
+        # check fft and simple give same result for each particle in each dimension
+        m_simple = MSD(u, SELECTION, msd_type=dim, fft=False)
+        m_simple.run()
+        per_particle_simple = m_simple.msds_by_particle
+        m_fft = MSD(u, SELECTION, msd_type=dim, fft=True)
+        m_fft.run()
+        per_particle_fft = m_fft.msds_by_particle
+        assert_almost_equal(per_particle_simple, per_particle_fft, decimal=4)
 
-@pytest.mark.parametrize("dim, dim_factor", \
-[('xyz', 3), ('xy', 2), ('xz', 2), ('yz', 2), ('x', 1), ('y', 1), ('z', 1)])
-def test_simple_step_traj_all_dims(step_traj, NSTEP, dim, dim_factor):
-    # testing the "simple" algorithm on constant velocity trajectory
-    # should fit the polynomial y=dim_factor*x**2
-    m_simple = MSD(step_traj, 'all', msd_type=dim, fft=False)
-    m_simple.run()
-    poly = characteristic_poly(NSTEP, dim_factor)
-    assert_almost_equal(m_simple.timeseries, poly, decimal=4)
+    @pytest.mark.parametrize("dim, dim_factor", \
+    [('xyz', 3), ('xy', 2), ('xz', 2), ('yz', 2), ('x', 1), ('y', 1), ('z', 1)])
+    def test_fft_step_traj_all_dims(self, step_traj, NSTEP, dim, dim_factor):
+        # testing the fft algorithm on constant velocity trajectory
+        # this should fit the polynomial y=dim_factor*x**2
+        # fft based tests require a slight decrease in expected prescision
+        # primarily due to roundoff in fft(ifft()) calls.
+        # relative accuracy expected to be around ~1e-12
+        m_simple = MSD(step_traj, 'all', msd_type=dim, fft=True)
+        m_simple.run()
+        poly = characteristic_poly(NSTEP, dim_factor)
+        # this was relaxed from decimal=4 for numpy=1.13 test
+        assert_almost_equal(m_simple.timeseries, poly, decimal=3)
 
-@pytest.mark.parametrize("dim, dim_factor", \
-[('xyz', 3), ('xy', 2), ('xz', 2), ('yz', 2), ('x', 1), ('y', 1), ('z', 1)])
-def test_simple_start_stop_step_all_dims(step_traj, NSTEP, dim, dim_factor):
-    # testing the "simple" algorithm on constant velocity trajectory
-    # test start stop step is working correctly
-    m_simple = MSD(step_traj, 'all', msd_type=dim, fft=False)
-    m_simple.run(start=10, stop=1000, step=10)
-    poly = characteristic_poly(NSTEP, dim_factor)
-    # polynomial must take offset start into account
-    assert_almost_equal(m_simple.timeseries, poly[0:990:10], decimal=4)
+    @pytest.mark.parametrize("dim, dim_factor", \
+    [('xyz', 3), ('xy', 2), ('xz', 2), ('yz', 2), ('x', 1), ('y', 1), ('z', 1)])
+    def test_fft_start_stop_step_all_dims(self, step_traj, NSTEP, dim, dim_factor):
+        # testing the fft algorithm on constant velocity trajectory
+        # test start stop step is working correctly
+        m_simple = MSD(step_traj, 'all', msd_type=dim, fft=True)
+        m_simple.run(start=10, stop=1000, step=10)
+        poly = characteristic_poly(NSTEP, dim_factor)
+        # polynomial must take offset start into account
+        assert_almost_equal(m_simple.timeseries, poly[0:990:10], decimal=3)
 
-
-@pytest.mark.parametrize("dim, dim_factor", \
-[('xyz', 3), ('xy', 2), ('xz', 2), ('yz', 2), ('x', 1), ('y', 1), ('z', 1)])
-def test_fft_step_traj_all_dims(step_traj, NSTEP, dim, dim_factor):
-    # testing the fft algorithm on constant velocity trajectory
-    # this should fit the polynomial y=dim_factor*x**2
-    # fft based tests require a slight decrease in expected prescision
-    # primarily due to roundoff in fft(ifft()) calls.
-    # relative accuracy expected to be around ~1e-12
-    m_simple = MSD(step_traj, 'all', msd_type=dim, fft=True)
-    m_simple.run()
-    poly = characteristic_poly(NSTEP, dim_factor)
-    # this was relaxed from decimal=4 for numpy=1.13 test
-    assert_almost_equal(m_simple.timeseries, poly, decimal=3)
-
-@pytest.mark.parametrize("dim, dim_factor", \
-[('xyz', 3), ('xy', 2), ('xz', 2), ('yz', 2), ('x', 1), ('y', 1), ('z', 1)])
-def test_fft_start_stop_step_all_dims(step_traj, NSTEP, dim, dim_factor):
-    # testing the fft algorithm on constant velocity trajectory
-    # test start stop step is working correctly
-    m_simple = MSD(step_traj, 'all', msd_type=dim, fft=True)
-    m_simple.run(start=10, stop=1000, step=10)
-    poly = characteristic_poly(NSTEP, dim_factor)
-    # polynomial must take offset start into account
-    assert_almost_equal(m_simple.timeseries, poly[0:990:10], decimal=3)
-
-
-def test_random_walk_u_simple(random_walk_u):
-    # regress against random_walk test data
-    msd_rw = MSD(random_walk_u, 'all', msd_type='xyz', fft=False)
-    msd_rw.run()
-    norm = np.linalg.norm(msd_rw.timeseries)
-    val = 3932.39927487146
-    assert_almost_equal(norm, val, decimal=5)
-
-
-def test_random_walk_u_fft(random_walk_u):
-    # regress against random_walk test data
-    msd_rw = MSD(random_walk_u, 'all', msd_type='xyz', fft=True)
-    msd_rw.run()
-    norm = np.linalg.norm(msd_rw.timeseries)
-    val = 3932.39927487146
-    assert_almost_equal(norm, val, decimal=5)
+    def test_random_walk_u_fft(self, random_walk_u):
+        # regress against random_walk test data
+        msd_rw = MSD(random_walk_u, 'all', msd_type='xyz', fft=True)
+        msd_rw.run()
+        norm = np.linalg.norm(msd_rw.timeseries)
+        val = 3932.39927487146
+        assert_almost_equal(norm, val, decimal=5)

--- a/testsuite/MDAnalysisTests/analysis/test_msd.py
+++ b/testsuite/MDAnalysisTests/analysis/test_msd.py
@@ -28,7 +28,7 @@ from numpy.testing import (assert_almost_equal, assert_equal)
 import numpy as np
 
 from MDAnalysisTests.datafiles import PSF, DCD, RANDOM_WALK, RANDOM_WALK_TOPO
-from MDAnalysisTests.util import block_import
+from MDAnalysisTests.util import block_import, import_not_available
 
 import pytest
 from importlib import import_module
@@ -145,16 +145,7 @@ class TestMSDSimple(object):
         assert_almost_equal(norm, val, decimal=5)
 
 
-def import_check(module):
-    try:
-        test = import_module(module)
-    except ImportError:
-        return True
-    else:
-        return False
-
-
-@pytest.mark.skipif(import_check("tidynamics"),
+@pytest.mark.skipif(import_not_available("tidynamics"),
                     reason="Test skipped because tidynamics not found")
 class TestMSDFFT(object):
 

--- a/testsuite/MDAnalysisTests/analysis/test_msd.py
+++ b/testsuite/MDAnalysisTests/analysis/test_msd.py
@@ -31,7 +31,6 @@ from MDAnalysisTests.datafiles import PSF, DCD, RANDOM_WALK, RANDOM_WALK_TOPO
 from MDAnalysisTests.util import block_import, import_not_available
 
 import pytest
-from importlib import import_module
 
 
 @pytest.fixture(scope='module')

--- a/testsuite/MDAnalysisTests/util.py
+++ b/testsuite/MDAnalysisTests/util.py
@@ -25,14 +25,9 @@ Useful functions for running tests
 
 """
 
-try:
-    import __builtin__
-    builtins_name = '__builtin__'
-    importer = __builtin__.__import__
-except ImportError:
-    import builtins
-    builtins_name = 'builtins'
-    importer = builtins.__import__
+import builtins
+builtins_name = 'builtins'
+importer = builtins.__import__
 
 from contextlib import contextmanager
 from functools import wraps
@@ -93,6 +88,38 @@ def executable_not_found(*args):
         if MDAnalysis.lib.util.which(name) is not None:
             return False
     return True
+
+
+def import_not_available(module_name):
+    """Helper function to check if a module cannot be imported, intended as an
+    argument of pytest.mark.skipif
+
+    Parameters
+    ----------
+    module_name : str
+        Name of module to test importing
+
+    Returns
+    -------
+    True
+        if module cannot be imported
+    False
+        otherwise (i.e. module can be imported)
+
+    Example
+    -------
+    To be used in the following manner::
+
+    @pytest.mark.skipif(import_not_available("module_name"),
+                        msg="skip test as module_name could not be imported")
+
+    """
+    try:
+        test = importlib.import_module(module_name)
+    except ImportError:
+        return True
+    else:
+        return False
 
 
 @contextmanager
@@ -213,6 +240,7 @@ class _NoDeprecatedCallContext(object):
                 __tracebackhide__ = True
                 msg = "Produced DeprecationWarning or PendingDeprecationWarning"
                 raise AssertionError(msg)
+
 
 def no_deprecated_call(func=None, *args, **kwargs):
 	# modified version of similar pytest function

--- a/testsuite/setup.py
+++ b/testsuite/setup.py
@@ -184,7 +184,6 @@ if __name__ == '__main__':
               'pytest>=3.3.0', # Raised to 3.3.0 due to Issue 2329
               'hypothesis',
               'psutil>=4.0.2',
-              'tidynamics>=1.0.0'
           ],
           # had 'KeyError' as zipped egg (2MB savings are not worth the
           # trouble)


### PR DESCRIPTION
Fixes #2782

Changes made in this Pull Request:
 - Removes tidynamics from install_requires lists
 - Refactors MSD tests to allow for partial testing when tidynamics is not available.
 - Make MSD FFT tests skip if no tidynamics

To do:
 - <s>There are two reasonably easy tests for MSD that I could add here whilst I'm at it (ImportError and ValueError). For the ImportError, I think the only way to get this done cleanly is to put the current tests in a class and put the skip as a decorator for that class only, thoughts?</s>
 - <s>PEP8 fixes</s>


PR Checklist
------------
 - [x] Tests?
 - [x] Docs? N/A
 - [x] CHANGELOG updated? Nothing changed for users here, is this necessary?
 - [x] Issue raised/referenced?
