### PR TITLE
renamed 'pbc' kwarg to 'wrap' for Group methods

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -52,6 +52,8 @@ Changes
     (NEP29)
 
 Deprecations
+  * Deprecated the 'pbc' kwarg for various Group methods, the 'wrap' kwarg
+    should be used instead. (Issue #1760)
 
 
 08/21/21 tylerjereddy, richardjgowers, IAlibay, hmacdope, orbeckst, cbouy,

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -437,7 +437,8 @@ def _pbc_to_wrap(function):
     @functools.wraps(function)
     def wrapped(group, *args, **kwargs):
         if kwargs.get('pbc', None) is not None:
-            warnings.warn("The 'pbc' kwarg has been deprecated, "
+            warnings.warn("The 'pbc' kwarg has been deprecated and will be "
+                          "removed in version 3.0., "
                           "please use 'wrap' instead",
                           DeprecationWarning)
             kwargs['wrap'] = kwargs.pop('pbc')
@@ -1038,7 +1039,9 @@ class GroupBase(_MutableBase):
             compounds
         .. versionchanged:: 0.20.0 Added `unwrap` parameter
         .. versionchanged:: 1.0.0 Removed flags affecting default behaviour
-        .. versionchanged:: 2.0.0 Renamed `pbc` kwarg to `wrap`
+        .. versionchanged::
+           2.1.0 Renamed `pbc` kwarg to `wrap`. `pbc` is still accepted but
+           is deprecated and will be removed in version 3.0.
         """
         atoms = self.atoms
 
@@ -1146,7 +1149,9 @@ class GroupBase(_MutableBase):
             compounds
         .. versionchanged:: 0.20.0 Added `unwrap` parameter
         .. versionchanged:: 1.0.0 Removed flags affecting default behaviour
-        .. versionchanged:: 2.0.0 Renamed 'pbc' kwarg to 'wrap'
+        .. versionchanged::
+           2.1.0 Renamed `pbc` kwarg to `wrap`. `pbc` is still accepted but
+           is deprecated and will be removed in version 3.0.
         """
         return self.center(None, wrap=wrap, compound=compound, unwrap=unwrap)
 
@@ -1289,7 +1294,9 @@ class GroupBase(_MutableBase):
         .. versionadded:: 0.7.2
         .. versionchanged:: 0.8 Added *pbc* keyword
         .. versionchanged:: 1.0.0 Removed flags affecting default behaviour
-        .. versionchanged:: 2.0.0 Renamed 'pbc' kwarg to 'wrap'
+        .. versionchanged::
+           2.1.0 Renamed `pbc` kwarg to `wrap`. `pbc` is still accepted but
+           is deprecated and will be removed in version 3.0.
         """
         # TODO: Add unwrap/compounds treatment
         atomgroup = self.atoms
@@ -1324,7 +1331,9 @@ class GroupBase(_MutableBase):
 
         .. versionadded:: 0.7.3
         .. versionchanged:: 0.8 Added *pbc* keyword
-        .. versionchanged:: 2.0.0 Renamed 'pbc' kwarg to 'wrap'
+        .. versionchanged::
+           2.1.0 Renamed `pbc` kwarg to `wrap`. `pbc` is still accepted but
+           is deprecated and will be removed in version 3.0.
         """
         atomgroup = self.atoms.unsorted_unique
 

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -437,7 +437,9 @@ def _pbc_to_wrap(function):
     @functools.wraps(function)
     def wrapped(group, *args, **kwargs):
         if kwargs.get('pbc', None) is not None:
-            warnings.warn("Use 'wrap' kwarg not 'pbc'", DeprecationWarning)
+            warnings.warn("The 'pbc' kwarg has been deprecated, "
+                          "please use 'wrap' instead",
+                          DeprecationWarning)
             kwargs['wrap'] = kwargs.pop('pbc')
 
         return function(group, *args, **kwargs)
@@ -1036,7 +1038,7 @@ class GroupBase(_MutableBase):
             compounds
         .. versionchanged:: 0.20.0 Added `unwrap` parameter
         .. versionchanged:: 1.0.0 Removed flags affecting default behaviour
-        .. versionchanged:: x.y.z Renamed `pbc` to `wrap`
+        .. versionchanged:: 2.0.0 Renamed `pbc` kwarg to `wrap`
         """
         atoms = self.atoms
 
@@ -1144,7 +1146,7 @@ class GroupBase(_MutableBase):
             compounds
         .. versionchanged:: 0.20.0 Added `unwrap` parameter
         .. versionchanged:: 1.0.0 Removed flags affecting default behaviour
-        .. versionchanged:: x.y.z Renamed 'pbc' kwarg to 'wrap'
+        .. versionchanged:: 2.0.0 Renamed 'pbc' kwarg to 'wrap'
         """
         return self.center(None, wrap=wrap, compound=compound, unwrap=unwrap)
 
@@ -1287,7 +1289,7 @@ class GroupBase(_MutableBase):
         .. versionadded:: 0.7.2
         .. versionchanged:: 0.8 Added *pbc* keyword
         .. versionchanged:: 1.0.0 Removed flags affecting default behaviour
-        .. versionchanged:: x.y.z Renamed 'pbc' kwarg to 'wrap'
+        .. versionchanged:: 2.0.0 Renamed 'pbc' kwarg to 'wrap'
         """
         # TODO: Add unwrap/compounds treatment
         atomgroup = self.atoms
@@ -1322,7 +1324,7 @@ class GroupBase(_MutableBase):
 
         .. versionadded:: 0.7.3
         .. versionchanged:: 0.8 Added *pbc* keyword
-        .. versionchanged:: x.y.z Renamed 'pbc' kwarg to 'wrap'
+        .. versionchanged:: 2.0.0 Renamed 'pbc' kwarg to 'wrap'
         """
         atomgroup = self.atoms.unsorted_unique
 

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -1123,14 +1123,16 @@ class GroupBase(_MutableBase):
             compounds intact. Instead, the resulting position vectors will be
             moved to the primary unit cell after calculation. Default False.
         unwrap : bool, optional
-            If ``True``, compounds will be unwrapped before computing their centers.
+            If ``True``, compounds will be unwrapped before computing their
+            centers.
         compound : {'group', 'segments', 'residues', 'molecules', 'fragments'}, optional
             If ``'group'``, the center of geometry of all :class:`Atoms<Atom>`
-            in the group will be returned as a single position vector. Else, the
-            centers of geometry of each :class:`Segment` or :class:`Residue`
-            will be returned as an array of position vectors, i.e. a 2d array.
-            Note that, in any case, *only* the positions of :class:`Atoms<Atom>`
-            *belonging to the group* will be taken into account.
+            in the group will be returned as a single position vector. Else,
+            the centers of geometry of each :class:`Segment` or
+            :class:`Residue` will be returned as an array of position vectors,
+            i.e. a 2d array. Note that, in any case, *only* the positions of
+            :class:`Atoms<Atom>` *belonging to the group* will be taken into
+            account.
 
         Returns
         -------

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -1507,7 +1507,9 @@ class Masses(AtomAttr):
         .. versionchanged:: 0.20.0 Added ``'molecules'`` and ``'fragments'``
             compounds
         .. versionchanged:: 0.20.0 Added `unwrap` parameter
-        .. versionchanged:: 2.0.0  Renamed `pbc` parameter to `wrap`
+        .. versionchanged::
+           2.1.0 Renamed `pbc` kwarg to `wrap`. `pbc` is still accepted but
+           is deprecated and will be removed in version 3.0.
         """
         atoms = group.atoms
         return atoms.center(weights=atoms.masses, wrap=wrap, compound=compound,
@@ -1568,7 +1570,9 @@ class Masses(AtomAttr):
 
         .. versionchanged:: 0.8 Added *pbc* keyword
         .. versionchanged:: 0.20.0 Added `unwrap` parameter
-        .. versionchanged:: 2.0.0 Renamed `pbc` kwarg to `wrap`
+        .. versionchanged::
+           2.1.0 Renamed `pbc` kwarg to `wrap`. `pbc` is still accepted but
+           is deprecated and will be removed in version 3.0.
         """
         atomgroup = group.atoms
         unwrap = kwargs.pop('unwrap', False)
@@ -1629,8 +1633,9 @@ class Masses(AtomAttr):
 
 
         .. versionchanged:: 0.8 Added *pbc* keyword
-        .. versionchanged:: 2.0.0
-           Renamed `pbc` kwarg to `wrap`
+        .. versionchanged::
+           2.1.0 Renamed `pbc` kwarg to `wrap`. `pbc` is still accepted but
+           is deprecated and will be removed in version 3.0.
         """
         atomgroup = group.atoms
         masses = atomgroup.masses
@@ -1665,8 +1670,9 @@ class Masses(AtomAttr):
 
         .. versionadded:: 0.7.7
         .. versionchanged:: 0.8 Added *pbc* keyword
-        .. versionchanged:: 2.0.0
-           Renamed `pbc` kwarg to `wrap`
+        .. versionchanged::
+           2.1.0 Renamed `pbc` kwarg to `wrap`. `pbc` is still accepted but
+           is deprecated and will be removed in version 3.0.
         """
         atomgroup = group.atoms
         masses = atomgroup.masses

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -1208,11 +1208,11 @@ class Atomnames(AtomStringAttr):
             4-atom selection in the correct order. If no CB and/or CG is found
             then this method returns ``None``.
 
-        .. versionchanged:: 1.0.0
-            Added arguments for flexible atom names and refactored code for
-            faster atom matching with boolean arrays.
 
         .. versionadded:: 0.7.5
+        .. versionchanged:: 1.0.0
+           Added arguments for flexible atom names and refactored code for
+           faster atom matching with boolean arrays.
         """
         names = [n_name, ca_name, cb_name, cg_name]
         ags = [residue.atoms.select_atoms(f"name {n}") for n in names]
@@ -1498,17 +1498,19 @@ class Masses(AtomAttr):
 
         Note
         ----
-        * This method can only be accessed if the underlying topology has
-          information about atomic masses.
+        This method can only be accessed if the underlying topology has
+        information about atomic masses.
 
 
-        .. versionchanged:: 0.8 Added `pbc` parameter
-        .. versionchanged:: 0.19.0 Added `compound` parameter
-        .. versionchanged:: 0.20.0 Added ``'molecules'`` and ``'fragments'``
-            compounds
-        .. versionchanged:: 0.20.0 Added `unwrap` parameter
-        .. versionchanged::
-           2.1.0 Renamed `pbc` kwarg to `wrap`. `pbc` is still accepted but
+        .. versionchanged:: 0.8
+           Added `pbc` parameter
+        .. versionchanged:: 0.19.0
+           Added `compound` parameter
+        .. versionchanged:: 0.20.0
+           Added ``'molecules'`` and ``'fragments'`` compounds;
+           added `unwrap` parameter
+        .. versionchanged:: 2.1.0
+           Renamed `pbc` kwarg to `wrap`. `pbc` is still accepted but
            is deprecated and will be removed in version 3.0.
         """
         atoms = group.atoms
@@ -1557,26 +1559,44 @@ class Masses(AtomAttr):
     @warn_if_not_unique
     @_pbc_to_wrap
     @check_wrap_and_unwrap
-    def moment_of_inertia(group, wrap=False, **kwargs):
+    def moment_of_inertia(group, wrap=False, unwrap=False, compound="group"):
         """Tensor moment of inertia relative to center of mass as 3x3 numpy
         array.
 
         Parameters
         ----------
         wrap : bool, optional
-            If ``True``, move all atoms within the primary unit cell before
-            calculation. [``False``]
+            If ``True`` and `compound` is ``'group'``, move all atoms to the
+            primary unit cell before calculation.
+            If ``True`` and `compound` is not ``group``, the
+            centers of mass of each compound will be calculated without moving
+            any atoms to keep the compounds intact. Instead, the resulting
+            center-of-mass position vectors will be moved to the primary unit
+            cell after calculation.
+        unwrap : bool, optional
+            If ``True``, compounds will be unwrapped before computing their
+            centers and tensor of inertia.
+        compound : {'group', 'segments', 'residues', 'molecules', 'fragments'},\
+                   optional
+            `compound` determines the behavior of `wrap`.
+            Note that, in any case, *only* the positions of :class:`Atoms<Atom>`
+            *belonging to the group* will be taken into account.
+
+        Returns
+        -------
+        I : array
+            Tensor of inertia as a 3 x 3 numpy array.
 
 
-        .. versionchanged:: 0.8 Added *pbc* keyword
-        .. versionchanged:: 0.20.0 Added `unwrap` parameter
-        .. versionchanged::
-           2.1.0 Renamed `pbc` kwarg to `wrap`. `pbc` is still accepted but
+        .. versionchanged:: 0.8
+           Added `pbc` keyword
+        .. versionchanged:: 0.20.0
+           Added `unwrap` parameter
+        .. versionchanged:: 2.1.0
+           Renamed `pbc` kwarg to `wrap`. `pbc` is still accepted but
            is deprecated and will be removed in version 3.0.
         """
         atomgroup = group.atoms
-        unwrap = kwargs.pop('unwrap', False)
-        compound = kwargs.pop('compound', 'group')
 
         com = atomgroup.center_of_mass(
             wrap=wrap, unwrap=unwrap, compound=compound)
@@ -1632,9 +1652,10 @@ class Masses(AtomAttr):
             calculation. [``False``]
 
 
-        .. versionchanged:: 0.8 Added *pbc* keyword
-        .. versionchanged::
-           2.1.0 Renamed `pbc` kwarg to `wrap`. `pbc` is still accepted but
+        .. versionchanged:: 0.8
+           Added `pbc` keyword
+        .. versionchanged:: 2.1.0
+           Renamed `pbc` kwarg to `wrap`. `pbc` is still accepted but
            is deprecated and will be removed in version 3.0.
         """
         atomgroup = group.atoms
@@ -1656,7 +1677,7 @@ class Masses(AtomAttr):
 
     @warn_if_not_unique
     @_pbc_to_wrap
-    def shape_parameter(group, wrap=False, **kwargs):
+    def shape_parameter(group, wrap=False):
         """Shape parameter.
 
         See [Dima2004a]_ for background information.
@@ -1669,10 +1690,12 @@ class Masses(AtomAttr):
 
 
         .. versionadded:: 0.7.7
-        .. versionchanged:: 0.8 Added *pbc* keyword
-        .. versionchanged::
-           2.1.0 Renamed `pbc` kwarg to `wrap`. `pbc` is still accepted but
+        .. versionchanged:: 0.8
+           Added `pbc` keyword
+        .. versionchanged:: 2.1.0
+           Renamed `pbc` kwarg to `wrap`. `pbc` is still accepted but
            is deprecated and will be removed in version 3.0.
+           Superfluous kwargs were removed.
         """
         atomgroup = group.atoms
         masses = atomgroup.masses
@@ -1717,9 +1740,13 @@ class Masses(AtomAttr):
 
 
         .. versionadded:: 0.7.7
-        .. versionchanged:: 0.8 Added *pbc* keyword
-        .. versionchanged:: 0.20.0 Added *unwrap* and *compound* parameter
-
+        .. versionchanged:: 0.8
+           Added `pbc` keyword
+        .. versionchanged:: 0.20.0
+           Added *unwrap* and *compound* parameter
+        .. versionchanged:: 2.1.0
+           Renamed `pbc` kwarg to `wrap`. `pbc` is still accepted but
+           is deprecated and will be removed in version 3.0.
         """
         atomgroup = group.atoms
         masses = atomgroup.masses
@@ -1767,7 +1794,7 @@ class Masses(AtomAttr):
 
         Parameters
         ----------
-        pbc : bool, optional
+        wrap : bool, optional
             If ``True``, move all atoms within the primary unit cell before
             calculation. [``False``]
 
@@ -1778,10 +1805,13 @@ class Masses(AtomAttr):
             ``v[2]`` as third eigenvector.
 
 
-        .. versionchanged:: 0.8 Added *pbc* keyword
+        .. versionchanged:: 0.8
+           Added `pbc` keyword
         .. versionchanged:: 1.0.0
-            Always return principal axes in right-hand convention.
-
+           Always return principal axes in right-hand convention.
+        .. versionchanged:: 2.1.0
+           Renamed `pbc` kwarg to `wrap`. `pbc` is still accepted but
+           is deprecated and will be removed in version 3.0.
         """
         atomgroup = group.atoms
         e_val, e_vec = np.linalg.eig(atomgroup.moment_of_inertia(wrap=wrap))

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -1560,7 +1560,7 @@ class Masses(AtomAttr):
     @_pbc_to_wrap
     @check_wrap_and_unwrap
     def moment_of_inertia(group, wrap=False, unwrap=False, compound="group"):
-        """Moment of inertia tensor relative to center of mass.
+        r"""Moment of inertia tensor relative to center of mass.
 
         Parameters
         ----------
@@ -1586,30 +1586,31 @@ class Masses(AtomAttr):
         moment_of_inertia : numpy.ndarray
             Moment of inertia tensor as a 3 x 3 numpy array.
 
-        Note
-        ----
+        Notes
+        -----
         The moment of inertia tensor :math:`\mathsf{I}` is calculated for a group of
         :math:`N` atoms with coordinates :math:`\mathbf{r}_i,\ 1 \le i \le N`
         relative to its center of mass from the relative coordinates
 
         .. math::
-           \mathbf{r}'_i = \mathbf{r}_i - \frac{1}{\sum_{i=1}^{N}} \sum_{i=1}^{N} m_i \mathbf{r}_i
+           \mathbf{r}'_i = \mathbf{r}_i - \frac{1}{\sum_{i=1}^{N} m_i} \sum_{i=1}^{N} m_i \mathbf{r}_i
 
         as
 
         .. math::
-           \mathsf{I} = \sum_{i=1}^{N} m_i [(\mathbf{r}'_i\cdot\mathbf{r}'_i) \sum_{\alpha=1}^{3}
-                 \hat{\mathbf{e}}_\alpha \otimes \hat{\mathbf{e}}_\alpha - \mathbf{r}'_i \otimes \mathbf{r}'_i]
+           \mathsf{I} = \sum_{i=1}^{N} m_i \Big[(\mathbf{r}'_i\cdot\mathbf{r}'_i) \sum_{\alpha=1}^{3}
+                 \hat{\mathbf{e}}_\alpha \otimes \hat{\mathbf{e}}_\alpha - \mathbf{r}'_i \otimes \mathbf{r}'_i\Big]
 
         where :math:`\hat{\mathbf{e}}_\alpha` are Cartesian unit vectors, or in Cartesian coordinates
 
         .. math::
            I_{\alpha,\beta} = \sum_{k=1}^{N} m_k
-                 \Big(\big(\sum_{\gamma=1}^3 (x'^{(k)}_{\alpha})^2 \big)\delta_{\alpha,\beta}
+                 \Big(\big(\sum_{\gamma=1}^3 (x'^{(k)}_{\gamma})^2 \big)\delta_{\alpha,\beta}
                  - x'^{(k)}_{\alpha} x'^{(k)}_{\beta} \Big).
 
         where :math:`x'^{(k)}_{\alpha}` are the Cartesian coordinates of the
         relative coordinates :math:`\mathbf{r}'_k`.
+
 
         .. versionchanged:: 0.8
            Added `pbc` keyword
@@ -1618,7 +1619,6 @@ class Masses(AtomAttr):
         .. versionchanged:: 2.1.0
            Renamed `pbc` kwarg to `wrap`. `pbc` is still accepted but
            is deprecated and will be removed in version 3.0.
-
         """
         atomgroup = group.atoms
 

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -55,7 +55,7 @@ from . import selection
 from .groups import (ComponentBase, GroupBase,
                      Atom, Residue, Segment,
                      AtomGroup, ResidueGroup, SegmentGroup,
-                     check_pbc_and_unwrap)
+                     check_wrap_and_unwrap, _pbc_to_wrap)
 from .. import _TOPOLOGY_ATTRS, _TOPOLOGY_TRANSPLANTS, _TOPOLOGY_ATTRNAMES
 
 
@@ -1451,9 +1451,10 @@ class Masses(AtomAttr):
         return masses
 
     @warn_if_not_unique
-    @check_pbc_and_unwrap
-    def center_of_mass(group, pbc=False, compound='group', unwrap=False):
-        r"""Center of mass of (compounds of) the group.
+    @_pbc_to_wrap
+    @check_wrap_and_unwrap
+    def center_of_mass(group, wrap=False, unwrap=False, compound='group'):
+        """Center of mass of (compounds of) the group.
 
         Computes the center of mass of :class:`Atoms<Atom>` in the group.
         Centers of mass per :class:`Residue`, :class:`Segment`, molecule, or
@@ -1464,14 +1465,17 @@ class Masses(AtomAttr):
 
         Parameters
         ----------
-        pbc : bool, optional
+        wrap : bool, optional
             If ``True`` and `compound` is ``'group'``, move all atoms to the
             primary unit cell before calculation.
-            If ``True`` and `compound` is ``'segments'`` or ``'residues'``, the
+            If ``True`` and `compound` is not ``group``, the
             centers of mass of each compound will be calculated without moving
             any atoms to keep the compounds intact. Instead, the resulting
             center-of-mass position vectors will be moved to the primary unit
             cell after calculation.
+        unwrap : bool, optional
+            If ``True``, compounds will be unwrapped before computing their
+            centers.
         compound : {'group', 'segments', 'residues', 'molecules', 'fragments'},\
                    optional
             If ``'group'``, the center of mass of all atoms in the group will
@@ -1481,8 +1485,6 @@ class Masses(AtomAttr):
             array.
             Note that, in any case, *only* the positions of :class:`Atoms<Atom>`
             *belonging to the group* will be taken into account.
-        unwrap : bool, optional
-            If ``True``, compounds will be unwrapped before computing their centers.
 
         Returns
         -------
@@ -1505,9 +1507,11 @@ class Masses(AtomAttr):
         .. versionchanged:: 0.20.0 Added ``'molecules'`` and ``'fragments'``
             compounds
         .. versionchanged:: 0.20.0 Added `unwrap` parameter
+        .. versionchanged:: x.y.z  Renamed `pbc` parameter to `wrap`
         """
         atoms = group.atoms
-        return atoms.center(weights=atoms.masses, pbc=pbc, compound=compound, unwrap=unwrap)
+        return atoms.center(weights=atoms.masses, wrap=wrap, compound=compound,
+                            unwrap=unwrap)
 
     transplants[GroupBase].append(
         ('center_of_mass', center_of_mass))
@@ -1549,33 +1553,34 @@ class Masses(AtomAttr):
         ('total_mass', total_mass))
 
     @warn_if_not_unique
-    @check_pbc_and_unwrap
-    def moment_of_inertia(group, pbc=False, **kwargs):
+    @_pbc_to_wrap
+    @check_wrap_and_unwrap
+    def moment_of_inertia(group, wrap=False, **kwargs):
         """Tensor moment of inertia relative to center of mass as 3x3 numpy
         array.
 
         Parameters
         ----------
-        pbc : bool, optional
+        wrap : bool, optional
             If ``True``, move all atoms within the primary unit cell before
             calculation. [``False``]
 
 
         .. versionchanged:: 0.8 Added *pbc* keyword
         .. versionchanged:: 0.20.0 Added `unwrap` parameter
-
+        .. versionchanged:: x.y.z Renamed `pbc` kwarg to `wrap`
         """
         atomgroup = group.atoms
         unwrap = kwargs.pop('unwrap', False)
         compound = kwargs.pop('compound', 'group')
 
         com = atomgroup.center_of_mass(
-            pbc=pbc, unwrap=unwrap, compound=compound)
+            wrap=wrap, unwrap=unwrap, compound=compound)
         if compound != 'group':
             com = (com * group.masses[:, None]
                    ).sum(axis=0) / group.masses.sum()
 
-        if pbc:
+        if wrap:
             pos = atomgroup.pack_into_box(inplace=False) - com
         elif unwrap:
             pos = atomgroup.unwrap(compound=compound, inplace=False) - com
@@ -1612,24 +1617,26 @@ class Masses(AtomAttr):
         ('moment_of_inertia', moment_of_inertia))
 
     @warn_if_not_unique
-    def radius_of_gyration(group, pbc=False, **kwargs):
+    @_pbc_to_wrap
+    def radius_of_gyration(group, wrap=False, **kwargs):
         """Radius of gyration.
 
         Parameters
         ----------
-        pbc : bool, optional
+        wrap : bool, optional
             If ``True``, move all atoms within the primary unit cell before
             calculation. [``False``]
 
 
         .. versionchanged:: 0.8 Added *pbc* keyword
-
+        .. versionchanged:: x.y.z
+           Renamed `pbc` kwarg to `wrap`
         """
         atomgroup = group.atoms
         masses = atomgroup.masses
 
-        com = atomgroup.center_of_mass(pbc=pbc)
-        if pbc:
+        com = atomgroup.center_of_mass(wrap=wrap)
+        if wrap:
             recenteredpos = atomgroup.pack_into_box(inplace=False) - com
         else:
             recenteredpos = atomgroup.positions - com
@@ -1643,27 +1650,29 @@ class Masses(AtomAttr):
         ('radius_of_gyration', radius_of_gyration))
 
     @warn_if_not_unique
-    def shape_parameter(group, pbc=False, **kwargs):
+    @_pbc_to_wrap
+    def shape_parameter(group, wrap=False, **kwargs):
         """Shape parameter.
 
         See [Dima2004a]_ for background information.
 
         Parameters
         ----------
-        pbc : bool, optional
+        wrap : bool, optional
             If ``True``, move all atoms within the primary unit cell before
             calculation. [``False``]
 
 
         .. versionadded:: 0.7.7
         .. versionchanged:: 0.8 Added *pbc* keyword
-
+        .. versionchanged:: x.y.z
+           Renamed `pbc` kwarg to `wrap`
         """
         atomgroup = group.atoms
         masses = atomgroup.masses
 
-        com = atomgroup.center_of_mass(pbc=pbc)
-        if pbc:
+        com = atomgroup.center_of_mass(wrap=wrap)
+        if wrap:
             recenteredpos = atomgroup.pack_into_box(inplace=False) - com
         else:
             recenteredpos = atomgroup.positions - com
@@ -1683,15 +1692,16 @@ class Masses(AtomAttr):
         ('shape_parameter', shape_parameter))
 
     @warn_if_not_unique
-    @check_pbc_and_unwrap
-    def asphericity(group, pbc=False, unwrap=None, compound='group'):
+    @_pbc_to_wrap
+    @check_wrap_and_unwrap
+    def asphericity(group, wrap=False, unwrap=None, compound='group'):
         """Asphericity.
 
         See [Dima2004b]_ for background information.
 
         Parameters
         ----------
-        pbc : bool, optional
+        wrap : bool, optional
             If ``True``, move all atoms within the primary unit cell before
             calculation. [``False``]
         unwrap : bool, optional
@@ -1709,12 +1719,12 @@ class Masses(AtomAttr):
         masses = atomgroup.masses
 
         com = atomgroup.center_of_mass(
-            pbc=pbc, unwrap=unwrap, compound=compound)
+            wrap=wrap, unwrap=unwrap, compound=compound)
         if compound != 'group':
             com = (com * group.masses[:, None]
                    ).sum(axis=0) / group.masses.sum()
 
