### PR TITLE
Adds macos-11 runner

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -47,7 +47,7 @@ jobs:
               install_hole: true
               codecov: true
             - name: macOS_catalina_py36
-              os: macOS-10.5
+              os: macOS-10.15
               python-version: 3.6
               run_type: FULL
               install_hole: true

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -50,7 +50,7 @@ jobs:
               os: macOS-10.5
               python-version: 3.6
               run_type: FULL
-              install_hole: false
+              install_hole: true
               codecov: false
             - name: minimal-ubuntu
               os: ubuntu-latest

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -85,7 +85,7 @@ jobs:
         # Set OS specific vars and compiler flags
         echo "OS_NAME=osx" >> $GITHUB_ENV
         # TODO: work out why this is necessary (from CI helpers)
-        echo "MACOSX_DEPLOYMENT_TARGET=10.14" >> $GITHUB_ENV
+        echo "MACOSX_DEPLOYMENT_TARGET=10.9" >> $GITHUB_ENV
         ulimit -S -n 2048
         clang -v
         echo "CC=clang" >> $GITHUB_ENV

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -40,16 +40,16 @@ jobs:
           install_hole: [true, ]
           codecov: [true, ]
           include:
-            - name: macOS_py39
-              os: macOS-latest
+            - name: macOS_bigsur_py39
+              os: macOS-11
               python-version: 3.9
               run_type: FULL
               install_hole: true
               codecov: true
-            - name: macOS_py36_min
-              os: macOS-latest
+            - name: macOS_catalina_py36
+              os: macOS-10.5
               python-version: 3.6
-              run_type: MIN
+              run_type: FULL
               install_hole: false
               codecov: false
             - name: minimal-ubuntu

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -85,7 +85,7 @@ jobs:
         # Set OS specific vars and compiler flags
         echo "OS_NAME=osx" >> $GITHUB_ENV
         # TODO: work out why this is necessary (from CI helpers)
-        echo "MACOSX_DEPLOYMENT_TARGET=10.9" >> $GITHUB_ENV
+        echo "MACOSX_DEPLOYMENT_TARGET=10.14" >> $GITHUB_ENV
         ulimit -S -n 2048
         clang -v
         echo "CC=clang" >> $GITHUB_ENV

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -34,7 +34,6 @@
 	    "six": [],
 	    "pytest": [],
 	    "nose": [],
-	    "psutil": [],
 	    "mock": [],
         "MDAnalysisTests": [],
     },

--- a/maintainer/conda/MDAnalysis/meta.yaml
+++ b/maintainer/conda/MDAnalysis/meta.yaml
@@ -32,7 +32,6 @@ requirements:
     - mock
     - seaborn
     - six
-    - psutil
     - netcdf4
     - mmtf-python
     - scikit-learn

--- a/maintainer/conda/environment.yml
+++ b/maintainer/conda/environment.yml
@@ -16,7 +16,6 @@ dependencies:
   - mock
   - networkx
   - numpy>=1.17.3
-  - psutil
   - pytest
   - python==3.7
   - scikit-learn

--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -12,7 +12,6 @@ netcdf4
 networkx
 numpy>=1.16.0
 parmed
-psutil
 pytest
 scikit-learn
 scipy

--- a/package/setup.py
+++ b/package/setup.py
@@ -301,9 +301,9 @@ def extensions(config):
     # needed to specify c++ runtime library on OSX
     if platform.system() == 'Darwin' and using_clang():
         cpp_extra_compile_args.append('-stdlib=libc++')
-        cpp_extra_compile_args.append('-mmacosx-version-min=10.14')
+        cpp_extra_compile_args.append('-mmacosx-version-min=10.9')
         cpp_extra_link_args.append('-stdlib=libc++')
-        cpp_extra_link_args.append('-mmacosx-version-min=10.14')
+        cpp_extra_link_args.append('-mmacosx-version-min=10.9')
 
     # Needed for large-file seeking under 32bit systems (for xtc/trr indexing
     # and access).

--- a/package/setup.py
+++ b/package/setup.py
@@ -301,9 +301,9 @@ def extensions(config):
     # needed to specify c++ runtime library on OSX
     if platform.system() == 'Darwin' and using_clang():
         cpp_extra_compile_args.append('-stdlib=libc++')
-        cpp_extra_compile_args.append('-mmacosx-version-min=10.9')
+        cpp_extra_compile_args.append('-mmacosx-version-min=10.14')
         cpp_extra_link_args.append('-stdlib=libc++')
-        cpp_extra_link_args.append('-mmacosx-version-min=10.7')
+        cpp_extra_link_args.append('-mmacosx-version-min=10.14')
 
     # Needed for large-file seeking under 32bit systems (for xtc/trr indexing
     # and access).

--- a/testsuite/setup.py
+++ b/testsuite/setup.py
@@ -185,7 +185,6 @@ if __name__ == '__main__':
               'MDAnalysis=={0!s}'.format(RELEASE),  # same as this release!
               'pytest>=3.3.0', # Raised to 3.3.0 due to Issue 2329
               'hypothesis',
-              'psutil>=4.0.2',
           ],
           # had 'KeyError' as zipped egg (2MB savings are not worth the
           # trouble)


### PR DESCRIPTION
Tries enabling macOS-11 runner (apparently we might have gotten access to the private preview now)

Changes made in this Pull Request:
 - CI now does bigsur 3.9 and catalina 3.6 checks [max/min if you wish]
 - setup now makes 10.9 the minimum macos deployment version
 - get rid of `psutil` as an MDAnalysisTests dependency


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
