### PR TITLE
Restructured WaterOrientationalRelaxation

### DIFF
--- a/package/MDAnalysis/analysis/waterdynamics.py
+++ b/package/MDAnalysis/analysis/waterdynamics.py
@@ -332,10 +332,10 @@ class WaterOrientationalRelaxation(AnalysisBase):
     r"""Water orientation relaxation analysis
 
     Class evaluating the water orientational relaxation proposed by Yu-ling
-    Yeh and Chung-Yuan Mou [Yeh1999_]. 
+    Yeh and Chung-Yuan Mou [Yeh1999_].
     `WaterOrientationalRelaxation` (WOR) indicates
-    "how fast" water molecules are rotating or changing direction. 
-    If WOR is very stable we can assume that water molecules are 
+    "how fast" water molecules are rotating or changing direction.
+    If WOR is very stable we can assume that water molecules are
     rotating/changing direction very slow, on the
     other hand, if WOR decay very fast, we can assume that water molecules are
     rotating/changing direction very fast. The results are
@@ -344,7 +344,7 @@ class WaterOrientationalRelaxation(AnalysisBase):
     .. math::
         C_{\hat u}(\tau)=\langle \mathit{P}_2[\mathbf{\hat{u}}(t_0)\cdot\mathbf{\hat{u}}(t_0+\tau)]\rangle
 
-    where :math:`P_2=(3x^2-1)/2` is the second-order Legendre polynomial 
+    where :math:`P_2=(3x^2-1)/2` is the second-order Legendre polynomial
     and :math:`\hat{u}` is a unit vector along HH, OH or dipole vector.
 
     Parameters
@@ -373,11 +373,11 @@ class WaterOrientationalRelaxation(AnalysisBase):
 
         import matplotlib.pyplot as plt
         import MDAnalysis as mda
-        from MDAnalysis.analysis.waterdynamics import WaterOrientationalRelaxation as WOR
+        from MDAnalysis.analysis.waterdynamics import WaterOrientationalRelaxation
 
         u = mda.Universe(waterPSF, waterDCD)
         select = "byres name OH2"
-        wor = WOR(u, select)
+        wor = WaterOrientationalRelaxation(u, select)
         wor.run(0, 7, 1)
 
         # Plot the results
@@ -414,7 +414,7 @@ class WaterOrientationalRelaxation(AnalysisBase):
 
     .. versionchanged:: 2.0.0
        `t0`, `tf` and `dtmax` are renamed to start, stop, step as attributes
-       of the `run` method providing a consistent behaviour with other 
+       of the `run` method providing a consistent behaviour with other
        modules.
     """
 
@@ -425,11 +425,11 @@ class WaterOrientationalRelaxation(AnalysisBase):
 
     def _compare_molecules(self, selection, cur_frame, other_frame):
         """
-        Compare the molecules in the `cur_frame` selection to the 
+        Compare the molecules in the `cur_frame` selection to the
         `other_frame` selection and
         select only those particles that are repeated in both frame. This is to
-        consider only those molecules that remain in the selection after 
-        a certain time has elapsed. The result is a list with the indices of 
+        consider only those molecules that remain in the selection after
+        a certain time has elapsed. The result is a list with the indices of
         the atoms.
         """
         a = set(selection[cur_frame])
@@ -438,7 +438,7 @@ class WaterOrientationalRelaxation(AnalysisBase):
 
     def _get_repeated_indices(self, selection, frame):
         """
-        Indicates the comparation between the current frame and all 
+        Indicates the comparation between the current frame and all
         following frames.
         The results is a list of lists with all the repeated index per frame.
         Ex: frame=1, so compare frames (1,2),(2,3),(3,4)...
@@ -522,7 +522,6 @@ class WaterOrientationalRelaxation(AnalysisBase):
         else:
             return 0, 0, 0
 
-
     def _get_mean_one_point(self, universe, selections):
         """
         This function gets one point of the plot C_vec vs t. It uses the
