### PR TITLE
[MAINT] Trying to re-enable testing for non-x86 archs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_install:
   - . "/home/travis/miniconda/etc/profile.d/conda.sh"
   - conda activate base
   - conda update --yes conda
-  - conda install --yes pip pytest==6.1.2 mmtf-python biopython networkx cython matplotlib-base scipy griddataformats hypothesis gsd codecov -c conda-forge -c biobuilds
+  - conda install --yes pip pytest==6.1.2 mmtf-python biopython networkx cython matplotlib-base "scipy>=1.6" griddataformats hypothesis gsd codecov -c conda-forge -c biobuilds
   - pip install pytest-xdist
   - conda info
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_install:
   - . "/home/travis/miniconda/etc/profile.d/conda.sh"
   - conda activate base
   - conda update --yes conda
-  - conda install pip pytest==6.1.2 mmtf-python biopython networkx cython matplotlib-base scipy griddataformats hypothesis gsd codecov -c conda-forge biobuilds
+  - conda install pip pytest==6.1.2 mmtf-python biopython networkx cython matplotlib-base scipy griddataformats hypothesis gsd codecov -c conda-forge -c biobuilds
   - pip install pytest-xdist
   - conda info
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,54 @@
+version: ~> 1.0
+language: generic
+group: travis_latest
+
+# Only build for develop
+branches:
+  only:
+    - develop
+
+matrix:
+  fast_finish: true
+  include:
+    - python: 3.8
+      name: "Power PC"
+      os: linux
+      arch: ppc64le
+      before_install:
+        - wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-ppc64le.sh -O miniconda.sh
+        - mkdir $HOME/.conda
+        - bash miniconda.sh -b -p $HOME/miniconda
+        - $HOME/miniconda/bin/conda init bash
+        - source ~/.bash_profile
+        - conda activate base
+        - conda update --yes conda
+        - conda install pip pytest==6.1.2 mmtf-python biopython networkx cython matplotlib-base scipy griddataformats hypothesis gsd codecov -c conda-forge biobuilds
+        - pip install pytest-xdist
+        - conda info
+      install:
+        - (cd package/ && python setup.py develop) && (cd testsuite/ && python setup.py install)
+      script:
+        # 4 threads per power9 cores, 2 cores = 8 threads
+        - python -m pytest ./MDAnalysisTests --disable-pytest-warnings -n 8
+
+    - os: linux
+      language: python
+      arch: arm64-graviton2
+      python: 3.8
+      dist: focal
+      virt: vm
+      group: edge
+      before_install:
+        - python -m pip install cython numpy scipy
+        - python -m pip install --no-build-isolation hypothesis matplotlib pytest pytest-cov pytest-xdist tqdm
+      install:
+        - cd package
+        - python setup.py install
+        - cd ../testsuite
+        - python setup.py install
+        - cd ..
+      script:
+        - cd testsuite
+        - python -m pytest ./MDAnalysisTests --disable-pytest-warnings -n 8 -rsx --cov=MDAnalysis
+      after_success:
+        - echo "Override this stage for ARM64"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
         - mkdir $HOME/.conda
         - bash miniconda.sh -b -p $HOME/miniconda
         - $HOME/miniconda/bin/conda init bash
-        - source ~/.bash_profile
+        - source ~/.bashrc
         - conda activate base
         - conda update --yes conda
         - conda install pip pytest==6.1.2 mmtf-python biopython networkx cython matplotlib-base scipy griddataformats hypothesis gsd codecov -c conda-forge biobuilds
@@ -30,11 +30,14 @@ matrix:
       script:
         # 4 threads per power9 cores, 2 cores = 8 threads
         - python -m pytest ./MDAnalysisTests --disable-pytest-warnings -n 8
+      after_success:
+        - echo "Override this stage for ppc64le"
 
     - os: linux
       language: python
       arch: arm64-graviton2
       python: 3.8
