### PR TITLE
Fixed wrong atom sorting in _split_by_compound_indices

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -23,6 +23,8 @@ The rules for this file:
   * 2.0.0
 
 Fixes
+  * Fixed sometimes wrong sorting of atoms into fragments when unwrapping
+    (Issue #3352, PR #3353)
   * Fixed missing array flatten preventing PCA from running when mean positions  
     provided and bugs causing tests to incorrectly pass (Issue #2728, PR #3296)
   * DL_POLY HISTORY file may contain unit cell dimensions even if there are

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -847,6 +847,11 @@ class GroupBase(_MutableBase):
         # essentially a non-split?
 
         compound_indices = self._get_compound_indices(compound)
+        compound_sizes = np.bincount(compound_indices)
+        size_per_atom = compound_sizes[compound_indices]
+        compound_sizes = compound_sizes[compound_sizes != 0]
+        unique_compound_sizes = unique_int_1d(compound_sizes)
+
         # Are we already sorted? argsorting and fancy-indexing can be expensive
         # so we do a quick pre-check.
         needs_sorting = np.any(np.diff(compound_indices) < 0)
@@ -858,11 +863,8 @@ class GroupBase(_MutableBase):
             else:
                 # Quicksort
                 sort_indices = np.argsort(compound_indices)
-
-        compound_sizes = np.bincount(compound_indices)
-        size_per_atom = compound_sizes[compound_indices]
-        compound_sizes = compound_sizes[compound_sizes != 0]
-        unique_compound_sizes = unique_int_1d(compound_sizes)
+            # We must sort size_per_atom accordingly (Issue #3352).
+            size_per_atom = size_per_atom[sort_indices]
 
         compound_masks = []
         atom_masks = []


### PR DESCRIPTION
Closes #3353

Changes made in this Pull Request:
 `_split_by_compound_indices` was not properly propagating the sorting when sorting was needed.

Tested initially on an example LAMMPS structure provided by @hejamu, but found that `1hvr.pdb` (`MDAnalysisTests.datafiles.CONECT`) also elicited the same problem when unwrapping. The implemented test uses the latter, but the fix does work for the LAMMPS case too. 

PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
