### PR TITLE
increase default Python to 3.7 on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
     - MDA_DOCDIR=${TRAVIS_BUILD_DIR}/package/doc/html/html
     - MAINTAIN_DIR=${TRAVIS_BUILD_DIR}/maintainer
     # Set default python version to avoid repetition later
-    - PYTHON_VERSION=3.5
+    - PYTHON_VERSION=3.7
     - BUILD_DOCS=false
     - CODECOV=false
     - PYTEST_FLAGS="--disable-pytest-warnings --durations=50"
@@ -44,7 +44,7 @@ env:
 
   jobs:
     # Run a coverage test for most versions
-    - CODECOV="true" SETUP_CMD="${PYTEST_FLAGS} --cov=MDAnalysis"
+    - PYTHON_VERSION=3.5 MAMBA=false CODECOV="true" SETUP_CMD="${PYTEST_FLAGS} --cov=MDAnalysis"
     - PYTHON_VERSION=3.8 CODECOV="true" SETUP_CMD="${PYTEST_FLAGS} --cov=MDAnalysis"
     - PYTHON_VERSION=3.7 CODECOV="true" SETUP_CMD="${PYTEST_FLAGS} --cov=MDAnalysis"
     - PYTHON_VERSION=3.6 CODECOV="true" SETUP_CMD="${PYTEST_FLAGS} --cov=MDAnalysis"
@@ -57,7 +57,6 @@ jobs:
     - env: NAME="Doc"
            MAIN_CMD="cd package && python setup.py"
            SETUP_CMD="build_sphinx"
-           PYTHON_VERSION=3.7
            BUILD_DOCS=true
            BUILD_CMD="cd ${TRAVIS_BUILD_DIR}/package && python setup.py build_ext --inplace"
            INSTALL_HOLE="false"

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ env:
     - PYTHON_VERSION=3.8 CODECOV="true" SETUP_CMD="${PYTEST_FLAGS} --cov=MDAnalysis"
     - PYTHON_VERSION=3.7 CODECOV="true" SETUP_CMD="${PYTEST_FLAGS} --cov=MDAnalysis"
     - PYTHON_VERSION=3.6 CODECOV="true" SETUP_CMD="${PYTEST_FLAGS} --cov=MDAnalysis"
-    - NUMPY_VERSION=1.13.3
+    - NUMPY_VERSION=1.13.3 PYTHON_VERSION=3.6
     - NUMPY_VERSION=dev  EVENT_TYPE="cron"
 
 jobs:
@@ -93,7 +93,6 @@ jobs:
            ASV_CHECK="true"
 
     - env: NAME="pypi check"
-           PYTHON_VERSION=3.7
            CODECOV="false"
            MAIN_CMD="cd package && python setup.py"
            SETUP_CMD="sdist"


### PR DESCRIPTION
Fixes : currently broken master (from 73cd1e69be88f1b47b1327c1918c0ad326bec302)

Changes made in this Pull Request:
    - set PYTHON_VERSION=3.7
    - set MAMBA=false for Python 3.5 (no mamba package available, fall back
      to conda)


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
