### PR TITLE
Add userguide information to docs

### DIFF
--- a/package/doc/sphinx/source/index.rst
+++ b/package/doc/sphinx/source/index.rst
@@ -59,6 +59,19 @@ members agree and adhere to --- please read it.
 
 .. _installation-instructions: 
 
+
+User Guide
+==========
+The MDAnalysis `userguide`_ provides comprehensive information on how to
+use the library. We would recommend that new users have a look at the
+`quick start guide`_. The userguide also has a set of `examples`_ on how to
+use the MDAnalysis library which may be of interest.
+
+.. _`userguide`: https://userguide.mdanalysis.org/stable/index.html
+.. _`quick start guide`: https://userguide.mdanalysis.org/stable/examples/quickstart.html
+.. _`examples`: https://userguide.mdanalysis.org/stable/examples/README.html
+
+
 Installing MDAnalysis
 =====================
 
@@ -113,7 +126,7 @@ examples in the documentation or the tutorials_, also install the
    conda install mdanalysistests            # with conda
 
 .. _install the latest release:
-   https://www.mdanalysis.org/pages/installation_quick_start/
+   https://userguide.mdanalysis.org/stable/installation.html#installation
 .. _pip:
    http://www.pip-installer.org/en/latest/index.html
 .. _conda:
@@ -127,15 +140,20 @@ Source Code
 
 **Source code** is available from
 https://github.com/MDAnalysis/mdanalysis/ under the `GNU Public
-Licence, version 2`_. Obtain the sources with `git`_
+Licence, version 2`_. Obtain the sources with `git`_.
 
 .. code-block:: bash
 
    git clone https://github.com/MDAnalysis/mdanalysis.git
 
+
+The userguide provides more information on how to
+`install the development version`_ of MDAnalysis.
+
 .. _GNU Public Licence, version 2:
    http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 .. _git: https://git-scm.com/
+.. _`install the development version`: https://userguide.mdanalysis.org/stable/installation.html#development-versions
 
 
 Citation

--- a/package/doc/sphinx/source/index.rst
+++ b/package/doc/sphinx/source/index.rst
@@ -61,39 +61,24 @@ members agree and adhere to --- please read it.
 
 User Guide
 ==========
+
 The MDAnalysis `User Guide`_ provides comprehensive information on how to
 use the library. We would recommend that new users have a look at the
-`quick start guide`_. The userguide also has a set of `examples`_ on how to
+`Quick Start Guide`_. The User Guide also has a set of `examples`_ on how to
 use the MDAnalysis library which may be of interest.
 
 .. _`User Guide`: https://userguide.mdanalysis.org/stable/index.html
-.. _`quick start guide`: https://userguide.mdanalysis.org/stable/examples/quickstart.html
+.. _`Quick Start Guide`: https://userguide.mdanalysis.org/stable/examples/quickstart.html
 .. _`examples`: https://userguide.mdanalysis.org/stable/examples/README.html
 
 
-.. _installation-instructions: 
+.. _installation-instructions:
+
 Installing MDAnalysis
 =====================
 
 The easiest approach to `install the latest release`_ is to use a package that
-can be installed either with pip_ or conda_.
-
-pip
----
-
-Installation with `pip`_ and a *minimal set of dependencies*:
-
-.. code-block:: bash 
-
-   pip install --upgrade MDAnalysis
-
-To install with a *full set of dependencies* (which includes everything needed
-for :mod:`MDAnalysis.analysis`), add the ``[analysis]`` tag:
-
-.. code-block:: bash 
-
-   pip install --upgrade MDAnalysis[analysis]
-
+can be installed either with conda_ or pip_.
 
 conda
 -----
@@ -113,6 +98,23 @@ To upgrade later:
 
    conda update mdanalysis
 
+pip
+---
+
+Installation with `pip`_ and a *minimal set of dependencies*:
+
+.. code-block:: bash 
+
+   pip install --upgrade MDAnalysis
+
+To install with a *full set of dependencies* (which includes everything needed
+for :mod:`MDAnalysis.analysis`), add the ``[analysis]`` tag:
+
+.. code-block:: bash 
+
+   pip install --upgrade MDAnalysis[analysis]
+
+
 Tests
 -----
 
@@ -122,8 +124,8 @@ examples in the documentation or the tutorials_, also install the
 
 .. code-block:: bash 
 
-   pip install --upgrade MDAnalysisTests    # with pip
    conda install mdanalysistests            # with conda
+   pip install --upgrade MDAnalysisTests    # with pip
 
 .. _install the latest release:
    https://userguide.mdanalysis.org/stable/installation.html#installation

--- a/package/doc/sphinx/source/index.rst
+++ b/package/doc/sphinx/source/index.rst
@@ -57,21 +57,21 @@ members agree and adhere to --- please read it.
    http://groups.google.com/group/mdnalysis-discussion
 .. _`Code of Conduct`: https://www.mdanalysis.org/pages/conduct/
 
-.. _installation-instructions: 
 
 
 User Guide
 ==========
-The MDAnalysis `userguide`_ provides comprehensive information on how to
+The MDAnalysis `User Guide`_ provides comprehensive information on how to
 use the library. We would recommend that new users have a look at the
 `quick start guide`_. The userguide also has a set of `examples`_ on how to
 use the MDAnalysis library which may be of interest.
 
-.. _`userguide`: https://userguide.mdanalysis.org/stable/index.html
+.. _`User Guide`: https://userguide.mdanalysis.org/stable/index.html
 .. _`quick start guide`: https://userguide.mdanalysis.org/stable/examples/quickstart.html
 .. _`examples`: https://userguide.mdanalysis.org/stable/examples/README.html
 
 
+.. _installation-instructions: 
 Installing MDAnalysis
 =====================
 
@@ -147,7 +147,7 @@ Licence, version 2`_. Obtain the sources with `git`_.
    git clone https://github.com/MDAnalysis/mdanalysis.git
 
 
-The userguide provides more information on how to
+The `User Guide`_ provides more information on how to
 `install the development version`_ of MDAnalysis.
 
 .. _GNU Public Licence, version 2:


### PR DESCRIPTION
Fixes #2735

Changes made in this Pull Request:
 - Adds extra information on the userguide to the main docs page.


PR Checklist
------------
 - Tests?
 - [x] Docs?
 - CHANGELOG updated?
 - [x] Issue raised/referenced?
