### PR TITLE
Update indexing in Charges and Masses get_residues

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -20,6 +20,8 @@ The rules for this file:
   * 2.0.0
 
 Fixes
+  * Avoid using deprecated array indexing in topology attributes
+    (Issue #2990, PR #2991)
   * ParmedParser no longer guesses elements if they are not recognised, instead
     empty strings are assigned (Issue #2933)
   * Instead of using ATOM for both ATOM and HETATM, HETATM record type

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -1116,7 +1116,7 @@ class Masses(AtomAttr):
 
         if isinstance(rg._ix, numbers.Integral):
             # for a single residue
-            masses = self.values[resatoms].sum()
+            masses = self.values[tuple(resatoms)].sum()
         else:
             # for a residuegroup
             masses = np.empty(len(rg))
@@ -1537,7 +1537,7 @@ class Charges(AtomAttr):
         resatoms = self.top.tt.residues2atoms_2d(rg.ix)
 
         if isinstance(rg._ix, numbers.Integral):
-            charges = self.values[resatoms].sum()
+            charges = self.values[tuple(resatoms)].sum()
         else:
             charges = np.empty(len(rg))
             for i, row in enumerate(resatoms):

--- a/testsuite/MDAnalysisTests/core/test_accumulate.py
+++ b/testsuite/MDAnalysisTests/core/test_accumulate.py
@@ -116,6 +116,11 @@ class TestTotals(object):
         ref = [sum(a.charges) for a in group.atoms.groupby(name).values()]
         assert_almost_equal(group.total_charge(compound=compound), ref)
 
+    @pytest.mark.filterwarnings(  # Prevents regression of issue #2990
+        "error:"
+        "Using a non-tuple sequence for multidimensional indexing is deprecated:"
+        "FutureWarning"
+    )
     def test_total_charge_duplicates(self, group):
         group2 = group + group[0]
         ref = group.total_charge() + group[0].charge
@@ -133,6 +138,11 @@ class TestTotals(object):
         ref = [sum(a.masses) for a in group.atoms.groupby(name).values()]
         assert_almost_equal(group.total_mass(compound=compound), ref)
 
+    @pytest.mark.filterwarnings(  # Prevents regression of issue #2990
+        "error:"
+        "Using a non-tuple sequence for multidimensional indexing is deprecated:"
+        "FutureWarning"
+    )
     def test_total_mass_duplicates(self, group):
         group2 = group + group[0]
         ref = group.total_mass() + group2[0].mass


### PR DESCRIPTION
Fixes #2990

Avoid indexing a numpy array with a list of arrays, use a tuple of array
instead. Multidimensional indexing of arrays with a non-tuple argument
is deprecated.

PR Checklist
------------
 - [X] Tests?
 - ~[ ] Docs?~
 - [x] CHANGELOG updated?
 - [X] Issue raised/referenced?