+      name: "ARM64"
       dist: focal
       virt: vm
       group: edge

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,6 @@ install:
   - (cd package/ && python setup.py develop) && (cd testsuite/ && python setup.py install)
 script:
   # 4 threads per power9 cores, 2 cores = 8 threads
-  - python -m pytest ./MDAnalysisTests --disable-pytest-warnings -n 8
+  - pytest testsuite/MDAnalysisTests --disable-pytest-warnings -n 8
 after_success:
   - echo "Override this stage for now"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,9 @@ matrix:
         - mkdir $HOME/.conda
         - bash miniconda.sh -b -p $HOME/miniconda
         - $HOME/miniconda/bin/conda init bash
-          #- source ~/.bashrc
-        - source activate base
+        - cat $HOME/.bashrc
+        - source $HOME/.bashrc
+        - conda activate base
         - conda update --yes conda
         - conda install pip pytest==6.1.2 mmtf-python biopython networkx cython matplotlib-base scipy griddataformats hypothesis gsd codecov -c conda-forge biobuilds
         - pip install pytest-xdist
@@ -55,3 +56,4 @@ matrix:
         - python -m pytest ./MDAnalysisTests --disable-pytest-warnings -n 8 -rsx --cov=MDAnalysis
       after_success:
         - echo "Override this stage for ARM64"
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,27 +13,7 @@ matrix:
     - python: 3.8
       name: "Power PC"
       os: linux
-      #dist: focal
       arch: ppc64le
-      #before_install:
-      #  - wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-ppc64le.sh -O miniconda.sh
-      #  - mkdir $HOME/.conda
-      #  - bash miniconda.sh -b -p $HOME/miniconda
-      #  - $HOME/miniconda/bin/conda init bash
-      #  - cat $HOME/.bashrc
-      #  - source $HOME/.bashrc
-      #  - conda activate base
-      #  - conda update --yes conda
-      #  - conda install pip pytest==6.1.2 mmtf-python biopython networkx cython matplotlib-base scipy griddataformats hypothesis gsd codecov -c conda-forge biobuilds
-      #  - pip install pytest-xdist
-      #  - conda info
-      #install:
-      #  - (cd package/ && python setup.py develop) && (cd testsuite/ && python setup.py install)
-      #script:
-      #  # 4 threads per power9 cores, 2 cores = 8 threads
-      #  - python -m pytest ./MDAnalysisTests --disable-pytest-warnings -n 8
-      #after_success:
-      #  - echo "Override this stage for ppc64le"
 
     - os: linux
       language: python
@@ -57,6 +37,7 @@ matrix:
         - python -m pytest ./MDAnalysisTests --disable-pytest-warnings -n 8 -rsx --cov=MDAnalysis
       after_success:
         - echo "Override this stage for ARM64"
+
 
 before_install:
   - wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-ppc64le.sh -O miniconda.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,24 @@ matrix:
       name: "Power PC"
       os: linux
       arch: ppc64le
+      before_install:
+        - wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-ppc64le.sh -O miniconda.sh
+        - mkdir $HOME/.conda
+        - bash miniconda.sh -b -p $HOME/miniconda
+        - $HOME/miniconda/bin/conda init bash
+        # for some reason the image does not like sourcing .bashrc
+        - . "/home/travis/miniconda/etc/profile.d/conda.sh"
+        - conda activate base
+        - conda update --yes conda
+        - conda install --yes pip pytest==6.1.2 mmtf-python biopython networkx cython matplotlib-base "scipy>=1.6" griddataformats hypothesis gsd codecov -c conda-forge -c biobuilds
+        - pip install pytest-xdist
+        - conda info
+      install:
+        - (cd package/ && python setup.py develop) && (cd testsuite/ && python setup.py install)
+      script:
+        - pytest testsuite/MDAnalysisTests --disable-pytest-warnings -n 2
+      after_sucess:
+        - echo "Override this stage for now"
 
     - os: linux
       language: python
