### PR TITLE
ParmEdConverter: fix NameError when catching NoDataError

### DIFF
--- a/package/MDAnalysis/coordinates/ParmEd.py
+++ b/package/MDAnalysis/coordinates/ParmEd.py
@@ -77,6 +77,7 @@ import functools
 from . import base
 from ..topology.tables import SYMB2Z
 from ..core.universe import Universe
+from ..exceptions import NoDataError
 
 
 class ParmEdReader(base.SingleFrameReaderBase):

--- a/package/MDAnalysis/coordinates/ParmEd.py
+++ b/package/MDAnalysis/coordinates/ParmEd.py
@@ -73,6 +73,8 @@ Classes
 
 """
 import functools
+import itertools
+import warnings
 
 from . import base
 from ..topology.tables import SYMB2Z

--- a/testsuite/MDAnalysisTests/coordinates/test_parmed.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_parmed.py
@@ -204,6 +204,17 @@ class BaseTestParmEdConverter:
                         p.improper == q.improper and
                         p.ignore_end == q.ignore_end) for q in original)
 
+    def test_missing_attr(self):
+            n_atoms = 10
+            u = mda.Universe.empty(n_atoms)
+            u.add_TopologyAttr("resid", [1])
+            u.add_TopologyAttr("segid", ["DUM"])
+            u.add_TopologyAttr("mass", [1] * n_atoms)
+            with pytest.warns(UserWarning,
+                            match="Supplied AtomGroup was missing the following "
+                                    "attributes"):
+                # should miss names and resnames
+                u.atoms.convert_to("PARMED")
 
 
 class BaseTestParmEdConverterSubset(BaseTestParmEdConverter):

--- a/testsuite/MDAnalysisTests/coordinates/test_parmed.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_parmed.py
@@ -205,16 +205,16 @@ class BaseTestParmEdConverter:
                         p.ignore_end == q.ignore_end) for q in original)
 
     def test_missing_attr(self):
-            n_atoms = 10
-            u = mda.Universe.empty(n_atoms)
-            u.add_TopologyAttr("resid", [1])
-            u.add_TopologyAttr("segid", ["DUM"])
-            u.add_TopologyAttr("mass", [1] * n_atoms)
-            with pytest.warns(UserWarning,
-                            match="Supplied AtomGroup was missing the following "
-                                    "attributes"):
-                # should miss names and resnames
-                u.atoms.convert_to("PARMED")
+        n_atoms = 10
+        u = mda.Universe.empty(n_atoms)
+        u.add_TopologyAttr("resid", [1])
+        u.add_TopologyAttr("segid", ["DUM"])
+        u.add_TopologyAttr("mass", [1] * n_atoms)
+        with pytest.warns(UserWarning,
+                          match="Supplied AtomGroup was missing the following "
+                                "attributes"):
+            # should miss names and resnames
+            u.atoms.convert_to("PARMED")
 
 
 class BaseTestParmEdConverterSubset(BaseTestParmEdConverter):


### PR DESCRIPTION
Converting to parmed when the AtomGroup doesn't have a resname leads to a NameError: the current code tries to catch the NoDataError but because NoDataError is not imported from exceptions.py it triggers a `NameError: name 'NoDataError' is not defined`

Changes made in this Pull Request:
 - import NoDataError from exceptions

Is the changelog update needed here ?

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
