### PR TITLE
Add check for too many grids in NSGrid

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -94,6 +94,7 @@ jobs:
         gfortran-9 -v
         echo "FC=gfortran-9" >> $GITHUB_ENV
         echo "numprocs=3" >> $GITHUB_ENV
+        echo "ENABLE_HIGH_MEM_UNIT_TESTS=true" >> $GITHUB_ENV
 
     - name: setup_linux
       if: startsWith(matrix.os, 'ubuntu')

--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -170,6 +170,7 @@ Chronological list of authors
   - Filip T. Szczypiński
   - Marcelo C. R. Melo
   - Mark D. Driver
+  - Kevin Boyd
 
 
 External code

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,7 +13,7 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-??/??/?? IAlibay, melomcr, mdd31, ianmkenney, richardjgowers
+??/??/?? IAlibay, melomcr, mdd31, ianmkenney, richardjgowers, scal444
 
  * 2.1.0
 

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -18,6 +18,7 @@ The rules for this file:
  * 2.1.0
 
 Fixes
+  * Avoid integer overflow in NSGrid with too many grids (Issue #3183)
   * Fix ITPParser charge reading (Issue #3419).
   * TRRWriter preserves timestep data (Issue #3350).
   * Fixed Universe creation from a custom object which only provided a topology,

--- a/package/MDAnalysis/lib/nsgrid.pyx
+++ b/package/MDAnalysis/lib/nsgrid.pyx
@@ -90,6 +90,10 @@ DEF XZ = 6
 DEF YZ = 7
 DEF ZZ = 8
 
+# Cube root of the maximum size of a 32 bit signed integer. If the system is divided into more
+# grids than this, integer overflow will occur.
+DEF MAX_GRID_DIM = 1290
+
 ctypedef float coordinate[3];
 
 cdef extern from "calc_distances.h" nogil:
@@ -283,6 +287,10 @@ cdef class FastNS(object):
         max_cutoff = self._prepare_box(box, pbc)
         if cutoff > max_cutoff:
             raise ValueError("Cutoff {} too large for box (max {})".format(cutoff, max_cutoff))
+        max_assigned_grid_dimension = np.max(self.ncells)
+        if max_assigned_grid_dimension > MAX_GRID_DIM:
+            raise ValueError("Cutoff {} too small for box (longest cell dimension is {}, max is {})"
+                             .format(self.cutoff, max_assigned_grid_dimension, MAX_GRID_DIM))
         self._pack_grid(coords)
 
     cdef float _prepare_box(self, box, bint pbc):

--- a/package/MDAnalysis/lib/nsgrid.pyx
+++ b/package/MDAnalysis/lib/nsgrid.pyx
@@ -71,7 +71,9 @@ not reflect in the results.
 .. versionadded:: 0.19.0
 .. versionchanged:: 1.0.2
    Rewrote module
-
+.. versionchanged:: 2.1.0
+   Capped max grid dimension to 1290, which when cubed is the max value of
+   a 32 bit signed integer.
 
 Classes
 -------

--- a/testsuite/MDAnalysisTests/lib/test_nsgrid.py
+++ b/testsuite/MDAnalysisTests/lib/test_nsgrid.py
@@ -52,8 +52,6 @@ def run_grid_search(u, ref_id, cutoff=3):
 
     return searcher.search(searchcoords)
 
-
-
 @pytest.mark.parametrize('box', [
     np.zeros(3),  # Bad shape
     np.zeros((3, 3)),  # Collapsed box
@@ -269,7 +267,7 @@ def test_around_overlapping():
     # check that around 0.0 catches when atoms *are* superimposed
     u = mda.Universe.empty(60, trajectory=True)
     xyz = np.zeros((60, 3))
-    x = np.tile(np.arange(12), (5,))+np.repeat(np.arange(5) * 100, 12)
+    x = np.tile(np.arange(12), (5,))+np.repeat(np.arange(5)*100, 12)
     # x is 5 images of 12 atoms
 
     xyz[:, 0] = x  # y and z are 0

--- a/testsuite/MDAnalysisTests/lib/test_nsgrid.py
+++ b/testsuite/MDAnalysisTests/lib/test_nsgrid.py
@@ -40,15 +40,17 @@ def universe():
     u = mda.Universe(GRO)
     return u
 
+
 def run_grid_search(u, ref_id, cutoff=3):
     coords = u.atoms.positions
     searchcoords = u.atoms.positions[ref_id]
-    if searchcoords.shape == (3, ):
+    if searchcoords.shape == (3,):
         searchcoords = searchcoords[None, :]
     # Run grid search
     searcher = nsgrid.FastNS(cutoff, coords, box=u.dimensions)
 
     return searcher.search(searchcoords)
+
 
 @pytest.mark.parametrize('box', [
     np.zeros(3),  # Bad shape
@@ -66,7 +68,8 @@ def test_pbc_box(box):
 
 
 @pytest.mark.parametrize('cutoff, match', ((-4, "Cutoff must be positive"),
-                                           (100000, "Cutoff 100000 too large for box")))
+                                           (100000,
+                                            "Cutoff 100000 too large for box")))
 def test_nsgrid_badcutoff(universe, cutoff, match):
     with pytest.raises(ValueError, match=match):
         run_grid_search(universe, 0, cutoff)
@@ -160,13 +163,16 @@ def test_nsgrid_distances(universe):
 
 @pytest.mark.parametrize('box, results',
                          ((None, [3, 13, 24]),
-                          (np.array([10000., 10000., 10000., 90., 90., 90.]), [3, 13, 24]),
-                          (np.array([10., 10., 10., 90., 90., 90.]), [3, 13, 24, 39, 67]),
-                          (np.array([10., 10., 10., 60., 75., 90.]), [3, 13, 24, 39, 60, 79])))
+                          (np.array([10000., 10000., 10000., 90., 90., 90.]),
+                           [3, 13, 24]),
+                          (np.array([10., 10., 10., 90., 90., 90.]),
+                           [3, 13, 24, 39, 67]),
+                          (np.array([10., 10., 10., 60., 75., 90.]),
+                           [3, 13, 24, 39, 60, 79])))
 def test_nsgrid_search(box, results):
     np.random.seed(90003)
     points = (np.random.uniform(low=0, high=1.0,
-                        size=(100, 3))*(10.)).astype(np.float32)
+                                size=(100, 3)) * (10.)).astype(np.float32)
     cutoff = 2.0
     query = np.array([1., 1., 1.], dtype=np.float32).reshape((1, 3))
 
@@ -175,7 +181,7 @@ def test_nsgrid_search(box, results):
         all_coords = np.concatenate([points, query])
         lmax = all_coords.max(axis=0)
         lmin = all_coords.min(axis=0)
-        pseudobox[:3] = 1.1*(lmax - lmin)
+        pseudobox[:3] = 1.1 * (lmax - lmin)
         pseudobox[3:] = 90.
         shiftpoints, shiftquery = points.copy(), query.copy()
         shiftpoints -= lmin
@@ -197,7 +203,7 @@ def test_nsgrid_search(box, results):
 def test_nsgrid_selfsearch(box, result):
     np.random.seed(90003)
     points = (np.random.uniform(low=0, high=1.0,
-                        size=(100, 3))*(10.)).astype(np.float32)
+                                size=(100, 3)) * (10.)).astype(np.float32)
     cutoff = 1.0
     if box is None or np.allclose(box[:3], 0):
         # create a pseudobox