@@ -38,23 +56,3 @@ matrix:
       after_success:
         - echo "Override this stage for ARM64"
 
-
-before_install:
-  - wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-ppc64le.sh -O miniconda.sh
-  - mkdir $HOME/.conda
-  - bash miniconda.sh -b -p $HOME/miniconda
-  - $HOME/miniconda/bin/conda init bash
-  - cat $HOME/.bashrc
-  - . "/home/travis/miniconda/etc/profile.d/conda.sh"
-  - conda activate base
-  - conda update --yes conda
-  - conda install --yes pip pytest==6.1.2 mmtf-python biopython networkx cython matplotlib-base "scipy>=1.6" griddataformats hypothesis gsd codecov -c conda-forge -c biobuilds
-  - pip install pytest-xdist
-  - conda info
-install:
-  - (cd package/ && python setup.py develop) && (cd testsuite/ && python setup.py install)
-script:
-  # 4 threads per power9 cores, 2 cores = 8 threads
-  - pytest testsuite/MDAnalysisTests --disable-pytest-warnings -n 8
-after_success:
-  - echo "Override this stage for now"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ matrix:
         - mkdir $HOME/.conda
         - bash miniconda.sh -b -p $HOME/miniconda
         - $HOME/miniconda/bin/conda init bash
-        - source ~/.bashrc
-        - conda activate base
+          #- source ~/.bashrc
+        - source activate base
         - conda update --yes conda
         - conda install pip pytest==6.1.2 mmtf-python biopython networkx cython matplotlib-base scipy griddataformats hypothesis gsd codecov -c conda-forge biobuilds
         - pip install pytest-xdist

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_install:
   - . "/home/travis/miniconda/etc/profile.d/conda.sh"
   - conda activate base
   - conda update --yes conda
-  - conda install pip pytest==6.1.2 mmtf-python biopython networkx cython matplotlib-base scipy griddataformats hypothesis gsd codecov -c conda-forge -c biobuilds
+  - conda install --yes pip pytest==6.1.2 mmtf-python biopython networkx cython matplotlib-base scipy griddataformats hypothesis gsd codecov -c conda-forge -c biobuilds
   - pip install pytest-xdist
   - conda info
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ before_install:
   - bash miniconda.sh -b -p $HOME/miniconda
   - $HOME/miniconda/bin/conda init bash
   - cat $HOME/.bashrc
-  - source $HOME/.bashrc
+  - . "/home/travis/miniconda/etc/profile.d/conda.sh"
   - conda activate base
   - conda update --yes conda
   - conda install pip pytest==6.1.2 mmtf-python biopython networkx cython matplotlib-base scipy griddataformats hypothesis gsd codecov -c conda-forge biobuilds

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,26 +13,27 @@ matrix:
     - python: 3.8
       name: "Power PC"
       os: linux
+      dist: focal
       arch: ppc64le
-      before_install:
-        - wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-ppc64le.sh -O miniconda.sh
-        - mkdir $HOME/.conda
-        - bash miniconda.sh -b -p $HOME/miniconda
-        - $HOME/miniconda/bin/conda init bash
-        - cat $HOME/.bashrc
-        - source $HOME/.bashrc
-        - conda activate base
-        - conda update --yes conda
-        - conda install pip pytest==6.1.2 mmtf-python biopython networkx cython matplotlib-base scipy griddataformats hypothesis gsd codecov -c conda-forge biobuilds
-        - pip install pytest-xdist
-        - conda info
-      install:
-        - (cd package/ && python setup.py develop) && (cd testsuite/ && python setup.py install)
-      script:
-        # 4 threads per power9 cores, 2 cores = 8 threads
-        - python -m pytest ./MDAnalysisTests --disable-pytest-warnings -n 8
-      after_success:
-        - echo "Override this stage for ppc64le"
+      #before_install:
+      #  - wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-ppc64le.sh -O miniconda.sh
+      #  - mkdir $HOME/.conda
+      #  - bash miniconda.sh -b -p $HOME/miniconda
+      #  - $HOME/miniconda/bin/conda init bash
+      #  - cat $HOME/.bashrc
+      #  - source $HOME/.bashrc
+      #  - conda activate base
+      #  - conda update --yes conda
+      #  - conda install pip pytest==6.1.2 mmtf-python biopython networkx cython matplotlib-base scipy griddataformats hypothesis gsd codecov -c conda-forge biobuilds
+      #  - pip install pytest-xdist
+      #  - conda info
+      #install:
+      #  - (cd package/ && python setup.py develop) && (cd testsuite/ && python setup.py install)
+      #script:
+      #  # 4 threads per power9 cores, 2 cores = 8 threads
+      #  - python -m pytest ./MDAnalysisTests --disable-pytest-warnings -n 8
+      #after_success:
+      #  - echo "Override this stage for ppc64le"
 
     - os: linux
       language: python
