### PR TITLE
Pbc dist bench

### DIFF
--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -21,7 +21,7 @@
 
     // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.
-    "pythons": ["3.7"],
+    "pythons": ["2.7"],
     // The matrix of dependencies to test.  Each key is the name of a
     // package (in PyPI) and the values are version numbers.  An empty
     // list indicates to just test against the default (latest)

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -21,7 +21,7 @@
 
     // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.
-    "pythons": ["2.7"],
+    "pythons": ["3.7"],
     // The matrix of dependencies to test.  Each key is the name of a
     // package (in PyPI) and the values are version numbers.  An empty
     // list indicates to just test against the default (latest)

--- a/benchmarks/benchmarks/analysis/distances.py
+++ b/benchmarks/benchmarks/analysis/distances.py
@@ -1,6 +1,12 @@
 import MDAnalysis
 import numpy as np
 
+
+try:
+    from MDAnalysis.lib import mdamath
+except:
+    pass
+
 try:
     from MDAnalysisTests.datafiles import GRO
 except:
@@ -18,10 +24,46 @@ class DistancesBench(object):
 
     # TODO: eventually we should include box / pbc
     # unit cell information in the benchmarks
-    params = (10, 100, 1000, 10000)
-    param_names = ['num_atoms']
+    temp_universe = MDAnalysis.Universe(GRO)
+    u = MDAnalysis.Universe(GRO)
+    tri_clinic_dimensions = u.dimensions
 
-    def setup(self, num_atoms):
+
+    params = ([10, 100, 1000, 10000], [None, 'orthogonal', 'triclinic'])
+    param_names = [ 'num_atoms','pbc_type']
+
+    def setup(self, num_atoms, pbc_type):
+
+        if pbc_type == None: 
+            self.u = MDAnalysis.Universe(GRO)
+            self.box_dims = None
+
+        elif pbc_type == 'orthogonal': 
+            self.u = MDAnalysis.Universe(GRO)
+            box_shape =  self.u.dimensions
+            basis_vectors = mdamath.triclinic_vectors(box_shape)
+
+            #this will calculate the furthest point from the origin on the unit cell.
+            furthest_point = np.sum(basis_vectors, axis = 0)
+            #get full size of cube and also deal with certain distance functions requiring float32
+            orthogonal_box_size = np.float32(np.max(furthest_point))
+            angle=np.float32(90.0)
+            
+            #make dummy cubic box, must be np.array, does not accept list
+            self.box_dims = np.array([orthogonal_box_size,orthogonal_box_size,orthogonal_box_size,angle,angle,angle])
+
+        elif pbc_type == 'triclinic': 
+            self.u = MDAnalysis.Universe(GRO)
+            print(self.u.dimensions)
+            self.box_dims = self.u.dimensions
+
+        else:
+            raise Exception("You must specify 'orthogonal', 'triclinic', or None for the box type")
+
+        self.ag1 = self.u.atoms[:num_atoms]
+        self.ag2 = self.u.atoms[num_atoms: 2 * num_atoms]
+        self.ag3 = self.u.atoms[-num_atoms:]
+
         np.random.seed(17809)
         self.coords_1 = np.random.random_sample((num_atoms, 3)).astype(np.float32)
         np.random.seed(9008716)
@@ -31,23 +73,19 @@ class DistancesBench(object):
         self.array_shape_1D = int(num_atoms * (num_atoms - 1) / 2.)
         self.allocated_array_1D = np.empty(self.array_shape_1D,
                                            dtype=np.float64)
-        self.u = MDAnalysis.Universe(GRO)
-        self.ag1 = self.u.atoms[:num_atoms]
-        self.ag2 = self.u.atoms[num_atoms: 2 * num_atoms]
-        self.ag3 = self.u.atoms[-num_atoms:]
 
