### PR TITLE
Adds test for datafiles import to cover failed import

### DIFF
--- a/testsuite/MDAnalysisTests/utils/test_datafiles.py
+++ b/testsuite/MDAnalysisTests/utils/test_datafiles.py
@@ -22,6 +22,15 @@
 #
 import pytest
 from numpy.testing import assert_equal
+from MDAnalysisTests.util import block_import
+
+
+@block_import('MDAnalysisTests.datafiles')
+def test_failed_import():
+    # Putting this test first to avoid datafiles already being loaded
+    errmsg = "MDAnalysisTests package not installed."
+    with pytest.raises(ImportError, match=errmsg):
+        import MDAnalysis.tests.datafiles
 
 
 def test_import():

--- a/testsuite/MDAnalysisTests/utils/test_datafiles.py
+++ b/testsuite/MDAnalysisTests/utils/test_datafiles.py
@@ -21,14 +21,19 @@
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
 import pytest
+import sys
 from numpy.testing import assert_equal
-from MDAnalysisTests.util import block_import
 
 
-@block_import('MDAnalysisTests.datafiles')
-def test_failed_import():
+def test_failed_import(monkeypatch):
     # Putting this test first to avoid datafiles already being loaded
     errmsg = "MDAnalysisTests package not installed."
+
+    monkeypatch.setitem(sys.modules, 'MDAnalysisTests.datafiles', None)
+
+    if 'MDAnalysis.tests.datafiles' in sys.modules:
+        monkeypatch.delitem(sys.modules, 'MDAnalysis.tests.datafiles')
+
     with pytest.raises(ImportError, match=errmsg):
         import MDAnalysis.tests.datafiles
 


### PR DESCRIPTION
This was making me a bit sad so I added a quick test: https://codecov.io/gh/MDAnalysis/mdanalysis/src/develop/package/MDAnalysis/tests/datafiles.py

Hopefully this should get coverage up a little bit.

PR Checklist
------------
 - [x] Tests?
 - Docs? N/A
 - CHANGELOG updated? Uncessary
 - Issue raised/referenced? N/A