@@ -207,7 +213,7 @@ def test_nsgrid_selfsearch(box, result):
         pseudobox = np.zeros(6, dtype=np.float32)
         lmax = points.max(axis=0)
         lmin = points.min(axis=0)
-        pseudobox[:3] = 1.1*(lmax - lmin)
+        pseudobox[:3] = 1.1 * (lmax - lmin)
         pseudobox[3:] = 90.
         shiftref = points.copy()
         shiftref -= lmin
@@ -218,6 +224,7 @@ def test_nsgrid_selfsearch(box, result):
         searchresults = searcher.self_search()
     pairs = searchresults.get_pairs()
     assert_equal(len(pairs), result)
+
 
 def test_nsgrid_probe_close_to_box_boundary():
     # FastNS.search used to segfault with this box, cutoff and reference
@@ -265,7 +272,7 @@ def test_around_overlapping():
     # check that around 0.0 catches when atoms *are* superimposed
     u = mda.Universe.empty(60, trajectory=True)
     xyz = np.zeros((60, 3))
-    x = np.tile(np.arange(12), (5,))+np.repeat(np.arange(5)*100, 12)
+    x = np.tile(np.arange(12), (5,)) + np.repeat(np.arange(5) * 100, 12)
     # x is 5 images of 12 atoms
 
     xyz[:, 0] = x  # y and z are 0

