### PR TITLE
Update docs for in-memory trajectory to match new AnalysisFromFunction API

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -168,6 +168,7 @@ Chronological list of authors
   - Sulay Shah
   - Alexander Yang
   - Filip T. Szczypiński
+  - Marcelo C. R. Melo
 
 
 External code

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,7 +13,7 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-??/??/?? IAlibay
+??/??/?? IAlibay, melomcr
 
  * 2.1.0
 

--- a/package/MDAnalysis/coordinates/memory.py
+++ b/package/MDAnalysis/coordinates/memory.py
@@ -127,7 +127,7 @@ same functionality for any supported trajectory format::
   u = mda.Universe(PDB, XTC)
 
   coordinates = AnalysisFromFunction(lambda ag: ag.positions.copy(),
-                                     u.atoms).run().results
+                                     u.atoms).run().results['timeseries']
   u2 = mda.Universe(PDB, coordinates, format=MemoryReader)
 
 .. _creating-in-memory-trajectory-label:
@@ -154,7 +154,7 @@ only the protein is created::
   protein = u.select_atoms("protein")
 
   coordinates = AnalysisFromFunction(lambda ag: ag.positions.copy(),
-                                     protein).run().results
+                                     protein).run().results['timeseries']
   u2 = mda.Merge(protein)            # create the protein-only Universe
   u2.load_new(coordinates, format=MemoryReader)
 
@@ -164,7 +164,7 @@ principle, this could have all be done in one line::
 
   u2 = mda.Merge(protein).load_new(
            AnalysisFromFunction(lambda ag: ag.positions.copy(),
-                                protein).run().results,
+                                protein).run().results['timeseries'],
            format=MemoryReader)
 
 The new :class:`~MDAnalysis.core.universe.Universe` ``u2`` can be used


### PR DESCRIPTION
The example code in the docs for creating in-memory trajectories is outdated for MDAnalysis version 2.0.0.

The new AnalysisFromFunction API does not return a numpy.ndarray with
coordinates anymore, but returns a dictionary with three elements:
timeseries, frames, and times. Therefore, the example was updated
to select the timeseries key from the AnalysisFromFunction results object.

Fixes #3412

Changes made in this Pull Request:
 - Updated documentation for MDAnalysis.coordinates.memory 
