### PR TITLE
Replace deprecated imp

### DIFF
--- a/package/MDAnalysis/coordinates/chemfiles.py
+++ b/package/MDAnalysis/coordinates/chemfiles.py
@@ -50,11 +50,11 @@ except ImportError:
     HAS_CHEMFILES = False
 
     # Allow building documentation even if chemfiles is not installed
-    import imp
+    import types
 
     class MockTrajectory:
         pass
-    chemfiles = imp.new_module("chemfiles")
+    chemfiles = types.ModuleType("chemfiles")
     chemfiles.Trajectory = MockTrajectory
 else:
     HAS_CHEMFILES = True


### PR DESCRIPTION
Fixes #2897

Changes made in this Pull Request:
 - replace deprecated `imp` with `types` to mock `chemfiles` when building docs.


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?
