### PR TITLE
Added get_connections

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -31,6 +31,9 @@ Changes
   * Maximum pinned versions in setup.py removed for python 3.6+ (PR #3139)
 
 Deprecations
+  * Deprecated current Group.bonds, angles, dihedrals, impropers
+    behavior where it returns connections to atoms outside the group
+    by default (Issue #1264, #2821, PR #3159)
   * NCDFWriter `scale_factor` writing will change in version 2.0 to
     better match AMBER outputs (Issue #2327)
   * Deprecated using the last letter of the segid as the
@@ -41,11 +44,14 @@ Deprecations
     replaced with hydrogenbonds.WaterBridgeAnalysis (#3111)
   * TPRParser indexing resids from 0 by default is deprecated.
     From 2.0 TPRParser will index resids from 1 by default.
+  
 
 Enhancements
+  * Added `get_connections` method to get bonds, angles, dihedrals, etc.
+    with or without atoms outside the group (Issues #1264, #2821, PR #3160)
   * Added `tpr_resid_from_one` keyword to select whether TPRParser
     indexes resids from 0 or 1 (Issue #2364, PR #3153)
-  
+
     
 01/17/21 richardjgowers, IAlibay, orbeckst, tylerjereddy, jbarnoud,
          yuxuanzhuang, lilyminium, VOD555, p-j-smith, bieniekmateusz,

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -388,6 +388,41 @@ class _MutableBase(object):
                 err += 'Did you mean {match}?'.format(match=match)
             raise AttributeError(err)
 
+    def get_connections(self, typename, outside=True):
+        """
+        Get bonded connections between atoms as a
+        :class:`~MDAnalysis.core.topologyobjects.TopologyGroup`.
+
+        Parameters
+        ----------
+        typename : str
+            group name. One of {"bonds", "angles", "dihedrals",
+            "impropers", "ureybradleys", "cmaps"}
+        outside : bool (optional)
+            Whether to include connections involving atoms outside
+            this group.
+
+        Returns
+        -------
+        TopologyGroup
+            containing the bonded group of choice, i.e. bonds, angles,
+            dihedrals, impropers, ureybradleys or cmaps.
+
+        .. versionadded:: 1.1.0
+        """
+        # AtomGroup has handy error messages for missing attributes
+        ugroup = getattr(self.universe.atoms, typename)
+        if not len(ugroup):
+            return ugroup
+        func = np.any if outside else np.all
+        try:
+            indices = self.atoms.ix_array
+        except AttributeError:  # if self is an Atom
+            indices = self.ix_array
+        seen = [np.in1d(col, indices) for col in ugroup._bix.T]
+        mask = func(seen, axis=0)
+        return ugroup[mask]
+
 
 class _ImmutableBase(object):
     """Class used to shortcut :meth:`__new__` to :meth:`object.__new__`.

--- a/testsuite/MDAnalysisTests/core/test_groups.py
+++ b/testsuite/MDAnalysisTests/core/test_groups.py
@@ -1477,7 +1477,7 @@ class TestGetConnectionsAtoms(object):
     """Test Atom and AtomGroup.get_connections"""
 
     @pytest.mark.parametrize("typename",
-                            ["bonds", "angles", "dihedrals", "impropers"])
+                             ["bonds", "angles", "dihedrals", "impropers"])
     def test_connection_from_atom_not_outside(self, tpr, typename):
         cxns = tpr.atoms[1].get_connections(typename, outside=False)
         assert len(cxns) == 0
@@ -1591,19 +1591,20 @@ class TestGetConnectionsResidues(object):
         assert len(imp) == 0
         assert len(cxns) == 0
 
+
 @pytest.mark.parametrize("typename, n_atoms", [
     ("bonds", 13),
     ("angles", 27),
     ("dihedrals", 38),
 ])
 def test_get_topologygroup_property_deprecated(tpr, typename, n_atoms):
-    err = ("This group contains all connections "
+    werr = ("This group contains all connections "
             "where at least one atom in the "
             "AtomGroup is involved. In MDAnalysis "
             "2.0 this behavior will change so that "
             "the group only contains connections "
             "where all atoms are in the AtomGroup.")
-    with pytest.warns(DeprecationWarning, match=err):
+    with pytest.warns(DeprecationWarning, match=werr):
         ag = tpr.atoms[:10]
         cxns = getattr(ag, typename)
         assert len(cxns) == n_atoms


### PR DESCRIPTION
Relates to #1264
Relates to #2821 

Changes made in this Pull Request:
 - Added `get_connections` method for Components and Groups to control which connections get returned
 - Added ``outside`` keyword to `get_atoms` argument of the Connection topology attributes, to easily toggle the behaviour of Groups.bonds, Groups.angles, etc. This is set to ``True`` to keep status quo for 1.1.0. It will be set to False in 2.0.0.
 - Added deprecation warning for the Groups.bonds, Groups.angles, etc. methods


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
