### PR TITLE
Change tmpdir fixture to tmpdir_factory

### DIFF
--- a/testsuite/MDAnalysisTests/formats/test_libdcd.py
+++ b/testsuite/MDAnalysisTests/formats/test_libdcd.py
@@ -360,10 +360,12 @@ def write_dcd(in_name, out_name, remarks='testing', header=None):
     alphabet=string.printable, min_size=0,
     max_size=239))  # handle the printable ASCII strings
 @example(remarks='')
-def test_written_remarks_property(remarks, tmpdir, dcd):
+def test_written_remarks_property(remarks, tmpdir_factory):
     # property based testing for writing of a wide range of string
     # values to REMARKS field
-    testfile = str(tmpdir.join('test.dcd'))
+    dcd = DCDFile(DCD)
+    dirname = str(id(remarks)) + "_"
+    testfile = str(tmpdir_factory.mktemp(dirname).join('test.dcd'))
     header = dcd.header
     header['remarks'] = remarks
     write_dcd(DCD, testfile, header=header)

--- a/testsuite/MDAnalysisTests/formats/test_libdcd.py
+++ b/testsuite/MDAnalysisTests/formats/test_libdcd.py
@@ -24,6 +24,7 @@ import platform
 
 import hypothesis.strategies as strategies
 from hypothesis import example, given
+import hypothesis
 import numpy as np
 
 from numpy.testing import (assert_array_almost_equal, assert_equal,
@@ -356,6 +357,8 @@ def write_dcd(in_name, out_name, remarks='testing', header=None):
                     and sys.maxsize <= 2**32) or
                     platform.machine() == 'aarch64',
                    reason="occasional fail on 32-bit windows and ARM")
+# occasionally fails due to unreliable test timings
+@hypothesis.settings(deadline=None)  # see Issue 3096
 @given(remarks=strategies.text(
     alphabet=string.printable, min_size=0,
     max_size=239))  # handle the printable ASCII strings


### PR DESCRIPTION
Fixes #2985
Fixes #3096 

Changes made in this Pull Request:
 - Changes function-scoped `tmpdir` to session-scoped `tmpdir_factory`
 - Makes a new temporary dir with the hash of the remark so it doesn't clash


PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
