### PR TITLE
Fixed import of several `__all__` lists

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -21,7 +21,7 @@ The rules for this file:
   * 2.0.0
 
 Fixes
-  * Removed missing `rdf_s` package from analysis `__all__` list (PR #3013)
+  * Fixed import of several `__all__` lists (PR #3013)
   * atommethods (_get_prev/next_residues_by_resid) returns empty residue group 
     when given empty residue group (Issue #3089)
   * MOL2 files without bonds can now be read and written (Issue #3057)

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -21,6 +21,7 @@ The rules for this file:
   * 2.0.0
 
 Fixes
+  * Removed missing `rdf_s` package from analysis `__all__` list (PR #3013)
   * atommethods (_get_prev/next_residues_by_resid) returns empty residue group 
     when given empty residue group (Issue #3089)
   * MOL2 files without bonds can now be read and written (Issue #3057)

--- a/package/MDAnalysis/analysis/__init__.py
+++ b/package/MDAnalysis/analysis/__init__.py
@@ -139,7 +139,6 @@ __all__ = [
     'pca',
     'psa',
     'rdf',
-    'rdf_s',
     'rms',
     'waterdynamics',
 ]

--- a/package/MDAnalysis/analysis/encore/clustering/__init__.py
+++ b/package/MDAnalysis/analysis/encore/clustering/__init__.py
@@ -23,9 +23,11 @@
 from . import ClusteringMethod
 from . import ClusterCollection
 
-__all__ = [
-    'ClusterCollection.ClusterCollection',
-    'ClusterCollection.Cluster',
-    'ClusteringMethod.AffinityPropagationNative'
-    'ClusteringMethod.AffinityPropagation'
-    'ClusteringMethod.DBSCAN']
+from .ClusteringMethod import AffinityPropagationNative
+from .ClusterCollection import ClusterCollection, Cluster
+
+__all__ = ['ClusterCollection', 'Cluster', 'AffinityPropagationNative']
+
+if ClusteringMethod.sklearn:
+    from .ClusteringMethod import AffinityPropagation, DBSCAN
+    __all__ += ['AffinityPropagation', 'DBSCAN']

--- a/package/MDAnalysis/analysis/encore/dimensionality_reduction/__init__.py
+++ b/package/MDAnalysis/analysis/encore/dimensionality_reduction/__init__.py
@@ -20,15 +20,12 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
+from . import DimensionalityReductionMethod
 
 from .DimensionalityReductionMethod import StochasticProximityEmbeddingNative
 
 __all__ = ['StochasticProximityEmbeddingNative']
 
-
-try:
+if DimensionalityReductionMethod.sklearn:
     from .DimensionalityReductionMethod import PrincipalComponentAnalysis
-    __all__.append('PrincipalComponentAnalysis')
-except ImportError as err:
-    import warnings
-    warnings.warn("{}".format(err), category=ImportWarning)
+    __all__ += ['PrincipalComponentAnalysis']

--- a/package/MDAnalysis/analysis/encore/dimensionality_reduction/__init__.py
+++ b/package/MDAnalysis/analysis/encore/dimensionality_reduction/__init__.py
@@ -20,9 +20,8 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from . import DimensionalityReductionMethod
 
-__all__ = [
-    'DimensionalityReductionMethod.StochasticProximityEmbeddingNative',
-    'DimensionalityReductionMethod.PrincipalComponentAnalysis'
-]
+__all__ = ['StochasticProximityEmbeddingNative', 'PrincipalComponentAnalysis']
+
+from .DimensionalityReductionMethod import StochasticProximityEmbeddingNative, \
+                                           PrincipalComponentAnalysis

--- a/package/MDAnalysis/analysis/encore/dimensionality_reduction/__init__.py
+++ b/package/MDAnalysis/analysis/encore/dimensionality_reduction/__init__.py
@@ -21,7 +21,14 @@
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
 
-__all__ = ['StochasticProximityEmbeddingNative', 'PrincipalComponentAnalysis']
+from .DimensionalityReductionMethod import StochasticProximityEmbeddingNative
 
-from .DimensionalityReductionMethod import StochasticProximityEmbeddingNative, \
-                                           PrincipalComponentAnalysis
+__all__ = ['StochasticProximityEmbeddingNative']
+
+
+try:
+    from .DimensionalityReductionMethod import PrincipalComponentAnalysis
+    __all__.append('PrincipalComponentAnalysis')
+except ImportError as err:
+    import warnings
+    warnings.warn("{}".format(err), category=ImportWarning)

--- a/package/MDAnalysis/core/__init__.py
+++ b/package/MDAnalysis/core/__init__.py
@@ -52,5 +52,5 @@ and write your own Python code.
 
 __all__ = ['AtomGroup', 'Selection']
 
-from . import groups
-from . import selection
+from .groups import AtomGroup
+from .selection import Selection

--- a/testsuite/MDAnalysisTests/test_api.py
+++ b/testsuite/MDAnalysisTests/test_api.py
@@ -24,7 +24,10 @@
 Test the user facing API is as we expect...
 """
 
+import importlib
+
 import MDAnalysis as mda
+import pytest
 
 
 def test_Universe():
@@ -49,3 +52,33 @@ def test_ResidueGroup():
 
 def test_SegmentGroup():
     assert mda.SegmentGroup is mda.core.groups.SegmentGroup
+
+
+@pytest.mark.parametrize('module',
+                         ('',
+                          '.analysis',
+                          '.analysis.data.filenames',
+                          '.analysis.distances',
+                          '.analysis.encore',
+                          '.analysis.encore.dimensionality_reduction',
+                          '.analysis.hbonds',
+                          '.analysis.hydrogenbonds',
+                          '.coordinates',
+                          '.core',
+                          '.lib._augment',
+                          '.lib._cutil',
+                          '.lib.formats',
+                          '.lib.pkdtree',
+                          '.topology',
+                          '.topology.tpr',
+                          '.visualization'
+                          )
+                         )
+def test_import_star(module):
+    try:
+        # This is really bad and ugly but I haven't found a way to run this
+        # using `importlib.import_module...`
+        exec("from MDAnalysis{} import *".format(module))
+    except (ImportError, AttributeError) as error:
+        # We want the test to fail, not to error
+        raise AssertionError(error)

--- a/testsuite/MDAnalysisTests/test_api.py
+++ b/testsuite/MDAnalysisTests/test_api.py
@@ -60,6 +60,7 @@ def test_SegmentGroup():
 
 
 def init_files():
+    """A generator yielding all MDAnalysis __init__ files."""
     os.chdir(mda_dirname)
     for root, dirs, files in os.walk("."):
         if "__init__.py" in files:
@@ -77,4 +78,5 @@ def test_all_import(submodule):
                 if name not in module.__dict__.keys()
                     and name not in [os.path.splitext(f)[0] for
                                         f in os.listdir(module_path)]]
-        assert_equal(missing, [], err_msg="{} has errors in __all__ list.".format(submodule))
+        assert_equal(missing, [], err_msg="{}".format(submodule) +
+                                          "has errors in __all__ list.")

--- a/testsuite/MDAnalysisTests/test_api.py
+++ b/testsuite/MDAnalysisTests/test_api.py
@@ -24,8 +24,6 @@
 Test the user facing API is as we expect...
 """
 
-import importlib
-
 import MDAnalysis as mda
 import pytest
 


### PR DESCRIPTION
Changes made in this Pull Request

When running `from MDAnalysis.analysis import * ` an `AttributeError` was raised since the `rdf_s` is missing.
If `sklearn` is not installed the `__all__` lists in `.analysis.encore` and `.analysis.encore.dimensionality_reduction` raised an error.

# PR Checklist

- [x] Tests?
- [ ] Docs?
- [x] CHANGELOG updated?
- [ ] Issue raised/referenced?