### PR TITLE
remove np.int and np.float

### DIFF
--- a/testsuite/MDAnalysisTests/coordinates/test_rdkit.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_rdkit.py
@@ -434,9 +434,11 @@ class TestRDKitFunctions(object):
 
     @pytest.mark.parametrize("attr, value, getter", [
         ("index", 42, "GetIntProp"),
-        ("index", np.int(42), "GetIntProp"),
+        ("index", np.int32(42), "GetIntProp"),
+        ("index", np.int64(42), "GetIntProp"),
         ("charge", 4.2, "GetDoubleProp"),
-        ("charge", np.float(4.2), "GetDoubleProp"),
+        ("charge", np.float32(4.2), "GetDoubleProp"),
+        ("charge", np.float64(4.2), "GetDoubleProp"),
         ("type", "C.3", "GetProp"),
     ])
     def test_set_atom_property(self, attr, value, getter):


### PR DESCRIPTION
Fixes #3113

Changes made in this Pull Request:
 - np.int is deprecated and will not work for numpy 1.20+
 - Changed np.int in RDKit tests to np.int32 and np.int64


PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?
