### PR TITLE
Add kwarg to index TPRParser from 0 or 1

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -133,8 +133,8 @@ Enhancements
     explicit in the topology (Issue #2468, PR #2775)
   
 Changes
-  * TPRParser now loads TPR files with `tpr_resid_from_one=True`
-    by default (PR #3152)
+  * TPRParser now loads TPR files with `tpr_resid_from_one=True` by default, 
+    which starts TPR resid indexing from 1 (instead of 0 as in 1.x) (Issue #2364, PR #3152)
   * Introduces encore specific C compiler arguments to allow for lowering of
     optimisations on non-x86 platforms (Issue #1389, PR #3149)
   * Continuous integration uses mamba rather than conda to install the

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -133,6 +133,8 @@ Enhancements
     explicit in the topology (Issue #2468, PR #2775)
   
 Changes
+  * TPRParser now loads TPR files with `tpr_resid_from_one=True`
+    by default (PR #3152)
   * Introduces encore specific C compiler arguments to allow for lowering of
     optimisations on non-x86 platforms (Issue #1389, PR #3149)
   * Continuous integration uses mamba rather than conda to install the

--- a/package/MDAnalysis/topology/TPRParser.py
+++ b/package/MDAnalysis/topology/TPRParser.py
@@ -176,7 +176,7 @@ class TPRParser(TopologyReaderBase):
     """
     format = 'TPR'
 
-    def parse(self, tpr_resid_from_one=False, **kwargs):
+    def parse(self, tpr_resid_from_one=True, **kwargs):
         """Parse a Gromacs TPR file into a MDAnalysis internal topology structure.
 
         Parameters
@@ -194,6 +194,9 @@ class TPRParser(TopologyReaderBase):
         .. versionchanged:: 1.0.2
             Added the ``tpr_resid_from_one`` keyword to control if
             resids are indexed from 0 or 1. Default ``False``.
+
+        .. versionchanged:: 2.0.0
+            Changed to ``tpr_resid_from_one=True`` by default.
         """
         with openany(self.filename, mode='rb') as infile:
             tprf = infile.read()

--- a/package/MDAnalysis/topology/TPRParser.py
+++ b/package/MDAnalysis/topology/TPRParser.py
@@ -191,7 +191,7 @@ class TPRParser(TopologyReaderBase):
         structure : dict
 
 
-        .. versionchanged:: 1.0.2
+        .. versionchanged:: 1.1.0
             Added the ``tpr_resid_from_one`` keyword to control if
             resids are indexed from 0 or 1. Default ``False``.
 

--- a/package/MDAnalysis/topology/TPRParser.py
+++ b/package/MDAnalysis/topology/TPRParser.py
@@ -176,12 +176,24 @@ class TPRParser(TopologyReaderBase):
     """
     format = 'TPR'
 
-    def parse(self, **kwargs):
+    def parse(self, tpr_resid_from_one=False, **kwargs):
         """Parse a Gromacs TPR file into a MDAnalysis internal topology structure.
+
+        Parameters
+        ----------
+        tpr_resid_from_one: bool (optional)
+            Toggle whether to index resids from 1 or 0 from TPR files.
+            TPR files index resids from 0 by default, even though GRO and ITP
+            files index from 1.
 
         Returns
         -------
         structure : dict
+
+
+        .. versionchanged:: 1.0.2
+            Added the ``tpr_resid_from_one`` keyword to control if
+            resids are indexed from 0 or 1. Default ``False``.
         """
         with openany(self.filename, mode='rb') as infile:
             tprf = infile.read()
@@ -219,7 +231,8 @@ class TPRParser(TopologyReaderBase):
             tpr_utils.ndo_real(data, state_ngtc)        # relevant to Berendsen tcoupl_lambda
 
         if th.bTop:
-            tpr_top = tpr_utils.do_mtop(data, th.fver)
+            tpr_top = tpr_utils.do_mtop(data, th.fver,
+                                        tpr_resid_from_one=tpr_resid_from_one)
         else:
             msg = f"{self.filename}: No topology found in tpr file"
             logger.critical(msg)

--- a/package/MDAnalysis/topology/tpr/utils.py
+++ b/package/MDAnalysis/topology/tpr/utils.py
@@ -286,7 +286,7 @@ def extract_box_info(data, fver):
     return obj.Box(box, box_rel, box_v)
 
 
-def do_mtop(data, fver, tpr_resid_from_one=False):
+def do_mtop(data, fver, tpr_resid_from_one=True):
     # mtop: the topology of the whole system
     symtab = do_symtab(data)
     do_symstr(data, symtab)  # system_name
@@ -375,14 +375,7 @@ def do_mtop(data, fver, tpr_resid_from_one=False):
     resids = np.array(resids, dtype=np.int32)
     if tpr_resid_from_one:
         resids += 1
-    else:
-        warnings.warn("TPR files index residues from 0. "
-                      "From MDAnalysis version 2.0, resids will start "
-                      "at 1 instead. If you wish to keep indexing "
-                      "resids from 0, please set "
-                      "`tpr_resid_from_one=False` as a keyword argument "
-                      "when you create a new Topology or Universe.",
-                      category=DeprecationWarning)
+
     resnames = np.array(resnames, dtype=object)
     (residx, new_resids,
      (new_resnames,

--- a/package/MDAnalysis/topology/tpr/utils.py
+++ b/package/MDAnalysis/topology/tpr/utils.py
@@ -46,7 +46,6 @@ Then compose the stuffs in the format :class:`MDAnalysis.Universe` reads in.
 
 The module also contains the :func:`do_inputrec` to read the TPR header with.
 """
-import warnings
 
 import numpy as np
 import xdrlib
@@ -286,7 +285,7 @@ def extract_box_info(data, fver):
     return obj.Box(box, box_rel, box_v)
 
 
-def do_mtop(data, fver, tpr_resid_from_one=True):
+def do_mtop(data, fver, tpr_resid_from_one=False):
     # mtop: the topology of the whole system
     symtab = do_symtab(data)
     do_symstr(data, symtab)  # system_name

--- a/package/MDAnalysis/topology/tpr/utils.py
+++ b/package/MDAnalysis/topology/tpr/utils.py
@@ -46,6 +46,8 @@ Then compose the stuffs in the format :class:`MDAnalysis.Universe` reads in.
 
 The module also contains the :func:`do_inputrec` to read the TPR header with.
 """
+import warnings
+
 import numpy as np
 import xdrlib
 import struct
@@ -284,7 +286,7 @@ def extract_box_info(data, fver):
     return obj.Box(box, box_rel, box_v)
 
 
-def do_mtop(data, fver):
+def do_mtop(data, fver, tpr_resid_from_one=False):
     # mtop: the topology of the whole system
     symtab = do_symtab(data)
     do_symstr(data, symtab)  # system_name
@@ -371,6 +373,16 @@ def do_mtop(data, fver):
     molnums = np.array(molnums, dtype=np.int32)
     segids = np.array(segids, dtype=object)
     resids = np.array(resids, dtype=np.int32)
+    if tpr_resid_from_one:
+        resids += 1
+    else:
+        warnings.warn("TPR files index residues from 0. "
+                      "From MDAnalysis version 2.0, resids will start "
+                      "at 1 instead. If you wish to keep indexing "
+                      "resids from 0, please set "
+                      "`tpr_resid_from_one=False` as a keyword argument "
+                      "when you create a new Topology or Universe.",
+                      category=DeprecationWarning)
     resnames = np.array(resnames, dtype=object)
     (residx, new_resids,
      (new_resnames,

--- a/testsuite/MDAnalysisTests/analysis/test_density.py
+++ b/testsuite/MDAnalysisTests/analysis/test_density.py
@@ -148,7 +148,7 @@ class DensityParameters(object):
 
     @pytest.fixture()
     def universe(self):
-        return mda.Universe(self.topology, self.trajectory)
+        return mda.Universe(self.topology, self.trajectory, tpr_resid_from_one=False)
 
 class TestDensityAnalysis(DensityParameters):
     def check_DensityAnalysis(self, ag, ref_meandensity,

--- a/testsuite/MDAnalysisTests/core/test_atomselections.py
+++ b/testsuite/MDAnalysisTests/core/test_atomselections.py
@@ -485,7 +485,7 @@ class TestSelectionsTPR(object):
     @staticmethod
     @pytest.fixture(scope='class')
     def universe():
-        return MDAnalysis.Universe(TPR,XTC)
+        return MDAnalysis.Universe(TPR, XTC, tpr_resid_from_one=False)
 
     @pytest.mark.parametrize('selstr', [
         'same fragment as bynum 1',
@@ -1299,7 +1299,7 @@ def test_mass_sel_warning(u_fake_masses):
 
 
 @pytest.mark.parametrize("selstr,n_res", [
-    ("resnum -10 to 3", 14),
+    ("resnum -10 to 3", 13),
     ("resnum -5--3", 3),  # select -5 to -3
     ("resnum -3 : -5", 0),  # wrong way around
 ])

--- a/testsuite/MDAnalysisTests/topology/test_tprparser.py
+++ b/testsuite/MDAnalysisTests/topology/test_tprparser.py
@@ -291,22 +291,11 @@ def test_elements():
 
 
 @pytest.mark.parametrize("resid_from_one,resid_addition", [
-    (False, 0),  # status quo for 1.x
-    (True, 1),
+    (False, 0),
+    (True, 1),  # status quo for 2.x
     ])
 def test_resids(resid_from_one, resid_addition):
     u = mda.Universe(TPR, tpr_resid_from_one=resid_from_one)
     resids = np.arange(len(u.residues)) + resid_addition
     assert_equal(u.residues.resids, resids,
                  err_msg="tpr_resid_from_one kwarg not switching resids")
-
-
-@pytest.mark.parametrize("kwargs", [
-    {},
-    {"tpr_resid_from_one": False},
-])
-def test_resid_false_deprecation_warning(kwargs):
-    err = ("indexing residues from 0 by default will be removed "
-           "in MDAnalysis version 2.0")
-    with pytest.warns(DeprecationWarning, match=err):
-        u = mda.Universe(TPR, **kwargs)

--- a/testsuite/MDAnalysisTests/topology/test_tprparser.py
+++ b/testsuite/MDAnalysisTests/topology/test_tprparser.py
@@ -39,6 +39,7 @@ from MDAnalysis.tests.datafiles import (
 )
 from MDAnalysisTests.topology.base import ParserBase
 import MDAnalysis.topology.TPRParser
+import MDAnalysis as mda
 
 BONDED_TPRS = (
     TPR510_bonded,
@@ -287,3 +288,25 @@ def test_elements():
         'H', '', 'Na', 'Na', 'Na', 'Na',
     ], dtype=object)
     assert_equal(topology.elements.values[-20:], reference)
+
+
+@pytest.mark.parametrize("resid_from_one,resid_addition", [
+    (False, 0),  # status quo for 1.x
+    (True, 1),
+    ])
+def test_resids(resid_from_one, resid_addition):
+    u = mda.Universe(TPR, tpr_resid_from_one=resid_from_one)
+    resids = np.arange(len(u.residues)) + resid_addition
+    assert_equal(u.residues.resids, resids,
+                 err_msg="tpr_resid_from_one kwarg not switching resids")
+
+
+@pytest.mark.parametrize("kwargs", [
+    {},
+    {"tpr_resid_from_one": False},
+])
+def test_resid_false_deprecation_warning(kwargs):
+    err = ("indexing residues from 0 by default will be removed "
+           "in MDAnalysis version 2.0")
+    with pytest.warns(DeprecationWarning, match=err):
+        u = mda.Universe(TPR, **kwargs)


### PR DESCRIPTION
Fixes #2364 

Changes made in this Pull Request:
 - Added keyword argument to index TPRParser from 0 or 1
 - Set the default to index from 1, changing the default behaviour

~This is easily undoable. I read the discussion in #2364 as supporting both including a kwarg and a warning. If that is not consensus, please let me know. I'll update CHANGELOG once we have this nailed down :-)~


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
