### PR TITLE
Set numpy and rdkit min version

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,7 +10,7 @@ cache:
 environment:
     global:
         CONDA_CHANNELS: conda-forge
-        CONDA_DEPENDENCIES: pip setuptools wheel cython biopython networkx joblib matplotlib scipy vs2015_runtime pytest mmtf-python GridDataFormats hypothesis pytest-cov codecov chemfiles tqdm tidynamics>=1.0.0 rdkit
+        CONDA_DEPENDENCIES: pip setuptools wheel cython biopython networkx joblib matplotlib scipy vs2015_runtime pytest mmtf-python GridDataFormats hypothesis pytest-cov codecov chemfiles tqdm tidynamics>=1.0.0 rdkit>=2020.03.1
         PIP_DEPENDENCIES: gsd==1.9.3 duecredit parmed
         DEBUG: "False"
         MINGW_64: C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ env:
     - SETUP_CMD="${PYTEST_FLAGS}"
     - BUILD_CMD="pip install -e package/ && (cd testsuite/ && python setup.py build)"
     - CONDA_MIN_DEPENDENCIES="mmtf-python biopython networkx cython matplotlib scipy griddataformats hypothesis gsd codecov"
-    - CONDA_DEPENDENCIES="${CONDA_MIN_DEPENDENCIES} seaborn>=0.7.0 clustalw=2.1 netcdf4 scikit-learn joblib>=0.12 chemfiles tqdm>=4.43.0 tidynamics>=1.0.0 rdkit"
+    - CONDA_DEPENDENCIES="${CONDA_MIN_DEPENDENCIES} seaborn>=0.7.0 clustalw=2.1 netcdf4 scikit-learn joblib>=0.12 chemfiles tqdm>=4.43.0 tidynamics>=1.0.0 rdkit>=2020.03.1"
     - CONDA_CHANNELS='biobuilds conda-forge'
     - CONDA_CHANNEL_PRIORITY=True
     - PIP_DEPENDENCIES="duecredit parmed"
@@ -43,7 +43,7 @@ env:
     - CODECOV="true" SETUP_CMD="${PYTEST_FLAGS} --cov=MDAnalysis"
     - PYTHON_VERSION=3.8 CODECOV="true" SETUP_CMD="${PYTEST_FLAGS} --cov=MDAnalysis"
     - PYTHON_VERSION=3.7 CODECOV="true" SETUP_CMD="${PYTEST_FLAGS} --cov=MDAnalysis"
-    - NUMPY_VERSION=1.13.3
+    - NUMPY_VERSION=1.16.0
     - NUMPY_VERSION=dev  EVENT_TYPE="cron"
 
 matrix:

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -47,6 +47,8 @@ Changes
   * Removes deprecated ProgressMeter (Issue #2739)
   * Removes deprecated MDAnalysis.units.N_Avogadro (PR #2737)
   * Dropped Python 2 support
+  * Changes the minimal NumPy version to 1.16.0 (Issue #2827, PR #2831)
+  * Sets the minimal RDKit version for CI to 2020.03.1 (Issue #2827, PR #2831)
 
 Deprecations
 

--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -10,7 +10,7 @@ mmtf-python
 msmb_theme==1.2.0
 netcdf4
 networkx
-numpy
+numpy>=1.16.0
 parmed
 psutil
 pytest

--- a/package/setup.py
+++ b/package/setup.py
@@ -188,7 +188,7 @@ def get_numpy_include():
         import numpy as np
     except ImportError:
         print('*** package "numpy" not found ***')
-        print('MDAnalysis requires a version of NumPy (>=1.13.3), even for setup.')
+        print('MDAnalysis requires a version of NumPy (>=1.16.0), even for setup.')
         print('Please get it from http://numpy.scipy.org/ or install it through '
               'your package manager.')
         sys.exit(-1)
@@ -546,7 +546,7 @@ if __name__ == '__main__':
     exts, cythonfiles = extensions(config)
 
     install_requires = [
-          'numpy>=1.13.3',
+          'numpy>=1.16.0',
           'biopython>=1.71',
           'networkx>=1.0',
           'GridDataFormats>=0.4.0',
@@ -587,13 +587,13 @@ if __name__ == '__main__':
                         ],
           },
           ext_modules=exts,
-          requires=['numpy (>=1.13.3)', 'biopython (>= 1.71)', 'mmtf (>=1.0.0)',
+          requires=['numpy (>=1.16.0)', 'biopython (>= 1.71)', 'mmtf (>=1.0.0)',
                     'networkx (>=1.0)', 'GridDataFormats (>=0.3.2)', 'joblib',
                     'scipy (>=1.0.0)', 'matplotlib (>=1.5.1)', 'tqdm (>=4.43.0)'],
           # all standard requirements are available through PyPi and
           # typically can be installed without difficulties through setuptools
           setup_requires=[
-              'numpy>=1.13.3',
+              'numpy>=1.16.0',
           ],
           install_requires=install_requires,
           # extras can be difficult to install through setuptools and/or

--- a/package/setup.py
+++ b/package/setup.py
@@ -609,7 +609,6 @@ if __name__ == '__main__':
                   'sklearn',  # For clustering and dimensionality reduction
                               # functionality in encore
                   'tidynamics>=1.0.0', # For MSD analysis method
-                  'rdkit>=2020.03.1', # For chemoinformatics analysis
               ],
           },
           test_suite="MDAnalysisTests",

--- a/package/setup.py
+++ b/package/setup.py
@@ -609,6 +609,7 @@ if __name__ == '__main__':
                   'sklearn',  # For clustering and dimensionality reduction
                               # functionality in encore
                   'tidynamics>=1.0.0', # For MSD analysis method
+                  'rdkit>=2020.03.1', # For chemoinformatics analysis
               ],
           },
           test_suite="MDAnalysisTests",


### PR DESCRIPTION
Fixes #2827 

Changes made in this Pull Request:
 - raise numpy minimum version from 1.13.3 to 1.16.0
 - set the minimum RDKit version to 2020.03.1 for tests

I'm not sure if there's a way to enforce RDKit>=2020.03.1 for users on install since it's a conda dependency

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