--- a/testsuite/MDAnalysisTests/lib/test_nsgrid.py
+++ b/testsuite/MDAnalysisTests/lib/test_nsgrid.py
@@ -42,16 +42,16 @@ def universe():
     u = mda.Universe(GRO)
     return u
 
-
 def run_grid_search(u, ref_id, cutoff=3):
     coords = u.atoms.positions
     searchcoords = u.atoms.positions[ref_id]
-    if searchcoords.shape == (3,):
+    if searchcoords.shape == (3, ):
         searchcoords = searchcoords[None, :]
     # Run grid search
     searcher = nsgrid.FastNS(cutoff, coords, box=u.dimensions)
 
     return searcher.search(searchcoords)
+
 
 
 @pytest.mark.parametrize('box', [
@@ -165,14 +165,12 @@ def test_nsgrid_distances(universe):
 
 @pytest.mark.parametrize('box, results',
                          ((None, [3, 13, 24]),
-                          (np.array([10., 10., 10., 90., 90., 90.]),
-                           [3, 13, 24, 39, 67]),
-                          (np.array([10., 10., 10., 60., 75., 90.]),
-                           [3, 13, 24, 39, 60, 79])))
+                          (np.array([10., 10., 10., 90., 90., 90.]), [3, 13, 24, 39, 67]),
+                          (np.array([10., 10., 10., 60., 75., 90.]), [3, 13, 24, 39, 60, 79])))
 def test_nsgrid_search(box, results):
     np.random.seed(90003)
     points = (np.random.uniform(low=0, high=1.0,
-                                size=(100, 3)) * (10.)).astype(np.float32)
+                        size=(100, 3))*(10.)).astype(np.float32)
     cutoff = 2.0
     query = np.array([1., 1., 1.], dtype=np.float32).reshape((1, 3))
 
@@ -181,7 +179,7 @@ def test_nsgrid_search(box, results):
         all_coords = np.concatenate([points, query])
         lmax = all_coords.max(axis=0)
         lmin = all_coords.min(axis=0)
-        pseudobox[:3] = 1.1 * (lmax - lmin)
+        pseudobox[:3] = 1.1*(lmax - lmin)
         pseudobox[3:] = 90.
         shiftpoints, shiftquery = points.copy(), query.copy()
         shiftpoints -= lmin
@@ -203,7 +201,7 @@ def test_nsgrid_search(box, results):
 def test_nsgrid_selfsearch(box, result):
     np.random.seed(90003)
     points = (np.random.uniform(low=0, high=1.0,
-                                size=(100, 3)) * (10.)).astype(np.float32)
+                        size=(100, 3))*(10.)).astype(np.float32)
     cutoff = 1.0
     if box is None or np.allclose(box[:3], 0):
         # create a pseudobox
@@ -213,7 +211,7 @@ def test_nsgrid_selfsearch(box, result):
         pseudobox = np.zeros(6, dtype=np.float32)
         lmax = points.max(axis=0)
         lmin = points.min(axis=0)
-        pseudobox[:3] = 1.1 * (lmax - lmin)
+        pseudobox[:3] = 1.1*(lmax - lmin)
         pseudobox[3:] = 90.
         shiftref = points.copy()
         shiftref -= lmin
@@ -224,7 +222,6 @@ def test_nsgrid_selfsearch(box, result):
         searchresults = searcher.self_search()
     pairs = searchresults.get_pairs()
     assert_equal(len(pairs), result)
-
 
 def test_nsgrid_probe_close_to_box_boundary():
     # FastNS.search used to segfault with this box, cutoff and reference
@@ -272,7 +269,7 @@ def test_around_overlapping():
     # check that around 0.0 catches when atoms *are* superimposed
     u = mda.Universe.empty(60, trajectory=True)
     xyz = np.zeros((60, 3))
-    x = np.tile(np.arange(12), (5,)) + np.repeat(np.arange(5) * 100, 12)
+    x = np.tile(np.arange(12), (5,))+np.repeat(np.arange(5) * 100, 12)
     # x is 5 images of 12 atoms
 
     xyz[:, 0] = x  # y and z are 0

--- a/testsuite/MDAnalysisTests/lib/test_nsgrid.py
+++ b/testsuite/MDAnalysisTests/lib/test_nsgrid.py
@@ -21,6 +21,7 @@
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
 
+from distutils.util import strtobool
 import os
 
 import pytest
@@ -377,14 +378,23 @@ def test_issue_2670():
     assert len(ag2.select_atoms('around 0.0 resid 3')) == 1
 
 
