### PR TITLE
MAINT: ARM64 CI cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,9 +105,7 @@ matrix:
       virt: vm
       group: edge
       before_install:
-        - python -m pip install cython numpy
-        # special test SciPy wheel for ARM64:
-        - python -m pip install https://anaconda.org/multibuild-wheels-staging/scipy/1.6.0.dev0+a240c17/download/scipy-1.6.0.dev0+a240c17-cp37-cp37m-manylinux2014_aarch64.whl
+        - python -m pip install cython numpy scipy
         - python -m pip install --no-build-isolation hypothesis matplotlib pytest pytest-cov pytest-xdist tqdm
       install:
         - cd package

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -66,6 +66,8 @@ Fixes
     would create a test artifact (Issue #2979, PR #2981)
 
 Enhancements
+  * Preliminary support for the Linux ARM64 platform with minimal
+    dependencies (PR #2956)
   * Refactored analysis.helanal into analysis.helix_analysis
     (Issue #2452, PR #2622)
   * Improved MSD code to accept `AtomGroup` and reject `UpdatingAtomGroup`


### PR DESCRIPTION
* I released SciPy `1.5.3` with "official" Linux ARM64 wheels
over the weekend, so let's try using those in CI instead of the
previous "special"/unreleased wheels

* add a `CHANGELOG` entry to reflect preliminary MDAnalysis support
for the Linux ARM64 platform (minimal dependencies)
