### PR TITLE
TRRWriter, use ts.data['step'] if it exists

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,12 +13,13 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-??/??/?? IAlibay, melomcr, mdd31 
+??/??/?? IAlibay, melomcr, mdd31, ianmkenney
 
  * 2.1.0
 
 Fixes
   * Fix ITPParser charge reading (Issue #3419).
+  * TRRWriter preserves timestep data (Issue #3350).
   
 Enhancements
 

--- a/package/MDAnalysis/coordinates/TRR.py
+++ b/package/MDAnalysis/coordinates/TRR.py
@@ -41,13 +41,18 @@ class TRRWriter(XDRBaseWriter):
     """Writer for the Gromacs TRR format.
 
     The Gromacs TRR trajectory format is a lossless format. The TRR format can
-    store *velocoties* and *forces* in addition to the coordinates. It is also
+    store *velocities* and *forces* in addition to the coordinates. It is also
     used by other Gromacs tools to store and process other data such as modes
     from a principal component analysis.
 
     If the data dictionary of a :class:`Timestep` contains the key
     'lambda' the corresponding value will be used as the lambda value
     for written TRR file.  If ``None`` is found the lambda is set to 0.
+
+    If the data dictionary of a :class:`Timestep` contains the key
+    'step' the corresponding value will be used as the step value for
+    the written TRR file. If the dictionary does not contain 'step', then
+    the step is set to the :class:`Timestep` frame attribute.
 
     """
 
@@ -75,6 +80,9 @@ class TRRWriter(XDRBaseWriter):
         .. versionchanged:: 2.0.0
            Deprecated support for Timestep argument has now been removed.
            Use AtomGroup or Universe as an input instead.
+        .. versionchanged:: 2.1.0
+           When possible, TRRWriter assigns `ts.data['step']` to `step` rather
+           than `ts.frame`.
         """
         try:
             ts = ag.ts
@@ -124,7 +132,7 @@ class TRRReader(XDRBaseReader):
     """Reader for the Gromacs TRR format.
 
     The Gromacs TRR trajectory format is a lossless format. The TRR format can
-    store *velocoties* and *forces* in addition to the coordinates. It is also
+    store *velocities* and *forces* in addition to the coordinates. It is also
     used by other Gromacs tools to store and process other data such as modes
     from a principal component analysis.
 

--- a/package/MDAnalysis/coordinates/TRR.py
+++ b/package/MDAnalysis/coordinates/TRR.py
@@ -105,7 +105,7 @@ class TRRWriter(XDRBaseWriter):
                 self.convert_forces_to_native(forces)
 
         time = ts.time
-        step = ts.frame
+        step = ts.data.get('step', ts.frame)
 
         if self._convert_units:
             dimensions = self.convert_dimensions_to_unitcell(ts, inplace=False)

--- a/testsuite/MDAnalysisTests/coordinates/test_xdr.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_xdr.py
@@ -29,7 +29,9 @@ import os
 import shutil
 import subprocess
 
-from numpy.testing import (assert_equal, assert_almost_equal)
+from numpy.testing import (assert_equal,
+                           assert_almost_equal,
+                           assert_allclose)
 
 from MDAnalysisTests import make_Universe
 from MDAnalysisTests.datafiles import (
@@ -442,6 +444,38 @@ class TestTRRWriter(_GromacsWriter):
             else:
                 with pytest.raises(mda.NoDataError):
                     getattr(written_ts, 'velocities')
+
+    def test_data_preservation(self, universe, Writer, outfile):
+
+        with Writer(outfile, universe.atoms.n_atoms, dt=universe.trajectory.dt) as W:
+            for ts in universe.trajectory:
+                W.write(universe)
+
+        uw = mda.Universe(GRO, outfile)
+
+        assert np.isclose(ts.data['time'], 0.0)
+        assert ts.data['step'] == 0
+        assert np.isclose(ts.data['lambda'], 0.0)
+        assert np.isclose(ts.data['dt'], 100.0)
+
+        # check that the data are identical for each time step
+        for orig_ts, written_ts in zip(universe.trajectory, uw.trajectory):
+            # data lengths must be the same
+            assert len(written_ts.data) == len(orig_ts.data)
+
+            # check that the keys exist in both dictionaries
+            for k in orig_ts.data:
+                assert k in written_ts.data
+
+            err_msg = ('mismatch between '
+                       'original and written trajectory at '
+                       f'frame {orig_ts.frame} vs {written_ts.frame}')
+
+            # check that each value is the same
+            for k in orig_ts.data:
+                assert_allclose(orig_ts.data[k],
+                                written_ts.data[k],
+                                err_msg=err_msg)
 
 
 class _GromacsWriterIssue101(object):


### PR DESCRIPTION
If ts.data['step'] exists, use this for the output
step value. Otherwise, use ts.frame, consistent
with previous behavior.

Fixes #3350 

Changes made in this Pull Request:
 - use `ts.data.get('step', ts.frame)` instead of `ts.frame` for the step variable


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
