### PR TITLE
[CI] Change concurrency group naming (Issue #3301)

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -9,8 +9,11 @@ on:
       - develop
       - master
 
-concurrency: 
-  group: ${{ github.head_ref }}
+concurrency:
+  # Probably overly cautious group naming.
+  # Commits to develop/master will cancel each other, but PRs will only cancel
+  # commits within the same PR
+  group: "${{ github.ref }}-${{ github.head_ref }}"
   cancel-in-progress: true
 
 defaults:

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -12,7 +12,7 @@ on:
 concurrency:
   # Probably overly cautious group naming.
   # Commits to develop/master will cancel each other, but PRs will only cancel
-  # commits within the same PR
+  # commits within the same PR -a
   group: "${{ github.ref }}-${{ github.head_ref }}"
   cancel-in-progress: true
 

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -12,7 +12,7 @@ on:
 concurrency:
   # Probably overly cautious group naming.
   # Commits to develop/master will cancel each other, but PRs will only cancel
-  # commits within the same PR -a
+  # commits within the same PR
   group: "${{ github.ref }}-${{ github.head_ref }}"
   cancel-in-progress: true
 


### PR DESCRIPTION
Fixes #3301

Changes made in this Pull Request:
 - Changes the concurrency group to "${{ github.ref }}-${{ github.head_ref }}"
   This means that for commits to `develop`, the group will be set to `refs/heads/develop`, so any other CI jobs running from a commit will be cancelled and this will run instead.
   For a PR (let's say this one), the group will be named `refs/pull/3302/merge-fix-3301`, so it will only kill CI jobs within that PR with the same group name.

Note: I tried checking if an external group collision could happen, thankfully it looks like that's not possible.

PR Checklist
------------
 - Tests?
 - Docs?
 - CHANGELOG updated?
 - Issue raised/referenced?
