### PR TITLE
Update to 1.1.1 [pre pypi upload release]

### DIFF
--- a/maintainer/conda/MDAnalysis/meta.yaml
+++ b/maintainer/conda/MDAnalysis/meta.yaml
@@ -1,7 +1,7 @@
 package:
   name: mdanalysis
   # This has to be changed after a release
-  version: "1.1.0"
+  version: "1.1.1"
 
 source:
    git_url: https://github.com/MDAnalysis/mdanalysis

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,6 +13,14 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
+05/01/21  IAlibay
+
+  * 1.1.1
+
+Fixes
+  * Remove absolute paths from package upload to pypi.
+
+
 04/28/21  richardjgowers, IAlibay, tylerjereddy, xiki-tempula, lilyminium,
           zemanj, PicoCentauri
 

--- a/package/MDAnalysis/version.py
+++ b/package/MDAnalysis/version.py
@@ -67,4 +67,4 @@ Data
 # e.g. with lib.log
 
 #: Release of MDAnalysis as a string, using `semantic versioning`_.
-__version__ = "1.1.0"  # NOTE: keep in sync with RELEASE in setup.py
+__version__ = "1.1.1"  # NOTE: keep in sync with RELEASE in setup.py

--- a/package/setup.py
+++ b/package/setup.py
@@ -74,7 +74,7 @@ else:
     from commands import getoutput
 
 # NOTE: keep in sync with MDAnalysis.__version__ in version.py
-RELEASE = "1.1.0"
+RELEASE = "1.1.1"
 
 is_release = 'dev' not in RELEASE
 

--- a/testsuite/MDAnalysisTests/__init__.py
+++ b/testsuite/MDAnalysisTests/__init__.py
@@ -98,7 +98,7 @@ import pytest
 logger = logging.getLogger("MDAnalysisTests.__init__")
 
 # keep in sync with RELEASE in setup.py
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 
 # Do NOT import MDAnalysis at this level. Tests should do it themselves.

--- a/testsuite/setup.py
+++ b/testsuite/setup.py
@@ -88,7 +88,7 @@ if sys.version_info[:2] < (2, 7):
 
 if __name__ == '__main__':
     # this must be in-sync with MDAnalysis
-    RELEASE = "1.1.0"
+    RELEASE = "1.1.1"
 
     with open("README") as summary:
         LONG_DESCRIPTION = summary.read()


### PR DESCRIPTION
We had to yank version 1.1.0 due to some erroneous SOURCES.txt contents.
This updates the version to 1.1.1 so we can keep track of what happened.

Changes made in this Pull Request:
 - 1.1.0 -> 1.1.1


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
