### PR TITLE
Adds NC file extension to NCDFWriter

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -20,6 +20,7 @@ The rules for this file:
   * 2.0.0
 
 Fixes
+  * Add '.nc' as a recognised extension for the NCDFWriter (Issue #3030)
   * PDB parser now assigns empty records for partially missing/invalid elements
     instead of not assigning the elements attribute at all (Issue #2422)
   * PDB writer now uses elements attribute instead of guessing elements from

--- a/package/MDAnalysis/coordinates/TRJ.py
+++ b/package/MDAnalysis/coordinates/TRJ.py
@@ -837,7 +837,7 @@ class NCDFWriter(base.WriterBase):
 
     """
 
-    format = 'NCDF'
+    format = ['NC', 'NCDF']
     multiframe = True
     version = "1.0"
     units = {'time': 'ps',

--- a/testsuite/MDAnalysisTests/coordinates/test_netcdf.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_netcdf.py
@@ -602,6 +602,12 @@ class _NCDFWriterTest(object):
     def universe(self):
         return mda.Universe(self.topology, self.filename)
 
+    @pytest.fixture(params=['nc', 'ncdf'])
+    def outfile_extensions(self, tmpdir, request):
+        # Issue 3030, test all extensions of NCDFWriter
+        ext = request.param
+        return str(tmpdir) + f'ncdf-writer-1.{ext}'
+
     @pytest.fixture()
     def outfile(self, tmpdir):
         return str(tmpdir) + 'ncdf-writer-1.ncdf'
@@ -654,11 +660,11 @@ class _NCDFWriterTest(object):
         finally:
             sys.modules['MDAnalysis.coordinates.TRJ'].netCDF4 = loaded_netCDF4
 
-    def test_OtherWriter(self, universe, outfile):
+    def test_OtherWriter(self, universe, outfile_extensions):
         t = universe.trajectory
-        with t.OtherWriter(outfile) as W:
+        with t.OtherWriter(outfile_extensions) as W:
             self._copy_traj(W, universe)
-        self._check_new_traj(universe, outfile)
+        self._check_new_traj(universe, outfile_extensions)
 
     def _copy_traj(self, writer, universe):
         for ts in universe.trajectory:


### PR DESCRIPTION
Fixes #3030 

Changes made in this Pull Request:
 - Adds the '.nc' extension as a recognised extension for the NCDFWriter (matching docs).


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
