### PR TITLE
Optimized and refactored common compound code.

### DIFF
--- a/benchmarks/benchmarks/ag_methods.py
+++ b/benchmarks/benchmarks/ag_methods.py
@@ -324,6 +324,62 @@ class AtomGroupAttrsBench(object):
         self.ag[:2].bond
 
 
+class CompoundSplitting(object):
+    """Test how fast can we split compounds into masks and apply them
+    
+    The benchmark used in Issue #3000. Parameterizes multiple compound number
+    and size combinations.
+    """
+    
+    params = [(100, 10000, 1000000),  # n_atoms
+              (1, 10, 100),           # n_compounds
+              (True, False),          # homogeneous
+              (True, False)]          # contiguous
+
+    def setup(self, n_atoms, n_compounds, homogeneous, contiguous):
+        rg = np.random.Generator(np.random.MT19937(3000))
+
+        # some parameter screening for nonsensical combinations.
+        if n_compounds > n_atoms:
+            raise NotImplementedError
+
+        if n_compounds == 1 and not (homogeneous and contiguous):
+            raise NotImplementedError
+            
+        if n_compounds == n_atoms:
+            if not (homogeneous and contiguous):
+                raise NotImplementedError
+            compound_indices = np.arange(n_compounds)
+        elif homogeneous:
+            ats_per_compound, remainder = divmod(n_atoms, n_compounds)
+            if remainder:
+                raise NotImplementedError
+            compound_indices = np.tile(np.arange(n_compounds),
+                                       (ats_per_compound, 1)).T.ravel()
+        else:
+            compound_indices = np.sort(np.floor(rg.random(n_atoms)
+                                                * n_compounds).astype(np.int))
+                
+        unique_indices = np.unique(compound_indices)
+        if len(unique_indices) != n_compounds:
+            raise RuntimeError
+        
+        if not contiguous:
+            rg.shuffle(compound_indices)
+        
+        self.u = MDAnalysis.Universe.empty(n_atoms,
+                                           n_residues=n_compounds,
+                                           n_segments=1,
+                                           atom_resindex=compound_indices,
+                                           trajectory=True)
+        self.u.atoms.positions = rg.random((n_atoms, 3),
+                                           dtype=np.float32) * 100
+        self.u.dimensions = [50, 50, 50, 90, 90, 90]
+
+    def time_center_compounds(self, *args):
+        self.u.atoms.center(None, compound='residues')
+
+
 class FragmentFinding(object):
     """Test how quickly we find fragments (distinct molecules from bonds)"""
     # if we try to parametrize over topology &

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -81,6 +81,8 @@ Fixes
   * Fix syntax warning over comparison of literals using is (Issue #3066)
 
 Enhancements
+  * Code for operations on compounds refactored, centralized and optimized for
+    performance (Issue #3000)
   * Added automatic selection class generation for TopologyAttrs,
     FloatRangeSelection, and BoolSelection (Issues #2925, #2875; PR #2927)
   * Added 'to' operator, negatives, scientific notation, and arbitrary

--- a/package/MDAnalysis/lib/_cutil.pyx
+++ b/package/MDAnalysis/lib/_cutil.pyx
@@ -129,7 +129,7 @@ def make_whole(atomgroup, reference_atom=None, inplace=True):
     atomgroup : AtomGroup
         The :class:`MDAnalysis.core.groups.AtomGroup` to work with.
         The positions of this are modified in place.  All these atoms
-        must belong in the same molecule or fragment.
+        must belong to the same molecule or fragment.
     reference_atom : :class:`~MDAnalysis.core.groups.Atom`
         The atom around which all other atoms will be moved.
         Defaults to atom 0 in the atomgroup.


### PR DESCRIPTION
Fixes #3000

Changes made in this Pull Request:
 - Implements the ideas in #3000;
 - Compound code in `core/group.py` refactored (more DRY now);
 - Caching functionally implemented, but cache invalidation still to do.

Performance benchmarks, in the discussion of #3000, are quite promising, especially with caching.

## Problem
Cached compound masks work great and can give large speedups, but invalidating them is tough: if I have an `AtomGroup` with cached masks for segments and the user moves a residue between segments those cached masks should no longer be valid, but how to notify an AtomGroup of something occurring at the `ResidueGroup`/`SegmentGroup` level? 

Pointers appreciated.

PR Checklist
------------
 - [ ] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
