### PR TITLE
backport fix for #2878 (pickle DCD and XDR readers at correct frame)

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,7 +13,7 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-??/??/20 orbeckst, VOD555, lilyminium
+??/??/20 orbeckst, VOD555, lilyminium, yuxuanzhuang
 
   * 1.0.1
 
@@ -24,6 +24,7 @@ Fixes
     density=True; the keyword was available since 0.19.0 but with incorrect
     semantics and not documented and did not produce correct results (Issue
     #2811, PR #2812)
+  * pickle correct frames of DCD, TRR, and XTC (#2878)
 
 
 06/09/20 richardjgowers, kain88-de, lilyminium, p-j-smith, bdice, joaomcteixeira,

--- a/package/MDAnalysis/lib/formats/libdcd.pyx
+++ b/package/MDAnalysis/lib/formats/libdcd.pyx
@@ -265,7 +265,8 @@ cdef class DCDFile:
             return
 
         current_frame = state[1]
-        self.seek(current_frame)
+        self.seek(current_frame - 1)
+        self.current_frame = current_frame
 
 
     def tell(self):

--- a/package/MDAnalysis/lib/formats/libmdaxdr.pyx
+++ b/package/MDAnalysis/lib/formats/libmdaxdr.pyx
@@ -306,7 +306,8 @@ cdef class _XDRFile:
 
         # where was I
         current_frame = state[1]
-        self.seek(current_frame)
+        self.seek(current_frame - 1)
+        self.current_frame = current_frame
 
     def seek(self, frame):
         """Seek to Frame.

--- a/package/setup.py
+++ b/package/setup.py
@@ -73,7 +73,7 @@ else:
     from commands import getoutput
 
 # NOTE: keep in sync with MDAnalysis.__version__ in version.py
-RELEASE = "1.0.0"
+RELEASE = "1.0.1-dev"
 
 is_release = 'dev' not in RELEASE
 

--- a/testsuite/MDAnalysisTests/coordinates/base.py
+++ b/testsuite/MDAnalysisTests/coordinates/base.py
@@ -25,7 +25,6 @@ import itertools
 import numpy as np
 import pytest
 from six.moves import zip, range
-from six.moves import cPickle as pickle
 from unittest import TestCase
 from numpy.testing import (assert_equal, assert_almost_equal,
                            assert_array_almost_equal, assert_allclose)
@@ -425,16 +424,6 @@ class BaseReaderTest(object):
         with pytest.raises(ValueError):
             transformed.add_transformations(translate([2,2,2]))
 
-    def test_pickle_reader(self, reader):
-        try:
-            reader_p = pickle.loads(pickle.dumps(reader))
-        except (TypeError, ValueError):
-            pytest.xfail("Pickling not yet implemented for format {}".format(
-                reader.format))
-        assert_equal(len(reader), len(reader_p))
-        assert_equal(reader.ts, reader_p.ts,
-                     "Timestep is changed after pickling")
-
 
 class MultiframeReaderTest(BaseReaderTest):
     def test_last_frame(self, ref, reader):
@@ -500,32 +489,6 @@ class MultiframeReaderTest(BaseReaderTest):
             assert_timestep_almost_equal(ts,
                                          ref.iter_ts(ref.aux_lowf_frames_with_steps[i]),
                                          decimal=ref.prec)
-
-    #  To make sure we not only save the current timestep information,
-    #  but also maintain its relative position.
-    def test_pickle_next_ts_reader(self, reader):
-        try:
-            reader_p = pickle.loads(pickle.dumps(reader))
-        except (TypeError, ValueError):
-            pytest.xfail("Pickling not yet implemented for format {}".format(
-                reader.format))
-        assert_equal(next(reader), next(reader_p),
-                     "Next timestep is changed after pickling")
-
-    #  To make sure pickle works for last frame.
-    def test_pickle_last_ts_reader(self, reader):
-        #  move current ts to last frame.
-        reader[-1]
-        try:
-            reader_p = pickle.loads(pickle.dumps(reader))
-        except (TypeError, ValueError):
-            pytest.xfail("Pickling not yet implemented for format {}".format(
-                reader.format))
-        assert_equal(len(reader), len(reader_p),
-                     "Last timestep is changed after pickling")
-        assert_equal(reader.ts, reader_p.ts,
-                     "Last timestep is changed after pickling")
-
 
 
 

--- a/testsuite/MDAnalysisTests/formats/test_libmdaxdr.py
+++ b/testsuite/MDAnalysisTests/formats/test_libmdaxdr.py
@@ -141,7 +141,6 @@ class TestCommonAPI(object):
         assert_almost_equal(frame.box, new_frame.box)
         assert frame.step == new_frame.step
         assert_almost_equal(frame.time, new_frame.time)
-        assert_almost_equal(frame.prec, new_frame.prec)
 
     def test_pickle(self, reader):
         mid = len(reader) // 2

--- a/testsuite/MDAnalysisTests/formats/test_libmdaxdr.py
+++ b/testsuite/MDAnalysisTests/formats/test_libmdaxdr.py
@@ -161,6 +161,16 @@ class TestCommonAPI(object):
         assert reader.fname == new_reader.fname
         assert reader.tell() != new_reader.tell()
 
+    #@pytest.mark.xfail
+    def test_pickle_immediately(self, reader):
+        # do not seek before pickling: this seems to leave the XDRFile
+        # object in weird state: is this supposed to work?
+        new_reader = pickle.loads(pickle.dumps(reader))
+
+        assert reader.fname == new_reader.fname
+        assert reader.tell() == new_reader.tell()
+
+
 
 @pytest.mark.parametrize("xdrfile, fname, offsets",
                          ((XTCFile, XTC_multi_frame, XTC_OFFSETS),

--- a/testsuite/MDAnalysisTests/formats/test_libmdaxdr.py
+++ b/testsuite/MDAnalysisTests/formats/test_libmdaxdr.py
@@ -26,7 +26,7 @@ from six.moves import cPickle as pickle
 import numpy as np
 
 from numpy.testing import (assert_almost_equal, assert_array_almost_equal,
-                           assert_array_equal)
+                           assert_array_equal, assert_equal)
 
 from MDAnalysis.lib.formats.libmdaxdr import TRRFile, XTCFile
 
@@ -128,20 +128,36 @@ class TestCommonAPI(object):
             with pytest.raises(IOError):
                 f.read()
 
-    def test_pickle(self, reader):
-        reader.seek(len(reader) - 1)
-        dump = pickle.dumps(reader)
-        new_reader = pickle.loads(dump)
+    @staticmethod
+    def _assert_compare_readers(old_reader, new_reader):
+        frame = old_reader.read()
+        new_frame = new_reader.read()
 
-        assert reader.fname == new_reader.fname
-        assert reader.tell() == new_reader.tell()
-        assert_almost_equal(reader.offsets, new_reader.offsets)
+        assert old_reader.fname == new_reader.fname
+        assert old_reader.tell() == new_reader.tell()
+
+        assert_equal(old_reader.offsets, new_reader.offsets)
+        assert_almost_equal(frame.x, new_frame.x)
+        assert_almost_equal(frame.box, new_frame.box)
+        assert frame.step == new_frame.step
+        assert_almost_equal(frame.time, new_frame.time)
+        assert_almost_equal(frame.prec, new_frame.prec)
+
+    def test_pickle(self, reader):
+        mid = len(reader) // 2
+        reader.seek(mid)
+        new_reader = pickle.loads(pickle.dumps(reader))
+        self._assert_compare_readers(reader, new_reader)
+
+    def test_pickle_last_frame(self, reader):
+        reader.seek(len(reader) - 1)
+        new_reader = pickle.loads(pickle.dumps(reader))
+        self._assert_compare_readers(reader, new_reader)
 
     def test_pickle_closed(self, reader):
         reader.seek(len(reader) - 1)
         reader.close()
-        dump = pickle.dumps(reader)
-        new_reader = pickle.loads(dump)
+        new_reader = pickle.loads(pickle.dumps(reader))
 
         assert reader.fname == new_reader.fname
         assert reader.tell() != new_reader.tell()

--- a/testsuite/setup.py
+++ b/testsuite/setup.py
@@ -88,7 +88,7 @@ if sys.version_info[:2] < (2, 7):
 
 if __name__ == '__main__':
     # this must be in-sync with MDAnalysis
-    RELEASE = "1.0.0"
+    RELEASE = "1.0.1-dev"
 
     with open("README") as summary:
         LONG_DESCRIPTION = summary.read()


### PR DESCRIPTION
Fixes #2878 (backport)

Changes made in this Pull Request:
 - change `__setstate__` for DCDReader and XTC/TRRReader according to https://github.com/MDAnalysis/mdanalysis/issues/2878#issuecomment-665973591
 - add tests (which xfail for any readers that cannot be pickled yet)


PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