-        if pbc:
+        if wrap:
             recenteredpos = (atomgroup.pack_into_box(inplace=False) - com)
         elif unwrap:
             recenteredpos = (atomgroup.unwrap(inplace=False) - com)
@@ -1737,7 +1747,8 @@ class Masses(AtomAttr):
         ('asphericity', asphericity))
 
     @warn_if_not_unique
-    def principal_axes(group, pbc=False):
+    @_pbc_to_wrap
+    def principal_axes(group, wrap=False):
         """Calculate the principal axes from the moment of inertia.
 
         e1,e2,e3 = AtomGroup.principal_axes()
@@ -1767,7 +1778,7 @@ class Masses(AtomAttr):
 
         """
         atomgroup = group.atoms
-        e_val, e_vec = np.linalg.eig(atomgroup.moment_of_inertia(pbc=pbc))
+        e_val, e_vec = np.linalg.eig(atomgroup.moment_of_inertia(wrap=wrap))
 
         # Sort
         indices = np.argsort(e_val)[::-1]

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -1560,8 +1560,7 @@ class Masses(AtomAttr):
     @_pbc_to_wrap
     @check_wrap_and_unwrap
     def moment_of_inertia(group, wrap=False, unwrap=False, compound="group"):
-        """Tensor moment of inertia relative to center of mass as 3x3 numpy
-        array.
+        """Moment of inertia tensor relative to center of mass.
 
         Parameters
         ----------
