### PR TITLE
retroactive CHANGELOG 1.0.0 fixes

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -173,7 +173,7 @@ Fixes
   * Clarifies density_from_Universe docs and adds user warning (Issue #2372)
   * Fix upstream deprecation of `matplotlib.axis.Tick` attributes in
     `MDAnalysis.analysis.psa`
-  * PDBWriter now uses first character of segid as ChainID (Issue #2224)
+  * PDBWriter now uses last character of segid as ChainID (Issue #2224)
   * Adds a more detailed warning when attempting to read chamber-style parm7
     files (Issue #2475)
   * ClusterCollection.get_ids now returns correctly (Issue #2464)
@@ -187,6 +187,7 @@ Fixes
     than one format (Issue #2353)
   * PDBQTParser now gives icode TopologyAttrs (Issue #2361)
   * GROReader and GROWriter now can handle boxes with box vectors >1000nm
+    (Issue #2371)
   * Guess atom element with uppercase name
   * TopologyGroup no longer reshapes the type, guessed, and order properties
     (Issue #2392)


### PR DESCRIPTION
Entry for 1.0.0 had incorrect entry (on PDBWriter and chainID writing) and a missing issue reference for GRO reader/parser.

Changes made in this Pull Request:
 - fix CHANGELOG 1.0.0 entry


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [ ] Issue raised/referenced?
