### PR TITLE
Remove as_Universe (Issue #2920)

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -86,6 +86,9 @@ Enhancements
     explicit in the topology (Issue #2468, PR #2775)
 
 Changes
+  * removes deprecated `as_Universe` function from MDAnalysis.core.universe,
+    as a result :class:`MDAnalysis.analysis.leaflet.LeafletFinder` now only
+    accepts Universes for its `universe` argument (Issue #2920)
   * deprecated NumPy type aliases have been replaced with their actual types
     (see upstream NumPy PR 14882), and our pytest configuration will raise an
     error for any violation when testing with development NumPy builds

--- a/package/MDAnalysis/__init__.py
+++ b/package/MDAnalysis/__init__.py
@@ -150,7 +150,7 @@ the OPLS/AA force field.
 
 """
 
-__all__ = ['Universe', 'as_Universe', 'Writer', 'fetch_mmtf',
+__all__ = ['Universe', 'Writer', 'fetch_mmtf',
            'AtomGroup', 'ResidueGroup', 'SegmentGroup']
 
 import logging
@@ -202,7 +202,7 @@ warnings.filterwarnings(action='once', category=DeprecationWarning,
 from . import units
 
 # Bring some often used objects into the current namespace
-from .core.universe import Universe, as_Universe, Merge
+from .core.universe import Universe, Merge
 from .core.groups import AtomGroup, ResidueGroup, SegmentGroup
 from .coordinates.core import writer as Writer
 

--- a/package/MDAnalysis/analysis/leaflet.py
+++ b/package/MDAnalysis/analysis/leaflet.py
@@ -93,9 +93,8 @@ class LeafletFinder(object):
 
     Parameters
     ----------
-    universe : Universe or str
-        :class:`MDAnalysis.Universe` or a file name (e.g., in PDB or
-        GRO format)
+    universe : Universe
+        :class:`~MDAnalysis.core.universe.Universe` object.
     select : AtomGroup or str
         A AtomGroup instance or a
         :meth:`Universe.select_atoms` selection string
@@ -119,7 +118,8 @@ class LeafletFinder(object):
     consecutively, starting at 0. To obtain the atoms in the input structure
     use :meth:`LeafletFinder.groups`::
 
-       L = LeafletFinder(PDB, 'name P*')
+       u_PDB = mda.Universe(PDB)
+       L = LeafletFinder(u_PDB, 'name P*')
        leaflet0 = L.groups(0)
        leaflet1 = L.groups(1)
 
@@ -132,12 +132,15 @@ class LeafletFinder(object):
 
        leaflet0.residues.atoms
 
+
     .. versionchanged:: 1.0.0
        Changed `selection` keyword to `select`
+    .. versionchanged:: 2.0.0
+       The universe keyword no longer accepts non-Universe arguments. Please
+       create a :class:`~MDAnalysis.core.universe.Universe` first.
     """
 
     def __init__(self, universe, select, cutoff=15.0, pbc=False, sparse=None):
-        universe = core.universe.as_Universe(universe)
         self.universe = universe
         self.selectionstring = select
         if isinstance(self.selectionstring, core.groups.AtomGroup):

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -1324,32 +1324,6 @@ class Universe(object):
         return cls(mol, **kwargs)
 
 
-# TODO: what is the point of this function???
-def as_Universe(*args, **kwargs):
-    """Return a universe from the input arguments.
-
-    1. If the first argument is a universe, just return it::
-
-         as_Universe(universe) --> universe
-
-    2. Otherwise try to build a universe from the first or the first
-       and second argument::
-
-         as_Universe(PDB, **kwargs) --> Universe(PDB, **kwargs)
-         as_Universe(PSF, DCD, **kwargs) --> Universe(PSF, DCD, **kwargs)
-         as_Universe(*args, **kwargs) --> Universe(*args, **kwargs)
-
-    Returns
-    -------
-    :class:`~MDAnalysis.core.groups.Universe`
-    """
-    if len(args) == 0:
-        raise TypeError("as_Universe() takes at least one argument (%d given)" % len(args))
-    elif len(args) == 1 and isinstance(args[0], Universe):
-        return args[0]
-    return Universe(*args, **kwargs)
-
-
 def Merge(*args):
     """Create a new new :class:`Universe` from one or more
     :class:`~MDAnalysis.core.groups.AtomGroup` instances.

--- a/testsuite/MDAnalysisTests/test_api.py
+++ b/testsuite/MDAnalysisTests/test_api.py
@@ -26,23 +26,26 @@ Test the user facing API is as we expect...
 
 import MDAnalysis as mda
 
+
 def test_Universe():
     assert mda.Universe is mda.core.universe.Universe
 
-def test_as_Universe():
-    assert mda.as_Universe is mda.core.universe.as_Universe
 
 def test_fetch_mmtf():
     assert mda.fetch_mmtf is mda.coordinates.MMTF.fetch_mmtf
 
+
 def test_Writer():
     assert mda.Writer is mda.coordinates.core.writer
+
 
 def test_AtomGroup():
     assert mda.AtomGroup is mda.core.groups.AtomGroup
 
+
 def test_ResidueGroup():
     assert mda.ResidueGroup is mda.core.groups.ResidueGroup
+
 
 def test_SegmentGroup():
     assert mda.SegmentGroup is mda.core.groups.SegmentGroup


### PR DESCRIPTION
Fixes #2920

Changes made in this Pull Request:
 - Removes `as_Universe` from MDAnalysis.core.universe
 - :class:`MDAnalysis.analysis.leaflet.LeafletFinder` no longer accepts paths to files for the `universe` argument.


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
