### PR TITLE
Use a fixture for npz files in test_bat

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -58,6 +58,8 @@ Fixes
     Universe (PR #2893)
   * ensure that unistd.h is included on macOS when compiling ENCORE's spe.c
     (Issue #2934)
+  * Fix tests for analysis.bat that could fail when run in parallel and that
+    would create a test artifact (Issue #2979, PR #2981)
 
 Enhancements
   * Refactored analysis.helanal into analysis.helix_analysis

--- a/testsuite/MDAnalysisTests/analysis/test_bat.py
+++ b/testsuite/MDAnalysisTests/analysis/test_bat.py
@@ -31,8 +31,6 @@ from MDAnalysisTests.datafiles import (PSF, DCD, mol2_comments_header, XYZ_mini,
                                        BATArray)
 from MDAnalysis.analysis.bat import BAT
 
-import os
-
 
 class TestBAT(object):
     @pytest.fixture()

--- a/testsuite/MDAnalysisTests/analysis/test_bat.py
+++ b/testsuite/MDAnalysisTests/analysis/test_bat.py
@@ -31,6 +31,8 @@ from MDAnalysisTests.datafiles import (PSF, DCD, mol2_comments_header, XYZ_mini,
                                        BATArray)
 from MDAnalysis.analysis.bat import BAT
 
+import os
+
 
 class TestBAT(object):
     @pytest.fixture()
@@ -44,6 +46,14 @@ class TestBAT(object):
         R = BAT(selected_residues)
         R.run()
         return R.bat
+
+    @pytest.fixture
+    def bat_npz(self, tmpdir, selected_residues):
+        filename = str(tmpdir / 'test_bat_IO.npy')
+        R = BAT(selected_residues)
+        R.run()
+        R.save(filename)
+        return filename
 
     def test_bat_root_selection(self, selected_residues):
         R = BAT(selected_residues)
@@ -79,11 +89,8 @@ class TestBAT(object):
             err_msg="error: Reconstructed Cartesian coordinates " + \
                     "don't match original")
 
-    def test_bat_IO(self, selected_residues, bat):
-        R = BAT(selected_residues)
-        R.run()
-        R.save('test_bat_IO.npy')
-        R2 = BAT(selected_residues, filename='test_bat_IO.npy')
+    def test_bat_IO(self, bat_npz, selected_residues, bat):
+        R2 = BAT(selected_residues, filename=bat_npz)
         test_bat = R2.bat
         assert_almost_equal(
             bat,
@@ -107,8 +114,8 @@ class TestBAT(object):
         with pytest.raises(ValueError):
             R = BAT(selected_residues)
 
-    def test_bat_incorrect_dims(self):
+    def test_bat_incorrect_dims(self, bat_npz):
         u = mda.Universe(PSF, DCD)
         selected_residues = u.select_atoms("resid 1-3")
         with pytest.raises(ValueError):
-            R = BAT(selected_residues, filename='test_bat_IO.npy')
+            R = BAT(selected_residues, filename=bat_npz)


### PR DESCRIPTION
Fixes #2979

The file test_bat_IO.npy was created in one test and used in
another one. This leads to the second test possibly failing
when the tests are run in parallel. This commit moves to create
the file into a fixture that the two tests depend.

The new fixture also uses the tmpdir fixture to avoid the file
created during the tests to remain in the test directory.

PR Checklist
------------
 - [X] Tests?
 - ~[ ] Docs?~
 - [x] CHANGELOG updated?
 - [X] Issue raised/referenced?
