### PR TITLE
Switch BAT to use Results

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -174,6 +174,8 @@ Enhancements
     checking if it can be used in parallel analysis. (Issue #2996, PR #2950)
 
 Changes
+  * `bat.BAT` now uses the `analysis.base.Results` class to store the `bat`
+    results attribute (Issue #3261)
   * `contacts.Contacts` now stores data using the `Contacts.results.timeseries`
     attribute. `Contacts.timeseries` is now deprecated (Issue #3261)
   * `DensityAnalysis` now uses the `results.density` attribute for storing

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -175,7 +175,7 @@ Enhancements
 
 Changes
   * `bat.BAT` now uses the `analysis.base.Results` class to store the `bat`
-    results attribute (Issue #3261)
+    results attribute (Issue #3261, #3272)
   * `contacts.Contacts` now stores data using the `Contacts.results.timeseries`
     attribute. `Contacts.timeseries` is now deprecated (Issue #3261)
   * `DensityAnalysis` now uses the `results.density` attribute for storing

--- a/package/MDAnalysis/analysis/bat.py
+++ b/package/MDAnalysis/analysis/bat.py
@@ -93,8 +93,8 @@ of adenylate kinase (AdK). The trajectory is included within the test data files
    R.run()
 
 After :meth:`R.run()<BAT.run>`, the coordinates can be accessed with
-:attr:`R.results.bat<BAT.bat>`. The following code snippets assume that the previous
-snippet has been executed.
+:attr:`R.results.bat<BAT.bat>`. The following code snippets assume that the
+previous snippet has been executed.
 
 Reconstruct Cartesian coordinates for the first frame::
 
@@ -422,7 +422,7 @@ class BAT(AnalysisBase):
         # Wrap torsions to between -np.pi and np.pi
         torsions = ((torsions + np.pi) % (2 * np.pi)) - np.pi
 
-        self.results.bat[self._frame_index, :] =  np.concatenate(
+        self.results.bat[self._frame_index, :] = np.concatenate(
                 (root_based, bonds, angles, torsions))
 
     def load(self, filename, start=None, stop=None, step=None):
@@ -450,14 +450,14 @@ class BAT(AnalysisBase):
         self.results.bat = np.load(filename)
 
         # Check array dimensions
-        if self.results.bat.shape!=(self.n_frames, 3*self._ag.n_atoms):
+        if self.results.bat.shape != (self.n_frames, 3*self._ag.n_atoms):
             errmsg = ('Dimensions of array in loaded file, '
                       f'({self.results.bat.shape[0]},'
                       f'{self.results.bat.shape[1]}), differ from required '
                       f'dimensions of ({self.n_frames, 3*self._ag.n_atoms})')
             raise ValueError(errmsg)
         # Check position of initial atom
-        if (self.results.bat[0,:3] != self._root[0].position).any():
+        if (self.results.bat[0, :3] != self._root[0].position).any():
             raise ValueError('Position of initial atom in file ' + \
                 'inconsistent with current trajectory in starting frame.')
         return self

--- a/testsuite/MDAnalysisTests/analysis/test_bat.py
+++ b/testsuite/MDAnalysisTests/analysis/test_bat.py
@@ -124,5 +124,6 @@ class TestBAT(object):
     def test_bat_incorrect_dims(self, bat_npz):
         u = mda.Universe(PSF, DCD)
         selected_residues = u.select_atoms("resid 1-3")
-        with pytest.raises(ValueError):
+        errmsg = 'Dimensions of array in loaded file'
+        with pytest.raises(ValueError, match=errmsg):
             R = BAT(selected_residues, filename=bat_npz)


### PR DESCRIPTION
Fixes #3272
Towards #3261 

Changes made in this Pull Request:
 - BAT is new in 2.0.0, so it's a direct switch from `bat` to `results.bat`.
 - Did a bit of cleaning up whilst I was there, including; a misindented code block and added a test.

PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
