### PR TITLE
Improve the performance of ParmEd converter. (Fix #3028)

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -150,6 +150,7 @@ Chronological list of authors
   - Edis Jakupovic
   - Nicholas Craven
   - Mieczyslaw Torchala
+  - Haochuan Chen
 
 External code
 -------------

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -15,7 +15,8 @@ The rules for this file:
 ------------------------------------------------------------------------------
 ??/??/?? tylerjereddy, richardjgowers, IAlibay, hmacdope, orbeckst, cbouy,
          lilyminium, daveminh, jbarnoud, yuxuanzhuang, VOD555, ianmkenney,
-         calcraven，xiki-tempula, mieczyslaw, manuel.nuno.melo, PicoCentauri
+         calcraven，xiki-tempula, mieczyslaw, manuel.nuno.melo, PicoCentauri,
+         hanatok
 
   * 2.0.0
 
@@ -107,6 +108,7 @@ Enhancements
     'protein' selection (#2751 PR #2755)
   * Added an RDKit converter that works for any input with all hydrogens
     explicit in the topology (Issue #2468, PR #2775)
+  * Improved performance of the ParmEd converter (Issue #3028, PR #3029)
 
 Changes
   * Continuous integration uses mamba rather than conda to install the

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -74,6 +74,7 @@ Fixes
     would create a test artifact (Issue #2979, PR #2981)
 
 Enhancements
+  * Improved performance of the ParmEd converter (Issue #3028, PR #3029)
   * Improved analysis class docstrings, and added missing classes to the 
     `__all__` list (PR #2998)
   * The PDB writer gives more control over how to write the atom ids
@@ -108,7 +109,6 @@ Enhancements
     'protein' selection (#2751 PR #2755)
   * Added an RDKit converter that works for any input with all hydrogens
     explicit in the topology (Issue #2468, PR #2775)
-  * Improved performance of the ParmEd converter (Issue #3028, PR #3029)
 
 Changes
   * Continuous integration uses mamba rather than conda to install the

--- a/package/MDAnalysis/coordinates/ParmEd.py
+++ b/package/MDAnalysis/coordinates/ParmEd.py
@@ -132,7 +132,7 @@ MDA2PMD = {
 }
 
 def get_indices_from_subset(i, atomgroup=None, universe=None):
-    return atomgroup.index(universe.atoms[i])
+    return atomgroup[universe.atoms[i]]
 
 class ParmEdConverter(base.ConverterBase):
     """Convert MDAnalysis AtomGroup or Universe to ParmEd :class:`~parmed.structure.Structure`.
@@ -262,8 +262,9 @@ class ParmEdConverter(base.ConverterBase):
             struct.box = None
 
         if hasattr(ag_or_ts, 'universe'):
+            atomgroup = {atom: index for index, atom in enumerate(list(ag_or_ts))}
             get_atom_indices = functools.partial(get_indices_from_subset,
-                                                 atomgroup=list(ag_or_ts),
+                                                 atomgroup=atomgroup,
                                                  universe=ag_or_ts.universe)
         else:
             get_atom_indices = lambda x: x

--- a/package/MDAnalysis/coordinates/ParmEd.py
+++ b/package/MDAnalysis/coordinates/ParmEd.py
@@ -262,7 +262,8 @@ class ParmEdConverter(base.ConverterBase):
             struct.box = None
 
         if hasattr(ag_or_ts, 'universe'):
-            atomgroup = {atom: index for index, atom in enumerate(list(ag_or_ts))}
+            atomgroup = {atom: index for index,
+                         atom in enumerate(list(ag_or_ts))}
             get_atom_indices = functools.partial(get_indices_from_subset,
                                                  atomgroup=atomgroup,
                                                  universe=ag_or_ts.universe)


### PR DESCRIPTION
The origin code used index() of list to lookup the atom indices, which
is nearly O(N^2) when iterating all atoms. This commit converts the list
to a dictionary mapping the atom objects to indices, and hence improves
the overall performance.

Fixes #3028

Changes made in this Pull Request:
 - 


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [X] Issue raised/referenced?