-    def time_distance_array(self, num_atoms):
+    def time_distance_array(self, num_atoms, pbc_type):
         """Benchmark calculation of all distances
         between two numpy arrays of coordinates,
         using default arguments to distance_array.
         """
         distances.distance_array(reference=self.coords_1,
                                  configuration=self.coords_2,
-                                 box=None,
+                                 box=self.box_dims,
                                  result=None,
                                  backend='serial')
 
-    def time_distance_array_pre_allocated(self, num_atoms):
+    def time_distance_array_pre_allocated(self, num_atoms, pbc_type):
         """Benchmark calculation of all distances
         between two numpy arrays of coordinates,
         using distance_array with a preallocated
@@ -55,32 +93,119 @@ class DistancesBench(object):
         """
         distances.distance_array(reference=self.coords_1,
                                  configuration=self.coords_2,
-                                 box=None,
+                                 box=self.box_dims,
                                  result=self.allocated_array_2D,
                                  backend='serial')
 
-    def time_self_distance_array(self, num_atoms):
+    def time_self_distance_array(self, num_atoms, pbc_type):
         """Benchmark calculation of all distances
         within a single numpy array of coordinates
         using default parameters to self_distance_array.
         """
         distances.self_distance_array(reference=self.coords_1,
-                                      box=None,
+                                      box=self.box_dims,
                                       result=None,
                                       backend='serial')
 
-    def time_self_distance_array_pre_allocated(self, num_atoms):
+    def time_self_distance_array_pre_allocated(self, num_atoms, pbc_type):
         """Benchmark calculation of all distances
         within a single numpy array of coordinates
         using self_distance_array with preallocated
         result array.
         """
         distances.self_distance_array(reference=self.coords_1,
-                                      box=None,
+                                      box=self.box_dims,
                                       result=self.allocated_array_1D,
                                       backend='serial')
 
-    def time_contact_matrix(self, num_atoms):
+
+    def time_dist(self, num_atoms, box_dims):
+        """Benchmark calculation of distances between
+        atoms in two atomgroups with no offsets
+        to resids.
+        """
+        distances.dist(A=self.ag1,
+                       B=self.ag2,
+                       box=self.box_dims,
+                       offset=0)
+
+    def time_dist_offsets(self, num_atoms, box_dims):
+        """Benchmark calculation of distances between
+        atoms in two atomgroups with offsets
+        to resids.
+        """
+        distances.dist(A=self.ag1,
+                       B=self.ag2,
+                       box=self.box_dims,
+                       offset=20)
+
+    def time_between(self, num_atoms,box_dims):
+        """Benchmark determination of subgroup
+        of atomgroup that is within a specific
+        distance of two other atomgroups.
+        """
+        distances.between(group=self.ag3,
+                          A=self.ag1,
+                          B=self.ag2, 
+                          distance=15.0)
+
+class ContactsBench(object):
+    """Benchmarks for MDAnalysis.analysis.distances
+    functions.
+    """
+
+    # TODO: eventually we should include box / pbc
+    # unit cell information in the benchmarks
+    temp_universe = MDAnalysis.Universe(GRO)
+    u = MDAnalysis.Universe(GRO)
+    tri_clinic_dimensions = u.dimensions
+
+
+    params = ([10, 100, 1000], [None, 'orthogonal', 'triclinic'])
+    param_names = [ 'num_atoms','pbc_type']
+
+    def setup(self, num_atoms, pbc_type):
+
+        if pbc_type == None: 
+            self.u = MDAnalysis.Universe(GRO)
+            self.box_dims = None
+
+        elif pbc_type == 'orthogonal': 
+            self.u = MDAnalysis.Universe(GRO)
+            box_shape =  self.u.dimensions
+            basis_vectors = mdamath.triclinic_vectors(box_shape)
+
+            #this will calculate the furthest point from the origin on the unit cell.
+            furthest_point = np.sum(basis_vectors, axis = 0)
+            #get full size of cube and also deal with certain distance functions requiring float32
+            orthogonal_box_size = np.float32(np.max(furthest_point))
+            angle=np.float32(90.0)
+            
+            #make dummy cubic box, must be np.array, does not accept list
+            self.box_dims = np.array([orthogonal_box_size, orthogonal_box_size, orthogonal_box_size, angle, angle, angle])
+
+        elif pbc_type == 'triclinic': 
+            self.u = MDAnalysis.Universe(GRO)
+            print(self.u.dimensions)
+            self.box_dims = self.u.dimensions
+        else:
+            raise Exception("You must specify 'orthogonal', 'triclinic', or None for the box type")
+
+        self.ag1 = self.u.atoms[:num_atoms]
+        self.ag2 = self.u.atoms[num_atoms: 2 * num_atoms]
+        self.ag3 = self.u.atoms[-num_atoms:]
+
+        np.random.seed(17809)
+        self.coords_1 = np.random.random_sample((num_atoms, 3)).astype(np.float32)
+        np.random.seed(9008716)
+        self.coords_2 = np.random.random_sample((num_atoms, 3)).astype(np.float32)
+        self.allocated_array_2D = np.empty((num_atoms, num_atoms),
+                                            dtype=np.float64)
+        self.array_shape_1D = int(num_atoms * (num_atoms - 1) / 2.)
+        self.allocated_array_1D = np.empty(self.array_shape_1D,
+                                           dtype=np.float64)
+
+    def time_contact_matrix(self, num_atoms, pbc_type):
         """Benchmark calculation of contacts within
         a single numpy array using the default arguments
         to contact_matrix.
@@ -88,9 +213,9 @@ class DistancesBench(object):
         distances.contact_matrix(coord=self.coords_1,
                                  cutoff=15.0,
                                  returntype='numpy',
-                                 box=None)
+                                 box=self.box_dims)
 
-    def time_contact_matrix_sparse(self, num_atoms):
+    def time_contact_matrix_sparse(self, num_atoms, box_dims):
         """Benchmark calculation of contacts within
         a single numpy array using the slower reduced
         memory implementation of contact_matrix intended
