### PR TITLE
[maint] numpy 1.20 type deprecations

### DIFF
--- a/package/MDAnalysis/coordinates/RDKit.py
+++ b/package/MDAnalysis/coordinates/RDKit.py
@@ -480,9 +480,9 @@ def _add_mda_attr_to_rdkit(attr, value, mi):
 
 def _set_atom_property(atom, attr, value):
     """Saves any attribute and value into an RDKit atom property"""
-    if isinstance(value, (float, np.float)):
+    if isinstance(value, (float, np.floating)):
         atom.SetDoubleProp(attr, float(value))
-    elif isinstance(value, (int, np.int)):
+    elif isinstance(value, (int, np.integer)):
         atom.SetIntProp(attr, int(value))
     else:
         atom.SetProp(attr, value)

--- a/testsuite/MDAnalysisTests/analysis/test_helix_analysis.py
+++ b/testsuite/MDAnalysisTests/analysis/test_helix_analysis.py
@@ -112,7 +112,7 @@ def test_local_screw_angles_plane_circle():
     The global axis is the x-axis and ref axis is the y-axis,
     so angles should be calculated to the xy-plane.
     """
-    angdeg = np.arange(0, 360, 12, dtype=np.int)
+    angdeg = np.arange(0, 360, 12, dtype=np.int32)
     angrad = np.deg2rad(angdeg, dtype=np.float64)
     xyz = np.array([[np.cos(a), np.sin(a), 0] for a in angrad],
                    dtype=np.float64)
@@ -129,7 +129,7 @@ def test_local_screw_angles_ortho_circle():
     The global axis is the x-axis and ref axis is the z-axis,
     so angles should be calculated to the xz-plane.
     """
-    angdeg = np.arange(0, 360, 12, dtype=np.int)
+    angdeg = np.arange(0, 360, 12, dtype=np.int32)
     angrad = np.deg2rad(angdeg, dtype=np.float64)
     xyz = np.array([[np.cos(a), np.sin(a), 0] for a in angrad],
                    dtype=np.float64)


### PR DESCRIPTION
Fixes #3113 

Changes made in this Pull Request:
 - test_helix_analysis int->int32 (to be fair int16 would be suitable here...)

Running as draft to see if there's extra stuff I'm missing since grep isn't always very helpful...


PR Checklist
------------
 - Tests?
 - Docs?
 - CHANGELOG updated?
 - [x] Issue raised/referenced?
