### PR TITLE
[test] aligntraj + transform on XTC file

### DIFF
--- a/testsuite/MDAnalysisTests/analysis/test_align.py
+++ b/testsuite/MDAnalysisTests/analysis/test_align.py
@@ -31,7 +31,7 @@ import pytest
 from MDAnalysis import SelectionError, SelectionWarning
 from MDAnalysisTests import executable_not_found
 from MDAnalysisTests.datafiles import (PSF, DCD, CRD, FASTA, ALIGN_BOUND,
-                                       ALIGN_UNBOUND)
+                                       ALIGN_UNBOUND, GRO, XTC)
 from numpy.testing import (
     assert_almost_equal,
     assert_equal,
@@ -504,6 +504,18 @@ class TestAlignmentProcessing(object):
                                                 "unexpected length")
         assert len(
             sel['mobile']) == 23090, "selection string has unexpected length"
+
+
+# temporary test to see if downstream issue can be replicated
+def test_aligntraj_xtc(tmpdir):
+    u = mda.Universe(GRO, XTC)
+
+    aligner = align.AlignTraj(u, u, select='protein and name CA',
+                              in_memory=True)
+
+    aligner.run()
+
+    assert 1 == 1
 
 
 def test_sequence_alignment():

--- a/testsuite/MDAnalysisTests/transformations/test_fit.py
+++ b/testsuite/MDAnalysisTests/transformations/test_fit.py
@@ -23,7 +23,9 @@ import numpy as np
 import pytest
 from numpy.testing import assert_array_almost_equal
 
+import MDAnalysis as mda
 from MDAnalysisTests import make_Universe
+from MDAnalysisTests.datafiles import TPR, XTC
 from MDAnalysis.transformations.fit import fit_translation, fit_rot_trans
 from MDAnalysis.lib.transformations import rotation_matrix
 
@@ -268,3 +270,11 @@ def test_fit_rot_trans_transformations_api(fit_universe):
     transform = fit_rot_trans(test_u, ref_u)
     test_u.trajectory.add_transformations(transform)
     assert_array_almost_equal(test_u.trajectory.ts.positions, ref_u.trajectory.ts.positions, decimal=3)
+
+
+def test_xtc_transform():
+    u = mda.Universe(TPR, XTC)
+    protein = u.select_atoms('protein')
+    align_transform = fit_rot_trans(protein, protein, weights=protein.masses)
+    u.trajectory.add_transformations(align_transform)
+    assert 1 == 1


### PR DESCRIPTION
Test for #2818 

Apologies for the excess noise here, I'm trying to see if the downstream issue I'm seeing can be replicated here.

Changes made in this Pull Request:
 - Adds an aligntraj test using GRO/XTC

Update:

Interestingly Travis here does not seem to fail in the way seen downstream. However, I can reproduce a similar segfault to what the userguide also gets, so I'm going to add the case for where the user guide fails and see if that also "works" here.

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