@@ -99,32 +224,5 @@ class DistancesBench(object):
         distances.contact_matrix(coord=self.coords_1,
                                  cutoff=15.0,
                                  returntype='sparse',
-                                 box=None)
+                                 box=self.box_dims)
 
-    def time_dist(self, num_atoms):
-        """Benchmark calculation of distances between
-        atoms in two atomgroups with no offsets
-        to resids.
-        """
-        distances.dist(A=self.ag1,
-                       B=self.ag2,
-                       offset=0)
-
-    def time_dist_offsets(self, num_atoms):
-        """Benchmark calculation of distances between
-        atoms in two atomgroups with offsets
-        to resids.
-        """
-        distances.dist(A=self.ag1,
-                       B=self.ag2,
-                       offset=20)
-
-    def time_between(self, num_atoms):
-        """Benchmark determination of subgroup
-        of atomgroup that is within a specific
-        distance of two other atomgroups.
-        """
-        distances.between(group=self.ag3,
-                          A=self.ag1,
-                          B=self.ag2,
-                          distance=15.0)

--- a/benchmarks/benchmarks/analysis/distances.py
+++ b/benchmarks/benchmarks/analysis/distances.py
@@ -22,8 +22,6 @@ class BetweenBench(object):
     """Benchmark for the MDAnalysis.analysis.distances.between
     function.
     """
-    u = MDAnalysis.Universe(GRO)
-    tri_clinic_dimensions = u.dimensions
 
     params = ([10, 100, 1000, 10000])
     param_names = (['num_atoms'])
@@ -61,9 +59,6 @@ class DistancesBench(object):
     """Benchmarks for MDAnalysis.analysis.distances
     functions. Excluding contact matrices.
     """
