### PR TITLE
WIP, CI: add newer msvc to Azure CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,6 +17,8 @@ pr:
 jobs:
 - job: Windows
   condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))  # skip for PR merges
+  pool:
+    vmImage: 'windows-2019'
   variables:
     MPLBACKEND: agg
   strategy:
@@ -24,32 +26,18 @@ jobs:
         Python37-32bit-full:
           PYTHON_VERSION: '3.7'
           PYTHON_ARCH: 'x86'
-          imageName: 'vs2017-win2016'
-        Python36-64bit-full:
-          PYTHON_VERSION: '3.6'
-          PYTHON_ARCH: 'x64'
-          imageName: 'vs2017-win2016'
         Python37-64bit-full:
           PYTHON_VERSION: '3.7'
           PYTHON_ARCH: 'x64'
-          imageName: 'vs2017-win2016'
         Python38-64bit-full:
           PYTHON_VERSION: '3.8'
           PYTHON_ARCH: 'x64'
-          imageName: 'vs2017-win2016'
         Python39-64bit-full:
           PYTHON_VERSION: '3.9'
           PYTHON_ARCH: 'x64'
         Python310-64bit-full:
           PYTHON_VERSION: '3.10'
           PYTHON_ARCH: 'x64'
-          imageName: 'vs2017-win2016'
-        Python38-64bit-full-msvc2019:
-          PYTHON_VERSION: '3.8'
-          PYTHON_ARCH: 'x64'
-          imageName: 'windows-2019'
-  pool:
-    vmImage: $(imageName)
   steps:
   - task: UsePythonVersion@0
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,8 +17,6 @@ pr:
 jobs:
 - job: Windows
   condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))  # skip for PR merges
-  pool:
-    vmImage: 'VS2017-Win2016'
   variables:
     MPLBACKEND: agg
   strategy:
@@ -26,18 +24,32 @@ jobs:
         Python37-32bit-full:
           PYTHON_VERSION: '3.7'
           PYTHON_ARCH: 'x86'
+          imageName: 'vs2017-win2016'
+        Python36-64bit-full:
+          PYTHON_VERSION: '3.6'
+          PYTHON_ARCH: 'x64'
+          imageName: 'vs2017-win2016'
         Python37-64bit-full:
           PYTHON_VERSION: '3.7'
           PYTHON_ARCH: 'x64'
+          imageName: 'vs2017-win2016'
         Python38-64bit-full:
           PYTHON_VERSION: '3.8'
           PYTHON_ARCH: 'x64'
+          imageName: 'vs2017-win2016'
         Python39-64bit-full:
           PYTHON_VERSION: '3.9'
           PYTHON_ARCH: 'x64'
         Python310-64bit-full:
           PYTHON_VERSION: '3.10'
           PYTHON_ARCH: 'x64'
+          imageName: 'vs2017-win2016'
+        Python38-64bit-full-msvc2019:
+          PYTHON_VERSION: '3.8'
+          PYTHON_ARCH: 'x64'
+          imageName: 'windows-2019'
+  pool:
+    vmImage: $(imageName)
   steps:
   - task: UsePythonVersion@0
     inputs:

--- a/package/setup.py
+++ b/package/setup.py
@@ -273,17 +273,8 @@ def extensions(config):
     use_cython = config.get('use_cython', default=cython_found)
     use_openmp = config.get('use_openmp', default=True)
 
-    if os.name == 'nt':
-        # lower optimization level on Windows
-        # because of gh-3248 (really only applies
-        # to msvc 2019+ it seems)
-        extra_compile_args = ['-std=c99', '-ffast-math', '-O2',
-                              '-funroll-loops',
-                              '-fsigned-zeros']  # see #2722
-    else:
-        extra_compile_args = ['-std=c99', '-ffast-math', '-O3',
-                              '-funroll-loops',
-                              '-fsigned-zeros']  # see #2722
+    extra_compile_args = ['-std=c99', '-ffast-math', '-O3', '-funroll-loops',
+                          '-fsigned-zeros'] # see #2722
     define_macros = []
     if config.get('debug_cflags', default=False):
         extra_compile_args.extend(['-Wall', '-pedantic'])

--- a/package/setup.py
+++ b/package/setup.py
@@ -273,8 +273,17 @@ def extensions(config):
     use_cython = config.get('use_cython', default=cython_found)
     use_openmp = config.get('use_openmp', default=True)
 
-    extra_compile_args = ['-std=c99', '-ffast-math', '-O3', '-funroll-loops',
-                          '-fsigned-zeros'] # see #2722
+    if os.name == 'nt':
+        # lower optimization level on Windows
+        # because of gh-3248 (really only applies
+        # to msvc 2019+ it seems)
+        extra_compile_args = ['-std=c99', '-ffast-math', '-O2',
+                              '-funroll-loops',
+                              '-fsigned-zeros']  # see #2722
+    else:
+        extra_compile_args = ['-std=c99', '-ffast-math', '-O3',
+                              '-funroll-loops',
+                              '-fsigned-zeros']  # see #2722
     define_macros = []
     if config.get('debug_cflags', default=False):
         extra_compile_args.extend(['-Wall', '-pedantic'])

--- a/package/setup.py
+++ b/package/setup.py
@@ -277,7 +277,7 @@ def extensions(config):
         # lower optimization level on Windows
         # because of gh-3248 (really only applies
         # to msvc 2019+ it seems)
-        extra_compile_args = ['-std=c99', '-ffast-math', '-O2',
+        extra_compile_args = ['-std=c99', '-ffast-math', '-O1',
                               '-funroll-loops',
                               '-fsigned-zeros']  # see #2722
     else:

--- a/package/setup.py
+++ b/package/setup.py
@@ -277,7 +277,7 @@ def extensions(config):
         # lower optimization level on Windows
         # because of gh-3248 (really only applies
         # to msvc 2019+ it seems)
-        extra_compile_args = ['-std=c99', '-ffast-math', '-O1',
+        extra_compile_args = ['-std=c99', '-ffast-math', '-O2',
                               '-funroll-loops',
                               '-fsigned-zeros']  # see #2722
     else:

--- a/testsuite/MDAnalysisTests/lib/test_augment.py
+++ b/testsuite/MDAnalysisTests/lib/test_augment.py
@@ -20,6 +20,7 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 
+import os
 import pytest
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_equal
@@ -67,6 +68,8 @@ qres = (
        )
 
 
+@pytest.mark.xfail(os.name == "nt",
+                   reason="see gh-3248")
 @pytest.mark.parametrize('b', (
                          np.array([10, 10, 10, 90, 90, 90], dtype=np.float32),
                          np.array([10, 10, 10, 45, 60, 90], dtype=np.float32)


### PR DESCRIPTION
* try to capture the test error described in
gh-3248 by using the newest possible Windows
base image/compiler toolset to run a matrix
entry

* I have not tried overriding with `imageName`
in a matrix entry like this before, but it seems
it is documented:
https://docs.microsoft.com/en-us/azure/devops/pipelines/get-started-multiplatform?view=azure-devops


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
