### PR TITLE
Add tpr_resid_from_one keyword to TPRParser

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -15,7 +15,7 @@ The rules for this file:
 ------------------------------------------------------------------------------
 ??/??/??  richardjgowers, IAlibay, tylerjereddy, xiki-tempula, lilyminium
 
-  * 1.0.2
+  * 1.1.0
 
 Fixes
   * Replaces decreated NumPy type aliases and fixes NEP 34 explicit ragged

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -174,6 +174,8 @@ Fixes
   * Contact Analysis class respects PBC (Issue #2368)
 
 Enhancements
+  * Added `tpr_resid_from_one` keyword to select whether TPRParser
+    indexes resids from 0 or 1 (Issue #2364, PR #3153)
   * Added support for FHI-AIMS input files (PR #2705)
   * vastly improved support for 32-bit Windows (PR #2696)
   * Added methods to compute the root-mean-square-inner-product of subspaces 
@@ -286,6 +288,8 @@ Changes
     function calls. (Issue #782)
 
 Deprecations
+  * TPRParser indexing resids from 0 by default is deprecated in 1.0.
+    From 2.0 TPRParser will index resids from 1 by default.
   * analysis.hole is deprecated in 1.0 (remove in 2.0)
   * analysis.hbonds.HydrogenBondAnalysis is deprecated in 1.0 (remove in 2.0)
   * analysis.density.density_from_Universe() (remove in 2.0)

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,7 +13,7 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-??/??/??  richardjgowers, IAlibay, tylerjereddy, xiki-tempula,
+??/??/??  richardjgowers, IAlibay, tylerjereddy, xiki-tempula, lilyminium
 
   * 1.0.2
 
@@ -29,6 +29,13 @@ Changes
 Deprecations
   * hbonds.WaterBridgeAnalysis will be removed in 2.0.0 and
     replaced with hydrogenbonds.WaterBridgeAnalysis (#3111)
+  * TPRParser indexing resids from 0 by default is deprecated.
+    From 2.0 TPRParser will index resids from 1 by default.
+
+Enhancements
+  * Added `tpr_resid_from_one` keyword to select whether TPRParser
+    indexes resids from 0 or 1 (Issue #2364, PR #3153)
+  
     
 01/17/21 richardjgowers, IAlibay, orbeckst, tylerjereddy, jbarnoud,
          yuxuanzhuang, lilyminium, VOD555, p-j-smith, bieniekmateusz,
@@ -174,8 +181,6 @@ Fixes
   * Contact Analysis class respects PBC (Issue #2368)
 
 Enhancements
-  * Added `tpr_resid_from_one` keyword to select whether TPRParser
-    indexes resids from 0 or 1 (Issue #2364, PR #3153)
   * Added support for FHI-AIMS input files (PR #2705)
   * vastly improved support for 32-bit Windows (PR #2696)
   * Added methods to compute the root-mean-square-inner-product of subspaces 
@@ -288,8 +293,6 @@ Changes
     function calls. (Issue #782)
 
 Deprecations
-  * TPRParser indexing resids from 0 by default is deprecated in 1.0.
-    From 2.0 TPRParser will index resids from 1 by default.
   * analysis.hole is deprecated in 1.0 (remove in 2.0)
   * analysis.hbonds.HydrogenBondAnalysis is deprecated in 1.0 (remove in 2.0)
   * analysis.density.density_from_Universe() (remove in 2.0)

--- a/package/MDAnalysis/topology/TPRParser.py
+++ b/package/MDAnalysis/topology/TPRParser.py
@@ -186,7 +186,7 @@ class TPRParser(TopologyReaderBase):
         structure : dict
 
 
-        .. versionchanged:: 1.0.2
+        .. versionchanged:: 1.1.0
             Added the ``tpr_resid_from_one`` keyword to control if
             resids are indexed from 0 or 1. Default ``False``.
         """

--- a/package/MDAnalysis/topology/TPRParser.py
+++ b/package/MDAnalysis/topology/TPRParser.py
@@ -171,12 +171,24 @@ class TPRParser(TopologyReaderBase):
     """
     format = 'TPR'
 
-    def parse(self, **kwargs):
+    def parse(self, tpr_resid_from_one=False, **kwargs):
         """Parse a Gromacs TPR file into a MDAnalysis internal topology structure.
+
+        Parameters
+        ----------
+        tpr_resid_from_one: bool (optional)
+            Toggle whether to index resids from 1 or 0 from TPR files.
+            TPR files index resids from 0 by default, even though GRO and ITP
+            files index from 1.
 
         Returns
         -------
         structure : dict
+
+
+        .. versionchanged:: 1.0.2
+            Added the ``tpr_resid_from_one`` keyword to control if
+            resids are indexed from 0 or 1. Default ``False``.
         """
         with openany(self.filename, mode='rb') as infile:
             tprf = infile.read()
@@ -219,7 +231,8 @@ class TPRParser(TopologyReaderBase):
             tpr_utils.fileVersion_err(V)
 
         if th.bTop:
-            tpr_top = tpr_utils.do_mtop(data, V)
+            tpr_top = tpr_utils.do_mtop(data, V,
+                                        tpr_resid_from_one=tpr_resid_from_one)
         else:
             msg = "{0}: No topology found in tpr file".format(self.filename)
             logger.critical(msg)

--- a/package/MDAnalysis/topology/tpr/utils.py
+++ b/package/MDAnalysis/topology/tpr/utils.py
@@ -49,6 +49,8 @@ The module also contains the :func:`do_inputrec` to read the TPR header with.
 from __future__ import absolute_import
 
 from six.moves import range
+import warnings
+
 import numpy as np
 import xdrlib
 import struct
@@ -296,7 +298,7 @@ def extract_box_info(data, fileVersion):
     return obj.Box(box, box_rel, box_v)
 
 
-def do_mtop(data, fver):
+def do_mtop(data, fver, tpr_resid_from_one=False):
     # mtop: the topology of the whole system
     symtab = do_symtab(data)
     do_symstr(data, symtab)  # system_name
@@ -381,6 +383,16 @@ def do_mtop(data, fver):
     molnums = np.array(molnums, dtype=np.int32)
     segids = np.array(segids, dtype=object)
     resids = np.array(resids, dtype=np.int32)
+    if tpr_resid_from_one:
+        resids += 1
+    else:
+        warnings.warn("TPR files index residues from 0. "
+                      "From MDAnalysis version 2.0, resids will start "
+                      "at 1 instead. If you wish to keep indexing "
+                      "resids from 0, please set "
+                      "`tpr_resid_from_one=False` as a keyword argument "
+                      "when you create a new Topology or Universe.",
+                      category=DeprecationWarning)
     resnames = np.array(resnames, dtype=object)
     (residx, new_resids,
      (new_resnames,


### PR DESCRIPTION
Fixes #2364

Master version of #3152.

Changes made in this Pull Request:
 - Add tpr_resid_from_one keyword to TPRParser
 - Set default to ``False``, keeping current status quo
 - Emits a warning for ``tpr_resid_from_one=False`` indicating that default behaviour will change in 2.0


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
