### PR TITLE
Add a reindex argument to the PDBWritter

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -62,6 +62,8 @@ Fixes
     would create a test artifact (Issue #2979, PR #2981)
 
 Enhancements
+  * The PDB writer gives more control over how to write the atom ids
+    (Issue #1072, PR #2886)
   * Refactored analysis.helanal into analysis.helix_analysis
     (Issue #2452, PR #2622)
   * Improved MSD code to accept `AtomGroup` and reject `UpdatingAtomGroup`

--- a/package/MDAnalysis/coordinates/PDB.py
+++ b/package/MDAnalysis/coordinates/PDB.py
@@ -827,7 +827,6 @@ class PDBWriter(base.WriterBase):
 
         con = collections.defaultdict(list)
         for a1, a2 in bonds:
-            print(a1, a2)
             if not (a1 in mapping and a2 in mapping):
                 continue
             con[a2].append(a1)

--- a/package/MDAnalysis/coordinates/PDB.py
+++ b/package/MDAnalysis/coordinates/PDB.py
@@ -534,7 +534,8 @@ class PDBWriter(base.WriterBase):
        An indexing issue meant it previously used the first charater (Issue #2224)
 
     .. versionchanged:: 2.0.0
-        Add the "reindex" argument.
+        Add the `redindex` argument. Setting this keyword to ``True``
+        (the default) preserves the behavior in earlier versions of MDAnalysis.
 
     """
     fmt = {

--- a/package/MDAnalysis/coordinates/PDB.py
+++ b/package/MDAnalysis/coordinates/PDB.py
@@ -806,7 +806,10 @@ class PDBWriter(base.WriterBase):
         bondset = set(itertools.chain(*(a.bonds for a in self.obj.atoms)))
         if self._reindex:
             index_attribute = 'index'
-            mapping = {index: i for i, index in enumerate(self.obj.atoms.indices, start=1)}
+            mapping = {
+                index: i
+                for i, index in enumerate(self.obj.atoms.indices, start=1)
+            }
             atoms = np.sort(self.obj.atoms.indices)
         else:
             index_attribute = 'id'
@@ -815,12 +818,18 @@ class PDBWriter(base.WriterBase):
         if self.bonds == "conect":
             # Write out only the bonds that were defined in CONECT records
             bonds = (
-                (getattr(bond[0], index_attribute), getattr(bond[1], index_attribute))
+                (
+                    getattr(bond[0], index_attribute),
+                    getattr(bond[1], index_attribute),
+                )
                 for bond in bondset if not bond.is_guessed
             )
         elif self.bonds == "all":
             bonds = (
-                (getattr(bond[0], index_attribute), getattr(bond[1], index_attribute))
+                (
+                    getattr(bond[0], index_attribute),
+                    getattr(bond[1], index_attribute),
+                )
                 for bond in bondset
             )
         else:

--- a/package/MDAnalysis/coordinates/PDB.py
+++ b/package/MDAnalysis/coordinates/PDB.py
@@ -800,9 +800,6 @@ class PDBWriter(base.WriterBase):
         if not self.obj or not hasattr(self.obj.universe, 'bonds'):
             return
 
-        if not self._reindex and not hasattr(self.obj.atoms, 'ids'):
-            return
-
         bondset = set(itertools.chain(*(a.bonds for a in self.obj.atoms)))
         if self._reindex:
             index_attribute = 'index'

--- a/package/MDAnalysis/coordinates/PDB.py
+++ b/package/MDAnalysis/coordinates/PDB.py
@@ -533,6 +533,9 @@ class PDBWriter(base.WriterBase):
        ChainID now comes from the last character of segid, as stated in the documentation.
        An indexing issue meant it previously used the first charater (Issue #2224)
 
+    .. versionchanged:: 2.0.0
+        Add the "reindex" argument.
+
     """
     fmt = {
         'ATOM': (
@@ -596,7 +599,7 @@ class PDBWriter(base.WriterBase):
 
     def __init__(self, filename, bonds="conect", n_atoms=None, start=0, step=1,
                  remarks="Created by PDBWriter",
-                 convert_units=True, multiframe=None):
+                 convert_units=True, multiframe=None, reindex=True):
         """Create a new PDBWriter
 
         Parameters
@@ -624,6 +627,9 @@ class PDBWriter(base.WriterBase):
            ``False``: write a single frame to the file; ``True``: create a
            multi frame PDB file in which frames are written as MODEL_ ... ENDMDL_
            records. If ``None``, then the class default is chosen.    [``None``]
+        reindex: bool (optional)
+            If ``True`` (default), the atom serial is set to be consecutive
+            numbers starting at 1. Else, use the atom id.
 
         """
         # n_atoms = None : dummy keyword argument
@@ -637,6 +643,7 @@ class PDBWriter(base.WriterBase):
         self.convert_units = convert_units
         self._multiframe = self.multiframe if multiframe is None else multiframe
         self.bonds = bonds
+        self._reindex = reindex
 
         if start < 0:
             raise ValueError("'Start' must be a positive value")
@@ -792,25 +799,39 @@ class PDBWriter(base.WriterBase):
         if not self.obj or not hasattr(self.obj.universe, 'bonds'):
             return
 
-        mapping = {index: i for i, index in enumerate(self.obj.atoms.indices)}
+        if not self._reindex and not hasattr(self.obj.atoms, 'ids'):
+            return
 
         bondset = set(itertools.chain(*(a.bonds for a in self.obj.atoms)))
+        if self._reindex:
+            index_attribute = 'index'
+            mapping = {index: i for i, index in enumerate(self.obj.atoms.indices, start=1)}
+            atoms = np.sort(self.obj.atoms.indices)
+        else:
+            index_attribute = 'id'
+            mapping = {id_: id_ for id_ in self.obj.atoms.ids}
+            atoms = np.sort(self.obj.atoms.ids)
         if self.bonds == "conect":
             # Write out only the bonds that were defined in CONECT records
-            bonds = ((bond[0].index, bond[1].index) for bond in bondset if not bond.is_guessed)
+            bonds = (
+                (getattr(bond[0], index_attribute), getattr(bond[1], index_attribute))
+                for bond in bondset if not bond.is_guessed
+            )
         elif self.bonds == "all":
-            bonds = ((bond[0].index, bond[1].index) for bond in bondset)
+            bonds = (
+                (getattr(bond[0], index_attribute), getattr(bond[1], index_attribute))
+                for bond in bondset
+            )
         else:
             raise ValueError("bonds has to be either None, 'conect' or 'all'")
 
         con = collections.defaultdict(list)
         for a1, a2 in bonds:
+            print(a1, a2)
             if not (a1 in mapping and a2 in mapping):
                 continue
             con[a2].append(a1)
             con[a1].append(a2)
-
-        atoms = np.sort(self.obj.atoms.indices)
 
         conect = ([mapping[a]] + sorted([mapping[at] for at in con[a]])
                   for a in atoms if a in con)
@@ -1042,9 +1063,22 @@ class PDBWriter(base.WriterBase):
         atomnames = get_attr('names', 'X')
         record_types = get_attr('record_types', 'ATOM')
 
+        # If reindex == False, we use the atom ids for the serial. We do not
+        # want to use a fallback here.
+        if not self._reindex:
+            try:
+                atom_ids = atoms.ids
+            except AttributeError:
+                raise NoDataError(
+                    'The "id" topology attribute is not set. '
+                    'Either set the attribute or use reindex=True.'
+                )
+        else:
+            atom_ids = np.arange(len(atoms)) + 1
+
         for i, atom in enumerate(atoms):
             vals = {}
-            vals['serial'] = util.ltruncate_int(i + 1, 5)  # check for overflow here?
+            vals['serial'] = util.ltruncate_int(atom_ids[i], 5)  # check for overflow here?
             vals['name'] = self._deduce_PDB_atom_name(atomnames[i], resnames[i])
             vals['altLoc'] = altlocs[i][:1]
             vals['resName'] = resnames[i][:4]
@@ -1153,7 +1187,7 @@ class PDBWriter(base.WriterBase):
         """Write CONECT_ record.
 
         """
-        conect = ["{0:5d}".format(entry + 1) for entry in conect]
+        conect = ["{0:5d}".format(entry) for entry in conect]
         conect = "".join(conect)
         self.pdbfile.write(self.fmt['CONECT'].format(conect))
 

--- a/testsuite/MDAnalysisTests/coordinates/test_pdb.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_pdb.py
@@ -513,6 +513,29 @@ class TestPDBWriter(object):
         with pytest.raises(ValueError, match=expected_msg):
             u.atoms.write(outfile)
 
+    def test_no_reindex(self, universe, tmpdir):
+        """
+        When setting the `reindex` keyword to False, the atom are
+        not reindexed.
+        """
+        pdb_path = str(tmpdir / 'output.pdb')
+        universe.atoms.ids = universe.atoms.ids + 23
+        universe.atoms.write(pdb_path, reindex=False)
+        read_universe = mda.Universe(pdb_path)
+        assert np.all(read_universe.atoms.ids == universe.atoms.ids)
+
+    def test_reindex(self, universe, tmpdir):
+        """
+        When setting the `reindex` keyword to True, the atom are
+        reindexed.
+        """
+        pdb_path = str(tmpdir / 'output.pdb')
+        universe.atoms.ids = universe.atoms.ids + 23
+        universe.atoms.write(pdb_path, reindex=True)
+        read_universe = mda.Universe(pdb_path)
+        # AG.ids is 1-based, while AG.indices is 0-based, hence the +1
+        assert np.all(read_universe.atoms.ids == universe.atoms.indices + 1)
+
 
 class TestMultiPDBReader(object):
     @staticmethod

--- a/testsuite/MDAnalysisTests/coordinates/test_pdb.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_pdb.py
@@ -524,6 +524,22 @@ class TestPDBWriter(object):
         read_universe = mda.Universe(pdb_path)
         assert np.all(read_universe.atoms.ids == universe.atoms.ids)
 
+    def test_no_reindex_bonds(self, universe, tmpdir):
+        """
+        When setting the `reindex` keyword to False, the connect
+        record match the non-reindexed atoms.
+        """
+        pdb_path = str(tmpdir / 'output.pdb')
+        universe.atoms.ids = universe.atoms.ids + 23
+        universe.atoms.write(pdb_path, reindex=False, bonds='all')
+        with open(pdb_path) as infile:
+            for line in infile:
+                if line.startswith('CONECT'):
+                    assert line.strip() == "CONECT   23   24   25   26   27"
+                    break
+            else:
+                raise AssertError('No CONECT record fond in the output.')
+
     def test_reindex(self, universe, tmpdir):
         """
         When setting the `reindex` keyword to True, the atom are


### PR DESCRIPTION
Fixes #1072

Changes made in this Pull Request:
 - Add a `reindex` argument to the `PDBWriter`. The argument is `True` by default and the atom serials are generated starting from 1. If the argument is set to `False`, then `atoms.ids` is used for the serial. This is reminiscent of #1781.


PR Checklist
------------
 - [x] Tests?
 - [X] Docs?
 - [x] CHANGELOG updated?
 - [X] Issue raised/referenced?
