### PR TITLE
Coverage density raised to 100%  [issue #3207]

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -14,7 +14,7 @@ The rules for this file:
 
 ------------------------------------------------------------------------------
 ??/??/?? IAlibay, melomcr, mdd31, ianmkenney, richardjgowers, hmacdope,
-         orbeckst, scal444, p-j-smith, edisj, Atharva7K
+         orbeckst, scal444, p-j-smith, edisj, Atharva7K, ojeda-e
 
  * 2.1.0
 

--- a/package/MDAnalysis/analysis/density.py
+++ b/package/MDAnalysis/analysis/density.py
@@ -865,7 +865,7 @@ class Density(Grid):
 
         """
         if not self.parameters['isDensity']:
-            errmsg = 'The grid is not a density so converty_density() makes no sense.'
+            errmsg = 'The grid is not a density so convert_density() makes no sense.'
             logger.fatal(errmsg)
             raise RuntimeError(errmsg)
         if unit == self.units['density']:

--- a/testsuite/MDAnalysisTests/analysis/test_density.py
+++ b/testsuite/MDAnalysisTests/analysis/test_density.py
@@ -115,13 +115,7 @@ class TestDensity(object):
 
     def test_check_set_unit_density_none(self, D):
         units = {'density': None}
-        assert D._check_set_unit(units) == None
-
-    def test_check_set_unit_density_none(self, D):
-        del D.units['density']
-        D._check_set_unit({})
-        assert D.units['density'] == None
-        assert D._check_set_unit(D.units) == None
+        assert D._check_set_unit(units) is None
 
     def test_parameters_isdensity(self, D):
         with pytest.warns(UserWarning, match='Running make_density()'):


### PR DESCRIPTION
Fixes #3207 
Density code test coverage raised to 100%.

Changes made in this Pull Request:
- Test coverage added in lines
-- 771-774 
-- 738-739
-- 754-755
-- 803-808
-- 810-869 (`convert_density`).

(No Docs needed)

PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
