### PR TITLE
Start 2.1.0-dev0

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -35,7 +35,7 @@ jobs:
         fail-fast: false
         matrix:
           os: [ubuntu-latest, ]
-          python-version: [3.6, 3.7, 3.8, 3.9]
+          python-version: [3.7, 3.8, 3.9]
           run_type: [FULL, ]
           install_hole: [true, ]
           codecov: [true, ]
@@ -46,25 +46,25 @@ jobs:
               run_type: FULL
               install_hole: true
               codecov: true
-            - name: macOS_catalina_py36
+            - name: macOS_catalina_py37
               os: macOS-10.15
-              python-version: 3.6
+              python-version: 3.7
               run_type: FULL
               install_hole: true
               codecov: false
             - name: minimal-ubuntu
               os: ubuntu-latest
-              python-version: 3.6
+              python-version: 3.7
               run_type: MIN
               install_hole: false
               codecov: true
             - name: numpy_min
               os: ubuntu-latest
-              python-version: 3.6
+              python-version: 3.7
               run_type: FULL
               install_hole: false
               codecov: false
-              numpy: numpy=1.16.0
+              numpy: numpy=1.18.0
             - name: asv_check
               os: ubuntu-latest
               python-version: 3.7

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -64,7 +64,7 @@ jobs:
               run_type: FULL
               install_hole: false
               codecov: false
-              numpy: numpy=1.18.0
+              numpy: numpy=1.18.1
             - name: asv_check
               os: ubuntu-latest
               python-version: 3.7

--- a/maintainer/conda/MDAnalysis/meta.yaml
+++ b/maintainer/conda/MDAnalysis/meta.yaml
@@ -1,7 +1,7 @@
 package:
   name: mdanalysis
   # This has to be changed after a release
-  version: "2.0.0-dev0"
+  version: "2.0.0"
 
 source:
    git_url: https://github.com/MDAnalysis/mdanalysis

--- a/maintainer/conda/MDAnalysis/meta.yaml
+++ b/maintainer/conda/MDAnalysis/meta.yaml
@@ -1,7 +1,7 @@
 package:
   name: mdanalysis
   # This has to be changed after a release
-  version: "2.0.0"
+  version: "2.1.0-dev0"
 
 source:
    git_url: https://github.com/MDAnalysis/mdanalysis

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,6 +13,21 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
+??/??/?? IAlibay
+
+ * 2.1.0
+
+Fixes
+
+Enhancements
+
+Changes
+  * Dropped python 3.6 support and raised minimum numpy version to 1.18.0
+    (NEP29)
+
+Deprecations
+
+
 08/21/21 tylerjereddy, richardjgowers, IAlibay, hmacdope, orbeckst, cbouy,
          lilyminium, daveminh, jbarnoud, yuxuanzhuang, VOD555, ianmkenney,
          calcraven，xiki-tempula, mieczyslaw, manuel.nuno.melo, PicoCentauri,

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,7 +13,7 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-??/??/?? tylerjereddy, richardjgowers, IAlibay, hmacdope, orbeckst, cbouy,
+08/21/21 tylerjereddy, richardjgowers, IAlibay, hmacdope, orbeckst, cbouy,
          lilyminium, daveminh, jbarnoud, yuxuanzhuang, VOD555, ianmkenney,
          calcraven，xiki-tempula, mieczyslaw, manuel.nuno.melo, PicoCentauri,
          hanatok, rmeli, aditya-kamath, tirkarthi, LeonardoBarneschi, hejamu,

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -68,21 +68,9 @@ import sys
 # trigger an MPI warning because importing the uuid module triggers a call to
 # os.fork(). This happens if MPI_Init() has been called prior to importing
 # MDAnalysis. The problem is actually caused by the uuid module and not by
-# MDAnalysis itself. Python 3.7 fixes the problem. However, for Python < 3.7,
-# the uuid module works perfectly fine with os.fork() disabled during import.
-# A clean solution is therefore simply to disable os.fork() prior to importing
-# the uuid module and to re-enable it afterwards.
+# MDAnalysis itself. Python 3.7 fixes the problem.
 import os
-
-# Windows doesn't have os.fork so can ignore
-# the issue for that platform
-if sys.version_info >= (3, 7) or os.name == 'nt':
-    import uuid
-else:
-    _os_dot_fork, os.fork = os.fork, None
-    import uuid
-    os.fork = _os_dot_fork
-    del _os_dot_fork
+import uuid
 
 from .. import _TOPOLOGY_ATTRS, _PARSERS
 from ..exceptions import NoDataError

--- a/package/MDAnalysis/version.py
+++ b/package/MDAnalysis/version.py
@@ -67,4 +67,4 @@ Data
 # e.g. with lib.log
 
 #: Release of MDAnalysis as a string, using `semantic versioning`_.
