### PR TITLE
Create .pep8speaks.yml

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -1,0 +1,5 @@
+scanner:
+  diff_only: True
+
+pycodestyle:
+  max-line-length: 100

--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -2,4 +2,4 @@ scanner:
   diff_only: True
 
 pycodestyle:
-  max-line-length: 100
+  max-line-length: 79


### PR DESCRIPTION
I found that the 79 char limit of pep8 is pretty restricting. Often extending it to 100 allows for more natural code. It works great for me to still view two files side by side on my laptop. Jake VanderPlas had a good entry about line length statistics in python on his [blog](https://jakevdp.github.io/blog/2017/11/09/exploring-line-lengths-in-python-packages/)

Fixes #

Changes made in this Pull Request:
 - 


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
