### PR TITLE
Adding py3.9 to gh actions CI matrix

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -28,7 +28,7 @@ jobs:
         fail-fast: false
         matrix:
           os: [ubuntu-latest, ]
-          python-version: [3.6, 3.7, 3.8]
+          python-version: [3.6, 3.7, 3.8, 3.9]
           run_type: [FULL, ]
           install_hole: [true, ]
           codecov: [true, ]

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -33,12 +33,18 @@ jobs:
           install_hole: [true, ]
           codecov: [true, ]
           include:
-            - name: macOS
+            - name: macOS_py39
               os: macOS-latest
-              python-version: 3.7
+              python-version: 3.9
               run_type: FULL
               install_hole: true
               codecov: true
+            - name: macOS_py36_min
+              os: macOS-latest
+              python-version: 3.6
+              run_type: MIN
+              install_hole: false
+              codecov: false
             - name: minimal-ubuntu
               os: ubuntu-latest
               python-version: 3.6

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -103,6 +103,7 @@ Fixes
   * Fix syntax warning over comparison of literals using is (Issue #3066)
 
 Enhancements
+  * Adds python 3.9 support (Issue #2974, PR #3027, #3245)
   * Added an MDAnalysis shields.io badge to the README (Issue #3227, PR #3229)
   * Added sort method to the atomgroup (Issue #2976, PR #3188) 
   * ITPParser now reads [ atomtypes ] sections in ITP files, used for charges

--- a/package/setup.py
+++ b/package/setup.py
@@ -577,6 +577,7 @@ if __name__ == '__main__':
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: C',
         'Topic :: Scientific/Engineering',
         'Topic :: Scientific/Engineering :: Bio-Informatics',

--- a/testsuite/setup.py
+++ b/testsuite/setup.py
@@ -104,6 +104,7 @@ if __name__ == '__main__':
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: C',
         'Topic :: Scientific/Engineering',
         'Topic :: Scientific/Engineering :: Bio-Informatics',


### PR DESCRIPTION
Fixes #2974 

A lot of our optional deps are now 3.9 compatible, let's see how well this goes / what fails.

Changes made in this Pull Request:
 - Adds py3.9 to the gh actions CI matrix
 - Completes the addition of formal support for py3.9.

PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
