### PR TITLE
Switch CI build badges from Travis to GH actions

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -1,4 +1,4 @@
-name: mda_gh_ci
+name: GH Actions CI
 on:
   push:
     branches:

--- a/README.rst
+++ b/README.rst
@@ -167,7 +167,7 @@ For citations of included algorithms and sub-modules please see the references_.
    :target: https://www.numfocus.org/
 
 .. |build| image:: https://github.com/MDAnalysis/mdanalysis/actions/workflows/gh-ci.yaml/badge.svg
-   :alt: Build Status
+   :alt: Github Actions Build Status
    :target: https://github.com/MDAnalysis/mdanalysis/actions/workflows/gh-ci.yaml
 
 .. |cov|   image:: https://codecov.io/gh/MDAnalysis/mdanalysis/branch/develop/graph/badge.svg

--- a/README.rst
+++ b/README.rst
@@ -168,7 +168,7 @@ For citations of included algorithms and sub-modules please see the references_.
 
 .. |build| image:: https://github.com/MDAnalysis/mdanalysis/actions/workflows/gh-ci.yaml/badge.svg
    :alt: Build Status
-   :target: https://github.com/MDAnalsis/mdanalysis/actions/workflows/gh-ci.yaml
+   :target: https://github.com/MDAnalysis/mdanalysis/actions/workflows/gh-ci.yaml
 
 .. |cov|   image:: https://codecov.io/gh/MDAnalysis/mdanalysis/branch/develop/graph/badge.svg
    :alt: Coverage Status

--- a/README.rst
+++ b/README.rst
@@ -166,9 +166,9 @@ For citations of included algorithms and sub-modules please see the references_.
    :alt: Powered by NumFOCUS
    :target: https://www.numfocus.org/
 
-.. |build| image:: https://travis-ci.com/MDAnalysis/mdanalysis.svg?branch=develop
+.. |build| image:: https://github.com/MDAnalysis/mdanalysis/actions/workflows/gh-ci.yaml/badge.svg
    :alt: Build Status
-   :target: https://travis-ci.com/MDAnalysis/mdanalysis
+   :target: https://github.com/MDAnalsis/mdanalysis/actions/workflows/gh-ci.yaml
 
 .. |cov|   image:: https://codecov.io/gh/MDAnalysis/mdanalysis/branch/develop/graph/badge.svg
    :alt: Coverage Status


### PR DESCRIPTION
Fixes <issue not raised>

Changes made in this Pull Request:
 - Changes README's CI build badge from Travis (which we no longer use [at least for now] on `develop` to GH Actions)
 - Renames GH Action's CI workflow name (honestly my initial choice for the workflow name was terrible)

Notes:

We can probably also add the azure pipelines badge if we wanted but I think I need access to the pipeline (@lilyminium ?)


PR Checklist
------------
 - Tests?
 - Docs?
 - CHANGELOG updated?
 - Issue raised/referenced?
