### PR TITLE
xfail on h5md write nt test, more py3.6->3.7 changes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,7 +54,7 @@ jobs:
       pytest-xdist
       scikit-learn
       scipy
-      h5py
+      "h5py<3.4.0"
       tqdm
       threadpoolctl
     displayName: 'Install dependencies'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,9 +26,6 @@ jobs:
         Python37-32bit-full:
           PYTHON_VERSION: '3.7'
           PYTHON_ARCH: 'x86'
-        Python36-64bit-full:
-          PYTHON_VERSION: '3.6'
-          PYTHON_ARCH: 'x64'
         Python37-64bit-full:
           PYTHON_VERSION: '3.7'
           PYTHON_ARCH: 'x64'

--- a/package/MDAnalysis/due.py
+++ b/package/MDAnalysis/due.py
@@ -57,16 +57,7 @@ try:
     # https://github.com/MDAnalysis/mdanalysis/pull/1822#issuecomment-373009050
     import sys
     import os
-    if sys.version_info >= (3, 7):
-        import duecredit
-    else:
-        from unittest.mock import patch
-        if not os.name == 'nt':
-            with patch('os.fork') as os_dot_fork, patch('os.popen') as os_dot_popen:
-                import duecredit
-        else:
-            # Windows doesn't have os.fork
-            import duecredit
+    import duecredit
 
     from duecredit import due, BibTeX, Doi, Url
     if 'due' in locals() and not hasattr(due, 'cite'):

--- a/package/setup.py
+++ b/package/setup.py
@@ -56,8 +56,8 @@ import warnings
 import platform
 
 # Make sure I have the right Python version.
-if sys.version_info[:2] < (3, 6):
-    print('MDAnalysis requires Python 3.6 or better. Python {0:d}.{1:d} detected'.format(*
+if sys.version_info[:2] < (3, 7):
+    print('MDAnalysis requires Python 3.7 or better. Python {0:d}.{1:d} detected'.format(*
           sys.version_info[:2]))
     print('Please upgrade your version of Python.')
     sys.exit(-1)

--- a/testsuite/MDAnalysisTests/coordinates/test_h5md.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_h5md.py
@@ -2,6 +2,7 @@ import pytest
 from numpy.testing import assert_almost_equal, assert_equal
 import numpy as np
 import sys
+import os
 import MDAnalysis as mda
 from MDAnalysis.coordinates.H5MD import HAS_H5PY
 if HAS_H5PY:
@@ -381,8 +382,6 @@ class TestH5MDReaderWithRealTrajectory(object):
         assert_equal(u.trajectory._file.driver, "core")
 
 
-@pytest.mark.xfail(os.name == 'nt',
-                   reason="occasional PermissionError on windows")
 @pytest.mark.skipif(not HAS_H5PY, reason="h5py not installed")
 class TestH5MDWriterWithRealTrajectory(object):
 
@@ -746,6 +745,8 @@ class TestH5MDWriterWithRealTrajectory(object):
         assert_equal(dset.compression, filter)
         assert_equal(dset.compression_opts, opts)
 
+    @pytest.mark.xfail(os.name == 'nt',
+                       reason="occasional PermissionError on windows")
     @pytest.mark.parametrize('driver', ('core', 'stdio'))
     def test_write_with_drivers(self, universe, outfile, Writer, driver):
         with Writer(outfile,

--- a/testsuite/MDAnalysisTests/coordinates/test_h5md.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_h5md.py
@@ -745,8 +745,8 @@ class TestH5MDWriterWithRealTrajectory(object):
         assert_equal(dset.compression, filter)
         assert_equal(dset.compression_opts, opts)
 
-    @pytest.mark.xfail(os.name == 'nt',
-                       reason="occasional PermissionError on windows")
+#    @pytest.mark.xfail(os.name == 'nt',
+#                       reason="occasional PermissionError on windows")
     @pytest.mark.parametrize('driver', ('core', 'stdio'))
     def test_write_with_drivers(self, universe, outfile, Writer, driver):
         with Writer(outfile,

--- a/testsuite/MDAnalysisTests/coordinates/test_h5md.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_h5md.py
@@ -381,6 +381,8 @@ class TestH5MDReaderWithRealTrajectory(object):
         assert_equal(u.trajectory._file.driver, "core")
 
 
+@pytest.mark.xfail(os.name == 'nt',
+                   reason="occasional PermissionError on windows")
 @pytest.mark.skipif(not HAS_H5PY, reason="h5py not installed")
 class TestH5MDWriterWithRealTrajectory(object):
 

--- a/testsuite/setup.py
+++ b/testsuite/setup.py
@@ -78,8 +78,8 @@ class MDA_SDist(sdist.sdist):
 
 
 # Make sure I have the right Python version.
-if sys.version_info[:2] < (3, 6):
-    print("MDAnalysis requires Python 3.6 or better. "
+if sys.version_info[:2] < (3, 7):
+    print("MDAnalysis requires Python 3.7 or better. "
           "Python {0:d}.{1:d} detected".format(*sys.version_info[:2]))
     print("Please upgrade your version of Python.")
     sys.exit(-1)


### PR DESCRIPTION
Temporarily addresses #3406

Changes made in this Pull Request:
 - xfail on windows NT for `TestH5MDWriterWithRealTrajectory.test_write_with_drivers`
 - more py3.6 -> py3.7 changes


PR Checklist
------------
 - [x] Tests?
 - Docs?
 - CHANGELOG updated?
 - [x] Issue raised/referenced?
