### PR TITLE
Set the segids as str in the OpenMM parser

### DIFF
--- a/package/MDAnalysis/converters/OpenMMParser.py
+++ b/package/MDAnalysis/converters/OpenMMParser.py
@@ -115,7 +115,7 @@ class OpenMMTopologyParser(TopologyReaderBase):
         resnames = [r.name for r in omm_topology.residues()]
         resids = [r.index + 1 for r in omm_topology.residues()]
         resnums = resids.copy()
-        segids = [c.index for c in omm_topology.chains()]
+        segids = [str(c.index) for c in omm_topology.chains()]
         bonds = [(b.atom1.index, b.atom2.index) for b in omm_topology.bonds()]
         bond_orders = [b.order for b in omm_topology.bonds()]
         bond_types = [b.type for b in omm_topology.bonds()]

--- a/testsuite/MDAnalysisTests/converters/test_openmm.py
+++ b/testsuite/MDAnalysisTests/converters/test_openmm.py
@@ -76,7 +76,7 @@ class TestOpenMMBasicSimulationReader():
         assert omm_sim_uni.residues.n_residues == 1
         assert omm_sim_uni.residues.resnames[0] == "RES"
         assert omm_sim_uni.segments.n_segments == 1
-        assert omm_sim_uni.segments.segids[0] == 0
+        assert omm_sim_uni.segments.segids[0] == '0'
         assert len(omm_sim_uni.bonds.indices) == 0
 
 

--- a/testsuite/MDAnalysisTests/converters/test_openmm_parser.py
+++ b/testsuite/MDAnalysisTests/converters/test_openmm_parser.py
@@ -90,6 +90,7 @@ class OpenMMTopologyBase(ParserBase):
 
     def test_segids(self, top):
         assert len(top.segids.values) == self.expected_n_segments
+        assert all(isinstance(segid, str) for segid in top.segids.values)
         if self.expected_n_segments:
             assert isinstance(top.segids.values, np.ndarray)
         else:


### PR DESCRIPTION
Fixes #3315

Changes made in this Pull Request:
 - fix type of the segids created by the OpenMM parser


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
