### PR TITLE
Create Universe from empty RDKit ROMol

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -154,6 +154,7 @@ Chronological list of authors
   - Karthikeyan Singaravelan
 2021
   - Aditya Kamath
+  - Leonardo Barneschi
   
 External code
 -------------

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -21,6 +21,8 @@ The rules for this file:
   * 2.0.0
 
 Fixes
+  * A Universe created from an ROMol with no atoms returns now a Universe 
+    with 0 atoms (Issue #3142)
   * ValueError raised when empty atomgroup is given to DensityAnalysis
     without a user defined grid. UserWarning displayed when user defined 
     grid is provided. (Issue #3055)

--- a/package/MDAnalysis/topology/RDKitParser.py
+++ b/package/MDAnalysis/topology/RDKitParser.py
@@ -179,7 +179,7 @@ class RDKitParser(TopologyReaderBase):
 
         try:
             atom = mol.GetAtomWithIdx(0)
-        except:
+        except RuntimeError:
             top = Topology(n_atoms=0, n_res=0, n_seg=0,
                            attrs=None,
                            atom_resindex=None,

--- a/package/MDAnalysis/topology/RDKitParser.py
+++ b/package/MDAnalysis/topology/RDKitParser.py
@@ -177,8 +177,16 @@ class RDKitParser(TopologyReaderBase):
         occupancies = []
         tempfactors = []
 
+        try:
+            atom = mol.GetAtomWithIdx(0)
+        except:
+            top = Topology(n_atoms=0, n_res=0, n_seg=0,
+                           attrs=None,
+                           atom_resindex=None,
+                           residue_segindex=None)
+            return top
+
         # check if multiple charges present
-        atom = mol.GetAtomWithIdx(0)
         if atom.HasProp('_GasteigerCharge') and (
         atom.HasProp('_TriposPartialCharge')
         ):
@@ -224,7 +232,6 @@ class RDKitParser(TopologyReaderBase):
                         charges.append(atom.GetDoubleProp('_TriposPartialCharge'))
                     except KeyError:
                         pass
-                
 
         # make Topology attributes
         attrs = []
@@ -274,7 +281,7 @@ class RDKitParser(TopologyReaderBase):
             attrs.append(Charges(np.array(charges, dtype=np.float32)))
         else:
             pass # no guesser yet
-        
+
         # PDB only
         for vals, Attr, dtype in (
             (altlocs, AltLocs, object),

--- a/testsuite/MDAnalysisTests/core/test_universe.py
+++ b/testsuite/MDAnalysisTests/core/test_universe.py
@@ -214,6 +214,9 @@ class TestUniverseCreation(object):
         Chem = pytest.importorskip("rdkit.Chem")
         mol = Chem.Mol()
         u = mda.Universe(mol, format="RDKIT")
+        assert u.empty
+        assert len(u.atoms) == 0
+
 
 class TestUniverseFromSmiles(object):
     def setup_class(self):

--- a/testsuite/MDAnalysisTests/core/test_universe.py
+++ b/testsuite/MDAnalysisTests/core/test_universe.py
@@ -214,7 +214,6 @@ class TestUniverseCreation(object):
         Chem = pytest.importorskip("rdkit.Chem")
         mol = Chem.Mol()
         u = mda.Universe(mol, format="RDKIT")
-        assert u.empty
         assert len(u.atoms) == 0
 
 

--- a/testsuite/MDAnalysisTests/core/test_universe.py
+++ b/testsuite/MDAnalysisTests/core/test_universe.py
@@ -210,6 +210,10 @@ class TestUniverseCreation(object):
         assert_equal(u.trajectory.n_frames, u2.trajectory.n_frames)
         assert u2._topology is u._topology
 
+    def test_universe_empty_ROMol(self):
+        Chem = pytest.importorskip("rdkit.Chem")
+        mol = Chem.Mol()
+        u = mda.Universe(mol, format="RDKIT")
 
 class TestUniverseFromSmiles(object):
     def setup_class(self):


### PR DESCRIPTION
Fixes #
A Universe created from an ROMol with no atoms returns now a Universe with 0 atoms

Changes made in this Pull Request:
 - included a try/except block in  RDKitParser.py
 - included corresponding test in test_universe.py

PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
