### PR TITLE
MAINT: char class regex improve

### DIFF
--- a/package/MDAnalysis/coordinates/GMS.py
+++ b/package/MDAnalysis/coordinates/GMS.py
@@ -202,7 +202,7 @@ class GMSReader(base.ReaderBase):
                     line) is not None):
                     flag = 2
                     continue
-                if (flag == 2) and (re.match(r'^\s*[-]+\s*', line) is not None):
+                if (flag == 2) and (re.match(r'^\s*-+\s*', line) is not None):
                     flag = 3
                     continue
                 if flag == 3 and counter < self.n_atoms:


### PR DESCRIPTION
* avoid the overhead of a regex character class
when that character class has only a single character
(i.e., serves no purpose)

* there is only one instance of this in MDA codebase
discovered by my [scraping code](https://github.com/tylerjereddy/regex-improve)

* for a longer explanation see my similar changes in
NumPy codebase:
https://github.com/numpy/numpy/pull/18083