### PR TITLE
[MAINT] removed --py3k argument for pylint

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -311,7 +311,7 @@ jobs:
       env:
         PYLINTRC: package/.pylintrc
       run: |
-        pylint --py3k package/MDAnalysis && pylint --py3k testsuite/MDAnalysisTests
+        pylint package/MDAnalysis && pylint testsuite/MDAnalysisTests
 
 
   pypi_check:

--- a/package/MDAnalysis/converters/RDKit.py
+++ b/package/MDAnalysis/converters/RDKit.py
@@ -452,7 +452,7 @@ def set_converter_cache_size(maxsize):
         conversions in memory. Using ``maxsize=None`` will remove all limits
         to the cache size, i.e. everything is cached.
     """
-    global atomgroup_to_mol
+    global atomgroup_to_mol   # pylint: disable=global-statement
     atomgroup_to_mol = lru_cache(maxsize=maxsize)(atomgroup_to_mol.__wrapped__)
 
 
@@ -638,7 +638,7 @@ def _standardize_patterns(mol, max_iter=200):
     +---------------+------------------------------------------------------------------------------+
     | nitro         | ``[N;X3;v3:1](-[O-;X1:2])-[O-;X1:3]>>[N+:1](-[O-:2])=[O+0:3]``               |
     +---------------+------------------------------------------------------------------------------+
- 
+
     """
 
     # standardize conjugated systems

--- a/package/MDAnalysis/coordinates/null.py
+++ b/package/MDAnalysis/coordinates/null.py
@@ -60,4 +60,3 @@ class NullWriter(base.WriterBase):
         except AttributeError:
             errmsg = "Input obj is neither an AtomGroup or Universe"
             raise TypeError(errmsg) from None
-        pass

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -2343,7 +2343,6 @@ class _ConnectionTopologyAttrMeta(_TopologyAttrMeta):
     to return only the connections within the atoms in the group.
     """
     def __init__(cls, name, bases, classdict):
-        type.__init__(type, name, bases, classdict)
         attrname = classdict.get('attrname')
 
         if attrname is not None:

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -2343,6 +2343,8 @@ class _ConnectionTopologyAttrMeta(_TopologyAttrMeta):
     to return only the connections within the atoms in the group.
     """
     def __init__(cls, name, bases, classdict):
+        super().__init__(name, bases, classdict)
+
         attrname = classdict.get('attrname')
 
         if attrname is not None:
@@ -2354,8 +2356,6 @@ class _ConnectionTopologyAttrMeta(_TopologyAttrMeta):
             method = MethodType(intra_connection, cls)
             prop = property(method, None, None, method.__doc__)
             cls.transplants[AtomGroup].append((f"intra_{attrname}", prop))
-
-        super().__init__(name, bases, classdict)
 
 
 class _Connection(AtomAttr, metaclass=_ConnectionTopologyAttrMeta):

--- a/testsuite/MDAnalysisTests/coordinates/test_timestep_api.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_timestep_api.py
@@ -439,7 +439,7 @@ class TestTimestep(object):
     def test_copy(self, func, ts):
         if self.uni_args is None:
             return
-        u = mda.Universe(*self.uni_args)
+        u = mda.Universe(*self.uni_args)  # pylint: disable=not-an-iterable
         ts = u.trajectory.ts
         func(self, self.name, ts)
 

--- a/testsuite/MDAnalysisTests/lib/test_util.py
+++ b/testsuite/MDAnalysisTests/lib/test_util.py
@@ -49,15 +49,9 @@ from MDAnalysisTests.datafiles import (
 
 def test_absence_cutil():
     with patch.dict('sys.modules', {'MDAnalysis.lib._cutil':None}):
-        #http://docs.python.org/library/sys.html#sys.hexversion
-        if sys.hexversion <= 0x03030000:
-            import imp
-            with pytest.raises(ImportError):
-                imp.reload(sys.modules['MDAnalysis.lib.util'])
-        else:
-            import importlib
-            with pytest.raises(ImportError):
-                importlib.reload(sys.modules['MDAnalysis.lib.util'])
+        import importlib
+        with pytest.raises(ImportError):
+            importlib.reload(sys.modules['MDAnalysis.lib.util'])
 
 def test_presence_cutil():
     mock = Mock()


### PR DESCRIPTION
Fixes #3422

Changes made in this Pull Request:
- removed `pylint --py3k` option from GH CI workflow (pylint is not used in Azure or Travis) 
- py3k checker was removed in pylint 2.11
  https://pylint.pycqa.org/en/latest/whatsnew/2.11.html#removed-checkers


PR Checklist
------------
 - n/a Tests?
 - n/a Docs?
 - n/a CHANGELOG updated?
 - [x] Issue raised/referenced?
