### PR TITLE
Clarifies the way MDAnalysis deals with MOL2 dimensions

### DIFF
--- a/package/MDAnalysis/coordinates/MOL2.py
+++ b/package/MDAnalysis/coordinates/MOL2.py
@@ -61,6 +61,16 @@ Classes
    :members:
 
 
+Notes
+-----
+
+* The MDAnalysis :class:`MOL2Reader` and :class:`MOL2Writer` only handle the
+  MOLECULE, SUBSTRUCTURE, ATOM, and BOND record types. Other records are not
+  currently read or preserved on writing.
+* As the CRYSIN record type is not parsed / written, MOL2 systems always have
+  dimensions set to ``None`` and dimensionless MOL2 files are written.
+
+
 MOL2 format notes
 -----------------
 

--- a/testsuite/MDAnalysisTests/coordinates/test_mol2.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_mol2.py
@@ -214,7 +214,5 @@ def test_mol2_universe_write(tmpdir):
         u2 = mda.Universe(outfile)
 
         assert_almost_equal(u.atoms.positions, u2.atoms.positions)
-        if u.dimensions is None:
-            assert u2.dimensions is None
-        else:
-            assert_almost_equal(u.dimensions, u2.dimensions)
+        # MDA does not current implement @<TRIPOS>CRYSIN reading
+        assert u2.dimensions is None


### PR DESCRIPTION
Fixes #3331 

Changes made in this Pull Request:
 - Streamlines MOL2 test, dimensions is always `None`.
 - Clarifies that we don't read from @<TRIPOS>CRYSIN


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - CHANGELOG updated? Not necessary
 - [x] Issue raised/referenced?
