### PR TITLE
Fixes AtomGroup.center when using compounds + unwrapping

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -15,11 +15,13 @@ The rules for this file:
 ------------------------------------------------------------------------------
 ??/??/?? tylerjereddy, richardjgowers, IAlibay, hmacdope, orbeckst, cbouy,
          lilyminium, daveminh, jbarnoud, yuxuanzhuang, VOD555, ianmkenney,
-         calcraven，xiki-tempula, mieczyslaw
+         calcraven，xiki-tempula, mieczyslaw, manuel.nuno.melo
 
   * 2.0.0
 
 Fixes
+  * AtomGroup.center now works correctly for compounds + unwrapping
+    (Issue #2984)
   * Avoid using deprecated array indexing in topology attributes
     (Issue #2990, PR #2991)
   * ParmedParser no longer guesses elements if they are not recognised, instead

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -830,12 +830,18 @@ class GroupBase(_MutableBase):
 
         # Sort positions and weights by compound index and promote to dtype if
         # required:
-        sort_indices = np.argsort(compound_indices)
+
+        # are we already sorted? argsorting and fancy-indexing can be expensive
+        if np.any(np.diff(compound_indices) < 0):
+            sort_indices = np.argsort(compound_indices)
+        else:
+            sort_indices = slice(None)
         compound_indices = compound_indices[sort_indices]
 
         # Unwrap Atoms
         if unwrap:
-            coords = atoms.unwrap(compound=comp, reference=None, inplace=False)
+            coords = atoms.unwrap(compound=comp, reference=None,
+                                  inplace=False)[sort_indices]
         else:
             coords = atoms.positions[sort_indices]
         if weights is None:


### PR DESCRIPTION
Fixes #2984

In `AtomGroup.center`, coordinates are now properly sorted after unwrapping, in tandem with `compound_indices` and `weights`. Additionally, sorting is now only even done if the `compound_indices` are not already monotonically increasing. Monotonicity is a rather cheap check for the most frequent use case, compared to the expensive sorting that's only really needed for the rarer cases of unordered/noncontiguous compounds. 

PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
