### PR TITLE
RDKitParser with table of attributes and icodes

### DIFF
--- a/package/MDAnalysis/topology/RDKitParser.py
+++ b/package/MDAnalysis/topology/RDKitParser.py
@@ -63,6 +63,7 @@ from ..core.topologyattrs import (
     Segids,
     AltLocs,
     ChainIDs,
+    ICodes,
     Occupancies,
     Tempfactors,
 )
@@ -94,6 +95,7 @@ class RDKitParser(TopologyReaderBase):
      - Resnames
      - AltLocs
      - ChainIDs
+     - ICodes
      - Occupancies
      - Tempfactors
 
@@ -171,6 +173,7 @@ class RDKitParser(TopologyReaderBase):
         segids = []
         altlocs = []
         chainids = []
+        icodes = []
         occupancies = []
         tempfactors = []
 
@@ -196,6 +199,7 @@ class RDKitParser(TopologyReaderBase):
                 segids.append(mi.GetSegmentNumber())
                 altlocs.append(mi.GetAltLoc().strip())
                 chainids.append(mi.GetChainId().strip())
+                icodes.append(mi.GetInsertionCode().strip())
                 occupancies.append(mi.GetOccupancy())
                 tempfactors.append(mi.GetTempFactor())
             else:
@@ -286,14 +290,16 @@ class RDKitParser(TopologyReaderBase):
             resnums = np.array(resnums, dtype=np.int32)
             resnames = np.array(resnames, dtype=object)
             segids = np.array(segids, dtype=object)
-            residx, (resnums, resnames, segids) = change_squash(
-                (resnums, resnames, segids), 
-                (resnums, resnames, segids))
+            icodes = np.array(icodes, dtype=object)
+            residx, (resnums, resnames, icodes, segids) = change_squash(
+                (resnums, resnames, icodes, segids), 
+                (resnums, resnames, icodes, segids))
             n_residues = len(resnums)
             for vals, Attr, dtype in (
                 (resnums, Resids, np.int32),
                 (resnums.copy(), Resnums, np.int32),
-                (resnames, Resnames, object)
+                (resnames, Resnames, object),
+                (icodes, ICodes, object),
             ):
                 attrs.append(Attr(np.array(vals, dtype=dtype)))
         else:

--- a/package/MDAnalysis/topology/RDKitParser.py
+++ b/package/MDAnalysis/topology/RDKitParser.py
@@ -292,7 +292,7 @@ class RDKitParser(TopologyReaderBase):
             segids = np.array(segids, dtype=object)
             icodes = np.array(icodes, dtype=object)
             residx, (resnums, resnames, icodes, segids) = change_squash(
-                (resnums, resnames, icodes, segids), 
+                (resnums, resnames, icodes, segids),
                 (resnums, resnames, icodes, segids))
             n_residues = len(resnums)
             for vals, Attr, dtype in (

--- a/package/MDAnalysis/topology/RDKitParser.py
+++ b/package/MDAnalysis/topology/RDKitParser.py
@@ -96,7 +96,43 @@ class RDKitParser(TopologyReaderBase):
      - ChainIDs
      - Occupancies
      - Tempfactors
-    
+
+    Attributes table:
+
+    +---------------------------------------------+-------------------------+
+    | RDKit attribute                             | MDAnalysis equivalent   |
+    +=============================================+=========================+
+    | atom.GetMonomerInfo().GetAltLoc()           | altLocs                 |
+    +---------------------------------------------+-------------------------+
+    | atom.GetIsAromatic()                        | aromaticities           |
+    +---------------------------------------------+-------------------------+
+    | atom.GetMonomerInfo().GetChainId()          | chainIDs                |
+    +---------------------------------------------+-------------------------+
+    | atom.GetDoubleProp('_GasteigerCharge')      | charges                 |
+    | atom.GetDoubleProp('_TriposPartialCharge')  |                         |
+    +---------------------------------------------+-------------------------+
+    | atom.GetSymbol()                            | elements                |
+    +---------------------------------------------+-------------------------+
+    | atom.GetMonomerInfo().GetInsertionCode()    | icodes                  |
+    +---------------------------------------------+-------------------------+
+    | atom.GetIdx()                               | indices                 |
+    +---------------------------------------------+-------------------------+
+    | atom.GetMass()                              | masses                  |
+    +---------------------------------------------+-------------------------+
+    | atom.GetMonomerInfo().GetName()             | names                   |
+    | atom.GetProp('_TriposAtomName')             |                         |
+    +---------------------------------------------+-------------------------+
+    | atom.GetMonomerInfo().GetOccupancy()        | occupancies             |
+    +---------------------------------------------+-------------------------+
+    | atom.GetMonomerInfo().GetResidueName()      | resnames                |
+    +---------------------------------------------+-------------------------+
+    | atom.GetMonomerInfo().GetResidueNumber()    | resnums                 |
+    +---------------------------------------------+-------------------------+
+    | atom.GetMonomerInfo().GetTempFactor()       | tempfactors             |
+    +---------------------------------------------+-------------------------+
+    | atom.GetProp('_TriposAtomType')             | types                   |
+    +---------------------------------------------+-------------------------+
+
 
     .. versionadded:: 2.0.0
     """

--- a/testsuite/MDAnalysisTests/topology/test_rdkit.py
+++ b/testsuite/MDAnalysisTests/topology/test_rdkit.py
@@ -140,7 +140,7 @@ class TestRDKitParserPDB(RDKitParserBase):
     ref_filename = PDB_helix
 
     expected_attrs = RDKitParserBase.expected_attrs + ['resnames', 'altLocs', 
-        'chainIDs', 'occupancies', 'tempfactors']
+        'chainIDs', 'occupancies', 'icodes', 'tempfactors']
     guessed_attrs = ['types']
     
     expected_n_atoms = 137

--- a/testsuite/MDAnalysisTests/topology/test_rdkit.py
+++ b/testsuite/MDAnalysisTests/topology/test_rdkit.py
@@ -139,8 +139,9 @@ class TestRDKitParserMOL2(RDKitParserBase):
 class TestRDKitParserPDB(RDKitParserBase):
     ref_filename = PDB_helix
 
-    expected_attrs = RDKitParserBase.expected_attrs + ['resnames', 'altLocs', 
-        'chainIDs', 'occupancies', 'icodes', 'tempfactors']
+    expected_attrs = RDKitParserBase.expected_attrs + [
+        'resnames', 'altLocs', 'chainIDs', 'occupancies', 'icodes',
+        'tempfactors']
     guessed_attrs = ['types']
     
     expected_n_atoms = 137


### PR DESCRIPTION
Changes made in this Pull Request:
 - Adds a table to the doc of the RDKitParser that lists the RDKit attributes and their equivalence in MDAnalysis
 - Adds the `icodes` attribute

I somehow forgot the "insertion codes" attribute when I created the parser...
Do I need to update the changelog for this ? Since the parser is not technically there yet

PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
