### PR TITLE
Install MDAnalysis on ReadTheDocs via pip

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,6 +17,9 @@ sphinx:
 # Optionally set the version of Python and requirements required to build your docs
 python:
   version: 3.7
+  install:
+    - method: setuptools
+      path: package
 
 conda:
   environment: maintainer/conda/environment.yml

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,7 +18,7 @@ sphinx:
 python:
   version: 3.7
   install:
-    - method: setuptools
+    - method: pip
       path: package
 
 conda:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,7 +16,6 @@ sphinx:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
   install:
     - method: pip
       path: package

--- a/maintainer/conda/environment.yml
+++ b/maintainer/conda/environment.yml
@@ -18,6 +18,7 @@ dependencies:
   - numpy>=1.17.3
   - psutil
   - pytest
+  - python==3.7
   - scikit-learn
   - scipy
   - pip

--- a/maintainer/conda/environment.yml
+++ b/maintainer/conda/environment.yml
@@ -31,5 +31,3 @@ dependencies:
       - parmed
       - msmb_theme==1.2.0
       - sphinx-sitemap==1.0.2
-      - git+https://github.com/MDAnalysis/mdanalysis@develop#egg=mdanalysis&subdirectory=package
-      - git+https://github.com/MDAnalysis/mdanalysis@develop#egg=MDAnalysisTests&subdirectory=testsuite


### PR DESCRIPTION
Fixes #3070 

Changes made in this Pull Request:
 - install via `pip install package/` to build current docs.
 - Works, as tested on #3069 https://readthedocs.org/projects/mdanalysis/builds/12528298/

Not sure why `setuptools` (`python package/setup.py install`) doesn't work, but, it doesn't.

Sorry @orbeckst 🤦‍♀️

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
