### PR TITLE
Alias bfactor to tempfactor

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -290,6 +290,9 @@ Changes
   * Writing a TRZ file with no box information now raises a warning (Issue #3307)
 
 Deprecations
+  * Deprecated the `bfactors` topology attribute in favour of `tempfactors`.
+    In 2.0 `bfactors` is simply an alias of `tempfactors`; in 3.0 `bfactors`
+    will be removed. (Issue #1901, PR #3345)
   * The attributes `p_components`, `variance`, `cumulated_variance` and 
     `mean_atoms` in `analysis.pca.PCA` are now deprecated in favour of 
     `results.p_components`, `results.variance`, `results.cumulated_variance` 

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -189,6 +189,7 @@ Enhancements
     to transfer data from HDF5 file into timestep. (PR #3293)
 
 Changes
+  * Aliased bfactors to tempfactors (Issue #1901, PR#3345)
   * The RDKitParser now raises an error if only part of the atoms have metadata
     on residues (Issue #3318, PR #3325)
   * `analysis.pca.PCA` class now stores `p_components`, `variance`, 

--- a/package/MDAnalysis/converters/RDKit.py
+++ b/package/MDAnalysis/converters/RDKit.py
@@ -102,7 +102,6 @@ else:
         "resids": "ResidueNumber",
         "segindices": "SegmentNumber",
         "tempfactors": "TempFactor",
-        "bfactors": "TempFactor",
     }
     PERIODIC_TABLE = Chem.GetPeriodicTable()
 
@@ -187,7 +186,7 @@ class RDKitConverter(base.ConverterBase):
     +-----------------------+-------------------------------------------+
     | tempfactors           | atom.GetMonomerInfo().GetTempFactor()     |
     +-----------------------+-------------------------------------------+
-    | bfactors              | atom.GetMonomerInfo().GetTempFactor()     |
+    | tempfactors           | atom.GetMonomerInfo().GetTempFactor()     |
     +-----------------------+-------------------------------------------+
     | charges               | atom.GetDoubleProp("_MDAnalysis_charge")  |
     +-----------------------+-------------------------------------------+
@@ -233,10 +232,6 @@ class RDKitConverter(base.ConverterBase):
 
     It also requires the `bonds` attribute, although they will be automatically
     guessed if not present.
-
-    If both ``tempfactors`` and ``bfactors`` attributes are present, the
-    conversion will fail, since only one of these should be present.
-    Refer to Issue #1901 for a solution
 
     Hydrogens should be explicit in the topology file. If this is not the case,
     use the parameter ``NoImplicit=False`` when using the converter to allow
@@ -371,12 +366,6 @@ def atomgroup_to_mol(ag, NoImplicit=True, max_iter=200, force=False):
 
     # attributes accepted in PDBResidueInfo object
     pdb_attrs = {}
-    if hasattr(ag, "bfactors") and hasattr(ag, "tempfactors"):
-        raise AttributeError(
-            "Both `tempfactors` and `bfactors` attributes are present but "
-            "only one can be assigned to the RDKit molecule. Please "
-            "delete the unnecessary one and retry."
-        )
     for attr in RDATTRIBUTES.keys():
         if hasattr(ag, attr):
             pdb_attrs[attr] = getattr(ag, attr)

--- a/package/MDAnalysis/converters/RDKit.py
+++ b/package/MDAnalysis/converters/RDKit.py
@@ -186,8 +186,6 @@ class RDKitConverter(base.ConverterBase):
     +-----------------------+-------------------------------------------+
     | tempfactors           | atom.GetMonomerInfo().GetTempFactor()     |
     +-----------------------+-------------------------------------------+
-    | tempfactors           | atom.GetMonomerInfo().GetTempFactor()     |
-    +-----------------------+-------------------------------------------+
     | charges               | atom.GetDoubleProp("_MDAnalysis_charge")  |
     +-----------------------+-------------------------------------------+
     | indices               | atom.GetIntProp("_MDAnalysis_index")      |

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -305,6 +305,15 @@ class _TopologyAttrMeta(type):
                     _TOPOLOGY_TRANSPLANTS[name] = [attrname, method, clstype]
                     clean = name.lower().replace('_', '')
                     _TOPOLOGY_ATTRNAMES[clean] = name
+        
+        aliases = classdict.get("aliases")
+        if aliases:
+            for alias in aliases:
+                al_attrname = alias.get("attrname")
+                al_singular = alias.get("singular", al_attrname)
+                if al_singular:
+                    _TOPOLOGY_ATTRS[al_singular] = _TOPOLOGY_ATTRS[al_attrname] = cls
+
 
         for attr in ['singular', 'attrname']:
             try:
@@ -1253,10 +1262,64 @@ class Tempfactors(AtomAttr):
     singular = 'tempfactor'
     per_object = 'atom'
     dtype = float
+    transplants = defaultdict(list)
+    aliases = [{"attrname": "bfactors", "singular": "bfactor"}]
 
     @staticmethod
     def _gen_initial_values(na, nr, ns):
         return np.zeros(na)
+
+    def bfactor(self):
+        """Tempfactor alias property for atom
+
+        .. versionadded:: 2.0.0
+        """
+        return self.universe.atoms[self.ix].tempfactor
+    
+    def bfactor_setter(self, value):
+        """Tempfactor alias property for atom
+
+        .. versionadded:: 2.0.0
+        """
+        self.universe.atoms[self.ix].tempfactor = value
+    
+    def bfactors(self):
+        """Tempfactor alias property for groups of atoms
+
+        .. versionadded:: 2.0.0
+        """
+        return self.universe.atoms[self.atoms.ix].tempfactors
+    
+    def bfactors_setter(self, value):
+        """Tempfactor alias property for atom
+
+        .. versionadded:: 2.0.0
+        """
+        self.universe.atoms[self.atoms.ix].tempfactors = value
+    
+    transplants[Atom].append(
+        ('bfactor', property(bfactor, bfactor_setter, None,
+                             bfactor.__doc__)))
+
+    transplants[AtomGroup].append(
+        ('bfactors', property(bfactors, bfactors_setter, None,
+                              bfactors.__doc__)))
+    
+    transplants[Residue].append(
+        ('bfactors', property(bfactors, bfactors_setter, None,
+                              bfactors.__doc__)))
+    
+    transplants[ResidueGroup].append(
+        ('bfactors', property(bfactors, bfactors_setter, None,
+                              bfactors.__doc__)))
+    
+    transplants[Segment].append(
+        ('bfactors', property(bfactors, bfactors_setter, None,
+                              bfactors.__doc__)))
+    
+    transplants[SegmentGroup].append(
+        ('bfactors', property(bfactors, bfactors_setter, None,
+                              bfactors.__doc__)))
 
 
 class Masses(AtomAttr):
@@ -1744,19 +1807,6 @@ class Charges(AtomAttr):
 
     transplants[GroupBase].append(
         ('total_charge', total_charge))
-
-
-# TODO: update docs to property doc
-class Bfactors(AtomAttr):
-    """Crystallographic B-factors in A**2 for each atom"""
-    attrname = 'bfactors'
-    singular = 'bfactor'
-    per_object = 'atom'
-    dtype = float
-
-    @staticmethod
-    def _gen_initial_values(na, nr, ns):
-        return np.zeros(na)
 
 
 # TODO: update docs to property doc

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -305,15 +305,15 @@ class _TopologyAttrMeta(type):
                     _TOPOLOGY_TRANSPLANTS[name] = [attrname, method, clstype]
                     clean = name.lower().replace('_', '')
                     _TOPOLOGY_ATTRNAMES[clean] = name
-        
+
         aliases = classdict.get("aliases")
         if aliases:
             for alias in aliases:
                 al_attrname = alias.get("attrname")
                 al_singular = alias.get("singular", al_attrname)
                 if al_singular:
-                    _TOPOLOGY_ATTRS[al_singular] = _TOPOLOGY_ATTRS[al_attrname] = cls
-
+                    _TOPOLOGY_ATTRS[al_singular] = cls
+                    _TOPOLOGY_ATTRS[al_attrname] = cls
 
         for attr in ['singular', 'attrname']:
             try:
@@ -1275,28 +1275,28 @@ class Tempfactors(AtomAttr):
         .. versionadded:: 2.0.0
         """
         return self.universe.atoms[self.ix].tempfactor
-    
+
     def bfactor_setter(self, value):
         """Tempfactor alias property for atom
 
         .. versionadded:: 2.0.0
         """
         self.universe.atoms[self.ix].tempfactor = value
-    
+
     def bfactors(self):
         """Tempfactor alias property for groups of atoms
 
         .. versionadded:: 2.0.0
         """
         return self.universe.atoms[self.atoms.ix].tempfactors
-    
+
     def bfactors_setter(self, value):
         """Tempfactor alias property for atom
 
         .. versionadded:: 2.0.0
         """
         self.universe.atoms[self.atoms.ix].tempfactors = value
-    
+
     transplants[Atom].append(
         ('bfactor', property(bfactor, bfactor_setter, None,
                              bfactor.__doc__)))
@@ -1304,19 +1304,19 @@ class Tempfactors(AtomAttr):
     transplants[AtomGroup].append(
         ('bfactors', property(bfactors, bfactors_setter, None,
                               bfactors.__doc__)))
-    
+
     transplants[Residue].append(
         ('bfactors', property(bfactors, bfactors_setter, None,
                               bfactors.__doc__)))
-    
+
     transplants[ResidueGroup].append(
         ('bfactors', property(bfactors, bfactors_setter, None,
                               bfactors.__doc__)))
-    
+
     transplants[Segment].append(
         ('bfactors', property(bfactors, bfactors_setter, None,
                               bfactors.__doc__)))
-    
+
     transplants[SegmentGroup].append(
         ('bfactors', property(bfactors, bfactors_setter, None,
                               bfactors.__doc__)))

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -1300,26 +1300,11 @@ class Tempfactors(AtomAttr):
     transplants[Atom].append(
         ('bfactor', property(bfactor, bfactor_setter, None,
                              bfactor.__doc__)))
-
-    transplants[AtomGroup].append(
-        ('bfactors', property(bfactors, bfactors_setter, None,
-                              bfactors.__doc__)))
-
-    transplants[Residue].append(
-        ('bfactors', property(bfactors, bfactors_setter, None,
-                              bfactors.__doc__)))
-
-    transplants[ResidueGroup].append(
-        ('bfactors', property(bfactors, bfactors_setter, None,
-                              bfactors.__doc__)))
-
-    transplants[Segment].append(
-        ('bfactors', property(bfactors, bfactors_setter, None,
-                              bfactors.__doc__)))
-
-    transplants[SegmentGroup].append(
-        ('bfactors', property(bfactors, bfactors_setter, None,
-                              bfactors.__doc__)))
+    
+    for group in (AtomGroup, Residue, ResidueGroup, Segment, SegmentGroup):
+        transplants[group].append("bfactors",
+                                  property(bfactors, bfactors_setter, None,
+                                           bfactors.__doc__))
 
 
 class Masses(AtomAttr):

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -1289,7 +1289,13 @@ class Tempfactors(AtomAttr):
     # TODO: remove bfactors in 3.0
     @deprecate_bfactor_warning
     def bfactor(self):
-        """Tempfactor alias property for atom
+        """Alias for tempfactor
+
+        The bfactor topology attribute is only 
+        provided as an alias to the tempfactor 
+        attribute. It will be removed in 
+        3.0. Please use the tempfactor attribute 
+        instead.
 
         .. versionadded:: 2.0.0
         """
@@ -1305,7 +1311,13 @@ class Tempfactors(AtomAttr):
 
     @deprecate_bfactor_warning
     def bfactors(self):
-        """Tempfactor alias property for groups of atoms
+        """Alias for tempfactors
+        
+        The bfactor topology attribute is only 
+        provided as an alias to the tempfactor 
+        attribute. It will be removed in 
+        3.0. Please use the tempfactor attribute 
+        instead.
 
         .. versionadded:: 2.0.0
         """

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -1302,9 +1302,9 @@ class Tempfactors(AtomAttr):
                              bfactor.__doc__)))
     
     for group in (AtomGroup, Residue, ResidueGroup, Segment, SegmentGroup):
-        transplants[group].append("bfactors",
-                                  property(bfactors, bfactors_setter, None,
-                                           bfactors.__doc__))
+        transplants[group].append(
+            ("bfactors", property(bfactors, bfactors_setter, None,
+                                  bfactors.__doc__)))
 
 
 class Masses(AtomAttr):

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -1291,13 +1291,17 @@ class Tempfactors(AtomAttr):
     def bfactor(self):
         """Alias for tempfactor
 
-        The bfactor topology attribute is only 
-        provided as an alias to the tempfactor 
-        attribute. It will be removed in 
-        3.0. Please use the tempfactor attribute 
+        The bfactor topology attribute is only
+        provided as an alias to the tempfactor
+        attribute. It will be removed in
+        3.0. Please use the tempfactor attribute
         instead.
 
         .. versionadded:: 2.0.0
+
+        .. deprecated:: 2.0.0
+            Will be removed in 3.0.0. Use the
+            ``tempfactor`` attribute instead.
         """
         return self.universe.atoms[self.ix].tempfactor
 
@@ -1312,14 +1316,18 @@ class Tempfactors(AtomAttr):
     @deprecate_bfactor_warning
     def bfactors(self):
         """Alias for tempfactors
-        
-        The bfactor topology attribute is only 
-        provided as an alias to the tempfactor 
-        attribute. It will be removed in 
-        3.0. Please use the tempfactor attribute 
+
+        The bfactor topology attribute is only
+        provided as an alias to the tempfactor
+        attribute. It will be removed in
+        3.0. Please use the tempfactor attribute
         instead.
 
         .. versionadded:: 2.0.0
+
+        .. deprecated:: 2.0.0
+            Will be removed in 3.0.0. Use the
+            ``tempfactor`` attribute instead.
         """
         return self.universe.atoms[self.atoms.ix].tempfactors
 

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -96,7 +96,7 @@ from .groups import (ComponentBase, GroupBase,
                      Atom, Residue, Segment,
                      AtomGroup, ResidueGroup, SegmentGroup)
 from .topology import Topology
-from .topologyattrs import AtomAttr, ResidueAttr, SegmentAttr
+from .topologyattrs import AtomAttr, ResidueAttr, SegmentAttr, BFACTOR_WARNING
 from .topologyobjects import TopologyObject
 
 
@@ -774,6 +774,8 @@ class Universe(object):
             they will be aliases of the same attribute.
         """
         if isinstance(topologyattr, str):
+            if topologyattr in ("bfactor", "bfactors"):
+                warnings.warn(BFACTOR_WARNING, DeprecationWarning)
             try:
                 tcls = _TOPOLOGY_ATTRS[topologyattr]
             except KeyError:

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -792,16 +792,6 @@ class Universe(object):
                     n_residues=self._topology.n_residues,
                     n_segments=self._topology.n_segments,
                     values=values)
-        alias_pairs = [("bfactors", "tempfactors"),
-                       ("tempfactors", "bfactors")]
-        for a, b in alias_pairs:
-            if topologyattr.attrname == a and hasattr(self._topology, b):
-                err = ("You are adding {a} to a Universe that "
-                       "has {b}. From MDAnalysis version 2.0, {a} "
-                       "and {b} will no longer be separate "
-                       "TopologyAttrs. Instead, they will be aliases "
-                       "of the same attribute.").format(a=a, b=b)
-                warnings.warn(err, DeprecationWarning)
         self._topology.add_TopologyAttr(topologyattr)
         self._process_attr(topologyattr)
 

--- a/package/MDAnalysis/topology/MMTFParser.py
+++ b/package/MDAnalysis/topology/MMTFParser.py
@@ -79,7 +79,7 @@ from ..core.topologyattrs import (
     Atomids,
     Atomnames,
     Atomtypes,
-    Bfactors,
+    Tempfactors,
     Bonds,
     Charges,
     ICodes,
@@ -199,9 +199,9 @@ class MMTFParser(base.TopologyReaderBase):
         else:
             attrs.append(AltLocs(['']*natoms))
         if len(mtop.b_factor_list):
-            attrs.append(Bfactors(mtop.b_factor_list))
+            attrs.append(Tempfactors(mtop.b_factor_list))
         else:
-            attrs.append(Bfactors([0]*natoms))
+            attrs.append(Tempfactors([0]*natoms))
         if len(mtop.occupancy_list):
             attrs.append(Occupancies(mtop.occupancy_list))
         else:

--- a/package/MDAnalysis/topology/MMTFParser.py
+++ b/package/MDAnalysis/topology/MMTFParser.py
@@ -35,6 +35,10 @@ attribute on Universe.
 .. versionchanged:: 0.20.0
    Can now read files with optional fields missing/empty
 
+.. versionchanged:: 2.0.0
+   Aliased ``bfactors`` topologyattribute to ``tempfactors``.
+   ``tempfactors`` is deprecated and will be removed in 3.0 (Issue #1901)
+
 Reads the following topology attributes:
 
 Atoms:

--- a/package/MDAnalysis/topology/MMTFParser.py
+++ b/package/MDAnalysis/topology/MMTFParser.py
@@ -40,7 +40,7 @@ Reads the following topology attributes:
 Atoms:
  - altLoc
  - atom ID
- - bfactor
+ - tempfactor
  - bonds
  - charge
  - masses (guessed)

--- a/package/MDAnalysis/topology/PDBParser.py
+++ b/package/MDAnalysis/topology/PDBParser.py
@@ -184,6 +184,8 @@ class PDBParser(TopologyReaderBase):
        Bonds attribute is not added if no bonds are present in PDB file.
        If elements are invalid or partially missing, empty elements records
        are now assigned (Issue #2422).
+       Aliased ``bfactors`` topologyattribute to ``tempfactors``.
+       ``tempfactors`` is deprecated and will be removed in 3.0 (Issue #1901)
     """
     format = ['PDB', 'ENT']
 

--- a/package/MDAnalysis/topology/PDBParser.py
+++ b/package/MDAnalysis/topology/PDBParser.py
@@ -158,7 +158,7 @@ class PDBParser(TopologyReaderBase):
     Creates the following Attributes:
      - names
      - chainids
-     - bfactors
+     - tempfactors
      - occupancies
      - record_types (ATOM/HETATM)
      - resids

--- a/package/MDAnalysis/topology/PDBParser.py
+++ b/package/MDAnalysis/topology/PDBParser.py
@@ -185,7 +185,7 @@ class PDBParser(TopologyReaderBase):
        If elements are invalid or partially missing, empty elements records
        are now assigned (Issue #2422).
        Aliased ``bfactors`` topologyattribute to ``tempfactors``.
-       ``tempfactors`` is deprecated and will be removed in 3.0 (Issue #1901)
+       ``bfactors`` is deprecated and will be removed in 3.0 (Issue #1901)
     """
     format = ['PDB', 'ENT']
 

--- a/package/MDAnalysis/topology/__init__.py
+++ b/package/MDAnalysis/topology/__init__.py
@@ -63,7 +63,7 @@ the attributes they provide.
                                 types,
                                 chainids,
                                 occupancies,
-                                bfactors,
+                                tempfactors,
                                 resids, icodes,
                                 resnames,
                                 segids,
@@ -158,9 +158,9 @@ the attributes they provide.
                                 dihedrals         :mod:`MDAnalysis.topology.GSDParser`
 
    MMTF [#a]_        mmtf       altLocs,          `Macromolecular Transmission Format (MMTF)`_. An
-                                bfactors, bonds,  efficient compact format for biomolecular
+                                tempfactors,      efficient compact format for biomolecular
                                 charges, masses,  structures.
-                                names,
+                                names, bonds,
                                 occupancies,
                                 types, icodes,
                                 resnames, resids,

--- a/testsuite/MDAnalysisTests/converters/test_rdkit.py
+++ b/testsuite/MDAnalysisTests/converters/test_rdkit.py
@@ -282,17 +282,6 @@ class TestRDKitConverter(object):
         rdvalue = getattr(mi, "Get%s" % RDATTRIBUTES[attr])()
         assert rdvalue == expected
 
-    def test_bfactors_tempfactors_raises_error(self):
-        u = mda.Universe.from_smiles("C")
-        bfactors = np.array(u.atoms.n_atoms*[1.0], dtype=np.float32)
-        u.add_TopologyAttr('bfactors', bfactors)
-        u.add_TopologyAttr('tempfactors', bfactors)
-        with pytest.raises(
-            AttributeError,
-            match="Both `tempfactors` and `bfactors` attributes are present"
-        ):
-            u.atoms.convert_to("RDKIT")
-
     @pytest.mark.parametrize("idx", [0, 10, 42])
     def test_other_attributes(self, mol2, idx):
         mol = mol2.atoms.convert_to("RDKIT")

--- a/testsuite/MDAnalysisTests/converters/test_rdkit.py
+++ b/testsuite/MDAnalysisTests/converters/test_rdkit.py
@@ -274,7 +274,6 @@ class TestRDKitConverter(object):
         ("resids", 123, 123),
         ("segindices", 1, 1),
         ("tempfactors", 0.8, 0.8),
-        ("bfactors", 0.8, 0.8),
     ])
     def test_add_mda_attr_to_rdkit(self, attr, value, expected):
         mi = Chem.AtomPDBResidueInfo()

--- a/testsuite/MDAnalysisTests/core/test_copying.py
+++ b/testsuite/MDAnalysisTests/core/test_copying.py
@@ -109,7 +109,6 @@ TA_FILLER = {
     (ta.Tempfactors, float),
     (ta.Masses, float),
     (ta.Charges, float),
-    (ta.Bfactors, float),
     (ta.Occupancies, float),
     (ta.AltLocs, object),
     (ta.Resids, int),

--- a/testsuite/MDAnalysisTests/core/test_topologyattrs.py
+++ b/testsuite/MDAnalysisTests/core/test_topologyattrs.py
@@ -30,7 +30,7 @@ from numpy.testing import (
     assert_almost_equal,
 )
 import pytest
-from MDAnalysisTests.datafiles import PSF, DCD, PDB_CHECK_RIGHTHAND_PA
+from MDAnalysisTests.datafiles import PSF, DCD, PDB_CHECK_RIGHTHAND_PA, MMTF
 from MDAnalysisTests import make_Universe, no_deprecated_call
 
 import MDAnalysis as mda
@@ -547,3 +547,41 @@ def test_warn_selection_for_strange_dtype():
             attrname = "stars"  # :(
             per_object = "atom"
             dtype = dict
+
+
+class TestDeprecateBFactor:
+
+    MATCH = "use the tempfactor attribute"
+
+    @pytest.fixture()
+    def universe(self):
+        return mda.Universe(MMTF)
+
+    def test_deprecate_bfactors_get_group(self, universe):
+        with pytest.warns(DeprecationWarning, match=self.MATCH):
+            universe.atoms.bfactors
+
+    def test_deprecate_bfactors_get_atom(self, universe):
+        with pytest.warns(DeprecationWarning, match=self.MATCH):
+            assert universe.atoms[0].bfactor == universe.atoms[0].tempfactor
+
+    def test_deprecate_bfactors_set_group(self, universe):
+        with pytest.warns(DeprecationWarning, match=self.MATCH):
+            universe.atoms[:2].bfactors = [3.14, 10]
+        assert universe.atoms.tempfactors[0] == 3.14
+        assert universe.atoms.tempfactors[1] == 10
+
+        with pytest.warns(DeprecationWarning, match=self.MATCH):
+            assert universe.atoms.bfactors[0] == 3.14
+            assert universe.atoms.bfactors[1] == 10
+
+    def test_deprecate_bfactors_set_atom(self, universe):
+        with pytest.warns(DeprecationWarning, match=self.MATCH):
+            universe.atoms[0].bfactor = 3.14
+        assert universe.atoms[0].tempfactor == 3.14
+        with pytest.warns(DeprecationWarning, match=self.MATCH):
+            assert universe.atoms[0].bfactor == 3.14
+
+    def test_deprecate_bfactor_sel(self, universe):
+        with pytest.warns(DeprecationWarning, match=self.MATCH):
+            universe.select_atoms("bfactor 3")

--- a/testsuite/MDAnalysisTests/core/test_universe.py
+++ b/testsuite/MDAnalysisTests/core/test_universe.py
@@ -1292,15 +1292,3 @@ class TestEmpty(object):
         with pytest.raises(TypeError) as exc:
             u = mda.Universe()
         assert 'Universe.empty' in str(exc.value)
-
-
-def test_deprecate_b_tempfactors():
-    u = mda.Universe(PDB)
-    with pytest.warns(DeprecationWarning, match="alias"):
-        u.add_TopologyAttr("bfactors")
-
-
-def test_deprecate_temp_bfactors():
-    u = mda.Universe(MMTF)
-    with pytest.warns(DeprecationWarning, match="alias"):
-        u.add_TopologyAttr("tempfactors")

--- a/testsuite/MDAnalysisTests/core/test_universe.py
+++ b/testsuite/MDAnalysisTests/core/test_universe.py
@@ -1296,5 +1296,7 @@ class TestEmpty(object):
 
 def test_deprecate_b_tempfactors():
     u = mda.Universe(PDB)
+    values = np.arange(len(u.atoms))
     with pytest.warns(DeprecationWarning, match="use the tempfactor"):
-        u.add_TopologyAttr("bfactors")
+        u.add_TopologyAttr("bfactors", values)
+    assert_array_equal(u.atoms.tempfactors, values)

--- a/testsuite/MDAnalysisTests/core/test_universe.py
+++ b/testsuite/MDAnalysisTests/core/test_universe.py
@@ -1292,3 +1292,9 @@ class TestEmpty(object):
         with pytest.raises(TypeError) as exc:
             u = mda.Universe()
         assert 'Universe.empty' in str(exc.value)
+
+
+def test_deprecate_b_tempfactors():
+    u = mda.Universe(PDB)
+    with pytest.warns(DeprecationWarning, match="use the tempfactor"):
+        u.add_TopologyAttr("bfactors")

--- a/testsuite/MDAnalysisTests/topology/test_mmtf.py
+++ b/testsuite/MDAnalysisTests/topology/test_mmtf.py
@@ -11,7 +11,7 @@ from MDAnalysisTests.datafiles import MMTF, MMTF_gz, MMTF_skinny, MMTF_skinny2
 
 class MMTFBase(ParserBase):
     expected_attrs = [
-        'ids', 'names', 'types', 'altLocs', 'bfactors', 'occupancies',
+        'ids', 'names', 'types', 'altLocs', 'tempfactors', 'occupancies',
         'charges', 'names', 'resnames', 'resids', 'resnums', 'icodes',
         'segids', 'bonds', 'models'
     ]


### PR DESCRIPTION
Fixes #1901

Changes made in this Pull Request:
 - Aliases `bfactor` to `tempfactor` ~with some abstract-ish machinery (aliases) in case we do this again in the future.~
 - Added deprecation warning on access

I forget, did we want to warn people that this attribute now has 2 names?

I kept most of the mentions of `bfactor` in the tests the same to make sure we're not altering behaviour.


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
