### PR TITLE
Add warning for unwrapped coordinates in MSD module

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -117,6 +117,8 @@ Fixes
   * new `Results` class now can be pickled/unpickled. (PR #3309) 
 
 Enhancements
+  * Added warning for the use of wrapped coordinates in the MSD module (Issue
+    #3074 PR #3357)
   * Added guessers for aromaticity and Gasteiger partial charges (Issue #2468,
     PR #2926)
   * Added `Results` class for storing analysis results (#3115, PR #3233)

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -117,8 +117,6 @@ Fixes
   * new `Results` class now can be pickled/unpickled. (PR #3309) 
 
 Enhancements
-  * Added warning for the use of wrapped coordinates in the MSD module (Issue
-    #3074 PR #3357)
   * Added guessers for aromaticity and Gasteiger partial charges (Issue #2468,
     PR #2926)
   * Added `Results` class for storing analysis results (#3115, PR #3233)

--- a/package/MDAnalysis/analysis/msd.py
+++ b/package/MDAnalysis/analysis/msd.py
@@ -66,9 +66,12 @@ the normal MDAnalysis citations.
     To correctly compute the MSD using this analysis module, you must supply
     coordinates in the **unwrapped** convention. That is, when atoms pass
     the periodic boundary, they must not be **wrapped** back into the primary
-    simulation cell. Various simulation packages provide utilities to convert
-    coordinates to this convention. In GROMACS for example, this can be
-    done using ``gmx trjconv`` with the ``-pbc nojump`` flag.
+    simulation cell. MDAnalysis does not currently offer this functionality in
+    the ``MDAnalysis.transformations`` API despite having functions with
+    similar names. We plan to implement the appropriate transformations in the
+    future. In the meantime, various simulation packages provide utilities to
+    convert coordinates to the unwrapped convention. In GROMACS for example,
+    this can be done using ``gmx trjconv`` with the ``-pbc nojump`` flag.
 
 Computing an MSD
 ----------------

--- a/package/MDAnalysis/analysis/msd.py
+++ b/package/MDAnalysis/analysis/msd.py
@@ -64,7 +64,7 @@ the normal MDAnalysis citations.
 
 .. warning::
     To correctly compute the MSD using this analysis module, you must supply
-    coordinates in the **unwrapped** convention. That is, when they pass
+    coordinates in the **unwrapped** convention. That is, when atoms pass
     the periodic boundary, they must not be **wrapped** back into the primary
     simulation cell. Various simulation packages provide utilities to convert
     coordinates to this convention. In GROMACS for example, this can be

--- a/package/MDAnalysis/analysis/msd.py
+++ b/package/MDAnalysis/analysis/msd.py
@@ -63,13 +63,12 @@ Please cite [Calandri2011]_ [Buyl2018]_ if you use this module in addition to
 the normal MDAnalysis citations.
 
 .. warning::
-    To correctly compute the MSD using this analysis module, you must supply 
+    To correctly compute the MSD using this analysis module, you must supply
     coordinates in the **unwrapped** convention. That is, when they pass
     the periodic boundary, they must not be **wrapped** back into the primary
     simulation cell. Various simulation packages provide utilities to convert
     coordinates to this convention. In GROMACS for example, this can be
-    done using ``gmx trjconv`` with the ``-pbc nojump`` flag.  
-    
+    done using ``gmx trjconv`` with the ``-pbc nojump`` flag.
 
 Computing an MSD
 ----------------

--- a/package/MDAnalysis/analysis/msd.py
+++ b/package/MDAnalysis/analysis/msd.py
@@ -62,6 +62,15 @@ installed; otherwise the code will raise an :exc:`ImportError`.
 Please cite [Calandri2011]_ [Buyl2018]_ if you use this module in addition to
 the normal MDAnalysis citations.
 
+.. warning::
+    To correctly compute the MSD using this analysis module, you must supply 
+    coordinates in the **unwrapped** convention. That is, when they pass
+    the periodic boundary, they must not be **wrapped** back into the primary
+    simulation cell. Various simulation packages provide utilities to convert
+    coordinates to this convention. In GROMACS for example, this can be
+    done using ``gmx trjconv`` with the ``-pbc nojump`` flag.  
+    
+
 Computing an MSD
 ----------------
 This example computes a 3D MSD for the movement of 100 particles undergoing a


### PR DESCRIPTION
Fixes #3074

Changes made in this Pull Request:
 - Add a warning suggesting the use of unwrapped coordinates to the MSD docs.


PR Checklist
------------

 - [X] Docs?
 - [X] CHANGELOG updated?
 - [X] Issue raised/referenced?
