### PR TITLE
Deprecates hbond_autocorrel

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -30,6 +30,8 @@ Changes
   * Maximum pinned versions in setup.py removed for python 3.6+ (PR #3139)
 
 Deprecations
+  * hbonds.hbond_autocorrel will be removed in 2.0.0 with functionality ported
+    to hydrogenbonds.hbond_analysis (Issue #2987)
   * Deprecated tempfactors and bfactors being separate
     TopologyAttrs, with a warning (PR #3161)
   * hbonds.WaterBridgeAnalysis will be removed in 2.0.0 and

--- a/package/MDAnalysis/analysis/hbonds/hbond_autocorrel.py
+++ b/package/MDAnalysis/analysis/hbonds/hbond_autocorrel.py
@@ -215,6 +215,7 @@ import warnings
 
 from MDAnalysis.lib.log import ProgressBar
 from MDAnalysis.lib.distances import capped_distance, calc_angles, calc_bonds
+from MDANalysis.lib.util import deprecate
 from MDAnalysis.core.groups import requires
 
 from MDAnalysis.due import due, Doi

--- a/package/MDAnalysis/analysis/hbonds/hbond_autocorrel.py
+++ b/package/MDAnalysis/analysis/hbonds/hbond_autocorrel.py
@@ -225,6 +225,16 @@ due.cite(Doi("10.1063/1.4922445"),
 del Doi
 
 
+warnings.warn(
+            "This module is deprecated as of MDAnalysis version 1.1.0 and "
+            "will be removed in MDAnalysis version 2.0. Most of the base "
+            "functionality will be moved to "
+            "MDAnalysis.analysis.hydrobonds.hbond_analysis instead.",
+            category=DeprecationWarning
+        )
+
+
+@deprecate(release="1.1.0", remove="2.0.0")
 @requires('bonds')
 def find_hydrogen_donors(hydrogens):
     """Returns the donor atom for each hydrogen
@@ -285,10 +295,15 @@ class HydrogenBondAutoCorrel(object):
     pbc : bool, optional
         Whether to consider periodic boundaries in calculations [``True``]
 
-    ..versionchanged: 1.0.0
-      ``save_results()`` method was removed. You can instead use ``np.savez()``
-      on :attr:`HydrogenBondAutoCorrel.solution['time']` and
-      :attr:`HydrogenBondAutoCorrel.solution['results']` instead.
+
+    .. versionchanged:: 1.0.0
+       ``save_results()`` method was removed. You can instead use ``np.savez()``
+       on :attr:`HydrogenBondAutoCorrel.solution['time']` and
+       :attr:`HydrogenBondAutoCorrel.solution['results']` instead.
+    .. deprecated:: 1.1.0
+       This class will be removed in favour of
+       :class:`MDAnalysis.analysis.hydrobonds.hbond_analysis` in
+       MDAnalysis 2.0.
     """
 
     def __init__(self, universe,

--- a/testsuite/MDAnalysisTests/analysis/test_hbonds.py
+++ b/testsuite/MDAnalysisTests/analysis/test_hbonds.py
@@ -29,6 +29,7 @@ import MDAnalysis
 import MDAnalysis.analysis.hbonds
 import itertools
 import pytest
+from six.moves import reload_module
 from MDAnalysis import SelectionError
 
 from numpy.testing import (
@@ -554,3 +555,9 @@ class TestHydrogenBondAnalysisTIP3PHeavyPBCStartStep(object):
 
         assert_array_almost_equal(times, ref_times)
         assert_array_equal(counts, ref_counts)
+
+
+def test_hbond_deprecation():
+    wmsg = "deprecated as of MDAnalysis version 1.0"
+    with pytest.warns(DeprecationWarning, match=wmsg):
+        reload_module(MDAnalysis.analysis.hbonds)

--- a/testsuite/MDAnalysisTests/analysis/test_hydrogenbondautocorrel.py
+++ b/testsuite/MDAnalysisTests/analysis/test_hydrogenbondautocorrel.py
@@ -24,7 +24,7 @@ from __future__ import division, absolute_import
 
 import pytest
 import six
-from six.moves import range
+from six.moves import range, reload_module
 
 from MDAnalysisTests.datafiles import (
     TRZ, TRZ_psf,
@@ -279,6 +279,13 @@ class TestHydrogenBondAutocorrel(object):
         )
         assert isinstance(repr(hbond), six.string_types)
 
+
+def test_hbond_autocorrel_deprecation():
+    wmsg = "deprecated as of MDAnalysis version 1.1.0"
+    with pytest.warns(DeprecationWarning, match=wmsg):
+        reload_module(MDAnalysis.analysis.hbonds)
+
+
 def test_find_donors():
     u = mda.Universe(waterPSF, waterDCD)
 
@@ -290,6 +297,16 @@ def test_find_donors():
     # check each O is bonded to the corresponding H
     for h_atom, o_atom in zip(H, D):
         assert o_atom in h_atom.bonded_atoms
+
+
+def test_find_donors_deprecation_warning():
+    u = mda.Universe(waterPSF, waterDCD)
+    H = u.select_atoms('name H*')
+
+    with pytest.raises(DeprecationWarning,
+                       match="will be removed in release 2.0.0"):
+        D = hbonds.find_hydrogen_donors(H)
+
 
 def test_donors_nobonds():
     u = mda.Universe(XYZ_mini)


### PR DESCRIPTION
Fixes #2987 

Changes made in this Pull Request:
 - Deprecates hbond_autocorrel, to be removed in 2.0.0.
 - Also adds missing test for deprecated hbonds.hbond_analysis

PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