@@ -57,3 +58,22 @@ matrix:
       after_success:
         - echo "Override this stage for ARM64"
 
+before_install:
+  - wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-ppc64le.sh -O miniconda.sh
+  - mkdir $HOME/.conda
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - $HOME/miniconda/bin/conda init bash
+  - cat $HOME/.bashrc
+  - source $HOME/.bashrc
+  - conda activate base
+  - conda update --yes conda
+  - conda install pip pytest==6.1.2 mmtf-python biopython networkx cython matplotlib-base scipy griddataformats hypothesis gsd codecov -c conda-forge biobuilds
+  - pip install pytest-xdist
+  - conda info
+install:
+  - (cd package/ && python setup.py develop) && (cd testsuite/ && python setup.py install)
+script:
+  # 4 threads per power9 cores, 2 cores = 8 threads
+  - python -m pytest ./MDAnalysisTests --disable-pytest-warnings -n 8
+after_success:
+  - echo "Override this stage for now"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
       name: "Power PC"
       os: linux
       arch: ppc64le
+      if: type = cron
       before_install:
         - wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-ppc64le.sh -O miniconda.sh
         - mkdir $HOME/.conda
@@ -41,6 +42,7 @@ matrix:
       dist: focal
       virt: vm
       group: edge
+      if: type = cron
       before_install:
         - python -m pip install cython numpy scipy
         - python -m pip install --no-build-isolation hypothesis matplotlib pytest pytest-cov pytest-xdist tqdm

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
     - python: 3.8
       name: "Power PC"
       os: linux
-      dist: focal
+      #dist: focal
       arch: ppc64le
       #before_install:
       #  - wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-ppc64le.sh -O miniconda.sh

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -134,7 +134,7 @@ Enhancements
   
 Changes
   * Introduces encore specific C compiler arguments to allow for lowering of
