### PR TITLE
Add concurrency group

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -9,6 +9,10 @@ on:
       - develop
       - master
 
+concurrency: 
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash -l {0}

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -9,7 +9,6 @@ on:
       - develop
       - master
 
-# comment to trigger CI
 concurrency: 
   group: ${{ github.head_ref }}
   cancel-in-progress: true

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -9,6 +9,7 @@ on:
       - develop
       - master
 
+# comment to trigger CI
 concurrency: 
   group: ${{ github.head_ref }}
   cancel-in-progress: true

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -9,6 +9,7 @@ on:
       - develop
       - master
 
+# an empty comment
 concurrency: 
   group: ${{ github.head_ref }}
   cancel-in-progress: true

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -9,7 +9,6 @@ on:
       - develop
       - master
 
-# an empty comment
 concurrency: 
   group: ${{ github.head_ref }}
   cancel-in-progress: true


### PR DESCRIPTION
<s>Fixes #</s>

Adds a concurrency group to the github action CI workflow which automatically kills workflows from the same PR that have already started working (see: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency).

This is quite useful, because we often have collaborative PRs were we get lots of reviewer commits (see #3299) or PRs where folks are trying things iteratively, and that tends to clog up CI. It also allows us to be a lot less wasteful, so we can feel a little bit less guilty about our carbon footprints :)

Changes made in this Pull Request:
 - Adds concurrency group to CI

This _might_ fix me having to manually cancel action runs all the time...

PR Checklist
------------
 - Tests?
 - Docs?
 - CHANGELOG updated?
 - Issue raised/referenced?
