### PR TITLE
Fix readme tutorial link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ of MDAnalysis.
 
 **Developers** may also want to refer to the `MDAnalysis API docs`_.
 
-A growing number of **`tutorials`_** are available that explain how to
+A growing number of `tutorials`_ are available that explain how to
 conduct RMSD calculations, structural alignment, distance and contact
 analysis, and many more.
 

--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ of MDAnalysis.
 
 **Developers** may also want to refer to the `MDAnalysis API docs`_.
 
-A growing number of **tutorials_** are available that explain how to
+A growing number of **`tutorials`_** are available that explain how to
 conduct RMSD calculations, structural alignment, distance and contact
 analysis, and many more.
 


### PR DESCRIPTION
I noticed the README.rst link for tutorials was broken.

Turns out that combining bold + reference is a non-trivial thing: https://docutils.sourceforge.io/FAQ.html#is-nested-inline-markup-possible.

It didn't seem immediately clear to me that bolding the tutorials link was necessary, so I just removed it. If we want to keep it I'll add in a substitution definition.

Changes made in this Pull Request:
 - Fix the link for tutorials in README.rst


PR Checklist
------------
 - Tests? N/A
 - Docs? N/A
 - CHANGELOG updated? N/A
 - Issue raised/referenced? N/A