@@ -1584,9 +1583,33 @@ class Masses(AtomAttr):
 
         Returns
         -------
-        I : array
-            Tensor of inertia as a 3 x 3 numpy array.
+        moment_of_inertia : numpy.ndarray
+            Moment of inertia tensor as a 3 x 3 numpy array.
 
+        Note
+        ----
+        The moment of inertia tensor :math:`\mathsf{I}` is calculated for a group of
+        :math:`N` atoms with coordinates :math:`\mathbf{r}_i,\ 1 \le i \le N`
+        relative to its center of mass from the relative coordinates
+
+        .. math::
+           \mathbf{r}'_i = \mathbf{r}_i - \frac{1}{\sum_{i=1}^{N}} \sum_{i=1}^{N} m_i \mathbf{r}_i
+
+        as
+
+        .. math::
+           \mathsf{I} = \sum_{i=1}^{N} m_i [(\mathbf{r}'_i\cdot\mathbf{r}'_i) \sum_{\alpha=1}^{3}
+                 \hat{\mathbf{e}}_\alpha \otimes \hat{\mathbf{e}}_\alpha - \mathbf{r}'_i \otimes \mathbf{r}'_i]
+
+        where :math:`\hat{\mathbf{e}}_\alpha` are Cartesian unit vectors, or in Cartesian coordinates
+
+        .. math::
+           I_{\alpha,\beta} = \sum_{k=1}^{N} m_k
+                 \Big(\big(\sum_{\gamma=1}^3 (x'^{(k)}_{\alpha})^2 \big)\delta_{\alpha,\beta}
+                 - x'^{(k)}_{\alpha} x'^{(k)}_{\beta} \Big).
+
+        where :math:`x'^{(k)}_{\alpha}` are the Cartesian coordinates of the
+        relative coordinates :math:`\mathbf{r}'_k`.
 
         .. versionchanged:: 0.8
            Added `pbc` keyword
@@ -1595,6 +1618,7 @@ class Masses(AtomAttr):
         .. versionchanged:: 2.1.0
            Renamed `pbc` kwarg to `wrap`. `pbc` is still accepted but
            is deprecated and will be removed in version 3.0.
+
         """
         atomgroup = group.atoms
 

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -1507,7 +1507,7 @@ class Masses(AtomAttr):
         .. versionchanged:: 0.20.0 Added ``'molecules'`` and ``'fragments'``
             compounds
         .. versionchanged:: 0.20.0 Added `unwrap` parameter
-        .. versionchanged:: x.y.z  Renamed `pbc` parameter to `wrap`
+        .. versionchanged:: 2.0.0  Renamed `pbc` parameter to `wrap`
         """
         atoms = group.atoms
         return atoms.center(weights=atoms.masses, wrap=wrap, compound=compound,
@@ -1568,7 +1568,7 @@ class Masses(AtomAttr):
 
         .. versionchanged:: 0.8 Added *pbc* keyword
         .. versionchanged:: 0.20.0 Added `unwrap` parameter
-        .. versionchanged:: x.y.z Renamed `pbc` kwarg to `wrap`
+        .. versionchanged:: 2.0.0 Renamed `pbc` kwarg to `wrap`
         """
         atomgroup = group.atoms
         unwrap = kwargs.pop('unwrap', False)
@@ -1629,7 +1629,7 @@ class Masses(AtomAttr):
 
 
         .. versionchanged:: 0.8 Added *pbc* keyword
-        .. versionchanged:: x.y.z
+        .. versionchanged:: 2.0.0
            Renamed `pbc` kwarg to `wrap`
         """
         atomgroup = group.atoms
@@ -1665,7 +1665,7 @@ class Masses(AtomAttr):
 
         .. versionadded:: 0.7.7
         .. versionchanged:: 0.8 Added *pbc* keyword
-        .. versionchanged:: x.y.z
+        .. versionchanged:: 2.0.0
            Renamed `pbc` kwarg to `wrap`
         """
         atomgroup = group.atoms

--- a/package/MDAnalysis/transformations/rotate.py
+++ b/package/MDAnalysis/transformations/rotate.py
@@ -173,7 +173,7 @@ class rotateby(TransformationBase):
                     raise TypeError(errmsg) from None
             self.center_method = partial(self.atoms.center,
                                          self.weights,
-                                         pbc=self.wrap)
+                                         wrap=self.wrap)
         else:
             raise ValueError('A point or an AtomGroup must be specified')
 

--- a/package/MDAnalysis/transformations/translate.py
+++ b/package/MDAnalysis/transformations/translate.py
@@ -122,7 +122,7 @@ class center_in_box(TransformationBase):
     -------
     :class:`~MDAnalysis.coordinates.base.Timestep` object
 
-    
+
     .. versionchanged:: 2.0.0
         The transformation was changed from a function/closure to a class
         with ``__call__``.

--- a/package/MDAnalysis/transformations/translate.py
+++ b/package/MDAnalysis/transformations/translate.py
@@ -122,7 +122,7 @@ class center_in_box(TransformationBase):
     -------
     :class:`~MDAnalysis.coordinates.base.Timestep` object
 
-
+    
     .. versionchanged:: 2.0.0
         The transformation was changed from a function/closure to a class
         with ``__call__``.
@@ -148,10 +148,10 @@ class center_in_box(TransformationBase):
         try:
             if self.center == 'geometry':
                 self.center_method = partial(self.ag.center_of_geometry,
-                                             pbc=pbc_arg)
+                                             wrap=pbc_arg)
             elif self.center == 'mass':
                 self.center_method = partial(self.ag.center_of_mass,
-                                             pbc=pbc_arg)
+                                             wrap=pbc_arg)
             else:
                 raise ValueError(f'{self.center} is valid for center')
         except AttributeError:

--- a/testsuite/MDAnalysisTests/core/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/core/test_atomgroup.py
@@ -1142,12 +1142,12 @@ class TestPBCFlag(object):
                                              'bbox',
                                              'bsphere',
                                              'principal_axes'))
-    def test_pbc(self, ag, wrap, ref, method_name):
+    def test_wrap(self, ag, wrap, ref, method_name):
         method = getattr(ag, method_name)
         if wrap:
             result = method(wrap=True)
         else:
-            # Test no-pbc as the default behaviour
+            # Test no-wrap as the default behaviour
             result = method()
 
         if method_name == 'bsphere':
@@ -1281,7 +1281,7 @@ class TestAtomGroup(object):
                for a in ag.groupby(name).values()]
         ref = distances.apply_PBC(np.asarray(ref, dtype=np.float32),
                                   ag.dimensions)
-        vals = getattr(ag, method_name)(wrap=True, compound=compound,
+        vals = getattr(ag, method_name)(compound=compound,
                                         unwrap=unwrap)
         assert_almost_equal(vals, ref, decimal=5)
 
@@ -1308,7 +1308,7 @@ class TestAtomGroup(object):
                for a in ag_molfrg.groupby(name).values()]
         ref = distances.apply_PBC(np.asarray(ref, dtype=np.float32),
                                   ag_molfrg.dimensions)
-        vals = getattr(ag_molfrg, method_name)(wrap=True, compound=compound,
+        vals = getattr(ag_molfrg, method_name)(compound=compound,
                                                unwrap=unwrap)
         assert_almost_equal(vals, ref, decimal=5)
 
@@ -1330,7 +1330,7 @@ class TestAtomGroup(object):
     def test_center_compounds_single(self, ag_molfrg, wrap, weights, compound):
         at = ag_molfrg[0]
         if weights is None or weights[0] != 0.0:
-            if pbc:
+            if wrap:
                 ref = distances.apply_PBC(at.position, ag_molfrg.dimensions)
                 ref = ref.astype(np.float64)
             else:
@@ -1340,7 +1340,7 @@ class TestAtomGroup(object):
         if compound != 'group':
             ref = ref.reshape((1, 3))
         ag_s = mda.AtomGroup([at])
-        assert_equal(ref, ag_s.center(weights, wrap=pbc, compound=compound))
+        assert_equal(ref, ag_s.center(weights, wrap=wrap, compound=compound))
 
     @pytest.mark.parametrize('wrap', (False, True))
     @pytest.mark.parametrize('weights', (None, np.array([])))
@@ -1622,7 +1622,7 @@ class TestAtomGroup(object):
     def test_bond_pbc(self, universe):
         sel2 = universe.select_atoms('segid 4AKE and resid 98'
                                      ).select_atoms("name OE1", "name OE2")
-        assert_almost_equal(sel2.bond.value(pbc=True), 2.1210737228393555, 3,
+        assert_almost_equal(sel2.bond.value(wrap=True), 2.1210737228393555, 3,
                             "distance of Glu98 OE1--OE2 wrong")
 
     def test_bond_ValueError(self, universe):

--- a/testsuite/MDAnalysisTests/core/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/core/test_atomgroup.py
@@ -1279,8 +1279,6 @@ class TestAtomGroup(object):
         ag.dimensions = [50, 50, 50, 90, 90, 90]
         ref = [getattr(a, method_name)(unwrap=unwrap)
                for a in ag.groupby(name).values()]
-        ref = distances.apply_PBC(np.asarray(ref, dtype=np.float32),
-                                  ag.dimensions)
         vals = getattr(ag, method_name)(compound=compound,
                                         unwrap=unwrap)
         assert_almost_equal(vals, ref, decimal=5)
@@ -1306,8 +1304,6 @@ class TestAtomGroup(object):
         ag_molfrg.dimensions = [50, 50, 50, 90, 90, 90]
         ref = [getattr(a, method_name)(unwrap=unwrap)
                for a in ag_molfrg.groupby(name).values()]
-        ref = distances.apply_PBC(np.asarray(ref, dtype=np.float32),
-                                  ag_molfrg.dimensions)
         vals = getattr(ag_molfrg, method_name)(compound=compound,
                                                unwrap=unwrap)
         assert_almost_equal(vals, ref, decimal=5)

--- a/testsuite/MDAnalysisTests/core/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/core/test_atomgroup.py
@@ -1622,7 +1622,7 @@ class TestAtomGroup(object):
     def test_bond_pbc(self, universe):
         sel2 = universe.select_atoms('segid 4AKE and resid 98'
                                      ).select_atoms("name OE1", "name OE2")
-        assert_almost_equal(sel2.bond.value(wrap=True), 2.1210737228393555, 3,
+        assert_almost_equal(sel2.bond.value(pbc=True), 2.1210737228393555, 3,
                             "distance of Glu98 OE1--OE2 wrong")
 
     def test_bond_ValueError(self, universe):

--- a/testsuite/MDAnalysisTests/core/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/core/test_atomgroup.py
@@ -479,19 +479,19 @@ class TestCenter(object):
             group = group.segments
 
         # get the expected results
-        center = group.center(weights=None, pbc=False,
+        center = group.center(weights=None, wrap=False,
                               compound=compound, unwrap=True)
 
         ref_center = u.center(compound=compound)
         assert_almost_equal(ref_center, center, decimal=4)
 
-    def test_center_unwrap_pbc_true_group(self):
+    def test_center_unwrap_wrap_true_group(self):
         u = UnWrapUniverse(is_triclinic=False)
         # select group appropriate for compound:
         group = u.atoms[39:47]  # molecule 12
         with pytest.raises(ValueError):
             group.center(weights=None, compound='group',
-                         unwrap=True, pbc=True)
+                         unwrap=True, wrap=True)
 
 
 class TestSplit(object):
@@ -1131,7 +1131,7 @@ class TestPBCFlag(object):
         universe = mda.Universe(TRZ_psf, TRZ)
         return universe.residues[0:3]
 
-    @pytest.mark.parametrize('pbc, ref', ((True, ref_PBC),
+    @pytest.mark.parametrize('wrap, ref', ((True, ref_PBC),
                                           (False, ref_noPBC)))
     @pytest.mark.parametrize('method_name', ('center_of_geometry',
                                              'center_of_mass',
@@ -1142,10 +1142,10 @@ class TestPBCFlag(object):
                                              'bbox',
                                              'bsphere',
                                              'principal_axes'))
-    def test_pbc(self, ag, pbc, ref, method_name):
+    def test_pbc(self, ag, wrap, ref, method_name):
         method = getattr(ag, method_name)
-        if pbc:
-            result = method(pbc=True)
+        if wrap:
+            result = method(wrap=True)
         else:
             # Test no-pbc as the default behaviour
             result = method()
@@ -1266,7 +1266,7 @@ class TestAtomGroup(object):
                                                 ('segids', 'segments')))
     def test_center_compounds(self, ag, name, compound, method_name):
         ref = [getattr(a, method_name)() for a in ag.groupby(name).values()]
-        vals = getattr(ag, method_name)(pbc=False, compound=compound)
+        vals = getattr(ag, method_name)(wrap=False, compound=compound)
         assert_almost_equal(vals, ref, decimal=5)
 
     @pytest.mark.parametrize('method_name', ('center_of_geometry',
@@ -1281,7 +1281,7 @@ class TestAtomGroup(object):
                for a in ag.groupby(name).values()]
         ref = distances.apply_PBC(np.asarray(ref, dtype=np.float32),
                                   ag.dimensions)
-        vals = getattr(ag, method_name)(pbc=True, compound=compound,
+        vals = getattr(ag, method_name)(wrap=True, compound=compound,
                                         unwrap=unwrap)
         assert_almost_equal(vals, ref, decimal=5)
 
@@ -1293,7 +1293,7 @@ class TestAtomGroup(object):
                                       compound, method_name):
         ref = [getattr(a, method_name)()
                for a in ag_molfrg.groupby(name).values()]
-        vals = getattr(ag_molfrg, method_name)(pbc=False, compound=compound)
+        vals = getattr(ag_molfrg, method_name)(wrap=False, compound=compound)
         assert_almost_equal(vals, ref, decimal=5)
 
     @pytest.mark.parametrize('method_name', ('center_of_geometry',
@@ -1308,7 +1308,7 @@ class TestAtomGroup(object):
                for a in ag_molfrg.groupby(name).values()]
         ref = distances.apply_PBC(np.asarray(ref, dtype=np.float32),
                                   ag_molfrg.dimensions)
-        vals = getattr(ag_molfrg, method_name)(pbc=True, compound=compound,
+        vals = getattr(ag_molfrg, method_name)(wrap=True, compound=compound,
                                                unwrap=unwrap)
         assert_almost_equal(vals, ref, decimal=5)
 
@@ -1326,8 +1326,8 @@ class TestAtomGroup(object):
                                          np.array([2.0])))
     @pytest.mark.parametrize('compound', ('group', 'residues', 'segments',
                                           'molecules', 'fragments'))
-    @pytest.mark.parametrize('pbc', (False, True))
-    def test_center_compounds_single(self, ag_molfrg, pbc, weights, compound):
+    @pytest.mark.parametrize('wrap', (False, True))
+    def test_center_compounds_single(self, ag_molfrg, wrap, weights, compound):
         at = ag_molfrg[0]
         if weights is None or weights[0] != 0.0:
             if pbc:
@@ -1340,24 +1340,24 @@ class TestAtomGroup(object):
         if compound != 'group':
             ref = ref.reshape((1, 3))
         ag_s = mda.AtomGroup([at])
-        assert_equal(ref, ag_s.center(weights, pbc=pbc, compound=compound))
+        assert_equal(ref, ag_s.center(weights, wrap=pbc, compound=compound))
 
-    @pytest.mark.parametrize('pbc', (False, True))
+    @pytest.mark.parametrize('wrap', (False, True))
     @pytest.mark.parametrize('weights', (None, np.array([])))
     @pytest.mark.parametrize('compound', ('group', 'residues', 'segments',
                                           'molecules', 'fragments'))
-    def test_center_compounds_empty(self, ag_molfrg, pbc, weights, compound):
+    def test_center_compounds_empty(self, ag_molfrg, wrap, weights, compound):
         ref = np.empty((0, 3), dtype=np.float64)
         ag_e = mda.AtomGroup([], ag_molfrg.universe)
-        assert_equal(ref, ag_e.center(weights, pbc=pbc, compound=compound))
+        assert_equal(ref, ag_e.center(weights, wrap=wrap, compound=compound))
 
-    @pytest.mark.parametrize('pbc', (False, True))
+    @pytest.mark.parametrize('wrap', (False, True))
     @pytest.mark.parametrize('name, compound', (('', 'group'),
                                                 ('resids', 'residues'),
                                                 ('segids', 'segments'),
                                                 ('molnums', 'molecules'),
                                                 ('fragindices', 'fragments')))
-    def test_center_compounds_zero_weights(self, ag_molfrg, pbc, name,
+    def test_center_compounds_zero_weights(self, ag_molfrg, wrap, name,
                                            compound):
         if compound == 'group':
             ref = np.full((3,), np.nan)
@@ -1365,7 +1365,7 @@ class TestAtomGroup(object):
             n_compounds = len(ag_molfrg.groupby(name))
             ref = np.full((n_compounds, 3), np.nan, dtype=np.float64)
         weights = np.zeros(len(ag_molfrg))
-        assert_equal(ref, ag_molfrg.center(weights, pbc=pbc,
+        assert_equal(ref, ag_molfrg.center(weights, wrap=wrap,
                                            compound=compound))
 
     def test_coordinates(self, ag):

--- a/testsuite/MDAnalysisTests/core/test_groups.py
+++ b/testsuite/MDAnalysisTests/core/test_groups.py
@@ -1541,9 +1541,17 @@ class TestDecorator(object):
 
         if pbc and unwrap:
             with pytest.raises(ValueError):
+                # We call a deprecated argument that does not appear in the
+                # function's signature. This is done on purpose to test the
+                # deprecation. We need to tell the linter.
+                # pylint: disable-next=unexpected-keyword-arg
                 self.dummy_funtion(compound=compound, pbc=pbc, unwrap=unwrap)
         else:
             with pytest.warns(DeprecationWarning):
+                # We call a deprecated argument that does not appear in the
+                # function's signature. This is done on purpose to test the
+                # deprecation. We need to tell the linter.
+                # pylint: disable-next=unexpected-keyword-arg
                 assert self.dummy_funtion(compound=compound, pbc=pbc, unwrap=unwrap) == 0
 
     @pytest.mark.parametrize('compound', ('fragments', 'molecules', 'residues',

--- a/testsuite/MDAnalysisTests/core/test_groups.py
+++ b/testsuite/MDAnalysisTests/core/test_groups.py
@@ -1528,21 +1528,35 @@ class TestInitGroup(object):
 
 
 class TestDecorator(object):
-    @groups.check_pbc_and_unwrap
-    def dummy_funtion(cls, compound="group", pbc=True, unwrap=True):
+    @groups._pbc_to_wrap
+    @groups.check_wrap_and_unwrap
+    def dummy_funtion(cls, compound="group", wrap=True, unwrap=True):
         return 0
 
     @pytest.mark.parametrize('compound', ('fragments', 'molecules', 'residues',
                                           'group', 'segments'))
     @pytest.mark.parametrize('pbc', (True, False))
     @pytest.mark.parametrize('unwrap', (True, False))
-    def test_decorator(self, compound, pbc, unwrap):
+    def test_wrap_and_unwrap_deprecation(self, compound, pbc, unwrap):
 
-        if compound == 'group' and pbc and unwrap:
+        if pbc and unwrap:
             with pytest.raises(ValueError):
                 self.dummy_funtion(compound=compound, pbc=pbc, unwrap=unwrap)
         else:
-            assert_equal(self.dummy_funtion(compound=compound, pbc=pbc, unwrap=unwrap), 0)
+            with pytest.warns(DeprecationWarning):
+                assert self.dummy_funtion(compound=compound, pbc=pbc, unwrap=unwrap) == 0
+
+    @pytest.mark.parametrize('compound', ('fragments', 'molecules', 'residues',
+                                          'group', 'segments'))
+    @pytest.mark.parametrize('wrap', (True, False))
+    @pytest.mark.parametrize('unwrap', (True, False))
+    def test_wrap_and_unwrap(self, compound, wrap, unwrap):
+
+        if wrap and unwrap:
+            with pytest.raises(ValueError):
+                self.dummy_funtion(compound=compound, wrap=wrap, unwrap=unwrap)
+        else:
+            assert self.dummy_funtion(compound=compound, wrap=wrap, unwrap=unwrap) == 0
 
 
 @pytest.fixture()

--- a/testsuite/MDAnalysisTests/core/test_wrap.py
+++ b/testsuite/MDAnalysisTests/core/test_wrap.py
@@ -74,10 +74,10 @@ class TestWrap(object):
         if compound == 'atoms':
             assert_in_box(group.atoms.positions, group.dimensions)
         elif center == 'com':
-            compos = group.atoms.center_of_mass(pbc=False, compound=compound)
+            compos = group.atoms.center_of_mass(wrap=False, compound=compound)
             assert_in_box(compos, group.dimensions)
         else:
-            cogpos = group.atoms.center_of_geometry(pbc=False,
+            cogpos = group.atoms.center_of_geometry(wrap=False,
                                                     compound=compound)
             assert_in_box(cogpos, group.dimensions)
 
@@ -441,9 +441,9 @@ class TestWrapTRZ(object):
         ag = u.atoms[:100]
         ag.wrap(compound='group', center=center)
         if center == 'com':
-            ctrpos = ag.center_of_mass(pbc=False, compound='group')
+            ctrpos = ag.center_of_mass(wrap=False, compound='group')
         elif center == 'cog':
-            ctrpos = ag.center_of_geometry(pbc=False, compound='group')
+            ctrpos = ag.center_of_geometry(wrap=False, compound='group')
         assert_in_box(ctrpos, u.dimensions)
 
     @pytest.mark.parametrize('center', ('com', 'cog'))
@@ -451,9 +451,9 @@ class TestWrapTRZ(object):
         ag = u.atoms[300:400].residues
         ag.wrap(compound='residues', center=center)
         if center == 'com':
-            ctrpos = ag.center_of_mass(pbc=False, compound='residues')
+            ctrpos = ag.center_of_mass(wrap=False, compound='residues')
         elif center == 'cog':
-            ctrpos = ag.center_of_geometry(pbc=False, compound='residues')
+            ctrpos = ag.center_of_geometry(wrap=False, compound='residues')
         assert_in_box(ctrpos, u.dimensions)
 
     @pytest.mark.parametrize('center', ('com', 'cog'))
@@ -461,9 +461,9 @@ class TestWrapTRZ(object):
         ag = u.atoms[1000:1200]
         ag.wrap(compound='segments', center=center)
         if center == 'com':
-            ctrpos = ag.center_of_mass(pbc=False, compound='segments')
+            ctrpos = ag.center_of_mass(wrap=False, compound='segments')
         elif center == 'cog':
-            ctrpos = ag.center_of_geometry(pbc=False, compound='segments')
+            ctrpos = ag.center_of_geometry(wrap=False, compound='segments')
         assert_in_box(ctrpos, u.dimensions)
 
     @pytest.mark.parametrize('center', ('com', 'cog'))
@@ -471,7 +471,7 @@ class TestWrapTRZ(object):
         ag = u.atoms[:250]
         ag.wrap(compound='fragments', center=center)
         if center == 'com':
-            ctrpos = ag.center_of_mass(pbc=False, compound='fragments')
+            ctrpos = ag.center_of_mass(wrap=False, compound='fragments')
         elif center == 'cog':
-            ctrpos = ag.center_of_geometry(pbc=False, compound='fragments')
+            ctrpos = ag.center_of_geometry(wrap=False, compound='fragments')
         assert_in_box(ctrpos, u.dimensions)


### PR DESCRIPTION
Related to issue #1760 in particular [@orbeckst ](https://github.com/MDAnalysis/mdanalysis/issues/1760#issuecomment-360320659) here

Changes made in this Pull Request:
 - pbc kwarg changed to wrap for Group methods

The `pbc` kwarg for center_of_mass has been confusing people for a while, it's not clear if this wraps (ie forcing atoms to inside the unit cell) or unwrap (ie makes bonds whole, possibly putting atoms outside the unit cell). 

The `pbc` option will still work for now but raise a deprecation warning

PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
