### PR TITLE
Remove flags section from core docs

### DIFF
--- a/package/doc/sphinx/source/documentation_pages/core_modules.rst
+++ b/package/doc/sphinx/source/documentation_pages/core_modules.rst
@@ -10,6 +10,10 @@ MDAnalysis, such as the central data structures in
 the selection definitions and parsing in
 :mod:`MDAnalysis.core.selection`.
 
+.. toctree::
+   :maxdepth: 1
+
+   core/init
 
 Important objects for users
 ===========================
@@ -53,13 +57,3 @@ The selection system is primarily of interest to developers.
 
    core/selection
 
-Flag system
-============
-
-The flag system contains the global behavior of MDAnalysis. It is
-normally not necessary to change anything here.
-
-.. toctree::
-   :maxdepth: 1
-
-   core/init


### PR DESCRIPTION
Was looking at the docs and noticed that the core section still had a mention for flags. As far as I remember that was removed in 1.0.0, so it probably has no place being there.

Changes made in this Pull Request:
 - 


PR Checklist
------------
 - Tests? N/A
 - [x] Docs?
 - CHANGELOG updated? N/A
 - Issue raised/referenced? N/A
