### PR TITLE
Issue 3437 new segment stringinterning

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -22,6 +22,8 @@ Fixes
   * TRRWriter preserves timestep data (Issue #3350).
   * Fixed Universe creation from a custom object which only provided a topology,
     previously raised a TypeError. (Issue #3443)
+  * Fixed string attributes (e.g. resname, segid) not working on Residues and Segments
+    created using add_Residue and add_Segment (Issue #3437)
 
 Enhancements
 

--- a/package/MDAnalysis/core/topology.py
+++ b/package/MDAnalysis/core/topology.py
@@ -552,7 +552,11 @@ class Topology(object):
         Raises
         ------
         NoDataError
-          If not all data was provided.  This error is raised before any
+          If not all data was provided.  This error is raised before any changes
+
+
+        .. versionchanged:: 2.1.0
+           Added use of _add_new to TopologyAttr resize
         """
         # Check that all data is here before making any changes
         for attr in self.attrs:
@@ -578,9 +582,27 @@ class Topology(object):
         return residx
 
     def add_Segment(self, **new_attrs):
-        # check new_attrs are sufficient, assigned from Universe
-        # raises - NoDataError
-        # returns - the idx of the new segment
+        """Adds a new Segment to the Topology
+
+        Parameters
+        ----------
+        new_attrs : dict
+          the new attributes for the new segment, eg {'segid': 'B'}
+
+        Raises
+        -------
+        NoDataError
+          if an attribute wasn't specified.
+
+        Returns
+        -------
+        ix : int
+          the idx of the new segment
+
+
+        .. versionchanged:: 2.1.0
+           Added use of _add_new to resize topology attrs
+        """
         for attr in self.attrs:
             if attr.per_object == 'segment':
                 if attr.singular not in new_attrs:

--- a/package/MDAnalysis/core/topology.py
+++ b/package/MDAnalysis/core/topology.py
@@ -573,11 +573,14 @@ class Topology(object):
             if not attr.per_object == 'residue':
                 continue
             newval = new_attrs[attr.singular]
-            attr.values = np.concatenate([attr.values, np.array([newval])])
+            attr._add_new(newval)
 
         return residx
 
     def add_Segment(self, **new_attrs):
+        # check new_attrs are sufficient, assigned from Universe
+        # raises - NoDataError
+        # returns - the idx of the new segment
         for attr in self.attrs:
             if attr.per_object == 'segment':
                 if attr.singular not in new_attrs:
@@ -594,7 +597,7 @@ class Topology(object):
             if not attr.per_object == 'segment':
                 continue
             newval = new_attrs[attr.singular]
-            attr.values = np.concatenate([attr.values, np.array([newval])])
+            attr._add_new(newval)
 
         return segidx
         

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -703,11 +703,19 @@ class _StringInternerMixin:
         self.name_lookup = np.array(name_lookup, dtype=object)
         self.values = self.name_lookup[self.nmidx]
 
-
     def _add_new(self, newval):
-        # resizes this attr to size+1 and adds newval as the value of the new entry
-        # for string interning this is slightly different
-        # newval - str
+        """Append new value to the TopologyAttr
+
+        Parameters
+        ----------
+        newval : str
+          value to append
+
+        resizes this attr to size+1 and adds newval as the value of the new entry
+        for string interning this is slightly different hence the override
+
+        .. versionadded:: 2.1.0
+        """
         try:
             newidx = self.namedict[newval]
         except KeyError:

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -664,15 +664,22 @@ class Atomids(AtomAttr):
 
 
 class _StringInternerMixin:
-    # string interning pattern
-    # self.namedict (dict)
-    # - maps actual string to string index (str->int)
-    # self.namelookup (array dtype object)
-    # - maps string index to actual string (int->str)
-    # self.nmidx (array dtype int)
-    # - maps atom index to string index (int->int)
-    # self.values (array dtype object)
-    # - the premade per-object string values
+    """String interning pattern
+
+    Used for faster matching of strings (see _ProtoStringSelection)
+
+     self.namedict (dict)
+     - maps actual string to string index (str->int)
+     self.namelookup (array dtype object)
+     - maps string index to actual string (int->str)
+     self.nmidx (array dtype int)
+     - maps atom index to string index (int->int)
+     self.values (array dtype object)
+     - the premade per-object string values
+
+    .. versionadded:: 2.1.0
+       Mashed together the different implementations to keep it DRY.
+    """
     def __init__(self, vals, guessed=False):
         self._guessed = guessed
 
@@ -739,7 +746,8 @@ class _StringInternerMixin:
             self.name_lookup = np.concatenate([self.name_lookup, newnames])
         self.values = self.name_lookup[self.nmidx]
 
-
+# woe betide anyone who switches this inheritance order
+# Mixin needs to be first (L to R) to get correct __init__ and set_atoms
 class _AtomStringAttr(_StringInternerMixin, AtomAttr):
     @_check_length
     def set_atoms(self, ag, values):
@@ -2027,6 +2035,8 @@ class ResidueAttr(TopologyAttr):
         raise _wronglevel_error(self, sg)
 
 
+# woe betide anyone who switches this inheritance order
+# Mixin needs to be first (L to R) to get correct __init__ and set_atoms
 class _ResidueStringAttr(_StringInternerMixin, ResidueAttr):
     @_check_length
     def set_residues(self, ag, values):
@@ -2228,6 +2238,8 @@ class SegmentAttr(TopologyAttr):
         self.values[sg.ix] = values
 
 
+# woe betide anyone who switches this inheritance order
+# Mixin needs to be first (L to R) to get correct __init__ and set_atoms
 class _SegmentStringAttr(_StringInternerMixin, SegmentAttr):
     @_check_length
     def set_segments(self, ag, values):

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -756,7 +756,7 @@ class _StringInternerMixin:
 
 # woe betide anyone who switches this inheritance order
 # Mixin needs to be first (L to R) to get correct __init__ and set_atoms
-class _AtomStringAttr(_StringInternerMixin, AtomAttr):
+class AtomStringAttr(_StringInternerMixin, AtomAttr):
     @_check_length
     def set_atoms(self, ag, values):
         return self._set_X(ag, values)
@@ -767,7 +767,7 @@ class _AtomStringAttr(_StringInternerMixin, AtomAttr):
 
 
 # TODO: update docs to property doc
-class Atomnames(_AtomStringAttr):
+class Atomnames(AtomStringAttr):
     """Name for each atom.
     """
     attrname = 'names'
@@ -1263,7 +1263,7 @@ class Atomnames(_AtomStringAttr):
 
 
 # TODO: update docs to property doc
-class Atomtypes(_AtomStringAttr):
+class Atomtypes(AtomStringAttr):
     """Type for each atom"""
     attrname = 'types'
     singular = 'type'
@@ -1272,7 +1272,7 @@ class Atomtypes(_AtomStringAttr):
 
 
 # TODO: update docs to property doc
-class Elements(_AtomStringAttr):
+class Elements(AtomStringAttr):
     """Element for each atom"""
     attrname = 'elements'
     singular = 'element'
@@ -1296,7 +1296,7 @@ class Radii(AtomAttr):
         return np.zeros(na)
 
 
-class RecordTypes(_AtomStringAttr):
+class RecordTypes(AtomStringAttr):
     """For PDB-like formats, indicates if ATOM or HETATM
 
     Defaults to 'ATOM'
@@ -1314,7 +1314,7 @@ class RecordTypes(_AtomStringAttr):
         return np.array(['ATOM'] * na, dtype=object)
 
 
-class ChainIDs(_AtomStringAttr):
+class ChainIDs(AtomStringAttr):
     """ChainID per atom
 
     Note
@@ -1902,7 +1902,7 @@ class Occupancies(AtomAttr):
 
 
 # TODO: update docs to property doc
-class AltLocs(_AtomStringAttr):
+class AltLocs(AtomStringAttr):
     """AltLocs for each atom"""
     attrname = 'altLocs'
     singular = 'altLoc'
@@ -2045,7 +2045,7 @@ class ResidueAttr(TopologyAttr):
 
 # woe betide anyone who switches this inheritance order
 # Mixin needs to be first (L to R) to get correct __init__ and set_atoms
-class _ResidueStringAttr(_StringInternerMixin, ResidueAttr):
+class ResidueStringAttr(_StringInternerMixin, ResidueAttr):
     @_check_length
     def set_residues(self, ag, values):
         return self._set_X(ag, values)
@@ -2068,7 +2068,7 @@ class Resids(ResidueAttr):
 
 
 # TODO: update docs to property doc
-class Resnames(_ResidueStringAttr):
+class Resnames(ResidueStringAttr):
     attrname = 'resnames'
     singular = 'resname'
     transplants = defaultdict(list)
@@ -2187,14 +2187,14 @@ class Resnums(ResidueAttr):
         return np.arange(1, nr + 1)
 
 
-class ICodes(_ResidueStringAttr):
+class ICodes(ResidueStringAttr):
     """Insertion code for Atoms"""
     attrname = 'icodes'
     singular = 'icode'
     dtype = object
 
 
-class Moltypes(_ResidueStringAttr):
+class Moltypes(ResidueStringAttr):
     """Name of the molecule type
 
     Two molecules that share a molecule type share a common template topology.
@@ -2248,7 +2248,7 @@ class SegmentAttr(TopologyAttr):
 
 # woe betide anyone who switches this inheritance order
 # Mixin needs to be first (L to R) to get correct __init__ and set_atoms
-class _SegmentStringAttr(_StringInternerMixin, SegmentAttr):
+class SegmentStringAttr(_StringInternerMixin, SegmentAttr):
     @_check_length
     def set_segments(self, ag, values):
         return self._set_X(ag, values)
@@ -2259,7 +2259,7 @@ class _SegmentStringAttr(_StringInternerMixin, SegmentAttr):
 
 
 # TODO: update docs to property doc
-class Segids(_SegmentStringAttr):
+class Segids(SegmentStringAttr):
     attrname = 'segids'
     singular = 'segid'
     transplants = defaultdict(list)

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -763,7 +763,7 @@ class _AtomStringAttr(_StringInternerMixin, AtomAttr):
 
     @staticmethod
     def _gen_initial_values(na, nr, ns):
-        return np.full('', na, dtype=object)
+        return np.full(na, '', dtype=object)
 
 
 # TODO: update docs to property doc
@@ -2052,7 +2052,7 @@ class _ResidueStringAttr(_StringInternerMixin, ResidueAttr):
 
     @staticmethod
     def _gen_initial_values(na, nr, ns):
-        return np.full('', nr, dtype=object)
+        return np.full(nr, '', dtype=object)
 
 
 # TODO: update docs to property doc
@@ -2255,7 +2255,7 @@ class _SegmentStringAttr(_StringInternerMixin, SegmentAttr):
 
     @staticmethod
     def _gen_initial_values(na, nr, ns):
-        return np.full('', ns, dtype=object)
+        return np.full(ns, '', dtype=object)
 
 
 # TODO: update docs to property doc

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -726,7 +726,6 @@ class _StringInternerMixin:
         self.nmidx = np.concatenate([self.nmidx, [newidx]])
         self.values = np.concatenate([self.values, [newval]])
 
-    @_check_length
     def _set_X(self, ag, values):
         newnames = []
 

--- a/testsuite/MDAnalysisTests/core/test_topologyattrs.py
+++ b/testsuite/MDAnalysisTests/core/test_topologyattrs.py
@@ -585,3 +585,37 @@ class TestDeprecateBFactor:
     def test_deprecate_bfactor_sel(self, universe):
         with pytest.warns(DeprecationWarning, match=self.MATCH):
             universe.select_atoms("bfactor 3")
+
+
+class TestStringInterning:
+    # try and trip up the string interning we use for string attributes
+    @pytest.fixture
+    def universe(self):
+        u = mda.Universe.empty(n_atoms=10)
+        u.add_TopologyAttr('names', values=['A'] * 10)
+        u.add_TopologyAttr('resnames', values=['ResA'])
+        u.add_TopologyAttr('segids', values=['SegA'])
+
+        return u
+
+    @pytest.mark.parametrize('newname', ['ResA', 'ResB'])
+    def test_add_residue(self, universe, newname):
+        newres = universe.add_Residue(resname=newname)
+
+        assert newres.resname == newname
+
+        ag = universe.atoms[2]
+        ag.residue = newres
+
+        assert ag.resname == newname
+
+    @pytest.mark.parametrize('newname', ['SegA', 'SegB'])
+    def test_add_segment(self, universe, newname):
+        newseg = universe.add_Segment(segid=newname)
+
+        assert newseg.segid == newname
+
+        rg = universe.residues[0]
+        rg.segment = newseg
+
+        assert rg.atoms[0].segid == newname

--- a/testsuite/MDAnalysisTests/core/test_universe.py
+++ b/testsuite/MDAnalysisTests/core/test_universe.py
@@ -55,7 +55,7 @@ from MDAnalysis.topology.base import TopologyReaderBase
 from MDAnalysis.transformations import translate
 from MDAnalysisTests import assert_nowarns
 from MDAnalysis.exceptions import NoDataError
-from MDAnalysis.core.topologyattrs import _AtomStringAttr
+from MDAnalysis.core.topologyattrs import AtomStringAttr
 
 
 class IOErrorParser(TopologyReaderBase):
@@ -780,7 +780,7 @@ class TestDelTopologyAttr(object):
             ag.resnames
 
     def test_del_func_from_universe(self, universe):
-        class RootVegetable(_AtomStringAttr):
+        class RootVegetable(AtomStringAttr):
             attrname = "tubers"
             singular = "tuber"
             transplants = defaultdict(list)


### PR DESCRIPTION
Fixes #3437

Changes made in this Pull Request:

The string interning we're using for string TopologyAttrs uses a more complex system than just a numpy array of values.  `Topology.add_Residue` and `Topology.add_Segment` previously just assumed a numpy array of values, so blindly "appended" values to this without respecting fancy data structures.

The fix is to add `_add_new` to each TopologyAttr which is a respectful way of appending to the TopologyAttr.


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
