### PR TITLE
Removing type guessing (Issue #2918)

### DIFF
--- a/package/MDAnalysis/topology/FHIAIMSParser.py
+++ b/package/MDAnalysis/topology/FHIAIMSParser.py
@@ -101,12 +101,11 @@ class FHIAIMSParser(TopologyReaderBase):
             natoms = len(names)
 
         # Guessing time
-        atomtypes = guessers.guess_types(names)
         masses = guessers.guess_masses(names)
 
         attrs = [Atomnames(names),
                  Atomids(np.arange(natoms) + 1),
-                 Atomtypes(atomtypes, guessed=True),
+                 Atomtypes(names),
                  Masses(masses, guessed=True),
                  Resids(np.array([1])),
                  Resnums(np.array([1])),

--- a/package/MDAnalysis/topology/XYZParser.py
+++ b/package/MDAnalysis/topology/XYZParser.py
@@ -92,12 +92,11 @@ class XYZParser(TopologyReaderBase):
                 names[i] = name
 
         # Guessing time
-        atomtypes = guessers.guess_types(names)
         masses = guessers.guess_masses(names)
 
         attrs = [Atomnames(names),
                  Atomids(np.arange(natoms) + 1),
-                 Atomtypes(atomtypes, guessed=True),
+                 Atomtypes(names),
                  Masses(masses, guessed=True),
                  Resids(np.array([1])),
                  Resnums(np.array([1])),

--- a/testsuite/MDAnalysisTests/topology/test_fhiaims.py
+++ b/testsuite/MDAnalysisTests/topology/test_fhiaims.py
@@ -29,8 +29,8 @@ from MDAnalysisTests.datafiles import FHIAIMS
 
 class TestFHIAIMS(ParserBase):
     parser = mda.topology.FHIAIMSParser.FHIAIMSParser
-    expected_attrs = ['names', 'elements']
-    guessed_attrs = ['masses', 'types']
+    expected_attrs = ['types', 'names', 'elements']
+    guessed_attrs = ['masses']
     expected_n_residues = 1
     expected_n_segments = 1
     expected_n_atoms = 6

--- a/testsuite/MDAnalysisTests/topology/test_xyz.py
+++ b/testsuite/MDAnalysisTests/topology/test_xyz.py
@@ -35,8 +35,9 @@ class XYZBase(ParserBase):
     parser = mda.topology.XYZParser.XYZParser
     expected_n_residues = 1
     expected_n_segments = 1
-    expected_attrs = ['names', "elements"]
-    guessed_attrs = ['types', 'masses']
+    expected_attrs = ['types', 'names', "elements"]
+    guessed_attrs = ['masses']
+
 
 class TestXYZMini(XYZBase):
     ref_filename = XYZ_mini


### PR DESCRIPTION
Towards #2918 

Changes made in this Pull Request:
 - Removes type guessing from XYZ and FHIAIMS parsers

To do:
 - Add tests for elements/names/types
 - Fix RDKitParser

Won't fix:
  - Won't be fixing PDBParser here, to be raised in issue, but I'm not convinced it's correct to say that names aren't types in PDB files.


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
