### PR TITLE
Quick fix for atommethods to return empty residue group

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -151,7 +151,8 @@ Chronological list of authors
   - Nicholas Craven
   - Mieczyslaw Torchala
   - Haochuan Chen
-
+2021
+  - Aditya Kamath
 External code
 -------------
 

--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -153,6 +153,7 @@ Chronological list of authors
   - Haochuan Chen
 2021
   - Aditya Kamath
+  
 External code
 -------------
 

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -21,6 +21,7 @@ The rules for this file:
   * 2.0.0
 
 Fixes
+  * atommethods(_get_prev/next_residues_by_resid) returns empty residue group when given empty residue group (Issue #3089)
   * MOL2 files without bonds can now be read and written (Issue #3057)
   * Write `CONECT` record only once in multi-model PDB files (Issue #3018)
   * Add '.nc' as a recognised extension for the NCDFWriter (Issue #3030)

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -16,7 +16,7 @@ The rules for this file:
 ??/??/?? tylerjereddy, richardjgowers, IAlibay, hmacdope, orbeckst, cbouy,
          lilyminium, daveminh, jbarnoud, yuxuanzhuang, VOD555, ianmkenney,
          calcraven，xiki-tempula, mieczyslaw, manuel.nuno.melo, PicoCentauri,
-         hanatok, rmeli
+         hanatok, rmeli, aditya-kamath
 
   * 2.0.0
 

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -874,7 +874,10 @@ class Atomnames(_AtomStringAttr):
 
         .. versionadded:: 1.0.0
         """
-        u = residues[0].universe
+        try:
+            u = residues[0].universe
+        except IndexError:
+            return residues
         nxres = np.array([None]*len(residues), dtype=object)
         ix = np.arange(len(residues))
         # no guarantee residues is ordered or unique
@@ -914,7 +917,10 @@ class Atomnames(_AtomStringAttr):
 
         .. versionadded:: 1.0.0
         """
-        u = residues[0].universe
+        try:
+            u = residues[0].universe
+        except IndexError:
+            return residues        
         pvres = np.array([None]*len(residues))
         pvres[:] = prev = u.residues[residues.ix-1]
         rsid = residues.segids

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -920,7 +920,7 @@ class Atomnames(_AtomStringAttr):
         try:
             u = residues[0].universe
         except IndexError:
-            return residues        
+            return residues
         pvres = np.array([None]*len(residues))
         pvres[:] = prev = u.residues[residues.ix-1]
         rsid = residues.segids

--- a/testsuite/MDAnalysisTests/core/test_topologyattrs.py
+++ b/testsuite/MDAnalysisTests/core/test_topologyattrs.py
@@ -184,12 +184,14 @@ class TestAtomnames(TestAtomAttr):
     def u(self):
         return mda.Universe(PSF, DCD)
 
-    def test_prev_emptyresidue(self,u):
-        assert_equal(u.residues[[]]._get_prev_residues_by_resid(),u.residues[[]])
+    def test_prev_emptyresidue(self, u):
+        assert_equal(u.residues[[]]._get_prev_residues_by_resid(),
+                           u.residues[[]])
 
-    def test_next_emptyresidue(self,u):
-        assert_equal(u.residues[[]]._get_next_residues_by_resid(),u.residues[[]])
-           
+    def test_next_emptyresidue(self, u):
+        assert_equal(u.residues[[]]._get_next_residues_by_resid(),
+                           u.residues[[]])
+
 
 class AggregationMixin(TestAtomAttr):
     def test_get_residues(self, attr):

--- a/testsuite/MDAnalysisTests/core/test_topologyattrs.py
+++ b/testsuite/MDAnalysisTests/core/test_topologyattrs.py
@@ -180,6 +180,11 @@ class TestAtomnames(TestAtomAttr):
     single_value = 'Ca2'
     attrclass = tpattrs.Atomnames
 
+class TestemptyAtomnames(TestAtomAttr): 
+    u = make_Universe() 
+    attrclass = tpattrs.Atomnames
+    assert_equal(attrclass._get_prev_residues_by_resid(u.residues[[]]),u.residues[[]])  
+    assert_equal(attrclass._get_next_residues_by_resid(u.residues[[]]),u.residues[[]]) 
 
 class AggregationMixin(TestAtomAttr):
     def test_get_residues(self, attr):

--- a/testsuite/MDAnalysisTests/core/test_topologyattrs.py
+++ b/testsuite/MDAnalysisTests/core/test_topologyattrs.py
@@ -180,7 +180,7 @@ class TestAtomnames(TestAtomAttr):
     single_value = 'Ca2'
     attrclass = tpattrs.Atomnames
 
-class TestemptyAtomnames(TestAtomAttr): 
+class TestemptyAtomnames(object): 
     u = make_Universe() 
     attrclass = tpattrs.Atomnames
     assert_equal(attrclass._get_prev_residues_by_resid(u.residues[[]]),u.residues[[]])  

--- a/testsuite/MDAnalysisTests/core/test_topologyattrs.py
+++ b/testsuite/MDAnalysisTests/core/test_topologyattrs.py
@@ -180,11 +180,16 @@ class TestAtomnames(TestAtomAttr):
     single_value = 'Ca2'
     attrclass = tpattrs.Atomnames
 
-class TestemptyAtomnames(object): 
-    u = make_Universe() 
-    attrclass = tpattrs.Atomnames
-    assert_equal(attrclass._get_prev_residues_by_resid(u.residues[[]]),u.residues[[]])  
-    assert_equal(attrclass._get_next_residues_by_resid(u.residues[[]]),u.residues[[]]) 
+    @pytest.fixture()
+    def u(self):
+        return mda.Universe(PSF, DCD)
+
+    def test_prev_emptyresidue(self,u):
+        assert_equal(u.residues[[]]._get_prev_residues_by_resid(),u.residues[[]])
+
+    def test_next_emptyresidue(self,u):
+        assert_equal(u.residues[[]]._get_next_residues_by_resid(),u.residues[[]])
+           
 
 class AggregationMixin(TestAtomAttr):
     def test_get_residues(self, attr):

--- a/testsuite/MDAnalysisTests/core/test_topologyattrs.py
+++ b/testsuite/MDAnalysisTests/core/test_topologyattrs.py
@@ -186,11 +186,11 @@ class TestAtomnames(TestAtomAttr):
 
     def test_prev_emptyresidue(self, u):
         assert_equal(u.residues[[]]._get_prev_residues_by_resid(),
-                           u.residues[[]])
+                     u.residues[[]])
 
     def test_next_emptyresidue(self, u):
         assert_equal(u.residues[[]]._get_next_residues_by_resid(),
-                           u.residues[[]])
+                     u.residues[[]])
 
 
 class AggregationMixin(TestAtomAttr):


### PR DESCRIPTION
Partially fixes #2879

Changes made in this Pull Request:
 - Returns empty residue group for _get_prev_residues_by_resid and _get_next_residues_by_resid


PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
