### PR TITLE
Remove assignment of bond attribute when PDB file contains no CONECT records

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -19,6 +19,8 @@ The rules for this file:
   * 2.0.0
 
 Fixes
+  * Bond attribute is no longer set if PDB file contains no CONECT records
+    (Issue #2832)
   * ResidueAttrs now have Atom as a target class by default; ICodes and 
     Molnums now have default target_classes (#2803, PR #2805)
   * Selections on emtpy AtomGroups now return an empty AtomGroup instead of an

--- a/package/MDAnalysis/topology/PDBParser.py
+++ b/package/MDAnalysis/topology/PDBParser.py
@@ -203,7 +203,7 @@ class PDBParser(TopologyReaderBase):
                           "bonds will not be parsed")
         else:
             # Issue 2832: don't append Bonds if there are no bonds
-            if len(bonds) > 0:
+            if bonds:
                 top.add_TopologyAttr(bonds)
 
         return top

--- a/package/MDAnalysis/topology/PDBParser.py
+++ b/package/MDAnalysis/topology/PDBParser.py
@@ -167,6 +167,7 @@ class PDBParser(TopologyReaderBase):
      - resnames
      - segids
      - elements
+     - bonds
 
     Guesses the following Attributes:
      - masses
@@ -175,11 +176,14 @@ class PDBParser(TopologyReaderBase):
     --------
     :class:`MDAnalysis.coordinates.PDB.PDBReader`
 
+
     .. versionadded:: 0.8
     .. versionchanged:: 0.18.0
        Added parsing of Record types
     .. versionchanged:: 1.0.0
        Added parsing of valid Elements
+    .. versionchanged:: 2.0.0
+       Bonds attribute is not added if no bonds are present in PDB file
     """
     format = ['PDB', 'ENT']
 
@@ -198,7 +202,9 @@ class PDBParser(TopologyReaderBase):
             warnings.warn("Invalid atom serials were present, "
                           "bonds will not be parsed")
         else:
-            top.add_TopologyAttr(bonds)
+            # Issue 2832: don't append Bonds if there are no bonds
+            if len(bonds) > 0:
+                top.add_TopologyAttr(bonds)
 
         return top
 

--- a/testsuite/MDAnalysisTests/topology/test_pdb.py
+++ b/testsuite/MDAnalysisTests/topology/test_pdb.py
@@ -39,8 +39,10 @@ from MDAnalysisTests.datafiles import (
     PDB_chainidnewres,
     PDB_sameresid_diffresname,
     PDB_metal,
+    PDB_helix,
 )
 from MDAnalysis.topology.PDBParser import PDBParser
+from MDAnalysis import NoDataError
 
 _PDBPARSER = mda.topology.PDBParser.PDBParser
 
@@ -71,7 +73,7 @@ def test_hy36decode(hybrid, integer):
 class PDBBase(ParserBase):
     expected_attrs = ['ids', 'names', 'record_types', 'resids',
                       'resnames', 'altLocs', 'icodes', 'occupancies',
-                      'bonds', 'tempfactors', 'chainIDs']
+                      'tempfactors', 'chainIDs']
     guessed_attrs = ['types', 'masses']
 
 
@@ -348,3 +350,14 @@ def test_wrong_elements_warnings():
     assert len(record) == 2
     assert record[1].message.args[0] == "Invalid elements found in the PDB "\
         "file, elements attributes will not be populated."
+
+
+def test_nobonds_error():
+    """Issue #2832: PDB without CONECT record should not have a bonds
+    attribute and raises NoDataError on access"""
+    u = mda.Universe(PDB_helix)
+
+    errmsg = "This Universe does not contain bonds information"
+
+    with pytest.raises(NoDataError, match=errmsg):
+        u.atoms.bonds

--- a/testsuite/MDAnalysisTests/topology/test_xpdb.py
+++ b/testsuite/MDAnalysisTests/topology/test_xpdb.py
@@ -33,7 +33,7 @@ class TestXPDBParser(ParserBase):
     ref_filename = XPDB_small
     expected_attrs = ['ids', 'names', 'record_types', 'resids',
                       'resnames', 'altLocs', 'icodes', 'occupancies',
-                      'bonds', 'tempfactors', 'chainIDs']
+                      'tempfactors', 'chainIDs']
     guessed_attrs = ['masses', 'types']
     expected_n_atoms = 5
     expected_n_residues = 5

--- a/testsuite/MDAnalysisTests/utils/test_modelling.py
+++ b/testsuite/MDAnalysisTests/utils/test_modelling.py
@@ -249,7 +249,7 @@ class TestMergeTopology(object):
 
         # merge_protein doesn't contain bond topology, so merged universe
         # shouldn't have one either
-        print(u_merge.atoms.bonds)
+        assert not hasattr(u_merge.atoms, 'bonds')
         # PDB reader yields empty Bonds group, which means bonds from
         # PSF/DCD survive the merge
         # assert(not hasattr(u_merge.atoms, 'bonds') or len(u_merge.atoms.bonds) == 0)


### PR DESCRIPTION
Fixes #2832

Changes made in this Pull Request:
 - If no bonds are parsed, bond attribute is no longer set in PDB files.


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