@@ -536,7 +535,10 @@ class WaterOrientationalRelaxation(AnalysisBase):
         n = 0
 
         for i in range(self.start, self.stop // self.frame - 1):
-            a = self._get_one_delta_point(universe, repeated_indices, i - 1, cum_frames)
+            a = self._get_one_delta_point(universe,
+                                          repeated_indices,
+                                          i - 1,
+                                          cum_frames)
             sumDeltaOH += a[0]
             sumDeltaHH += a[1]
             sumDeltadip += a[2]
@@ -560,14 +562,14 @@ class WaterOrientationalRelaxation(AnalysisBase):
         self.dip = []
 
         # List storing the atoms inside selection for every frame
-        self.selection_out = []
+        self.sel_atoms = []
         for _ in self._trajectory:
-            self.selection_out.append(self.universe.select_atoms(self.selection))
+            self.sel_atoms.append(self.universe.select_atoms(self.selection))
 
     def _single_frame(self):
         self.frame = self._frame_index + self.step
-        results_ts = self._get_mean_one_point(self.universe, 
-                                              self.selection_out)
+        results_ts = self._get_mean_one_point(self.universe,
+                                              self.sel_atoms)
         self.OH.append(results_ts[0])
         self.HH.append(results_ts[1])
         self.dip.append(results_ts[2])
@@ -924,7 +926,7 @@ class SurvivalProbability(object):
        Using the MDAnalysis.lib.correlations.py to carry out the intermittency
        and autocorrelation calculations.
        Changed `selection` keyword to `select`.
-       Removed support for the deprecated `t0`, `tf`, and `dtmax` keywords. 
+       Removed support for the deprecated `t0`, `tf`, and `dtmax` keywords.
        These should instead be passed to :meth:`SurvivalProbability.run` as
        the `start`, `stop`, and `tau_max` keywords respectively.
        The `stop` keyword as passed to :meth:`SurvivalProbability.run` has now

--- a/package/MDAnalysis/analysis/waterdynamics.py
+++ b/package/MDAnalysis/analysis/waterdynamics.py
@@ -336,7 +336,7 @@ class WaterOrientationalRelaxation(AnalysisBase):
     `WaterOrientationalRelaxation` (WOR) indicates
     "how fast" water molecules are rotating or changing direction.
     If WOR is very stable we can assume that water molecules are
-    rotating/changing direction very slow, on the
+    rotating/changing direction very slowly, on the
     other hand, if WOR decay very fast, we can assume that water molecules are
     rotating/changing direction very fast. The results are
     time correlation functions given by:
@@ -427,8 +427,8 @@ class WaterOrientationalRelaxation(AnalysisBase):
         """
         Compare the molecules in the `cur_frame` selection to the
         `other_frame` selection and
-        select only those particles that are repeated in both frame. This is to
-        consider only those molecules that remain in the selection after
+        select only those particles that are repeated in both frames. This is 
+        to consider only those molecules that remain in the selection after
         a certain time has elapsed. The result is a list with the indices of
         the atoms.
         """
@@ -438,7 +438,7 @@ class WaterOrientationalRelaxation(AnalysisBase):
 
     def _get_repeated_indices(self, selection, frame):
         """
-        Indicates the comparation between the current frame and all
+        Indicates the comparasion between the current frame and all
         following frames.
         The results is a list of lists with all the repeated index per frame.
         Ex: frame=1, so compare frames (1,2),(2,3),(3,4)...
@@ -777,7 +777,7 @@ class MeanSquareDisplacement(object):
     def _repeatedIndex(self, selection, dt, totalFrames):
         """
         Indicate the comparation between all the t+dt.
-        The results is a list of list with all the repeated index per frame
+        The results is a list of list with all the repeated indices per frame
         (or time).
 
         - Ex: dt=1, so compare frames (1,2),(2,3),(3,4)...

--- a/testsuite/MDAnalysisTests/analysis/test_waterdynamics.py
+++ b/testsuite/MDAnalysisTests/analysis/test_waterdynamics.py
@@ -42,9 +42,10 @@ def universe():
 
 def test_WaterOrientationalRelaxation(universe):
     wor = waterdynamics.WaterOrientationalRelaxation(universe, SELECTION1)
-    wor.run(0,5,1)
+    wor.run(0, 5, 1)
     assert_almost_equal(wor.dip[1], 0.35887,
                         decimal=5)
+
 
 def test_WaterOrientationalRelaxation_different_step(universe):
     wor = waterdynamics.WaterOrientationalRelaxation(universe, SELECTION1)
@@ -52,9 +53,10 @@ def test_WaterOrientationalRelaxation_different_step(universe):
     assert_almost_equal(wor.dip[1], 0.43486,
                         decimal=5)
 
+
 def test_WaterOrientationalRelaxation_zeroMolecules(universe):
     wor = waterdynamics.WaterOrientationalRelaxation(universe, SELECTION2)
-    wor.run(0,5,1)
+    wor.run(0, 5, 1)
     assert_almost_equal(wor.dip[1], (0.0, 0.0, 0.0))
 
 

--- a/testsuite/MDAnalysisTests/analysis/test_waterdynamics.py
+++ b/testsuite/MDAnalysisTests/analysis/test_waterdynamics.py
@@ -29,7 +29,7 @@ from MDAnalysisTests.datafiles import waterPSF, waterDCD
 import pytest
 import numpy as np
 from unittest.mock import patch, Mock
-from numpy.testing import assert_almost_equal, assert_equal
+from numpy.testing import assert_almost_equal, assert_equal, assert_allclose
 
 SELECTION1 = "byres name OH2"
 SELECTION2 = "byres name P1"
@@ -43,21 +43,19 @@ def universe():
 def test_WaterOrientationalRelaxation(universe):
     wor = waterdynamics.WaterOrientationalRelaxation(universe, SELECTION1)
     wor.run(0, 5, 1)
-    assert_almost_equal(wor.dip[1], 0.35887,
-                        decimal=5)
+    assert_allclose(wor.dip[1], 0.35887, rtol=1e-4)
 
 
 def test_WaterOrientationalRelaxation_different_step(universe):
     wor = waterdynamics.WaterOrientationalRelaxation(universe, SELECTION1)
     wor.run(0, 10, 2)
-    assert_almost_equal(wor.dip[1], 0.43486,
-                        decimal=5)
+    assert_allclose(wor.dip[1], 0.43486, rtol=1e-4)
 
 
 def test_WaterOrientationalRelaxation_zeroMolecules(universe):
     wor = waterdynamics.WaterOrientationalRelaxation(universe, SELECTION2)
     wor.run(0, 5, 1)
-    assert_almost_equal(wor.dip[1], (0.0, 0.0, 0.0))
+    assert_allclose(wor.dip[1], (0.0, 0.0, 0.0))
 
 
 def test_AngularDistribution(universe):

--- a/testsuite/MDAnalysisTests/analysis/test_waterdynamics.py
+++ b/testsuite/MDAnalysisTests/analysis/test_waterdynamics.py
@@ -41,18 +41,21 @@ def universe():
 
 
 def test_WaterOrientationalRelaxation(universe):
-    wor = waterdynamics.WaterOrientationalRelaxation(
-        universe, SELECTION1, 0, 5, 2)
-    wor.run()
-    assert_almost_equal(wor.timeseries[1][2], 0.35887,
+    wor = waterdynamics.WaterOrientationalRelaxation(universe, SELECTION1)
+    wor.run(0,5,1)
+    assert_almost_equal(wor.dip[1], 0.35887,
                         decimal=5)
 
+def test_WaterOrientationalRelaxation_different_step(universe):
+    wor = waterdynamics.WaterOrientationalRelaxation(universe, SELECTION1)
+    wor.run(0, 10, 2)
+    assert_almost_equal(wor.dip[1], 0.43486,
+                        decimal=5)
 
 def test_WaterOrientationalRelaxation_zeroMolecules(universe):
-    wor_zero = waterdynamics.WaterOrientationalRelaxation(
-        universe, SELECTION2, 0, 5, 2)
-    wor_zero.run()
-    assert_almost_equal(wor_zero.timeseries[1], (0.0, 0.0, 0.0))
+    wor = waterdynamics.WaterOrientationalRelaxation(universe, SELECTION2)
+    wor.run(0,5,1)
+    assert_almost_equal(wor.dip[1], (0.0, 0.0, 0.0))
 
 
 def test_AngularDistribution(universe):


### PR DESCRIPTION
Partly Fixes MDAnalysis/waterdynamics#22 

Changes made in this Pull Request:

The `WaterOrientationalRelaxation` was restructured to follow the `start`, `stop` and `step` attributes of the `AnalysisBase`.
The documentation was also improved and the example was adjusted to a pure water system. I also moved everything 
into the class documentation.

It seems that the results after my restructuring are okay but maybe somebody who knows how these correlation function should look takes a look at the results.

PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?
