### PR TITLE
BLD: handle gcc on MacOS

### DIFF
--- a/package/setup.py
+++ b/package/setup.py
@@ -253,7 +253,19 @@ def using_clang():
     compiler = new_compiler()
     customize_compiler(compiler)
     compiler_ver = getoutput("{0} -v".format(compiler.compiler[0]))
-    return 'clang' in compiler_ver
+    if 'Spack GCC' in compiler_ver:
+        # when gcc toolchain is built from source with spack
+        # using clang, the 'clang' string may be present in
+        # the compiler metadata, but it is not clang
+        is_clang = False
+    elif 'clang' in compiler_ver:
+        # by default, Apple will typically alias gcc to
+        # clang, with some mention of 'clang' in the
+        # metadata
+        is_clang = True
+    else:
+        is_clang = False
+    return is_clang
 
 
 def extensions(config):


### PR DESCRIPTION
* gracefully handle the case where `gcc` toolchain
in use on MacOS has been built from source using `clang`
by `spack` (so it really is `gcc` in use, not `clang`)

* we could try to add regression testing, but a few problems:
  - `using_clang()` is inside `setup.py`, which probably
can't be safely imported because it has unguarded statements/
code blocks that run right away
  - testing build issues is typically tricky with mocking, etc.
(though in this case, probably just need to move `using_clang()`
somewhere else and then test it against a variety of compiler
metadata strings)

Fixes #3109

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
