### PR TITLE
Fix arch option in setup.py to work properly + not trigger on MSVC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
       name: "Power PC"
       os: linux
       arch: ppc64le
-      if: type = cron
+      #if: type = cron
       before_install:
         - wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-ppc64le.sh -O miniconda.sh
         - mkdir $HOME/.conda
@@ -42,7 +42,7 @@ matrix:
       dist: focal
       virt: vm
       group: edge
-      if: type = cron
+      #if: type = cron
       before_install:
         - python -m pip install cython "numpy>=1.19.2" scipy
         - python -m pip install --no-build-isolation hypothesis matplotlib pytest pytest-cov pytest-xdist tqdm threadpoolctl

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
       name: "Power PC"
       os: linux
       arch: ppc64le
-      #if: type = cron
+      if: type = cron
       before_install:
         - wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-ppc64le.sh -O miniconda.sh
         - mkdir $HOME/.conda
@@ -42,7 +42,7 @@ matrix:
       dist: focal
       virt: vm
       group: edge
-      #if: type = cron
+      if: type = cron
       before_install:
         - python -m pip install cython "numpy>=1.19.2" scipy
         - python -m pip install --no-build-isolation hypothesis matplotlib pytest pytest-cov pytest-xdist tqdm threadpoolctl

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,7 +13,7 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-??/??/?? IAlibay, melomcr, mdd31 
+??/??/?? hmacdope, IAlibay, melomcr, mdd31 
 
  * 2.1.0
 
