### PR TITLE
MAINT, CI: pin Azure h5py

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,10 +54,11 @@ jobs:
       pytest-xdist
       scikit-learn
       scipy
-      h5py
+      h5py==2.10.0
       tqdm
     displayName: 'Install dependencies'
   # TODO: recent rdkit is not on PyPI
+  # NOTE: h5py pinned because of gh-3019
   - script: >-
       python -m pip install
       biopython


### PR DESCRIPTION
* pin the version of `h5py` used in Azure Windows CI testing
because of gh-3019; CI failures were observed to start/coincide
with a recent release of `h5py`

Fixes #3019 (I hope)