### PR TITLE
Increase codecov action version to v2

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -186,7 +186,7 @@ jobs:
 
     - name: codecov
       if: matrix.codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v2
       with:
         file: coverage.xml
         fail_ci_if_error: True


### PR DESCRIPTION
Change ahead of 2022 deprecation.

Really early on this one but doing it so I don't forget later: https://github.com/codecov/codecov-action#%EF%B8%8F--deprecration-of-v1

Changes made in this Pull Request:
 - increase codecov action version to v2


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
