### PR TITLE
Issue 2327 - Warn of upcoming scale_factor changes

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -31,6 +31,8 @@ Changes
   * Maximum pinned versions in setup.py removed for python 3.6+ (PR #3139)
 
 Deprecations
+  * NCDFWriter `scale_factor` writing will change in version 2.0 to
+    better match AMBER outputs (Issue #2327)
   * Deprecated tempfactors and bfactors being separate
     TopologyAttrs, with a warning (PR #3161)
   * hbonds.WaterBridgeAnalysis will be removed in 2.0.0 and

--- a/package/MDAnalysis/coordinates/TRJ.py
+++ b/package/MDAnalysis/coordinates/TRJ.py
@@ -817,6 +817,18 @@ class NCDFWriter(base.WriterBase):
     .. _`Issue #506`:
        https://github.com/MDAnalysis/mdanalysis/issues/506#issuecomment-225081416
 
+    Raises
+    ------
+    FutureWarning
+        When writing. The :class:`NCDFWriter` currently does not write any
+        `scale_factor` values for the data variables. Whilst not in breach
+        of the AMBER NetCDF standard, this behaviour differs from that of
+        most AMBER writers, especially for velocities which usually have a
+        `scale_factor` of 20.455. In MDAnalysis 2.0, the :class:`NCDFWriter`
+        will enforce `scale_factor` writing to either match user inputs (either
+        manually defined or via the :class:`NCDFReader`) or those as written by
+        AmberTools's :program:`sander` under default operation.
+
     See Also
     --------
     :class:`NCDFReader`
@@ -875,6 +887,13 @@ class NCDFWriter(base.WriterBase):
         self.has_velocities = kwargs.get('velocities', False)
         self.has_forces = kwargs.get('forces', False)
         self.curr_frame = 0
+
+        # warn users of upcoming changes
+        wmsg = ("In MDAnalysis v2.0, `scale_factor` writing will change ("
+                "currently these are not written), to better match the way "
+                "they are written by AMBER programs. See NCDFWriter docstring "
+                "for more details.")
+        warnings.warn(wmsg, FutureWarning)
 
     def _init_netcdf(self, periodic=True):
         """Initialize netcdf AMBER 1.0 trajectory.

--- a/testsuite/MDAnalysisTests/coordinates/test_netcdf.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_netcdf.py
@@ -901,7 +901,7 @@ class TestNCDFWriterErrorsWarnings(object):
 
     def test_scale_factor_future(self, outfile):
         u = mda.Universe(GRO)
-        with NCDFWriter(outfile, u.trajectory.n_atoms) as w:
-            wmsg = "`scale_factor` writing will change"
-            with pytest.warns(FutureWarning, match=wmsg):
+        wmsg = "`scale_factor` writing will change"
+        with pytest.warns(FutureWarning, match=wmsg):
+            with NCDFWriter(outfile, u.trajectory.n_atoms) as w:
                 w.write(u.atoms)

--- a/testsuite/MDAnalysisTests/coordinates/test_netcdf.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_netcdf.py
@@ -33,7 +33,7 @@ from numpy.testing import (
     assert_equal,
     assert_almost_equal
 )
-from MDAnalysis.coordinates.TRJ import NCDFReader
+from MDAnalysis.coordinates.TRJ import NCDFReader, NCDFWriter
 
 from MDAnalysisTests.datafiles import (PFncdf_Top, PFncdf_Trj,
                                        GRO, TRR, XYZ_mini,
@@ -884,21 +884,24 @@ class TestNCDFWriterUnits(object):
             assert_equal(unit, expected)
 
 
-class TestNCDFWriterErrors(object):
+class TestNCDFWriterErrorsWarnings(object):
     @pytest.fixture()
     def outfile(self, tmpdir):
         return str(tmpdir) + 'out.ncdf'
 
     def test_zero_atoms_VE(self, outfile):
-        from MDAnalysis.coordinates.TRJ import NCDFWriter
-
         with pytest.raises(ValueError):
             NCDFWriter(outfile, 0)
 
     def test_wrong_n_atoms(self, outfile):
-        from MDAnalysis.coordinates.TRJ import NCDFWriter
-
         with NCDFWriter(outfile, 100) as w:
             u = make_Universe(trajectory=True)
             with pytest.raises(IOError):
                 w.write(u.trajectory.ts)
+
+    def test_scale_factor_future(self, outfile):
+        with NCDFWriter(outfile) as w:
+            u = mda.Universe(GRO)
+            wmsg = "`scale_factor` writing will change"
+            with pytest.warn(FutureWarning, match=wmsg):
+                w.write(u.atoms)

--- a/testsuite/MDAnalysisTests/coordinates/test_netcdf.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_netcdf.py
@@ -900,8 +900,8 @@ class TestNCDFWriterErrorsWarnings(object):
                 w.write(u.trajectory.ts)
 
     def test_scale_factor_future(self, outfile):
-        with NCDFWriter(outfile) as w:
-            u = mda.Universe(GRO)
+        u = mda.Universe(GRO)
+        with NCDFWriter(outfile, u.trajectory.n_atoms) as w:
             wmsg = "`scale_factor` writing will change"
-            with pytest.warn(FutureWarning, match=wmsg):
+            with pytest.warns(FutureWarning, match=wmsg):
                 w.write(u.atoms)


### PR DESCRIPTION
Towards #2327 

Changes made in this Pull Request:
 - Adds FutureWarning & docstring related to the upcoming changes to the way in which we write `scale_factor` entries with the NCDFWriter.


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
