### PR TITLE
changes cython language_level to 3

### DIFF
--- a/package/MDAnalysis/lib/_augment.pyx
+++ b/package/MDAnalysis/lib/_augment.pyx
@@ -26,8 +26,8 @@ import cython
 import numpy as np
 from .mdamath import triclinic_vectors
 cimport numpy as np
-cimport _cutil
-from _cutil cimport _dot ,_norm, _cross
+cimport MDAnalysis.lib._cutil
+from MDAnalysis.lib._cutil cimport _dot ,_norm, _cross
 
 from libcpp.vector cimport vector
 

--- a/package/MDAnalysis/lib/formats/libmdaxdr.pyx
+++ b/package/MDAnalysis/lib/formats/libmdaxdr.pyx
@@ -62,7 +62,7 @@ own please see the source code in `lib/formats/libmdaxdr.pyx`_ for the time bein
 
 cimport numpy as np
 cimport cython
-from cython_util cimport ptr_to_ndarray
+from MDAnalysis.lib.formats.cython_util cimport ptr_to_ndarray
 from libc.stdint cimport int64_t
 
 from libc.stdio cimport SEEK_SET, SEEK_CUR, SEEK_END

--- a/package/setup.py
+++ b/package/setup.py
@@ -426,7 +426,8 @@ def extensions(config):
         extensions = cythonize(
             pre_exts,
             compiler_directives={'linetrace' : cython_linetrace,
-                                 'embedsignature' : False},
+                                 'embedsignature' : False,
+                                 'language_level': '3'},
         )
         if cython_linetrace:
             print("Cython coverage will be enabled")

--- a/package/setup.py
+++ b/package/setup.py
@@ -425,8 +425,8 @@ def extensions(config):
     if use_cython:
         extensions = cythonize(
             pre_exts,
-            compiler_directives={'linetrace' : cython_linetrace,
-                                 'embedsignature' : False,
+            compiler_directives={'linetrace': cython_linetrace,
+                                 'embedsignature': False,
                                  'language_level': '3'},
         )
         if cython_linetrace:


### PR DESCRIPTION
Fixes #2853 

Changes made in this Pull Request:
 - Changes language_level to 3
 - Gets rid of implicit imports


PR Checklist
------------
 - Tests? N/A
 - Docs? N/A
 - CHANGELOG updated? N/A : we didn't add changelog entries for other py2 deprecations
 - [x] Issue raised/referenced?
