### PR TITLE
MAINT: fixes for NumPy master

### DIFF
--- a/package/MDAnalysis/core/selection.py
+++ b/package/MDAnalysis/core/selection.py
@@ -530,7 +530,7 @@ class StringSelection(Selection):
 
     @return_empty_on_apply
     def apply(self, group):
-        mask = np.zeros(len(group), dtype=np.bool)
+        mask = np.zeros(len(group), dtype=bool)
         for val in self.values:
             values = getattr(group, self.field)
             mask |= [fnmatch.fnmatch(x, val) for x in values]

--- a/package/MDAnalysis/topology/base.py
+++ b/package/MDAnalysis/topology/base.py
@@ -196,7 +196,7 @@ def change_squash(criteria, to_squash):
 
     # 2) Allocate new arrays
     # Per atom record of what residue they belong to
-    residx = np.zeros_like(criteria[0], dtype=np.int)
+    residx = np.zeros_like(criteria[0], dtype=int)
     # Per residue record of various attributes
     new_others = [np.zeros(nres, dtype=o.dtype) for o in to_squash]
 


### PR DESCRIPTION
* fixes needed to get full MDA test suite passing
with NumPy `master` branch

* remove usage of pertinent deprecated NumPy type aliases
like `np.int`; see https://github.com/numpy/numpy/pull/14882

* this only removes the deprecated type aliases that cause
MDAnalysis test suite failures; there are still deprecated uses
that do not cause failures, however the volume of warnings
emitted by the MDAnalysis test suite is so large that only
actual test failures are addressed at this time (I will try
to follow-up for the remainder later)

* it may be worthwhile to consider addition of a CI matrix
entry using a NumPy pre-release wheel, although that addition
is not made here

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
