### PR TITLE
Fix python_requires

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ env:
     - MAIN_CMD="pytest ${PYTEST_LIST}"
     - SETUP_CMD="${PYTEST_FLAGS} --cov=MDAnalysis"
     - BUILD_CMD="pip install -e package/ && (cd testsuite/ && python setup.py build)"
-    - CONDA_MIN_DEPENDENCIES="mmtf-python biopython networkx cython matplotlib scipy griddataformats hypothesis gsd codecov"
+    - CONDA_MIN_DEPENDENCIES="pip<21.0 mmtf-python biopython networkx cython matplotlib scipy griddataformats hypothesis gsd codecov"
     - CONDA_PY2_DEPENDENCIES="six funcsigs"
     - CONDA_STANDARD_DEPENDENCIES="${CONDA_MIN_DEPENDENCIES} seaborn>=0.7.0 clustalw=2.1 netcdf4==1.3.1 scikit-learn joblib>=0.12 tqdm>=4.43.0"
     - CONDA_DEPENDENCIES="${CONDA_STANDARD_DEPENDENCIES} mock chemfiles"

--- a/package/setup.py
+++ b/package/setup.py
@@ -626,7 +626,7 @@ if __name__ == '__main__':
                         ],
           },
           ext_modules=exts,
-          python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3,!=3.4.*,!=3.5.*,<3.9",
+          python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3,!=3.4.*,<3.9",
           # all standard requirements are available through PyPi and
           # typically can be installed without difficulties through setuptools
           setup_requires=[

--- a/package/setup.py
+++ b/package/setup.py
@@ -626,7 +626,7 @@ if __name__ == '__main__':
                         ],
           },
           ext_modules=exts,
-          python_requires=">=2.7,!=3.0,!=3.1,!=3.2,!=3.3,!=3.4,!=3.5",
+          python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3,!=3.4.*,!=3.5.*,<3.9",
           # all standard requirements are available through PyPi and
           # typically can be installed without difficulties through setuptools
           setup_requires=[


### PR DESCRIPTION
Fixes #3103 

Changes made in this Pull Request:
 - Fixes `python_requires` in setup.py by specifying the minor version
 - Also sets the max python version to <3.9 (we aren't testing 3.9 for master right now, so if we release it, it's best we avoid allowing users to install 3.9+).

# To do

For some reason we don't let 3.5 on `master` anymore. I was under the impression that we still allowed py3.5 on 1.0.x. I think @orbeckst made the change (from the blame history)?

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
