### PR TITLE
Implements cache validation at the Universe level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@ authors.py
 *.DS_Store
 # ignore files from tests
 .hypothesis/
+# ignore results from asv
+benchmarks/results
 
 # duecredit
 .duecredit.p

--- a/benchmarks/benchmarks/ag_methods.py
+++ b/benchmarks/benchmarks/ag_methods.py
@@ -404,6 +404,7 @@ class FragmentFinding(object):
     def time_find_fragments(self, universe_type):
         frags = self.u.atoms.fragments
 
+
 class FragmentCaching(FragmentFinding):
     """Test how quickly we find cached fragments"""
     def setup(self, universe_type):

--- a/benchmarks/benchmarks/ag_methods.py
+++ b/benchmarks/benchmarks/ag_methods.py
@@ -403,3 +403,12 @@ class FragmentFinding(object):
 
     def time_find_fragments(self, universe_type):
         frags = self.u.atoms.fragments
+
+class FragmentCaching(FragmentFinding):
+    """Test how quickly we find cached fragments"""
+    def setup(self, universe_type):
+        super(FragmentCaching, self).setup(universe_type)
+        frags = self.u.atoms.fragments  # Priming the cache
+
+    def time_find_cached_fragments(self, universe_type):
+        frags = self.u.atoms.fragments

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -81,8 +81,11 @@ Fixes
   * Fix syntax warning over comparison of literals using is (Issue #3066)
 
 Enhancements
+  * Caches can now undergo central validation at the Universe level, opening
+    the door to more useful caching. Already applied to fragment caching
+    (Issue #2376, PR #3135)
   * Code for operations on compounds refactored, centralized and optimized for
-    performance (Issue #3000)
+    performance (Issue #3000, PR #3005)
   * Added automatic selection class generation for TopologyAttrs,
     FloatRangeSelection, and BoolSelection (Issues #2925, #2875; PR #2927)
   * Added 'to' operator, negatives, scientific notation, and arbitrary

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -2404,6 +2404,7 @@ class Bonds(_Connection):
         """
         return self.universe._fragdict[self.ix].ix
 
+    @cached('fragindices', universe_validation=True)
     def fragindices(self):
         r"""The
         :class:`fragment indices<MDAnalysis.core.topologyattrs.Bonds.fragindex>`
@@ -2437,6 +2438,7 @@ class Bonds(_Connection):
         """
         return self.universe._fragdict[self.ix].fragment
 
+    @cached('fragments', universe_validation=True)
     def fragments(self):
         """Read-only :class:`tuple` of
         :class:`fragments<MDAnalysis.core.topologyattrs.Bonds.fragment>`.

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -308,7 +308,7 @@ class Universe(object):
                  in_memory_step=1, **kwargs):
 
         self._trajectory = None  # managed attribute holding Reader
-        self._cache = {}
+        self._cache = {'_valid': {}}
         self.atoms = None
         self.residues = None
         self.segments = None
@@ -1002,7 +1002,10 @@ class Universe(object):
         """
         self._add_topology_objects('bonds', values, types=types,
                                  guessed=guessed, order=order)
+        # Invalidate bond-related caches
         self._cache.pop('fragments', None)
+        self._cache['_valid'].pop('fragments', None)
+        self._cache['_valid'].pop('fragindices', None)
 
     def add_angles(self, values, types=None, guessed=False):
         """Add new Angles to this Universe.
@@ -1139,7 +1142,10 @@ class Universe(object):
         .. versionadded:: 1.0.0
         """
         self._delete_topology_objects('bonds', values)
+        # Invalidate bond-related caches
         self._cache.pop('fragments', None)
+        self._cache['_valid'].pop('fragments', None)
+        self._cache['_valid'].pop('fragindices', None)
 
     def delete_angles(self, values):
         """Delete Angles from this Universe.

--- a/testsuite/MDAnalysisTests/core/test_fragments.py
+++ b/testsuite/MDAnalysisTests/core/test_fragments.py
@@ -212,6 +212,24 @@ class TestFragments(object):
         with pytest.raises(NoDataError):
             getattr(u.atoms[10], 'fragindex')
 
+    def test_atomgroup_fragment_cache_invalidation_bond_making(self):
+        u = case1()
+        fgs = u.atoms.fragments
+        assert fgs is u.atoms._cache['fragments']
+        assert u.atoms._cache_key in u._cache['_valid']['fragments']
+        u.add_bonds((fgs[0][-1] + fgs[1][0],))  # should trigger invalidation
+        assert 'fragments' not in u._cache['_valid']
+        assert len(fgs) > len(u.atoms.fragments)  # recomputed
+
+    def test_atomgroup_fragment_cache_invalidation_bond_breaking(self):
+        u = case1()
+        fgs = u.atoms.fragments
+        assert fgs is u.atoms._cache['fragments']
+        assert u.atoms._cache_key in u._cache['_valid']['fragments']
+        u.delete_bonds((u.atoms.bonds[3],))  # should trigger invalidation
+        assert 'fragments' not in u._cache['_valid']
+        assert len(fgs) < len(u.atoms.fragments)  # recomputed
+
 
 def test_tpr_fragments():
     ag = mda.Universe(TPR, XTC).atoms


### PR DESCRIPTION
Objects keep their own caches, but those can now be set to be validated against a centralized registry under object.universe. This simplifies the centralized invalidation of object caches.

This PR implements a mix of the ideas floated in #2376, #3005 and in the [mailing list discussion](https://groups.google.com/g/mdnalysis-devel/c/Sj8AkV9P1No/m/gVETgr1dAwAJ): caches are still stored under an object's own `_cache` but now, if asked to, the cache retrieval can check `universe._cache['_valid'][key]` for cache validity. This solution, compared to storing the actual cache under `universe`, prevents garbage collection from getting blocked when an object references itself in a cache.

Applied to fragment caching and added asv benchmark (`FragmentCaching.time_find_cached_fragments`). Already large speedup in fragment accession (Fixes #2376):
```
=============================== ============ =============
         universe_type           no caching     caching
------------------------------- ------------ -------------
 large_fragment_small_solvents   275±0.9ms    1.56±0.01μs
         large_fragment           167±9ms     1.56±0.01μs
         polymer_chains          47.9±0.2ms   1.58±0.01μs
=============================== ============ =============
```
Tests include cache invalidation when bonds are added/removed.

Also added asv's benchmarks/results subdir to `.gitignore`

PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
