### PR TITLE
Have CI use mamba

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ env:
     - INSTALL_HOLE="true"
     - CYTHON_TRACE_NOGIL=1
     - MPLBACKEND=agg
+    - MAMBA=true
 
   matrix:
     # Run a coverage test for most versions

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -90,6 +90,8 @@ Enhancements
     explicit in the topology (Issue #2468, PR #2775)
 
 Changes
+  * Continuous integration uses mamba rather than conda to install the
+    dependencies (PR #2983)
   * removes deprecated `as_Universe` function from MDAnalysis.core.universe,
     as a result :class:`MDAnalysis.analysis.leaflet.LeafletFinder` now only
     accepts Universes for its `universe` argument (Issue #2920)


### PR DESCRIPTION
mamba is a drop-in replacement for the conda CLI but faster

Hopefully, this will make CI goes faster by saving on install time. 


PR Checklist
------------
 - ~[ ] Tests?~
 - ~[ ] Docs?~
 - [X] CHANGELOG updated?
 - [ ] Issue raised/referenced?
