### PR TITLE
Adds python_requires >= 3.6 to develop

### DIFF
--- a/package/setup.py
+++ b/package/setup.py
@@ -635,9 +635,11 @@ if __name__ == '__main__':
                         ],
           },
           ext_modules=exts,
+          python_requires='>=3.6',
           requires=['numpy (>=1.16.0)', 'biopython (>= 1.71)', 'mmtf (>=1.0.0)',
                     'networkx (>=1.0)', 'GridDataFormats (>=0.3.2)', 'joblib',
                     'scipy (>=1.0.0)', 'matplotlib (>=1.5.1)', 'tqdm (>=4.43.0)',
+                    'threadpoolctl',
                     ],
           # all standard requirements are available through PyPi and
           # typically can be installed without difficulties through setuptools

--- a/package/setup.py
+++ b/package/setup.py
@@ -636,11 +636,6 @@ if __name__ == '__main__':
           },
           ext_modules=exts,
           python_requires='>=3.6',
-          requires=['numpy (>=1.16.0)', 'biopython (>= 1.71)', 'mmtf (>=1.0.0)',
-                    'networkx (>=1.0)', 'GridDataFormats (>=0.3.2)', 'joblib',
-                    'scipy (>=1.0.0)', 'matplotlib (>=1.5.1)', 'tqdm (>=4.43.0)',
-                    'threadpoolctl',
-                    ],
           # all standard requirements are available through PyPi and
           # typically can be installed without difficulties through setuptools
           setup_requires=[


### PR DESCRIPTION
Fixes #3333 

Simple one, we're just adding a python_requires back so that folks don't try to install with py3.5 or py2.7.

Changes made in this Pull Request:
 - adds back a `python_requires` to setup.py

PR Checklist
------------
 - Tests?
 - Docs?
 - CHANGELOG updated?
 - [x] Issue raised/referenced?
