### PR TITLE
Adds warning for writing DCD files with no dimensions

### DIFF
--- a/package/MDAnalysis/coordinates/DCD.py
+++ b/package/MDAnalysis/coordinates/DCD.py
@@ -321,12 +321,11 @@ class DCDWriter(base.WriterBase):
     and writes positions in Å and time in AKMA time units.
 
 
-    Notes
-    -----
-    When writing out timesteps without ``dimensions`` (i.e. set ``None``) the
-    :class:`DCDWriter` will write out a zeroed unitcell (i.e.
-    ``[0, 0, 0, 0, 0, 0]``). As this behaviour is poorly defined, it may not
-    match the expectations of other software.
+    .. note::
+        When writing out timesteps without ``dimensions`` (i.e. set ``None``)
+        the :class:`DCDWriter` will write out a zeroed unitcell (i.e.
+        ``[0, 0, 0, 0, 0, 0]``). As this behaviour is poorly defined, it may
+        not match the expectations of other software.
 
     """
     format = 'DCD'

--- a/package/MDAnalysis/coordinates/DCD.py
+++ b/package/MDAnalysis/coordinates/DCD.py
@@ -320,6 +320,14 @@ class DCDWriter(base.WriterBase):
     in Å and angle-cosines, ``[A, cos(gamma), B, cos(beta), cos(alpha), C]``)
     and writes positions in Å and time in AKMA time units.
 
+
+    Notes
+    -----
+    When writing out timesteps without ``dimensions`` (i.e. set ``None``) the
+    :class:`DCDWriter` will write out a zeroed unitcell (i.e.
+    ``[0, 0, 0, 0, 0, 0]``). As this behaviour is poorly defined, it may not
+    match the expectations of other software.
+
     """
     format = 'DCD'
     multiframe = True
@@ -418,6 +426,9 @@ class DCDWriter(base.WriterBase):
         try:
             dimensions = ts.dimensions.copy()
         except AttributeError:
+            wmsg = ('No dimensions set for current frame, zeroed unitcell '
+                    'will be written')
+            warnings.warn(wmsg)
             dimensions = np.zeros(6)
 
         if self._convert_units:

--- a/testsuite/MDAnalysisTests/coordinates/test_dcd.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_dcd.py
@@ -33,7 +33,8 @@ from MDAnalysisTests.datafiles import (DCD, PSF, DCD_empty, PRMncdf, NCDF,
                                        COORDINATES_TOPOLOGY, COORDINATES_DCD,
                                        PSF_TRICLINIC, DCD_TRICLINIC,
                                        PSF_NAMD_TRICLINIC, DCD_NAMD_TRICLINIC,
-                                       PSF_NAMD_GBIS, DCD_NAMD_GBIS)
+                                       PSF_NAMD_GBIS, DCD_NAMD_GBIS,
+                                       PDB_closed)
 from MDAnalysisTests.coordinates.base import (MultiframeReaderTest,
                                               BaseReference,
                                               BaseWriterTest)
@@ -132,6 +133,16 @@ def test_write_random_unitcell(tmpdir):
                                   random_unitcells[index],
                                   decimal=5)
 
+
+def test_empty_dimension_warning(tmpdir):
+
+    u = mda.Universe(PDB_closed)
+    testname = str(tmpdir.join('test.dcd'))
+
+    with mda.Writer(testname, n_atoms=u.atoms.n_atoms) as w:
+        msg = "zeroed unitcell will be written"
+        with pytest.warns(UserWarning, match=msg):
+            w.write(u.atoms)
 
 
 ################


### PR DESCRIPTION
Fixes #3303 

Changes made in this Pull Request:
 - Adds warning & docs about what happens when you write out a system without dimensions using the DCDWriter


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - CHANGELOG updated? - not a user facing change, just a clarification
 - [x] Issue raised/referenced?