@@ -21,6 +21,8 @@ Fixes
   * Fix ITPParser charge reading (Issue #3419).
   
 Enhancements
+  * Add option for custom compiler flags for C/C++ on build and remove march
+    option from setup.cfg (Issue #3428, PR #3429).
 
 Changes
   * Dropped python 3.6 support and raised minimum numpy version to 1.18.0

--- a/package/setup.cfg
+++ b/package/setup.cfg
@@ -7,7 +7,7 @@
 #use_cython=False
 #keep_cythonized=True
 ## enable cpu specific optimizations
-#march="native"
+#march=native
 [wheel]
 universal = 1
 

--- a/package/setup.cfg
+++ b/package/setup.cfg
@@ -6,8 +6,8 @@
 ## Uncomment the following two lines to get the _release_ behavior.
 #use_cython=False
 #keep_cythonized=True
-## enable cpu specific optimizations
-march=native
+## any additional compiler flags
+#extra_cflags = 
 [wheel]
 universal = 1
 

--- a/package/setup.cfg
+++ b/package/setup.cfg
@@ -6,7 +6,7 @@
 ## Uncomment the following two lines to get the _release_ behavior.
 #use_cython=False
 #keep_cythonized=True
-## any additional compiler flags
+## any additional compiler flags for core C routines, excluding ENCORE
 #extra_cflags = 
 [wheel]
 universal = 1

--- a/package/setup.cfg
+++ b/package/setup.cfg
@@ -7,7 +7,7 @@
 #use_cython=False
 #keep_cythonized=True
 ## enable cpu specific optimizations
-#march=native
+march=native
 [wheel]
 universal = 1
 

--- a/package/setup.py
+++ b/package/setup.py
@@ -296,26 +296,14 @@ def extensions(config):
     else:
         encore_compile_args.append('-O3')
 
-    # allow using architecture specific instructions. This allows people to
-    # build optimized versions of MDAnalysis. Do here so not included in encore
-    arch = config.get('march', default=False)
-    if arch:
-        if using_msvc():
-            # MSVC doesn't have a good equivalent for the march flag
-            pass
-        else:
-            if platform.machine() == 'x86_64':
-                extra_compile_args.append('-march={}'.format(arch))
-            elif platform.machine() == 'arm':
-                # arm prefers the use of  mcpu only
-                extra_compile_args.append('-mcpu={}'.format(arch))
-            elif platform.machine() == 'ppc64le':
-                # PowerPC prefers the use of mcpu and mtune
-                extra_compile_args.append('-mcpu={}'.format(arch))
-                extra_compile_args.append('-mtune={}'.format(arch))
-            else:
-                # platform specific optimizations skipped
-                pass
+    # allow using custom c/c++ flags and architecture specific instructions.
+    # This allows people to build optimized versions of MDAnalysis.
+    # Do here so not included in encore
+    extra_cflags = config.get('extra_cflags', default=False)
+    if extra_cflags:
+        flags = extra_cflags.split()
+        for flag in flags:
+            extra_compile_args.append(flag)
 
     cpp_extra_compile_args = [a for a in extra_compile_args if 'std' not in a]
     cpp_extra_compile_args.append('-std=c++11')

--- a/package/setup.py
+++ b/package/setup.py
@@ -307,7 +307,7 @@ def extensions(config):
         else:
             if platform.machine() == "x86_64":
                 extra_compile_args.append('-march={}'.format(arch))
-            elif: platform.machine == "arm":
+            elif platform.machine == "arm":
             `   # arm prefers the use of  mcpu only
                 extra_compile_args.append('-mcpu={}'.format(arch))
             else:

--- a/package/setup.py
+++ b/package/setup.py
@@ -307,7 +307,7 @@ def extensions(config):
         else:
             if platform.machine() == "x86_64":
                 extra_compile_args.append('-march={}'.format(arch))
-            elif platform.machine == "arm":
+            elif platform.machine() == "arm":
                 # arm prefers the use of  mcpu only
                 extra_compile_args.append('-mcpu={}'.format(arch))
             else:

--- a/package/setup.py
+++ b/package/setup.py
@@ -310,8 +310,8 @@ def extensions(config):
                 # arm prefers the use of  mcpu only
                 extra_compile_args.append('-mcpu={}'.format(arch))
             elif platform.machine() == 'ppc64le':
-                #PowerPC prefers the use of mcpu and mtune
-                extra_compile_args.append('-mcpu={}'.format(arch))        
+                # PowerPC prefers the use of mcpu and mtune
+                extra_compile_args.append('-mcpu={}'.format(arch))
                 extra_compile_args.append('-mtune={}'.format(arch))
             else:
                 # platform specific optimizations skipped

--- a/package/setup.py
+++ b/package/setup.py
@@ -46,7 +46,6 @@ Google groups forbids any name that contains the string `anal'.)
 from setuptools import setup, Extension, find_packages
 from distutils.ccompiler import new_compiler
 from distutils.sysconfig import customize_compiler
-from distutils.msvccompiler import MSVCCompiler
 import codecs
 import os
 import sys

--- a/package/setup.py
+++ b/package/setup.py
@@ -305,7 +305,15 @@ def extensions(config):
             # MSVC doesn't have a good equivalent for the march flag
             pass
         else:
-            extra_compile_args.append('-march={}'.format(arch))
+            if platform.machine() == "x86_64":
+                extra_compile_args.append('-march={}'.format(arch))
+            elif: platform.machine == "arm":
+            `   # arm prefers the use of  mcpu only
+                extra_compile_args.append('-mcpu={}'.format(arch))
+            else:
+                # platform specific optimizations skipped
+                pass
+            
 
     cpp_extra_compile_args = [a for a in extra_compile_args if 'std' not in a]
     cpp_extra_compile_args.append('-std=c++11')

--- a/package/setup.py
+++ b/package/setup.py
@@ -268,13 +268,6 @@ def using_clang():
     return is_clang
 
 
-def using_msvc():
-    """Will we be using an MSVC compiler?"""
-    # from numpy.random setup.py
-    is_msvc = (platform.platform().startswith('Windows') and
-               platform.python_compiler().startswith('MS'))
-    return is_msvc
-
 def extensions(config):
     # usually (except coming from release tarball) cython files must be generated
     use_cython = config.get('use_cython', default=cython_found)
@@ -302,8 +295,7 @@ def extensions(config):
     extra_cflags = config.get('extra_cflags', default=False)
     if extra_cflags:
         flags = extra_cflags.split()
-        for flag in flags:
-            extra_compile_args.append(flag)
+        extra_compile_args.extend(flags)
 
     cpp_extra_compile_args = [a for a in extra_compile_args if 'std' not in a]
     cpp_extra_compile_args.append('-std=c++11')

--- a/package/setup.py
+++ b/package/setup.py
@@ -267,11 +267,12 @@ def using_clang():
         is_clang = False
     return is_clang
 
+
 def using_msvc():
     """Will we be using an MSVC compiler?"""
     # from numpy.random setup.py
     is_msvc = (platform.platform().startswith('Windows') and
-        platform.python_compiler().startswith('MS'))
+               platform.python_compiler().startswith('MS'))
     return is_msvc
 
 def extensions(config):
@@ -285,8 +286,6 @@ def extensions(config):
     if config.get('debug_cflags', default=False):
         extra_compile_args.extend(['-Wall', '-pedantic'])
         define_macros.extend([('DEBUG', '1')])
-
-
 
     # encore is sensitive to floating point accuracy, especially on non-x86
     # to avoid reducing optimisations on everything, we make a set of compile
@@ -305,15 +304,18 @@ def extensions(config):
             # MSVC doesn't have a good equivalent for the march flag
             pass
         else:
-            if platform.machine() == "x86_64":
+            if platform.machine() == 'x86_64':
                 extra_compile_args.append('-march={}'.format(arch))
-            elif platform.machine() == "arm":
+            elif platform.machine() == 'arm':
                 # arm prefers the use of  mcpu only
                 extra_compile_args.append('-mcpu={}'.format(arch))
+            elif platform.machine() == 'ppc64le':
+                #PowerPC prefers the use of mcpu and mtune
+                extra_compile_args.append('-mcpu={}'.format(arch))        
+                extra_compile_args.append('-mtune={}'.format(arch))
             else:
                 # platform specific optimizations skipped
                 pass
-            
 
     cpp_extra_compile_args = [a for a in extra_compile_args if 'std' not in a]
     cpp_extra_compile_args.append('-std=c++11')

--- a/package/setup.py
+++ b/package/setup.py
@@ -308,7 +308,7 @@ def extensions(config):
             if platform.machine() == "x86_64":
                 extra_compile_args.append('-march={}'.format(arch))
             elif platform.machine == "arm":
-            `   # arm prefers the use of  mcpu only
+                # arm prefers the use of  mcpu only
                 extra_compile_args.append('-mcpu={}'.format(arch))
             else:
                 # platform specific optimizations skipped

--- a/package/setup.py
+++ b/package/setup.py
@@ -46,6 +46,7 @@ Google groups forbids any name that contains the string `anal'.)
 from setuptools import setup, Extension, find_packages
 from distutils.ccompiler import new_compiler
 from distutils.sysconfig import customize_compiler
+from distutils.msvccompiler import MSVCCompiler
 import codecs
 import os
 import sys
@@ -267,6 +268,16 @@ def using_clang():
         is_clang = False
     return is_clang
 
+def using_msvc():
+    """Will we be using an MSVC compiler?"""
+    # how portable is this?
+    compiler = new_compiler()
+    customize_compiler(compiler)
+    if isinstance(compiler, MSVCCompiler):
+        is_msvc = True
+    else:
+        is_msvc = False
+    return is_msvc
 
 def extensions(config):
     # usually (except coming from release tarball) cython files must be generated
@@ -284,7 +295,11 @@ def extensions(config):
     # build optimized versions of MDAnalysis.
     arch = config.get('march', default=False)
     if arch:
-        extra_compile_args.append('-march={}'.format(arch))
+        if using_msvc():
+            # MSVC doesn't have a good equivalent for the march flag
+            pass
+        else:
+            extra_compile_args.append('-march={}'.format(arch))
 
     # encore is sensitive to floating point accuracy, especially on non-x86
     # to avoid reducing optimisations on everything, we make a set of compile


### PR DESCRIPTION
Fixes #3428

Changes made in this Pull Request:
 -  ~~fixes~~ removes march option in setup.cfg
 - ~~checks for MSVC (WIP??)~~
 - ~~only allows if not on MSVC~~
 - allow any additional compiler flags to be used for build excluding encore

Questions:
- ~~Do we want to check if the **flag** `march` is accepted rather than using the compiler identity? E.g what about icc, pgi etc etc~~
- ~~Do we want to improve documentation of this option?~~
- Do we want to add this option to CI? My guess is probably not?



PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [X] Issue raised/referenced?
