### PR TITLE
Adds temporary warning on accuracy of RDKit converter

### DIFF
--- a/package/MDAnalysis/converters/RDKit.py
+++ b/package/MDAnalysis/converters/RDKit.py
@@ -53,7 +53,7 @@ molecule::
     infers the structures of approximately 90% of the `ChEMBL27`_ dataset.
     Work is currently ongoing on further improving this and updates to the
     converter are expected in future releases of MDAnalysis.
-    Please see `Issue #3044`_ for more details.
+    Please see `Pull Request #3044`_ for more details.
 
 
 
@@ -76,7 +76,7 @@ Classes
 .. Links
 
 .. _`ChEMBL27`: https://ftp.ebi.ac.uk/pub/databases/chembl/ChEMBLdb/releases/chembl_27/
-.. _`Issue #3044`: https://github.com/MDAnalysis/mdanalysis/pull/3044
+.. _`Pull Request #3044`: https://github.com/MDAnalysis/mdanalysis/pull/3044
 
 """
 

--- a/package/MDAnalysis/converters/RDKit.py
+++ b/package/MDAnalysis/converters/RDKit.py
@@ -47,6 +47,16 @@ molecule::
     <rdkit.Chem.rdchem.Mol object at 0x7fcebb958148>
 
 
+.. warning::
+    The RDKit converter is currently *experimental* and may not work as
+    expected for all molecules. Currently the converter accurately
+    infers the structures of approximately 90% of the `ChEMBL27`_ dataset.
+    Work is currently ongoing on further improving this and updates to the
+    converter are expected in future releases of MDAnalysis.
+    Please see `Issue #3044`_ for more details.
+
+
+
 Classes
 -------
 
@@ -61,6 +71,12 @@ Classes
 .. autofunction:: _standardize_patterns
 
 .. autofunction:: _rebuild_conjugated_bonds
+
+
+.. Links
+
+.. _`ChEMBL27`: https://ftp.ebi.ac.uk/pub/databases/chembl/ChEMBLdb/releases/chembl_27/
+.. _`Issue #3044`: https://github.com/MDAnalysis/mdanalysis/pull/3044
 
 """
 


### PR DESCRIPTION
As discussed in https://github.com/MDAnalysis/mdanalysis/pull/3044#issuecomment-900521290 this adds a warning to mention that future changes that will improve the accuracy of the RDKit converter are coming. This will allow us to accelerate the 2.0 release and put @cbouy's awesome work to 2.1.0.


PR Checklist
------------
 - Tests?
 - Docs?
 - CHANGELOG updated?
 - Issue raised/referenced?
