### PR TITLE
Fix syntax warning over comparison of literals using is.

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -151,6 +151,7 @@ Chronological list of authors
   - Nicholas Craven
   - Mieczyslaw Torchala
   - Haochuan Chen
+  - Karthikeyan Singaravelan
 
 External code
 -------------

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -16,7 +16,7 @@ The rules for this file:
 ??/??/?? tylerjereddy, richardjgowers, IAlibay, hmacdope, orbeckst, cbouy,
          lilyminium, daveminh, jbarnoud, yuxuanzhuang, VOD555, ianmkenney,
          calcraven，xiki-tempula, mieczyslaw, manuel.nuno.melo, PicoCentauri,
-         hanatok, rmeli
+         hanatok, rmeli, tirkarthi
 
   * 2.0.0
 

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -75,6 +75,7 @@ Fixes
     (Issue #2934)
   * Fix tests for analysis.bat that could fail when run in parallel and that
     would create a test artifact (Issue #2979, PR #2981)
+  * Fix syntax warning over comparison of literals using is (Issue #3066)
 
 Enhancements
   * Added automatic selection class generation for TopologyAttrs,

--- a/package/MDAnalysis/analysis/legacy/x3dna.py
+++ b/package/MDAnalysis/analysis/legacy/x3dna.py
@@ -423,7 +423,7 @@ class BaseX3DNA(object):
             ax.set_xlabel(r"Nucleic Acid Number")
             param = self.profiles.values()[0].dtype.names[k]
             if param in ["Shear", "Stretch", "Stagger", "Rise", "Shift", "Slide"]:
-                ax.set_ylabel("{0!s} ($\AA$)".format((param)))
+                ax.set_ylabel(r"{!s} ($\AA$)".format(param))
             else:
                 ax.set_ylabel("{0!s} (deg)".format((param)))
             ax.figure.savefig("{0!s}.png".format((param)))

--- a/testsuite/MDAnalysisTests/lib/test_util.py
+++ b/testsuite/MDAnalysisTests/lib/test_util.py
@@ -1474,7 +1474,7 @@ class TestStaticVariables(object):
 
         @static_variables(foo=0, bar={'test': x})
         def myfunc():
-            assert myfunc.foo is 0
+            assert myfunc.foo == 0
             assert type(myfunc.bar) is type(dict())
             if 'test2' not in myfunc.bar:
                 myfunc.bar['test2'] = "a"
@@ -1488,14 +1488,14 @@ class TestStaticVariables(object):
 
         y = myfunc()
         assert y is x
-        assert x[0] is 1
-        assert myfunc.bar['test'][0] is 1
+        assert x[0] == 1
+        assert myfunc.bar['test'][0] == 1
         assert myfunc.bar['test2'] == "a"
 
         x = [0]
         y = myfunc()
         assert y is not x
-        assert myfunc.bar['test'][0] is 2
+        assert myfunc.bar['test'][0] == 2
         assert myfunc.bar['test2'] == "aa"
 
 
@@ -1536,7 +1536,7 @@ class TestWarnIfNotUnique(object):
         assert atoms.isunique
         with pytest.warns(None) as w:
             x = outer(atoms)
-            assert x is 0
+            assert x == 0
             assert not w.list
 
         # Check that a warning is raised for a group with duplicates:
@@ -1548,7 +1548,7 @@ class TestWarnIfNotUnique(object):
             # Assert that the "warned" state is restored:
             assert warn_if_not_unique.warned is False
             # Check correct function execution:
-            assert x is 0
+            assert x == 0
             # Only one warning must have been raised:
             assert len(w) == 1
             # For whatever reason pytest.warns(DuplicateWarning, match=msg)
@@ -1602,7 +1602,7 @@ class TestWarnIfNotUnique(object):
             # Assert that the "warned" state is restored:
             assert warn_if_not_unique.warned is False
             # Check correct function execution:
-            assert x is 0
+            assert x == 0
             # Only one warning must have been raised:
             assert len(w) == 1
             assert w[0].message.args[0] == msg


### PR DESCRIPTION
Fixes #3066 

Changes made in this Pull Request:

Fix syntax warning over using is.


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?