### PR TITLE
CI: migrate to Azure for Win

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,12 +22,16 @@ jobs:
   variables:
     MPLBACKEND: agg    
   strategy:
-    maxParallel: 4
     matrix:
         Python37-32bit-full:
           PYTHON_VERSION: '3.7'
           PYTHON_ARCH: 'x86'
-          BITS: 32
+        Python36-64bit-full:
+          PYTHON_VERSION: '3.6'
+          PYTHON_ARCH: 'x64'
+        Python38-64bit-full:
+          PYTHON_VERSION: '3.8'
+          PYTHON_ARCH: 'x64'
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -39,6 +43,7 @@ jobs:
   - script: >-
       python -m pip install
       cython
+      hypothesis
       matplotlib
       numpy
       pytest
@@ -47,6 +52,22 @@ jobs:
       scikit-learn
       scipy
     displayName: 'Install dependencies'
+  # TODO: recent rdkit is not on PyPI
+  - script: >-
+      python -m pip install
+      biopython
+      chemfiles
+      duecredit
+      gsd==1.9.3
+      joblib
+      GridDataFormats 
+      mmtf-python
+      networkx
+      parmed
+      tidynamics>=1.0.0
+      tqdm
+    displayName: 'Install additional dependencies for 64-bit tests'
+    condition: and(succeeded(), eq(variables['PYTHON_ARCH'], 'x64'))
   - powershell: |
       cd package
       python setup.py install

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,6 +29,9 @@ jobs:
         Python36-64bit-full:
           PYTHON_VERSION: '3.6'
           PYTHON_ARCH: 'x64'
+        Python37-64bit-full:
+          PYTHON_VERSION: '3.7'
+          PYTHON_ARCH: 'x64'
         Python38-64bit-full:
           PYTHON_VERSION: '3.8'
           PYTHON_ARCH: 'x64'
@@ -51,6 +54,7 @@ jobs:
       pytest-xdist
       scikit-learn
       scipy
+      tqdm
     displayName: 'Install dependencies'
   # TODO: recent rdkit is not on PyPI
   - script: >-
@@ -65,7 +69,6 @@ jobs:
       networkx
       parmed
       tidynamics>=1.0.0
-      tqdm
     displayName: 'Install additional dependencies for 64-bit tests'
     condition: and(succeeded(), eq(variables['PYTHON_ARCH'], 'x64'))
   - powershell: |


### PR DESCRIPTION
Fixes #2846

* the majority of Windows CI testing previously provided
by Appveyor is now avaiable in the Azure CI Windows test
matrix; 64-bit Python 3.6 and 3.8 have been added to Azure
CI Windows testing

* however, Azure CI has been kept PyPI/`pip`-only, to avoid
mixing `conda` and `pip`, which has meant the exclusion of the
`RDKit` dependency

* as a result, it may be advisable to keep the Appveyor testing
in our CI for the moment to test Windows + `RDKit` until
they provide a wheel; possibly, we could consider slimming
down the tests executed in Appveyor CI to only exercise `RDKit`
and other `conda`-only code paths

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