-__version__ = "2.0.0-dev0"  # NOTE: keep in sync with RELEASE in setup.py
+__version__ = "2.0.0"  # NOTE: keep in sync with RELEASE in setup.py

--- a/package/MDAnalysis/version.py
+++ b/package/MDAnalysis/version.py
@@ -67,4 +67,4 @@ Data
 # e.g. with lib.log
 
 #: Release of MDAnalysis as a string, using `semantic versioning`_.
-__version__ = "2.0.0"  # NOTE: keep in sync with RELEASE in setup.py
+__version__ = "2.1.0-dev0"  # NOTE: keep in sync with RELEASE in setup.py

--- a/package/setup.py
+++ b/package/setup.py
@@ -73,7 +73,7 @@ else:
     from commands import getoutput
 
 # NOTE: keep in sync with MDAnalysis.__version__ in version.py
-RELEASE = "2.0.0-dev0"
+RELEASE = "2.0.0"
 
 is_release = 'dev' not in RELEASE
 

--- a/package/setup.py
+++ b/package/setup.py
@@ -73,7 +73,7 @@ else:
     from commands import getoutput
 
 # NOTE: keep in sync with MDAnalysis.__version__ in version.py
-RELEASE = "2.0.0"
+RELEASE = "2.1.0-dev0"
 
 is_release = 'dev' not in RELEASE
 
@@ -574,7 +574,6 @@ if __name__ == '__main__':
         'Operating System :: Microsoft :: Windows ',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
@@ -588,7 +587,7 @@ if __name__ == '__main__':
     exts, cythonfiles = extensions(config)
 
     install_requires = [
-          'numpy>=1.16.0',
+          'numpy>=1.18.0',
           'biopython>=1.71',
           'networkx>=1.0',
           'GridDataFormats>=0.4.0',
@@ -635,11 +634,11 @@ if __name__ == '__main__':
                         ],
           },
           ext_modules=exts,
-          python_requires='>=3.6',
+          python_requires='>=3.7',
           # all standard requirements are available through PyPi and
           # typically can be installed without difficulties through setuptools
           setup_requires=[
-              'numpy>=1.16.0',
+              'numpy>=1.18.0',
           ],
           install_requires=install_requires,
           # extras can be difficult to install through setuptools and/or

--- a/testsuite/MDAnalysisTests/__init__.py
+++ b/testsuite/MDAnalysisTests/__init__.py
@@ -97,7 +97,7 @@ import pytest
 logger = logging.getLogger("MDAnalysisTests.__init__")
 
 # keep in sync with RELEASE in setup.py
-__version__ = "2.0.0-dev0"
+__version__ = "2.0.0"
 
 
 # Do NOT import MDAnalysis at this level. Tests should do it themselves.

--- a/testsuite/MDAnalysisTests/__init__.py
+++ b/testsuite/MDAnalysisTests/__init__.py
@@ -97,7 +97,7 @@ import pytest
 logger = logging.getLogger("MDAnalysisTests.__init__")
 
 # keep in sync with RELEASE in setup.py
-__version__ = "2.0.0"
+__version__ = "2.1.0-dev0"
 
 
 # Do NOT import MDAnalysis at this level. Tests should do it themselves.

--- a/testsuite/setup.py
+++ b/testsuite/setup.py
@@ -87,7 +87,7 @@ if sys.version_info[:2] < (3, 6):
 
 if __name__ == '__main__':
     # this must be in-sync with MDAnalysis
-    RELEASE = "2.0.0"
+    RELEASE = "2.1.0-dev0"
     with open("README") as summary:
         LONG_DESCRIPTION = summary.read()
 
@@ -101,7 +101,6 @@ if __name__ == '__main__':
         'Operating System :: Microsoft :: Windows ',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',

--- a/testsuite/setup.py
+++ b/testsuite/setup.py
@@ -87,7 +87,7 @@ if sys.version_info[:2] < (3, 6):
 
 if __name__ == '__main__':
     # this must be in-sync with MDAnalysis
-    RELEASE = "2.0.0-dev0"
+    RELEASE = "2.0.0"
     with open("README") as summary:
         LONG_DESCRIPTION = summary.read()
 


### PR DESCRIPTION
Fixes #3254

Changes made in this Pull Request:
 - Starts off 2.1.0-dev0
 - Raises minimum python version to 3.7 and numpy to 1.18 in accordance to current NEP29 support. If we have an idea of when the release is going to be we can provide a more accurate minimum version here. Ideally I'd like 2.1.0 to be out faster than normal so we can add the RDKit fixes.

PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