-    optimisations on non-x86 platforms (PR #3149)
+    optimisations on non-x86 platforms (Issue #1389, PR #3149)
   * Continuous integration uses mamba rather than conda to install the
     dependencies (PR #2983)
   * removes deprecated `as_Universe` function from MDAnalysis.core.universe,

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -84,6 +84,8 @@ Fixes
   * Fix syntax warning over comparison of literals using is (Issue #3066)
 
 Enhancements
+  * Adds preliminary support for the ppc64le platform with minimal
+    dependencies (Issue #3127, PR #3149)
   * Caches can now undergo central validation at the Universe level, opening
     the door to more useful caching. Already applied to fragment caching
     (Issue #2376, PR #3135)
@@ -131,6 +133,8 @@ Enhancements
     explicit in the topology (Issue #2468, PR #2775)
   
 Changes
+  * Introduces encore specific C compiler arguments to allow for lowering of
+    optimisations on non-x86 platforms (PR #3149)
   * Continuous integration uses mamba rather than conda to install the
     dependencies (PR #2983)
   * removes deprecated `as_Universe` function from MDAnalysis.core.universe,

--- a/package/setup.py
+++ b/package/setup.py
@@ -261,15 +261,8 @@ def extensions(config):
     use_cython = config.get('use_cython', default=not is_release)
     use_openmp = config.get('use_openmp', default=True)
 
-    if platform.machine() == 'aarch64':
-        # reduce optimization level for ARM64 machines
-        # because of issues with test failures sourcing to:
-        # MDAnalysis/analysis/encore/clustering/src/ap.c
-        extra_compile_args = ['-std=c99', '-ffast-math', '-O1', '-funroll-loops',
-                              '-fsigned-zeros']
-    else:
-        extra_compile_args = ['-std=c99', '-ffast-math', '-O3', '-funroll-loops',
-                              '-fsigned-zeros']  # see #2722
+    extra_compile_args = ['-std=c99', '-ffast-math', '-O3', '-funroll-loops',
+                          '-fsigned-zeros']  # see #2722
     define_macros = []
     if config.get('debug_cflags', default=False):
         extra_compile_args.extend(['-Wall', '-pedantic'])
@@ -280,6 +273,15 @@ def extensions(config):
     arch = config.get('march', default=False)
     if arch:
         extra_compile_args.append('-march={}'.format(arch))
+
+    # encore is sensitive to floating point accuracy, especially on non-x86
+    # to avoid reducing optimisations on everything, we make a set of compile
+    # args specific to encore see #2997 for an example of this.
+    encore_compile_args = [a for a in extra_compile_args if 'O3' not in a]
+    if platform.machine() == 'aarch64' or platform.machine() == 'ppc64le':
+        encore_compile_args.append('-O1')
+    else:
+        encore_compile_args.append('-O3')
 
     cpp_extra_compile_args = [a for a in extra_compile_args if 'std' not in a]
     cpp_extra_compile_args.append('-std=c++11')
@@ -401,21 +403,21 @@ def extensions(config):
                                 sources=['MDAnalysis/analysis/encore/cutils' + source_suffix],
                                 include_dirs=include_dirs,
                                 define_macros=define_macros,
-                                extra_compile_args=extra_compile_args)
+                                extra_compile_args=encore_compile_args)
     ap_clustering = MDAExtension('MDAnalysis.analysis.encore.clustering.affinityprop',
                                  sources=['MDAnalysis/analysis/encore/clustering/affinityprop' + source_suffix,
                                           'MDAnalysis/analysis/encore/clustering/src/ap.c'],
                                  include_dirs=include_dirs+['MDAnalysis/analysis/encore/clustering/include'],
                                  libraries=mathlib,
                                  define_macros=define_macros,
-                                 extra_compile_args=extra_compile_args)
+                                 extra_compile_args=encore_compile_args)
     spe_dimred = MDAExtension('MDAnalysis.analysis.encore.dimensionality_reduction.stochasticproxembed',
                               sources=['MDAnalysis/analysis/encore/dimensionality_reduction/stochasticproxembed' + source_suffix,
                                        'MDAnalysis/analysis/encore/dimensionality_reduction/src/spe.c'],
                               include_dirs=include_dirs+['MDAnalysis/analysis/encore/dimensionality_reduction/include'],
                               libraries=mathlib,
                               define_macros=define_macros,
-                              extra_compile_args=extra_compile_args)
+                              extra_compile_args=encore_compile_args)
     nsgrid = MDAExtension('MDAnalysis.lib.nsgrid',
                              ['MDAnalysis/lib/nsgrid' + cpp_source_suffix],
                              include_dirs=include_dirs,


### PR DESCRIPTION
Partially fixes #1389 and #3127

Changes made in this Pull Request:
 - Make encore compile args a separate list so we can selectively reduce optimisation (it's the only part of the code that seems more sensitive to floating point errors).
 - Adds Travis cron jobs for ppc64le and aarch64

PR Checklist
------------
 - Tests?
 - Docs? - N/A?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
