### PR TITLE
ensure that unistd.h is included on recent clang

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -53,7 +53,9 @@ Fixes
   * libmdaxdr and libdcd classes in their last frame can now be pickled
     (Issue #2878, PR #2911)
   * AtomGroup now are pickled/unpickled without looking for its anchored
-    Universe (PR #2893) 
+    Universe (PR #2893)
+  * ensure that unistd.h is included on macOS when compiling ENCORE's spe.c
+    (Issue #2934)
 
 Enhancements
   * Refactored analysis.helanal into analysis.helix_analysis

--- a/package/MDAnalysis/analysis/encore/dimensionality_reduction/src/spe.c
+++ b/package/MDAnalysis/analysis/encore/dimensionality_reduction/src/spe.c
@@ -27,12 +27,10 @@
 #include <time.h>
 #include <sys/types.h>
 
-#ifdef __unix__
-    #include <unistd.h>
-#endif
-
 #ifdef _WIN32
     #include <io.h>
+#else /* unix-like __unix__ || __APPLE__ */
+    #include <unistd.h>
 #endif
 
 #define EPSILON 1e-8


### PR DESCRIPTION
Fixes #2934

Changes made in this Pull Request:
 - look for unistd.h when __unix__ or __APPLE__ is defined


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
