### PR TITLE
MAINT: simplify guessers regex

### DIFF
--- a/package/MDAnalysis/topology/guessers.py
+++ b/package/MDAnalysis/topology/guessers.py
@@ -179,7 +179,7 @@ def guess_atom_type(atomname):
 
 
 NUMBERS = re.compile(r'[0-9]') # match numbers
-SYMBOLS = re.compile(r'[\*\+\-]')  # match *, +, -
+SYMBOLS = re.compile(r'[*+-]')  # match *, +, -
 
 def guess_atom_element(atomname):
     """Guess the element of the atom from the name.


### PR DESCRIPTION
* the `SYMBOLS` regex in `guessers.py` does not require
any escape sequences because the metacharacters are inactive
in the character class (this includes the range metacharacter
when placed at the start or end of the character class)