### PR TITLE
removed funcsigs (not needed for Py >= 3.6)

### DIFF
--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -42,13 +42,7 @@ import numbers
 import numpy as np
 import warnings
 import textwrap
-
-# inspect.signature was added in python 3.3, earlier versions require
-# funcsigs as backport.
-try:
-    from inspect import signature as inspect_signature
-except ImportError:
-    from funcsigs import signature as inspect_signature
+from inspect import signature as inspect_signature
 
 from ..lib.util import (cached, convert_aa_code, iterable, warn_if_not_unique,
                         unique_int_1d)

--- a/package/setup.py
+++ b/package/setup.py
@@ -617,7 +617,7 @@ if __name__ == '__main__':
           requires=['numpy (>=1.16.0)', 'biopython (>= 1.71)', 'mmtf (>=1.0.0)',
                     'networkx (>=1.0)', 'GridDataFormats (>=0.3.2)', 'joblib',
                     'scipy (>=1.0.0)', 'matplotlib (>=1.5.1)', 'tqdm (>=4.43.0)',
-                    'funcsigs'],
+                    ],
           # all standard requirements are available through PyPi and
           # typically can be installed without difficulties through setuptools
           setup_requires=[


### PR DESCRIPTION
Changes made in this Pull Request:
 - removed funcsigs that were introduced in PR #2427 as a compatibility layer (needed for backport PR #3007)
 - not needed for 2.x (Python ≥ 3.6)


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
