### PR TITLE
Helix_analysis coverage raised to 100% [#3209]

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -160,6 +160,7 @@ Chronological list of authors
   - Orion Cohen
   - Dimitrios Papageorgiou
   - Hannah Pollak
+  - Estefania Barreto-Ojeda
 
 External code
 -------------

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -22,6 +22,8 @@ The rules for this file:
   * 2.0.0
 
 Fixes
+  * Helix_analysis coverage raised to 100% and `from __future__ import`
+    removed (Issue #3209) 
   * Fixed 'sphzone', 'sphlayer', 'cyzone', and 'cylayer' to return empty if the
    zone/layer is empty, consistent with 'around' (Issue #2915)
   * A Universe created from an ROMol with no atoms returns now a Universe 

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -17,7 +17,7 @@ The rules for this file:
          lilyminium, daveminh, jbarnoud, yuxuanzhuang, VOD555, ianmkenney,
          calcraven，xiki-tempula, mieczyslaw, manuel.nuno.melo, PicoCentauri,
          hanatok, rmeli, aditya-kamath, tirkarthi, LeonardoBarneschi, hejamu,
-         biogen98, orioncohen, z3y50n, hp115
+         biogen98, orioncohen, z3y50n, hp115, ojeda-e
 
   * 2.0.0
 

--- a/package/MDAnalysis/analysis/helix_analysis.py
+++ b/package/MDAnalysis/analysis/helix_analysis.py
@@ -78,7 +78,6 @@ equivalent::
     hel_xyz = hel.helix_analysis(u.atoms.positions, ref_axis=[0, 0, 1])
 
 """
-from __future__ import division, absolute_import
 
 import warnings
 import numpy as np

--- a/testsuite/MDAnalysisTests/analysis/test_helix_analysis.py
+++ b/testsuite/MDAnalysisTests/analysis/test_helix_analysis.py
@@ -397,6 +397,12 @@ class TestHELANAL(object):
         assert len(u.atoms) == len(helanal.atomgroups[0])-2
         assert len(u.trajectory) == 70
 
+    def test_universe_from_origins_except(self, psf_ca):
+        ha = hel.HELANAL(psf_ca, select='resnum 161-187')
+        with pytest.raises(Exception) as rec:
+            u = ha.universe_from_origins()
+            assert u.local_origins
+
     def test_multiple_atoms_per_residues(self):
         u = mda.Universe(XYZ)
         with pytest.warns(UserWarning) as rec:
@@ -429,6 +435,15 @@ class TestHELANAL(object):
         warnmsg = rec[0].message.args[0]
         assert 'has gaps in the residues' in warnmsg
         assert 'Splitting into' not in warnmsg
+
+    def test_len_groups_short(self, psf_ca):
+        sel = 'resnum 161-168'
+        with pytest.warns(UserWarning) as rec:
+            ha = hel.HELANAL(psf_ca, select=sel)
+            ha.run()
+            assert len(ha.atomgroups) < 9
+        assert len(rec) == 1
+        assert 'Fewer than 9 atoms found' in rec[0].message.args[0]
 
     @pytest.mark.parametrize('ref_axis,screw_angles', [
         # input vectors zigzag between [-1, 0, 0] and [1, 0, 0]

--- a/testsuite/MDAnalysisTests/analysis/test_helix_analysis.py
+++ b/testsuite/MDAnalysisTests/analysis/test_helix_analysis.py
@@ -400,7 +400,6 @@ class TestHELANAL(object):
         ha = hel.HELANAL(psf_ca, select='resnum 161-187')
         with pytest.raises(ValueError, match=r'Call run\(\) before universe_from_origins'):
             u = ha.universe_from_origins()
-            #assert u.local_origins
 
     def test_multiple_atoms_per_residues(self):
         u = mda.Universe(XYZ)
@@ -437,12 +436,10 @@ class TestHELANAL(object):
 
     def test_len_groups_short(self, psf_ca):
         sel = 'resnum 161-168'
-        with pytest.warns(UserWarning) as rec:
+        with pytest.warns(UserWarning, match='Fewer than 9 atoms found'):
             ha = hel.HELANAL(psf_ca, select=sel)
             ha.run()
             assert len(ha.atomgroups) < 9
-        assert len(rec) == 1
-        assert 'Fewer than 9 atoms found' in rec[0].message.args[0]
 
     @pytest.mark.parametrize('ref_axis,screw_angles', [
         # input vectors zigzag between [-1, 0, 0] and [1, 0, 0]

--- a/testsuite/MDAnalysisTests/analysis/test_helix_analysis.py
+++ b/testsuite/MDAnalysisTests/analysis/test_helix_analysis.py
@@ -398,9 +398,9 @@ class TestHELANAL(object):
 
     def test_universe_from_origins_except(self, psf_ca):
         ha = hel.HELANAL(psf_ca, select='resnum 161-187')
-        with pytest.raises(Exception) as rec:
+        with pytest.raises(ValueError, match=r'Call run\(\) before universe_from_origins'):
             u = ha.universe_from_origins()
-            assert u.local_origins
+            #assert u.local_origins
 
     def test_multiple_atoms_per_residues(self):
         u = mda.Universe(XYZ)

--- a/testsuite/MDAnalysisTests/analysis/test_helix_analysis.py
+++ b/testsuite/MDAnalysisTests/analysis/test_helix_analysis.py
@@ -438,7 +438,6 @@ class TestHELANAL(object):
         sel = 'resnum 161-168'
         with pytest.warns(UserWarning, match='Fewer than 9 atoms found'):
             ha = hel.HELANAL(psf_ca, select=sel)
-            ha.run()
             assert len(ha.atomgroups) < 9
 
     @pytest.mark.parametrize('ref_axis,screw_angles', [

--- a/testsuite/MDAnalysisTests/analysis/test_helix_analysis.py
+++ b/testsuite/MDAnalysisTests/analysis/test_helix_analysis.py
@@ -20,7 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from __future__ import absolute_import, division
 import re
 
 import numpy as np

--- a/testsuite/MDAnalysisTests/analysis/test_helix_analysis.py
+++ b/testsuite/MDAnalysisTests/analysis/test_helix_analysis.py
@@ -398,7 +398,7 @@ class TestHELANAL(object):
 
     def test_universe_from_origins_except(self, psf_ca):
         ha = hel.HELANAL(psf_ca, select='resnum 161-187')
-        with pytest.raises(ValueError, match=r'Call run\(\) before universe_from_origins'):
+        with pytest.raises(ValueError, match=r'before universe_from_origins'):
             u = ha.universe_from_origins()
 
     def test_multiple_atoms_per_residues(self):


### PR DESCRIPTION
Fixes #3209 

Changes made in this Pull Request:
 - Added  `test_len_groups_short(self, psf_ca)` to add coverage in line 389 by selecting short sequence of residues that satisfies `ng < 9`.
-  Added  `test_universe_from_origins_except(self, psf_ca)` to add coverage in line 476 by passing an "un-run" helix_analysis object. 

From what I can tell no change to doc required. Please correct me if I am mistaken.

PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