-reason = "Turned off by default. The test can be enabled by setting the ENABLE_HIGH_MEM_UNIT_TESTS " \
-         "environment variable. Make sure you have at least 10GB of RAM."
+def high_mem_tests_enabled():
+    """ Returns true if ENABLE_HIGH_MEM_UNIT_TESTS is set to true."""
+    env = os.getenv("ENABLE_HIGH_MEM_UNIT_TESTS", default="0")
+    try:
+        return strtobool(env)
+    except ValueError:
+        return False
+
+
+reason = ("Turned off by default. The test can be enabled by setting the ENABLE_HIGH_MEM_UNIT_TESTS "
+          "environment variable. Make sure you have at least 10GB of RAM.")
 
 
 # Tests that with a tiny cutoff to box ratio, the number of grids is capped
 # to avoid indexing overflow. Expected results copied from test_nsgrid_search
 # with no box.
-@pytest.mark.skipif(not os.getenv("ENABLE_HIGH_MEM_UNIT_TESTS"), reason=reason)
+@pytest.mark.skipif(not high_mem_tests_enabled(), reason=reason)
 def test_issue_3183():
     np.random.seed(90003)
     points = (np.random.uniform(low=0, high=1.0,

--- a/testsuite/MDAnalysisTests/lib/test_nsgrid.py
+++ b/testsuite/MDAnalysisTests/lib/test_nsgrid.py
@@ -71,6 +71,11 @@ def test_nsgrid_badcutoff(universe, cutoff):
         run_grid_search(universe, 0, cutoff)
 
 
+def test_nsgrid_too_many_grids(universe):
+    universe.dimensions[:3] *= 1000
+    with pytest.raises(ValueError):
+        run_grid_search(universe, 0, 1)
+
 def test_ns_grid_noneighbor(universe):
     """Check that grid search returns empty lists/arrays when there is no neighbors"""
     ref_id = 0

--- a/testsuite/MDAnalysisTests/lib/test_nsgrid.py
+++ b/testsuite/MDAnalysisTests/lib/test_nsgrid.py
@@ -65,16 +65,12 @@ def test_pbc_box(box):
         nsgrid.FastNS(4.0, coords, box=box)
 
 
-@pytest.mark.parametrize('cutoff', [-4, 100000])
-def test_nsgrid_badcutoff(universe, cutoff):
-    with pytest.raises(ValueError):
+@pytest.mark.parametrize('cutoff, match', ((-4, "Cutoff must be positive"),
+                                           (100000, "Cutoff 100000 too large for box")))
+def test_nsgrid_badcutoff(universe, cutoff, match):
+    with pytest.raises(ValueError, match=match):
         run_grid_search(universe, 0, cutoff)
 
-
-def test_nsgrid_too_many_grids(universe):
-    universe.dimensions[:3] *= 1000
-    with pytest.raises(ValueError):
-        run_grid_search(universe, 0, 1)
 
 def test_ns_grid_noneighbor(universe):
     """Check that grid search returns empty lists/arrays when there is no neighbors"""
@@ -164,6 +160,7 @@ def test_nsgrid_distances(universe):
 
 @pytest.mark.parametrize('box, results',
                          ((None, [3, 13, 24]),
+                          (np.array([10000., 10000., 10000., 90., 90., 90.]), [3, 13, 24]),
                           (np.array([10., 10., 10., 90., 90., 90.]), [3, 13, 24, 39, 67]),
                           (np.array([10., 10., 10., 60., 75., 90.]), [3, 13, 24, 39, 60, 79])))
 def test_nsgrid_search(box, results):

--- a/testsuite/MDAnalysisTests/lib/test_nsgrid.py
+++ b/testsuite/MDAnalysisTests/lib/test_nsgrid.py
@@ -387,7 +387,8 @@ def high_mem_tests_enabled():
         return False
 
 
-reason = ("Turned off by default. The test can be enabled by setting the ENABLE_HIGH_MEM_UNIT_TESTS "
+reason = ("Turned off by default. The test can be enabled by setting "
+          "the ENABLE_HIGH_MEM_UNIT_TESTS "
           "environment variable. Make sure you have at least 10GB of RAM.")
 
 


### PR DESCRIPTION
The NSGrid cython code uses integer indexing, which is typically
32 bit. 3D grids with small cutoffs or giant box sizes can have
grids > 1000 per dimension, which leads to integer overflow when
trying to index the grids.

Fixes #3183

Changes made in this Pull Request:
 - 


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
