### PR TITLE
improved specifications for keyword arguments of run method

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -155,7 +155,7 @@ Chronological list of authors
 2021
   - Aditya Kamath
   - Leonardo Barneschi
-  
+  - Ahmad Nasir
 External code
 -------------
 

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -16,7 +16,7 @@ The rules for this file:
 ??/??/?? tylerjereddy, richardjgowers, IAlibay, hmacdope, orbeckst, cbouy,
          lilyminium, daveminh, jbarnoud, yuxuanzhuang, VOD555, ianmkenney,
          calcraven，xiki-tempula, mieczyslaw, manuel.nuno.melo, PicoCentauri,
-         hanatok, rmeli, aditya-kamath, tirkarthi
+         hanatok, rmeli, aditya-kamath, tirkarthi, amdnsr
 
   * 2.0.0
 
@@ -133,6 +133,9 @@ Enhancements
     'protein' selection (#2751 PR #2755)
   * Added an RDKit converter that works for any input with all hydrogens
     explicit in the topology (Issue #2468, PR #2775)
+  * Added kwargs in the run method of analysis/base.py which can be passed to tqdm,
+    via the ProgressBar class, a (subclass of tqdm), to provide access to the
+    functionality provided by tqdm (Issue #3190, PR #3191)
   
 Changes
   * TPRParser now loads TPR files with `tpr_resid_from_one=True` by default, 

--- a/package/MDAnalysis/analysis/base.py
+++ b/package/MDAnalysis/analysis/base.py
@@ -174,6 +174,9 @@ class AnalysisBase(object):
             number of frames to skip between each analysed frame
         verbose : bool, optional
             Turn on verbosity
+        kwargs : keyword arguments, which will be used to access the
+            underlying functionality in tqdm class, via ProgressBar class,
+            specifically, to adjust the location of the bar on the screen
         """
         logger.info("Choosing frames to analyze")
         # if verbose unchanged, use class default

--- a/package/MDAnalysis/analysis/base.py
+++ b/package/MDAnalysis/analysis/base.py
@@ -161,7 +161,7 @@ class AnalysisBase(object):
         """
         pass  # pylint: disable=unnecessary-pass
 
-    def run(self, start=None, stop=None, step=None, verbose=None):
+    def run(self, start=None, stop=None, step=None, verbose=None, **kwargs):
         """Perform the calculation
 
         Parameters
@@ -179,13 +179,15 @@ class AnalysisBase(object):
         # if verbose unchanged, use class default
         verbose = getattr(self, '_verbose',
                           False) if verbose is None else verbose
+        kwargs['verbose'] = verbose
 
         self._setup_frames(self._trajectory, start, stop, step)
         logger.info("Starting preparation")
         self._prepare()
+
         for i, ts in enumerate(ProgressBar(
                 self._trajectory[self.start:self.stop:self.step],
-                verbose=verbose)):
+                **kwargs)):
             self._frame_index = i
             self._ts = ts
             self.frames[i] = ts.frame


### PR DESCRIPTION
Fixes #3190

Changes made in this Pull Request:
 - added `kwargs` in `run `method
 - made `verbose` a part of `kwargs` before passing it to `ProgressBar `constructor


PR Checklist
------------
 - [ ] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
