### PR TITLE
Fixes AttributeError in HydrogenBondAnalysis 

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -34,8 +34,9 @@ Fixes
     density=True; the keyword was available since 0.19.0 but with incorrect
     semantics and not documented and did not produce correct results (Issue
     #2811, PR #2812)
-  * Attribute error was thrown when finding D-H pairs via the topology if
-    `hydrogens` was an empty AtomGroup (Issue #2848)
+  * In hydrogenbonds.hbond_analysis.HydrogenbondAnalysis an AttributeError 
+    was thrown when finding D-H pairs via the topology if `hydrogens` was an 
+    empty AtomGroup (Issue #2848)
 
 Enhancements
   * Added the RDKitParser which creates a `core.topology.Topology` object from

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -34,6 +34,8 @@ Fixes
     density=True; the keyword was available since 0.19.0 but with incorrect
     semantics and not documented and did not produce correct results (Issue
     #2811, PR #2812)
+  * Attribute error was thrown when finding D-H pairs via the topology if
+    `hydrogens` was an empty AtomGroup (Issue #2848)
 
 Enhancements
   * Added the RDKitParser which creates a `core.topology.Topology` object from

--- a/package/MDAnalysis/analysis/hydrogenbonds/hbond_analysis.py
+++ b/package/MDAnalysis/analysis/hydrogenbonds/hbond_analysis.py
@@ -219,7 +219,7 @@ from .. import base
 from MDAnalysis.lib.distances import capped_distance, calc_angles
 from MDAnalysis.lib.correlations import autocorrelation, correct_intermittency
 from MDAnalysis.exceptions import NoDataError
-from MDAnalysis import AtomGroup
+from MDAnalysis.core.groups import AtomGroup
 
 from ...due import due, Doi
 

--- a/package/MDAnalysis/analysis/hydrogenbonds/hbond_analysis.py
+++ b/package/MDAnalysis/analysis/hydrogenbonds/hbond_analysis.py
@@ -219,6 +219,7 @@ from .. import base
 from MDAnalysis.lib.distances import capped_distance, calc_angles
 from MDAnalysis.lib.correlations import autocorrelation, correct_intermittency
 from MDAnalysis.exceptions import NoDataError
+from MDAnalysis import AtomGroup
 
 from ...due import due, Doi
 
@@ -504,7 +505,8 @@ class HydrogenBondAnalysis(base.AnalysisBase):
                                   'can be used.')
 
             hydrogens = self.u.select_atoms(self.hydrogens_sel)
-            donors = sum(h.bonded_atoms[0] for h in hydrogens)
+            donors = sum(h.bonded_atoms[0] for h in hydrogens) if hydrogens \
+                else AtomGroup([], self.u)
 
         # Otherwise, use d_h_cutoff as a cutoff distance
         else:

--- a/testsuite/MDAnalysisTests/analysis/test_hydrogenbonds_analysis.py
+++ b/testsuite/MDAnalysisTests/analysis/test_hydrogenbonds_analysis.py
@@ -195,7 +195,7 @@ class TestHydrogenBondAnalysisIdeal(object):
             h = HydrogenBondAnalysis(universe, **kwargs)
             h._get_dh_pairs()
 
-    def test_first(self, hydrogen_bonds):
+    def test_first_hbond(self, hydrogen_bonds):
         assert len(hydrogen_bonds.hbonds) == 2
 
         frame_no, donor_index, hydrogen_index, acceptor_index, da_dst, angle =\
@@ -383,6 +383,20 @@ class TestHydrogenBondAnalysisTIP3P_GuessAcceptors_GuessHydrogens_UseTopology_(T
         'd_a_cutoff': 3.0,
         'd_h_a_angle_cutoff': 120.0
     }
+
+    def test_no_hydrogens(self, universe):
+        # If no hydrogens are identified at a given frame, check an
+        # empty donor atom group is created
+        test_kwargs = TestHydrogenBondAnalysisTIP3P.kwargs.copy()
+        test_kwargs['donors_sel'] = None         # use topology to find pairs
+        test_kwargs['hydrogens_sel'] = "name H"  # no atoms have name H
+
+        h = HydrogenBondAnalysis(universe, **test_kwargs)
+        h.run()
+
+        assert h._hydrogens.n_atoms == 0
+        assert h._donors.n_atoms == 0
+        assert h.hbonds.size == 0
 
 class TestHydrogenBondAnalysisTIP3P_GuessDonors_NoTopology(object):
     """Guess the donor atoms involved in hydrogen bonds using the partial charges of the atoms.


### PR DESCRIPTION
Fixes #2848 

Changes made in this Pull Request:
 - An attribute error is thrown when finding D-H pairs via the topology if `hydrogens` is an empty AtomGroup. This has been fixed so that an empty `donors` group is created, rather than assigning `donors = 0`.
 - Added a test case that raises the attribute without the fix.

PR Checklist
------------
 - [X] Tests?
 - [X] Docs?
 - [X] CHANGELOG updated?
 - [X] Issue raised/referenced?

Co-authored-by: bieniekmateusz <bieniekmat@gmail.com>
