### PR TITLE
Add Travis CI shield.io badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
   MDAnalysis Repository README
 ================================
 
-|numfocus| |build| |cov| [*]_
+|numfocus| |build| |travis| |cov| [*]_
 
 |docs| |devdocs| |usergroup| |developergroup| |anaconda| |mybinder|
 
@@ -169,6 +169,10 @@ For citations of included algorithms and sub-modules please see the references_.
 .. |build| image:: https://github.com/MDAnalysis/mdanalysis/actions/workflows/gh-ci.yaml/badge.svg
    :alt: Github Actions Build Status
    :target: https://github.com/MDAnalysis/mdanalysis/actions/workflows/gh-ci.yaml
+
+.. |travis| image:: https://img.shields.io/travis/MDAnalysis/mdanalysis/develop?label=Travis%20CI
+   :alt: Travis CI Build Status
+   :target: https://travis-ci.com/MDAnalysis/mdanalysis
 
 .. |cov|   image:: https://codecov.io/gh/MDAnalysis/mdanalysis/branch/develop/graph/badge.svg
    :alt: Coverage Status


### PR DESCRIPTION
Now that #3149 has been enabled with a weekly Travis CI cron job for aarch64 and ppc64le, I thought it might be worth re-adding a Travis CI status badge on our CI.

To make it more obvious as to what that badge relates to, I used shields.io to create a custom labelled shield.

Changes made in this Pull Request:
 - Adds shield.io version of Travis CI badge to README.rst

PR Checklist
------------
 - Tests?
 - Docs?
 - CHANGELOG updated?
 - Issue raised/referenced?
