### PR TITLE
Redirect docs to non-dev version

### DIFF
--- a/maintainer/update_json_stubs_sitemap.py
+++ b/maintainer/update_json_stubs_sitemap.py
@@ -79,6 +79,7 @@ REDIRECT = """
 for ver in versions[::-1]:
     if ver['latest']:
         latest_url = ver['url']
+        break
 else:
     try:
         latest_url = versions[-1]['url']


### PR DESCRIPTION
Changes made in this Pull Request:
 - break the for-else loop so docs.mdanalysis.org/latest ignores versions with "dev" in the name


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
