### PR TITLE
Fix permission error test to not be language centric

### DIFF
--- a/testsuite/MDAnalysisTests/core/test_universe.py
+++ b/testsuite/MDAnalysisTests/core/test_universe.py
@@ -24,6 +24,7 @@ import pickle
 
 import os
 import subprocess
+import errno
 
 from io import StringIO
 
@@ -163,7 +164,7 @@ class TestUniverseCreation(object):
                 os.chmod(temp_file, 0o200)
 
             # Issue #3221 match by PermissionError and error number instead
-            with pytest.raises(PermissionError, match="13"):
+            with pytest.raises(PermissionError, match=f"Errno {errno.EACCES}"):
                 mda.Universe('permission.denied.tpr')
 
     def test_load_new_VE(self):

--- a/testsuite/MDAnalysisTests/core/test_universe.py
+++ b/testsuite/MDAnalysisTests/core/test_universe.py
@@ -161,12 +161,10 @@ class TestUniverseCreation(object):
                                 shell=True)
             else:
                 os.chmod(temp_file, 0o200)
-            try:
+
+            # Issue #3221 match by PermissionError and error number instead
+            with pytest.raises(PermissionError, match="13"):
                 mda.Universe('permission.denied.tpr')
-            except IOError as e:
-                assert 'Permission denied' in str(e.strerror)
-            else:
-                raise AssertionError
 
     def test_load_new_VE(self):
         u = mda.Universe.empty(0)


### PR DESCRIPTION
Fixes #3221 

Changes made in this Pull Request:
 - Changes check to be on PermissionError (which reflects what we are testing) and the error number [13].


PR Checklist
------------
 - [x] Tests?
 - CHANGELOG updated? N/A
 - [x] Issue raised/referenced?
