### PR TITLE
MAINT: use modern ConfigParser

### DIFF
--- a/package/setup.py
+++ b/package/setup.py
@@ -126,7 +126,7 @@ class Config(object):
     def __init__(self, fname='setup.cfg'):
         fname = abspath(fname)
         if os.path.exists(fname):
-            self.config = configparser.SafeConfigParser()
+            self.config = configparser.ConfigParser()
             self.config.read(fname)
 
     def get(self, option_name, default=None):


### PR DESCRIPTION
* when MDAnalysis is built from source with Python 3.8 there's
a deprecation warning:

```
setup.py:129: DeprecationWarning: The SafeConfigParser class has been
renamed to ConfigParser in Python 3.2. This alias will be removed in
future versions. Use ConfigParser directly instead.
```

* fix it by doing what is says, since we are `Python >= 3.6` now

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
