### PR TITLE
Coverage for diffusionmap raised to 100% [Issue #3208]

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -22,6 +22,7 @@ The rules for this file:
   * 2.0.0
 
 Fixes
+  * Improve diffusionmap coverage (Issue #3208)
   * Removed deprecated parameters `n_jobs` and `precompute_distances` of
     sklearn.cluster.KMeans (Issue #2986)
   * Helix_analysis coverage raised to 100% and `from __future__ import`

--- a/testsuite/MDAnalysisTests/analysis/test_diffusionmap.py
+++ b/testsuite/MDAnalysisTests/analysis/test_diffusionmap.py
@@ -81,14 +81,16 @@ def test_transform(u, dmap):
     diffusion_space = dmap.transform(n_eigenvectors, 1)
     assert diffusion_space.shape == (eigvects.shape[0], n_eigenvectors)
 
+
 def test_long_traj(u):
     with pytest.warns(UserWarning, match='The distance matrix is very large'):
         dmap = diffusionmap.DiffusionMap(u)
-        dmap._dist_matrix.run()
+        dmap._dist_matrix.run(stop=1)
         dmap._dist_matrix.n_frames = 5001
-        assert dmap.run()
+        dmap.run()
 
-def test_universe(u):
+
+def test_not_universe_error(u):
     trj_only = u.trajectory
-    with pytest.raises(ValueError, match='U is not a Universe'):       
-        assert diffusionmap.DiffusionMap(trj_only)
+    with pytest.raises(ValueError, match='U is not a Universe'):    
+        diffusionmap.DiffusionMap(trj_only)

--- a/testsuite/MDAnalysisTests/analysis/test_diffusionmap.py
+++ b/testsuite/MDAnalysisTests/analysis/test_diffusionmap.py
@@ -92,5 +92,5 @@ def test_long_traj(u):
 
 def test_not_universe_error(u):
     trj_only = u.trajectory
-    with pytest.raises(ValueError, match='U is not a Universe'):    
+    with pytest.raises(ValueError, match='U is not a Universe'):
         diffusionmap.DiffusionMap(trj_only)

--- a/testsuite/MDAnalysisTests/analysis/test_diffusionmap.py
+++ b/testsuite/MDAnalysisTests/analysis/test_diffusionmap.py
@@ -81,7 +81,7 @@ def test_transform(u, dmap):
     diffusion_space = dmap.transform(n_eigenvectors, 1)
     assert diffusion_space.shape == (eigvects.shape[0], n_eigenvectors)
 
-def test_long_traj(u, tmpdir):
+def test_long_traj(u):
     with pytest.warns(UserWarning, match='The distance matrix is very large'):
         dmap = diffusionmap.DiffusionMap(u)
         dmap._dist_matrix.run()
@@ -90,6 +90,5 @@ def test_long_traj(u, tmpdir):
 
 def test_universe(u):
     trj_only = u.trajectory
-    with pytest.raises(ValueError,  match='U is not a Universe'):       
-        assert diffusionmap.DiffusionMap(trj_only) 
-
+    with pytest.raises(ValueError, match='U is not a Universe'):       
+        assert diffusionmap.DiffusionMap(trj_only)

--- a/testsuite/MDAnalysisTests/analysis/test_diffusionmap.py
+++ b/testsuite/MDAnalysisTests/analysis/test_diffusionmap.py
@@ -80,3 +80,16 @@ def test_transform(u, dmap):
     dmap.run()
     diffusion_space = dmap.transform(n_eigenvectors, 1)
     assert diffusion_space.shape == (eigvects.shape[0], n_eigenvectors)
+
+def test_long_traj(u, tmpdir):
+    with pytest.warns(UserWarning, match='The distance matrix is very large'):
+        dmap = diffusionmap.DiffusionMap(u)
+        dmap._dist_matrix.run()
+        dmap._dist_matrix.n_frames = 5001
+        assert dmap.run()
+
+def test_universe(u):
+    trj_only = u.trajectory
+    with pytest.raises(ValueError,  match='U is not a Universe'):       
+        assert diffusionmap.DiffusionMap(trj_only) 
+


### PR DESCRIPTION
Fixes #3208 
Coverage for diffusionmap is 100% covered, including lines 312 and 338.

Changes made in this Pull Request:
 - Raised value error when not a Universe by parsing trajectory only, with the `pytest.raises(ValueError,  match=<pattern>)` approach.
 - Raised warning when `n_frames > 5000` by manually patching `_dist_matrix`  instead of parsing long trajectory. 
 It takes a very long time to test/run using a dummy trajectory with `n_frames>5000` even when selecting 1 atom only.

PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
