### PR TITLE
Undo half of PR 3160

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -31,9 +31,6 @@ Changes
   * Maximum pinned versions in setup.py removed for python 3.6+ (PR #3139)
 
 Deprecations
-  * Deprecated current Group.bonds, angles, dihedrals, impropers
-    behavior where it returns connections to atoms outside the group
-    by default (Issue #1264, #2821, PR #3159)
   * ParmEdConverter no longer accepts Timestep objects at all
     (Issue #3031, PR #3172)
   * NCDFWriter `scale_factor` writing will change in version 2.0 to

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -2250,20 +2250,14 @@ class _Connection(AtomAttr):
     def set_atoms(self, ag):
         return NotImplementedError("Cannot set bond information")
 
-    def get_atoms(self, ag, outside=True):
+    def get_atoms(self, ag):
         """
         Get subset for atoms.
 
         Parameters
         ----------
         ag : AtomGroup
-        outside : bool (optional)
-            Whether to include connections to atoms outside the given
-            AtomGroup.
 
-        .. versionchanged:: 1.1.0
-            Added the ``outside`` keyword. Set to ``True`` by default
-            to give the same behavior as previously
         """
         warn = True
         try:
@@ -2274,22 +2268,6 @@ class _Connection(AtomAttr):
             unique_bonds = self._bondDict[ag.ix]
             warn = False
         unique_bonds = np.array(sorted(unique_bonds), dtype=object)
-        if not outside:
-            indices = np.array([list(bd[0]) for bd in unique_bonds])
-            try:
-                mask = np.all(np.isin(indices, ag.ix), axis=1)
-            except np.AxisError:
-                mask = []
-            unique_bonds = unique_bonds[mask]
-        elif warn:
-            warnings.warn("This group contains all connections "
-                          "where at least one atom in the "
-                          "AtomGroup is involved. In MDAnalysis "
-                          "2.0 this behavior will change so that "
-                          "the group only contains connections "
-                          "where all atoms are in the AtomGroup.",
-                          DeprecationWarning)
-
         bond_idx, types, guessed, order = np.hsplit(unique_bonds, 4)
         bond_idx = np.array(bond_idx.ravel().tolist(), dtype=np.int32)
         types = types.ravel()

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -2259,14 +2259,12 @@ class _Connection(AtomAttr):
         ag : AtomGroup
 
         """
-        warn = True
         try:
             unique_bonds = set(itertools.chain(
                 *[self._bondDict[a] for a in ag.ix]))
         except TypeError:
             # maybe we got passed an Atom
             unique_bonds = self._bondDict[ag.ix]
-            warn = False
         unique_bonds = np.array(sorted(unique_bonds), dtype=object)
         bond_idx, types, guessed, order = np.hsplit(unique_bonds, 4)
         bond_idx = np.array(bond_idx.ravel().tolist(), dtype=np.int32)

--- a/testsuite/MDAnalysisTests/core/test_groups.py
+++ b/testsuite/MDAnalysisTests/core/test_groups.py
@@ -1590,23 +1590,3 @@ class TestGetConnectionsResidues(object):
         cxns = ag.get_connections("impropers", outside=outside)
         assert len(imp) == 0
         assert len(cxns) == 0
-
-
-@pytest.mark.parametrize("typename, n_atoms", [
-    ("bonds", 13),
-    ("angles", 27),
-    ("dihedrals", 38),
-])
-def test_get_topologygroup_property_deprecated(tpr, typename, n_atoms):
-    werr = ("This group contains all connections "
-            "where at least one atom in the "
-            "AtomGroup is involved. In MDAnalysis "
-            "2.0 this behavior will change so that "
-            "the group only contains connections "
-            "where all atoms are in the AtomGroup.")
-    with pytest.warns(DeprecationWarning, match=werr):
-        ag = tpr.atoms[:10]
-        cxns = getattr(ag, typename)
-        assert len(cxns) == n_atoms
-        indices = np.ravel(cxns.to_indices())
-        assert not np.all(np.in1d(indices, ag.indices))


### PR DESCRIPTION
~Fixes #~

Changes made in this Pull Request:
 - Undo deprecating AtomGroup.bonds to return bonds outside the group (and angles, etc.)


PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [ ] Issue raised/referenced?
