### PR TITLE
MAINT: comprehensive type alias cleanup

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,8 +13,8 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-??/??/?? richardjgowers, IAlibay, hmacdope, orbeckst, cbouy, lilyminium,
-         daveminh, jbarnoud, yuxuanzhuang
+??/??/?? tylerjereddy, richardjgowers, IAlibay, hmacdope, orbeckst, cbouy,
+         lilyminium, daveminh, jbarnoud, yuxuanzhuang
 
   * 2.0.0
 
@@ -42,6 +42,10 @@ Enhancements
   * Added converter between Cartesian and Bond-Angle-Torsion coordinates (PR #2668)
 
 Changes
+  * deprecated NumPy type aliases have been replaced with their actual types
+    (see upstream NumPy PR 14882), and our pytest configuration will raise an
+    error for any violation when testing with development NumPy builds 
+    (`1.20.0`)
   * Changes development status from Beta to Mature (Issue #2773)
   * Removes deprecated MDAnalysis.analysis.hole, please use
     MDAnalysis.analysis.hole2.hole instead (Issue #2739)

--- a/package/MDAnalysis/analysis/hydrogenbonds/hbond_analysis.py
+++ b/package/MDAnalysis/analysis/hydrogenbonds/hbond_analysis.py
@@ -514,7 +514,7 @@ class HydrogenBondAnalysis(base.AnalysisBase):
         indices /= self.step
 
         counts = np.zeros_like(self.frames)
-        counts[indices.astype(np.int)] = tmp_counts
+        counts[indices.astype(int)] = tmp_counts
         return counts
 
     def count_by_type(self):
@@ -532,11 +532,11 @@ class HydrogenBondAnalysis(base.AnalysisBase):
         acceptor atoms in a hydrogen bond.
         """
 
-        d = self.u.atoms[self.hbonds[:, 1].astype(np.int)]
-        a = self.u.atoms[self.hbonds[:, 3].astype(np.int)]
+        d = self.u.atoms[self.hbonds[:, 1].astype(int)]
+        a = self.u.atoms[self.hbonds[:, 3].astype(int)]
 
         tmp_hbonds = np.array([d.resnames, d.types, a.resnames, a.types],
-                              dtype=np.str).T
+                              dtype=str).T
         hbond_type, type_counts = np.unique(
             tmp_hbonds, axis=0, return_counts=True)
         hbond_type_list = []
@@ -561,9 +561,9 @@ class HydrogenBondAnalysis(base.AnalysisBase):
         in a hydrogen bond.
         """
 
-        d = self.u.atoms[self.hbonds[:, 1].astype(np.int)]
-        h = self.u.atoms[self.hbonds[:, 2].astype(np.int)]
-        a = self.u.atoms[self.hbonds[:, 3].astype(np.int)]
+        d = self.u.atoms[self.hbonds[:, 1].astype(int)]
+        h = self.u.atoms[self.hbonds[:, 2].astype(int)]
+        a = self.u.atoms[self.hbonds[:, 3].astype(int)]
 
         tmp_hbonds = np.array([d.ids, h.ids, a.ids]).T
         hbond_ids, ids_counts = np.unique(tmp_hbonds, axis=0,

--- a/package/MDAnalysis/coordinates/CRD.py
+++ b/package/MDAnalysis/coordinates/CRD.py
@@ -206,7 +206,7 @@ class CRDWriter(base.WriterBase):
         for attr, default in (
                 ('resnames', itertools.cycle(('UNK',))),
                 # Resids *must* be an array because we index it later
-                ('resids', np.ones(n_atoms, dtype=np.int)),
+                ('resids', np.ones(n_atoms, dtype=int)),
                 ('names', itertools.cycle(('X',))),
                 ('tempfactors', itertools.cycle((0.0,))),
         ):

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -1570,7 +1570,7 @@ class ProtoReader(IOBase, metaclass=_Readermeta):
         elif isinstance(frame, (list, np.ndarray)):
             if len(frame) != 0 and isinstance(frame[0], (bool, np.bool_)):
                 # Avoid having list of bools
-                frame = np.asarray(frame, dtype=np.bool)
+                frame = np.asarray(frame, dtype=bool)
                 # Convert bool array to int array
                 frame = np.arange(len(self))[frame]
             return FrameIteratorIndices(self, frame)

--- a/package/MDAnalysis/core/selection.py
+++ b/package/MDAnalysis/core/selection.py
@@ -665,7 +665,7 @@ class ResidSelection(Selection):
 
     def _sel_without_icodes(self, vals):
         # Final mask that gets applied to group
-        mask = np.zeros(len(vals), dtype=np.bool)
+        mask = np.zeros(len(vals), dtype=bool)
 
         for (u_resid, _), (l_resid, _) in zip(self.uppers, self.lowers):
             if u_resid is not None:  # range selection
@@ -680,7 +680,7 @@ class ResidSelection(Selection):
 
     def _sel_with_icodes(self, vals, icodes):
         # Final mask that gets applied to group
-        mask = np.zeros(len(vals), dtype=np.bool)
+        mask = np.zeros(len(vals), dtype=bool)
 
         for (u_resid, u_icode), (l_resid, l_icode) in zip(self.uppers, self.lowers):
             if u_resid is not None:  # Selecting a range
@@ -753,7 +753,7 @@ class RangeSelection(Selection):
         self.uppers = uppers
 
     def apply(self, group):
-        mask = np.zeros(len(group), dtype=np.bool)
+        mask = np.zeros(len(group), dtype=bool)
         vals = getattr(group, self.field) + self.value_offset
 
         for upper, lower in zip(self.uppers, self.lowers):

--- a/package/MDAnalysis/core/topologyobjects.py
+++ b/package/MDAnalysis/core/topologyobjects.py
@@ -593,7 +593,7 @@ class TopologyGroup(object):
         elif guessed is True or guessed is False:
             guessed = np.repeat(guessed, nbonds)
         else:
-            guessed = np.asarray(guessed, dtype=np.bool)
+            guessed = np.asarray(guessed, dtype=bool)
         if order is None:
             order = np.repeat(None, nbonds)
 

--- a/package/MDAnalysis/lib/nsgrid.pyx
+++ b/package/MDAnalysis/lib/nsgrid.pyx
@@ -663,7 +663,7 @@ cdef class _NSGrid(object):
 
         cdef ns_int i, cellindex = -1
         cdef ns_int ncoords = coords.shape[0]
-        cdef ns_int[:] beadcounts = np.empty(self.size, dtype=np.int)
+        cdef ns_int[:] beadcounts = np.empty(self.size, dtype=int)
 
         with nogil:
             # Initialize buffers

--- a/package/MDAnalysis/topology/MMTFParser.py
+++ b/package/MDAnalysis/topology/MMTFParser.py
@@ -132,7 +132,7 @@ class ModelSelection(RangeSelection):
     field = 'models'
 
     def apply(self, group):
-        mask = np.zeros(len(group), dtype=np.bool)
+        mask = np.zeros(len(group), dtype=bool)
         vals = group.models
 
         for upper, lower in zip(self.uppers, self.lowers):

--- a/package/MDAnalysis/topology/PDBParser.py
+++ b/package/MDAnalysis/topology/PDBParser.py
@@ -420,7 +420,7 @@ def _parse_conect(conect):
     RuntimeError
         Raised if ``conect`` is not a valid CONECT record
     """
-    atom_id = np.int(conect[6:11])
+    atom_id = int(conect[6:11])
     n_bond_atoms = len(conect[11:]) // 5
 
     try:

--- a/package/MDAnalysis/topology/TXYZParser.py
+++ b/package/MDAnalysis/topology/TXYZParser.py
@@ -85,7 +85,7 @@ class TXYZParser(TopologyReaderBase):
             #header
             natoms = int(inf.readline().split()[0])
 
-            atomids = np.zeros(natoms, dtype=np.int)
+            atomids = np.zeros(natoms, dtype=int)
             names = np.zeros(natoms, dtype=object)
             types = np.zeros(natoms, dtype=object)
             bonds = []

--- a/testsuite/MDAnalysisTests/analysis/test_align.py
+++ b/testsuite/MDAnalysisTests/analysis/test_align.py
@@ -52,7 +52,7 @@ class TestRotationMatrix(object):
     @pytest.mark.parametrize('a, b, weights', (
             (a, b, None),
             (a, b, w),
-            (a.astype(np.int), b.astype(np.int), w.astype(np.float32))
+            (a.astype(int), b.astype(int), w.astype(np.float32))
     ))
     def test_rotation_matrix_input(self, a, b, weights):
         rot, rmsd = align.rotation_matrix(a, b, weights)

--- a/testsuite/MDAnalysisTests/analysis/test_distances.py
+++ b/testsuite/MDAnalysisTests/analysis/test_distances.py
@@ -62,7 +62,7 @@ class TestContactMatrix(object):
                            [0, 1, 0, 0, 0],
                            [1, 0, 1, 0, 0],
                            [0, 0, 0, 1, 0],
-                           [0, 0, 0, 0, 1]], dtype=np.bool)
+                           [0, 0, 0, 0, 1]], dtype=bool)
     
     @staticmethod
     @pytest.fixture()
@@ -71,7 +71,7 @@ class TestContactMatrix(object):
                         [0, 1, 0, 0, 0],
                         [1, 0, 1, 1, 1],
                         [1, 0, 1, 1, 1],
-                        [1, 0, 1, 1, 1]], dtype=np.bool)
+                        [1, 0, 1, 1, 1]], dtype=bool)
 
     def test_np(self, coord, shape, res_no_pbc):
         contacts = MDAnalysis.analysis.distances.contact_matrix(

--- a/testsuite/MDAnalysisTests/core/test_topology.py
+++ b/testsuite/MDAnalysisTests/core/test_topology.py
@@ -508,7 +508,7 @@ class TestDownshiftArrays(object):
             np.array([0, 0, 2, 2, 3, 3]), 4)
         self.assert_rows_match(out,
                                np.array([np.array([0, 1]),
-                                         np.array([], dtype=np.int),
+                                         np.array([], dtype=int),
                                          np.array([2, 3]),
                                          np.array([4, 5]),
                                          None], dtype=object))
@@ -518,8 +518,8 @@ class TestDownshiftArrays(object):
             np.array([0, 0, 3, 3, 4, 4]), 5)
         self.assert_rows_match(out,
                                np.array([np.array([0, 1]),
-                                         np.array([], dtype=np.int),
-                                         np.array([], dtype=np.int),
+                                         np.array([], dtype=int),
+                                         np.array([], dtype=int),
                                          np.array([2, 3]),
                                          np.array([4, 5]),
                                          None], dtype=object))
@@ -530,7 +530,7 @@ class TestDownshiftArrays(object):
                                np.array([np.array([0, 1]),
                                          np.array([2, 3]),
                                          np.array([4, 5]),
-                                         np.array([], dtype=np.int),
+                                         np.array([], dtype=int),
                                          None], dtype=object))
 
     def test_missing_end_values_2(self):
@@ -539,8 +539,8 @@ class TestDownshiftArrays(object):
                                np.array([np.array([0, 1]),
                                          np.array([2, 3]),
                                          np.array([4, 5]),
-                                         np.array([], dtype=np.int),
-                                         np.array([], dtype=np.int),
+                                         np.array([], dtype=int),
+                                         np.array([], dtype=int),
                                          None], dtype=object))
 
 

--- a/testsuite/setup.cfg
+++ b/testsuite/setup.cfg
@@ -4,7 +4,11 @@ universal = 1
 # "encountered in " Runtimewarnings come from numpy for unit cell conversions.
 # They should be activated again once we fixed the occurrence in the code.
 [tool:pytest]
-filterwarnings= always
+filterwarnings= 
+    always
+    error:`np.*` is a deprecated alias for the builtin:DeprecationWarning
+    # don't enforce for third party packages though:
+    ignore:`np.*` is a deprecated alias for the builtin:DeprecationWarning:networkx.*:
 
 # Settings to test for warnings we throw
 # [tool:pytest]


### PR DESCRIPTION
* the NumPy type aliasing `DeprecationWarning`s are now
converted to errors for the `pytest` suite to enforce
future-proofed `dtype` specifications and prevent regression
(see NumPy PR 14882), though this will not take effect
in our CI until the next NumPy release, or until we adopt
a pre-release wheel test with NumPy

* NOTE: in the future we should switch to `pytest.ini` or
`pyproject.toml` for `pytest` config because of this complication:
https://docs.pytest.org/en/latest/customize.html#setup-cfg

* fix all cases of the type aliasing detected by the full test suite via warnings
converted to errors when running with latest NumPy checkout


Changes made in this Pull Request:
 - 


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [ ] Issue raised/referenced?
