### PR TITLE
make Atom target class of ResidueAttr by default

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -23,6 +23,7 @@ Fixes
   * TOPParser no longer guesses elements when missing atomic number records
     (Issues #2449, #2651)
   * Testsuite does not any more matplotlib.use('agg') (#2191)
+  * ResidueAttrs now have Atom as a target class by default (#2803)
 
 Enhancements
   * Added the RDKitParser which creates a `core.topology.Topology` object from 

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -18,12 +18,13 @@ The rules for this file:
   * 2.0.0
 
 Fixes
+  * ResidueAttrs now have Atom as a target class by default; ICodes and 
+    Molnums now have default target_classes (#2803, PR #2805)
   * Selections on emtpy AtomGroups now return an empty AtomGroup instead of an
     error (Issue #2765)
   * TOPParser no longer guesses elements when missing atomic number records
     (Issues #2449, #2651)
   * Testsuite does not any more matplotlib.use('agg') (#2191)
-  * ResidueAttrs now have Atom as a target class by default (#2803)
 
 Enhancements
   * Added the RDKitParser which creates a `core.topology.Topology` object from 

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -576,9 +576,9 @@ class Atomnames(AtomAttr):
                 except IndexError:
                     invalid.append(i)
             prev = sum(prevls)
-        
+
         keep_prev = [sum(r.atoms.names == c_name) == 1 for r in prev]
-        keep_res = [all(sum(r.atoms.names == n) == 1 for n in ncac_names) 
+        keep_res = [all(sum(r.atoms.names == n) == 1 for n in ncac_names)
                     for r in residues]
         keep = np.array(keep_prev) & np.array(keep_res)
         keep[invalid] = False
@@ -587,7 +587,7 @@ class Atomnames(AtomAttr):
         prev = prev[keep]
         residues = residues[keep]
         keepix = np.where(keep)[0]
-        
+
         c_ = prev.atoms[prev.atoms.names == c_name]
         n = residues.atoms[residues.atoms.names == n_name]
         ca = residues.atoms[residues.atoms.names == ca_name]
@@ -596,7 +596,6 @@ class Atomnames(AtomAttr):
         return list(results)
 
     transplants[ResidueGroup].append(('phi_selections', phi_selections))
-
 
     def psi_selection(residue, c_name='C', n_name='N', ca_name='CA'):
         """Select AtomGroup corresponding to the psi protein backbone dihedral
@@ -724,7 +723,6 @@ class Atomnames(AtomAttr):
                     pvres[i] = None
         return pvres
 
-    
     transplants[ResidueGroup].append(('_get_prev_residues_by_resid',
                                       _get_prev_residues_by_resid))
 
@@ -758,13 +756,13 @@ class Atomnames(AtomAttr):
         ncac_names = [n_name, ca_name, c_name]
 
         keep_nxt = [sum(r.atoms.names == n_name) == 1 for r in nxt]
-        keep_res = [all(sum(r.atoms.names == n) == 1 for n in ncac_names) 
+        keep_res = [all(sum(r.atoms.names == n) == 1 for n in ncac_names)
                     for r in residues]
         keep = np.array(keep_nxt) & np.array(keep_res)
         nxt = nxt[keep]
         residues = residues[keep]
         keepix = np.where(keep)[0]
-        
+
         n = residues.atoms[residues.atoms.names == n_name]
         ca = residues.atoms[residues.atoms.names == ca_name]
         c = residues.atoms[residues.atoms.names == c_name]
@@ -863,18 +861,18 @@ class Atomnames(AtomAttr):
         rix = np.where(nxtres)[0]
         nxt = sum(nxtres[rix])
         residues = residues[rix]
-        
+
         nxtatoms = [ca_name, n_name]
         resatoms = [ca_name, c_name]
-        keep_nxt = [all(sum(r.atoms.names == n) == 1 for n in nxtatoms) 
+        keep_nxt = [all(sum(r.atoms.names == n) == 1 for n in nxtatoms)
                     for r in nxt]
-        keep_res = [all(sum(r.atoms.names == n) == 1 for n in resatoms) 
+        keep_res = [all(sum(r.atoms.names == n) == 1 for n in resatoms)
                     for r in residues]
         keep = np.array(keep_nxt) & np.array(keep_res)
         nxt = nxt[keep]
         residues = residues[keep]
         keepix = np.where(keep)[0]
-        
+
         c = residues.atoms[residues.atoms.names == c_name]
         ca = residues.atoms[residues.atoms.names == ca_name]
         n_ = nxt.atoms[nxt.atoms.names == n_name]
@@ -885,7 +883,7 @@ class Atomnames(AtomAttr):
 
     transplants[ResidueGroup].append(('omega_selections', omega_selections))
 
-    def chi1_selection(residue, n_name='N', ca_name='CA', cb_name='CB', 
+    def chi1_selection(residue, n_name='N', ca_name='CA', cb_name='CB',
                        cg_name='CG'):
         """Select AtomGroup corresponding to the chi1 sidechain dihedral N-CA-CB-CG.
 
@@ -914,13 +912,13 @@ class Atomnames(AtomAttr):
         """
         names = [n_name, ca_name, cb_name, cg_name]
         ags = [residue.atoms[residue.atoms.names == n] for n in names]
-        if any(len(ag)!= 1 for ag in ags):
+        if any(len(ag) != 1 for ag in ags):
             return None
         return sum(ags)
 
     transplants[Residue].append(('chi1_selection', chi1_selection))
 
-    def chi1_selections(residues, n_name='N', ca_name='CA', cb_name='CB', 
+    def chi1_selections(residues, n_name='N', ca_name='CA', cb_name='CB',
                         cg_name='CG'):
         """Select list of AtomGroups corresponding to the chi1 sidechain dihedral 
         N-CA-CB-CG.
@@ -946,7 +944,7 @@ class Atomnames(AtomAttr):
         """
         results = np.array([None]*len(residues))
         names = [n_name, ca_name, cb_name, cg_name]
-        keep = [all(sum(r.atoms.names == n) == 1 for n in names) 
+        keep = [all(sum(r.atoms.names == n) == 1 for n in names)
                 for r in residues]
         keepix = np.where(keep)[0]
         residues = residues[keep]
@@ -955,7 +953,7 @@ class Atomnames(AtomAttr):
         ags = [residues.atoms[atnames == n] for n in names]
         results[keepix] = [sum(atoms) for atoms in zip(*ags)]
         return list(results)
-    
+
     transplants[ResidueGroup].append(('chi1_selections', chi1_selections))
 
 
@@ -1875,7 +1873,6 @@ class Molnums(ResidueAttr):
     """
     attrname = 'molnums'
     singular = 'molnum'
-    target_classes = [AtomGroup, ResidueGroup, Atom, Residue]
     dtype = np.intp
 
 # segment attributes
@@ -1887,7 +1884,8 @@ class SegmentAttr(TopologyAttr):
     """
     attrname = 'segmentattrs'
     singular = 'segmentattr'
-    target_classes = [AtomGroup, ResidueGroup, SegmentGroup, Atom, Residue, Segment]
+    target_classes = [AtomGroup, ResidueGroup,
+                      SegmentGroup, Atom, Residue, Segment]
     per_object = 'segment'
 
     def get_atoms(self, ag):

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -1687,7 +1687,7 @@ class Aromaticities(AtomAttr):
 class ResidueAttr(TopologyAttr):
     attrname = 'residueattrs'
     singular = 'residueattr'
-    target_classes = [AtomGroup, ResidueGroup, SegmentGroup, Residue]
+    target_classes = [AtomGroup, ResidueGroup, SegmentGroup, Atom, Residue]
     per_object = 'residue'
 
     def get_atoms(self, ag):
@@ -1722,7 +1722,6 @@ class Resids(ResidueAttr):
     """Residue ID"""
     attrname = 'resids'
     singular = 'resid'
-    target_classes = [AtomGroup, ResidueGroup, SegmentGroup, Atom, Residue]
     dtype = int
 
     @staticmethod
@@ -1734,7 +1733,6 @@ class Resids(ResidueAttr):
 class Resnames(ResidueAttr):
     attrname = 'resnames'
     singular = 'resname'
-    target_classes = [AtomGroup, ResidueGroup, SegmentGroup, Atom, Residue]
     transplants = defaultdict(list)
     dtype = object
 
@@ -1844,7 +1842,6 @@ class Resnames(ResidueAttr):
 class Resnums(ResidueAttr):
     attrname = 'resnums'
     singular = 'resnum'
-    target_classes = [AtomGroup, ResidueGroup, SegmentGroup, Atom, Residue]
     dtype = int
 
     @staticmethod
@@ -1870,14 +1867,11 @@ class Moltypes(ResidueAttr):
     """
     attrname = 'moltypes'
     singular = 'moltype'
-    target_classes = [AtomGroup, ResidueGroup, SegmentGroup, Atom, Residue]
     dtype = object
 
 
 class Molnums(ResidueAttr):
-    """Name of the molecule type
-
-    Two molecules that share a molecule type share a common template topology.
+    """Index of molecule from 0
     """
     attrname = 'molnums'
     singular = 'molnum'
@@ -1893,7 +1887,7 @@ class SegmentAttr(TopologyAttr):
     """
     attrname = 'segmentattrs'
     singular = 'segmentattr'
-    target_classes = [AtomGroup, ResidueGroup, SegmentGroup, Segment]
+    target_classes = [AtomGroup, ResidueGroup, SegmentGroup, Atom, Residue, Segment]
     per_object = 'segment'
 
     def get_atoms(self, ag):
@@ -1922,8 +1916,6 @@ class SegmentAttr(TopologyAttr):
 class Segids(SegmentAttr):
     attrname = 'segids'
     singular = 'segid'
-    target_classes = [AtomGroup, ResidueGroup, SegmentGroup,
-                      Atom, Residue, Segment]
     transplants = defaultdict(list)
     dtype = object
 

--- a/testsuite/MDAnalysisTests/core/test_topologyattrs.py
+++ b/testsuite/MDAnalysisTests/core/test_topologyattrs.py
@@ -80,6 +80,10 @@ class TopologyAttrMixin(object):
     def attr(self, top):
         return getattr(top, self.attrclass.attrname)
 
+    @pytest.fixture()
+    def universe(self, top):
+        return mda.Universe(top)
+
     def test_len(self, attr):
         assert len(attr) == len(attr.values)
 
@@ -215,6 +219,10 @@ class TestResidueAttr(TopologyAttrMixin):
         assert_equal(attr.get_atoms(DummyGroup([7, 3, 9])),
                            self.values[[3, 2, 2]])
 
+    def test_get_atom(self, universe):
+        attr = getattr(universe.atoms[0], self.attrclass.singular)
+        assert_equal(attr, self.values[0])
+
     def test_get_residues(self, attr):
         assert_equal(attr.get_residues(DummyGroup([1, 2, 1, 3])),
                            self.values[[1, 2, 1, 3]])
@@ -246,6 +254,9 @@ class TestResidueAttr(TopologyAttrMixin):
         assert_equal(attr.get_segments(DummyGroup([0, 1, 1])),
                            [self.values[[0, 3]], self.values[[1, 2]], self.values[[1, 2]]])
 
+class TestICodes(TestResidueAttr):
+    values = np.array(['a', 'b', '', 'd'])
+    attrclass = tpattrs.ICodes
 
 class TestResids(TestResidueAttr):
     values = np.array([10, 11, 18, 20])


### PR DESCRIPTION
Fixes #2803 

Changes made in this Pull Request:
 - made Atom a target class of ResidueAttr by default
 - made ICode therefore an Atom attribute
 - ~left Molnums alone but I feel that this should also be a SegmentGroup attribute, like Moltypes? Or even a SegmentAttr as the code seems to start a new segment for each gmx molecule (pinging @jbarnoud)~
 - made Molnums have default target classes, thereby adding it as a SegmentGroup attribute
   - Molnums cannot be a SegmentAttr [per @jbarnoud's comment](https://github.com/MDAnalysis/mdanalysis/pull/2805#issuecomment-651590532)


PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