-    u = MDAnalysis.Universe(GRO)
-    tri_clinic_dimensions = u.dimensions
-
     params = ([10, 100, 1000, 10000], [None, 'orthogonal', 'triclinic'])
     param_names = ['num_atoms', 'pbc_type']
 
@@ -86,7 +81,8 @@ class DistancesBench(object):
             orthogonal_box_size = np.float32(np.max(furthest_point))
             angle = np.float32(90.0)
 
-            # make dummy cubic box, must be np.array, does not accept list
+            # make dummy cubic box, must be np.array, distance functions do
+            # not accept list
             self.box_dims = np.array([orthogonal_box_size,
                                       orthogonal_box_size,
                                       orthogonal_box_size,
@@ -94,9 +90,6 @@ class DistancesBench(object):
 
         elif pbc_type == 'triclinic':
             self.box_dims = self.u.dimensions
-
-        else:
-            raise Exception("Specify only 'orthogonal', 'triclinic', or None for the box type")
 
         self.ag1 = self.u.atoms[:num_atoms]
         self.ag2 = self.u.atoms[num_atoms: 2 * num_atoms]
@@ -181,9 +174,6 @@ class ContactsBench(object):
     """Benchmarks for the MDAnalysis.analysis.distances.contact_matrix
     function in both default and sparse settings.
     """
-    u = MDAnalysis.Universe(GRO)
-    tri_clinic_dimensions = u.dimensions
-
     params = ([10, 100, 1000], [None, 'orthogonal', 'triclinic'])
     param_names = ['num_atoms', 'pbc_type']
 
@@ -209,7 +199,7 @@ class ContactsBench(object):
             orthogonal_box_size = np.float32(np.max(furthest_point))
             angle = np.float32(90.0)
 
-            # make dummy cubic box, must be np.array, some functions do
+            # make dummy cubic box, must be np.array, distance functions do
             # not accept list
             self.box_dims = np.array([orthogonal_box_size,
                                       orthogonal_box_size,
@@ -220,8 +210,6 @@ class ContactsBench(object):
             self.u = MDAnalysis.Universe(GRO)
             print(self.u.dimensions)
             self.box_dims = self.u.dimensions
-        else:
-            raise Exception("Specify only 'orthogonal', 'triclinic', or None for the box type")
 
         self.ag1 = self.u.atoms[:num_atoms]
         self.ag2 = self.u.atoms[num_atoms: 2 * num_atoms]

--- a/benchmarks/benchmarks/analysis/distances.py
+++ b/benchmarks/benchmarks/analysis/distances.py
@@ -17,13 +17,13 @@ try:
 except:
     pass
 
+
 class BetweenBench(object):
     """Benchmark for the MDAnalysis.analysis.distances.between
     function.
     """
     u = MDAnalysis.Universe(GRO)
     tri_clinic_dimensions = u.dimensions
-
 
     params = ([10, 100, 1000, 10000])
     param_names = (['num_atoms'])
@@ -41,11 +41,10 @@ class BetweenBench(object):
         np.random.seed(9008716)
         self.coords_2 = np.random.random_sample((num_atoms, 3)).astype(np.float32)
         self.allocated_array_2D = np.empty((num_atoms, num_atoms),
-                                            dtype=np.float64)
+                                           dtype=np.float64)
         self.array_shape_1D = int(num_atoms * (num_atoms - 1) / 2.)
         self.allocated_array_1D = np.empty(self.array_shape_1D,
                                            dtype=np.float64)
-
 
     def time_between(self, num_atoms):
         """Benchmark determination of subgroup
@@ -54,8 +53,9 @@ class BetweenBench(object):
         """
         distances.between(group=self.ag3,
                           A=self.ag1,
-                          B=self.ag2, 
+                          B=self.ag2,
                           distance=15.0)
+
 
 class DistancesBench(object):
     """Benchmarks for MDAnalysis.analysis.distances
@@ -64,35 +64,39 @@ class DistancesBench(object):
     u = MDAnalysis.Universe(GRO)
     tri_clinic_dimensions = u.dimensions
 
-
     params = ([10, 100, 1000, 10000], [None, 'orthogonal', 'triclinic'])
-    param_names = [ 'num_atoms','pbc_type']
+    param_names = ['num_atoms', 'pbc_type']
 
     def setup(self, num_atoms, pbc_type):
 
         self.u = MDAnalysis.Universe(GRO)
 
-        if pbc_type == None: 
+        if pbc_type is None:
             self.box_dims = None
 
-        elif pbc_type == 'orthogonal': 
-            box_shape =  self.u.dimensions
+        elif pbc_type == 'orthogonal':
+            box_shape = self.u.dimensions
             basis_vectors = mdamath.triclinic_vectors(box_shape)
 
-            #this will calculate the furthest point from the origin on the unit cell.
-            furthest_point = np.sum(basis_vectors, axis = 0)
-            #get full size of cube and also deal with certain distance functions requiring float32
+            # this will calculate the furthest point from the origin on
+            # the triclinic unit cell.
+            furthest_point = np.sum(basis_vectors, axis=0)
+            # get full size of cube and also deal with certain distance
+            # functions requiring float32
             orthogonal_box_size = np.float32(np.max(furthest_point))
-            angle=np.float32(90.0)
-            
-            #make dummy cubic box, must be np.array, does not accept list
-            self.box_dims = np.array([orthogonal_box_size,orthogonal_box_size,orthogonal_box_size,angle,angle,angle])
+            angle = np.float32(90.0)
 
-        elif pbc_type == 'triclinic': 
+            # make dummy cubic box, must be np.array, does not accept list
+            self.box_dims = np.array([orthogonal_box_size,
+                                      orthogonal_box_size,
+                                      orthogonal_box_size,
+                                      angle, angle, angle])
+
+        elif pbc_type == 'triclinic':
             self.box_dims = self.u.dimensions
 
         else:
-            raise Exception("You must specify 'orthogonal', 'triclinic', or None for the box type")
+            raise Exception("Specify only 'orthogonal', 'triclinic', or None for the box type")
 
         self.ag1 = self.u.atoms[:num_atoms]
         self.ag2 = self.u.atoms[num_atoms: 2 * num_atoms]
@@ -103,7 +107,7 @@ class DistancesBench(object):
         np.random.seed(9008716)
         self.coords_2 = np.random.random_sample((num_atoms, 3)).astype(np.float32)
         self.allocated_array_2D = np.empty((num_atoms, num_atoms),
-                                            dtype=np.float64)
+                                           dtype=np.float64)
         self.array_shape_1D = int(num_atoms * (num_atoms - 1) / 2.)
         self.allocated_array_1D = np.empty(self.array_shape_1D,
                                            dtype=np.float64)
@@ -152,7 +156,6 @@ class DistancesBench(object):
                                       result=self.allocated_array_1D,
                                       backend='serial')
 
-
     def time_dist(self, num_atoms, box_dims):
         """Benchmark calculation of distances between
         atoms in two atomgroups with no offsets
@@ -173,6 +176,7 @@ class DistancesBench(object):
                        box=self.box_dims,
                        offset=20)
 
+
 class ContactsBench(object):
     """Benchmarks for the MDAnalysis.analysis.distances.contact_matrix
     function in both default and sparse settings.
@@ -181,36 +185,43 @@ class ContactsBench(object):
     tri_clinic_dimensions = u.dimensions
 
     params = ([10, 100, 1000], [None, 'orthogonal', 'triclinic'])
-    param_names = [ 'num_atoms','pbc_type']
+    param_names = ['num_atoms', 'pbc_type']
 
     def setup(self, num_atoms, pbc_type):
 
-        if pbc_type == None: 
+        if pbc_type is None:
             self.u = MDAnalysis.Universe(GRO)
             self.box_dims = None
 
-        elif pbc_type == 'orthogonal': 
-            #some strange math/type 
+        elif pbc_type == 'orthogonal':
+            # Some strange math/type issues. Essentially we create the smallest
+            # cubic box which encloses the triclinic unit cell.
             self.u = MDAnalysis.Universe(GRO)
-            box_shape =  self.u.dimensions
+            box_shape = self.u.dimensions
             basis_vectors = mdamath.triclinic_vectors(box_shape)
 
-            #this will calculate the furthest point from the origin on the unit cell.
-            furthest_point = np.sum(basis_vectors, axis = 0)
+            # This will calculate the furthest point from the origin on the
+            # triclinic unit cell.
+            furthest_point = np.sum(basis_vectors, axis=0)
 
-            #get full size of cube and deal with certain distance functions requiring float32
+            # Get full size of cube and deal with certain distance functions
+            # requiring float32.
             orthogonal_box_size = np.float32(np.max(furthest_point))
-            angle=np.float32(90.0)
-            
-            #make dummy cubic box, must be np.array, does not accept list
-            self.box_dims = np.array([orthogonal_box_size, orthogonal_box_size, orthogonal_box_size, angle, angle, angle])
+            angle = np.float32(90.0)
 
-        elif pbc_type == 'triclinic': 
+            # make dummy cubic box, must be np.array, some functions do
+            # not accept list
+            self.box_dims = np.array([orthogonal_box_size,
+                                      orthogonal_box_size,
+                                      orthogonal_box_size,
+                                      angle, angle, angle])
+
+        elif pbc_type == 'triclinic':
             self.u = MDAnalysis.Universe(GRO)
             print(self.u.dimensions)
             self.box_dims = self.u.dimensions
         else:
-            raise Exception("You must specify 'orthogonal', 'triclinic', or None for the box type")
+            raise Exception("Specify only 'orthogonal', 'triclinic', or None for the box type")
 
         self.ag1 = self.u.atoms[:num_atoms]
         self.ag2 = self.u.atoms[num_atoms: 2 * num_atoms]
@@ -221,7 +232,7 @@ class ContactsBench(object):
         np.random.seed(9008716)
         self.coords_2 = np.random.random_sample((num_atoms, 3)).astype(np.float32)
         self.allocated_array_2D = np.empty((num_atoms, num_atoms),
-                                            dtype=np.float64)
+                                           dtype=np.float64)
         self.array_shape_1D = int(num_atoms * (num_atoms - 1) / 2.)
         self.allocated_array_1D = np.empty(self.array_shape_1D,
                                            dtype=np.float64)
@@ -246,4 +257,3 @@ class ContactsBench(object):
                                  cutoff=15.0,
                                  returntype='sparse',
                                  box=self.box_dims)
-


### PR DESCRIPTION
Fixes #3206 and #2794

Changes made in this Pull Request:
 - Added, for relevant functions, benchmarks for testing orthogona and triclinic 
 - PBC settings
 - Also removed 10000 atom benchmarks for contact matrix
functions to avoid timeout failiures.

Had to split the DistancesBench class into 3 classes to avoid
failiures and uncessary reruns of the benchmark. These failiures
were due to time outs when too many atoms were run in the
benchmarks or distances.between not taking box type as an argument.
The latter case meant, to avoid failiure, we had to either split
the classes out or run redundant benchmarks. I chose the latter
and created BetweenBench.

The 3 classes and the distribution of testing functions is

BetweenBench
   - time_between
DistancesBench
   - time_distance_array
   - time_distance_array_pre_allocated
   - time_self_distance_array
   - time_self_distance_array_pre_allocated
   - time_dist
   - time_dist_offsets
ContactsBench
   - time_contact_matrix
   - time_contact_matrix_sparse

Splitting the classes like this was necessary because asv does not
allow us to easily skip certain combinations of parameters at the
function level, only in the setup()
function of the class.


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
