### PR TITLE
add docs for analysis.align.AverageStructure

### DIFF
--- a/package/MDAnalysis/analysis/align.py
+++ b/package/MDAnalysis/analysis/align.py
@@ -167,6 +167,7 @@ Functions and Classes
 
 .. autofunction:: alignto
 .. autoclass:: AlignTraj
+.. autoclass:: AverageStructure
 .. autofunction:: rotation_matrix
 
 
@@ -803,13 +804,8 @@ class AverageStructure(AnalysisBase):
           already a :class:`MemoryReader` then it is *always* treated as if
           ``in_memory`` had been set to ``True``.
 
+
         .. versionadded:: 1.0.0
-
-        .. versionchanged:: 1.0.0
-           Support for the ``start``, ``stop``, and ``step`` keywords has been
-           removed. These should instead be passed
-           to :meth:`AverageStructure.run`.
-
         """
         if in_memory or isinstance(mobile.trajectory, MemoryReader):
             mobile.transfer_to_memory()


### PR DESCRIPTION
Fixes #2943 

Changes made in this Pull Request:
 - backport PR #2944 to 1.0.x
 - cherry picked from commit 7cae0345af729c9dccba1e3043d4cc4004dad6a2
 - Add missing docs for AverageStructure
 - clean up versionchanged for AverageStructure 

PR Checklist
------------
 - n/a Tests?
 - [x] Docs?
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?
