### PR TITLE
Issue 3443 coordinateless objects

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,14 +13,16 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-??/??/?? IAlibay, melomcr, mdd31, ianmkenney
+??/??/?? IAlibay, melomcr, mdd31, ianmkenney, richardjgowers
 
  * 2.1.0
 
 Fixes
   * Fix ITPParser charge reading (Issue #3419).
   * TRRWriter preserves timestep data (Issue #3350).
-  
+  * Fixed Universe creation from a custom object which only provided a topology,
+    previously raised a TypeError. (Issue #3443)
+
 Enhancements
 
 Changes

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -143,7 +143,7 @@ def _resolve_coordinates(filename, *coordinates, format=None,
     if all_coordinates or not coordinates and filename is not None:
         try:
             get_reader_for(filename, format=format)
-        except ValueError:
+        except (ValueError, TypeError):
             warnings.warn('No coordinate reader found for {}. Skipping '
                             'this file.'.format(filename))
         else:

--- a/testsuite/MDAnalysisTests/core/test_universe.py
+++ b/testsuite/MDAnalysisTests/core/test_universe.py
@@ -1300,3 +1300,28 @@ def test_deprecate_b_tempfactors():
     with pytest.warns(DeprecationWarning, match="use the tempfactor"):
         u.add_TopologyAttr("bfactors", values)
     assert_array_equal(u.atoms.tempfactors, values)
+
+
+class Thingy:
+    def __init__(self, val):
+        self.v = val
+
+
+class ThingyParser(TopologyReaderBase):
+    format='THINGY'
+
+    @staticmethod
+    def _format_hint(thing):
+        return isinstance(thing, Thingy)
+
+    def parse(self, **kwargs):
+        return mda.core.topology.Topology(n_atoms=10)
+
+
+class TestOnlyTopology:
+    def test_only_top(self):
+        t = Thingy(20)
+
+        u = mda.Universe(t)
+
+        assert len(u.atoms) == 10

--- a/testsuite/MDAnalysisTests/core/test_universe.py
+++ b/testsuite/MDAnalysisTests/core/test_universe.py
@@ -1320,8 +1320,11 @@ class ThingyParser(TopologyReaderBase):
 
 class TestOnlyTopology:
     def test_only_top(self):
+        # issue 3443
         t = Thingy(20)
 
-        u = mda.Universe(t)
+        with pytest.warns(UserWarning,
+                          match="No coordinate reader found for"):
+            u = mda.Universe(t)
 
         assert len(u.atoms) == 10


### PR DESCRIPTION
Fixes #3443 

Changes made in this Pull Request:
 - fixes the check on if a filename (here an object) can also be a coordinate file as well as topology


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
