### PR TITLE
WIP: Lammpsdump velocities (and other fields)

### DIFF
--- a/package/MDAnalysis/coordinates/LAMMPS.py
+++ b/package/MDAnalysis/coordinates/LAMMPS.py
@@ -630,6 +630,8 @@ class DumpReader(base.ReaderBase):
         ts.positions = ts.positions[order]
         if ts.has_velocities:
             ts.velocities = ts.velocities[order]
+            # LAMMPS reader only supports real units
+            ts.velocities *= units.speedUnit_factor['Angstrom/femtosecond']
         if (self.lammps_coordinate_convention.startswith("scaled")):
             # if coordinates are given in scaled format, undo that
             ts.positions = distances.transform_StoR(ts.positions,

--- a/package/MDAnalysis/coordinates/LAMMPS.py
+++ b/package/MDAnalysis/coordinates/LAMMPS.py
@@ -502,7 +502,7 @@ class DumpReader(base.ReaderBase):
         self.close()
         self._file = util.anyopen(self.filename)
         self.ts = self._Timestep(self.n_atoms, **self._ts_kwargs)
-        self.ts.frame = -1
+        self.ts.frame = 0
 
     @property
     @cached('n_atoms')

--- a/package/MDAnalysis/coordinates/LAMMPS.py
+++ b/package/MDAnalysis/coordinates/LAMMPS.py
@@ -610,7 +610,7 @@ class DumpReader(base.ReaderBase):
 
         # pass possible additional fields from LAMMPS dump
         # pass velocities
-        velocity_col_names = ["vx","vy","vz"]
+        velocity_col_names = ["vx", "vy", "vz"]
         if any(item in attrs for item in velocity_col_names):
             for cv_name, cv_col_names in enumerate(velocity_col_names):
                 try:

--- a/package/MDAnalysis/coordinates/LAMMPS.py
+++ b/package/MDAnalysis/coordinates/LAMMPS.py
@@ -55,8 +55,9 @@ however this can be customised, see :ref:`atom_style_kwarg`.
 Dump files
 ----------
 
-The DumpReader expects ascii dump files written with the default
-`LAMMPS dump format`_ of 'atom'
+The DumpReader expects ascii dump files. Currently supported are
+coordinates (dump style atom) and velocities for custom dump styles.
+Other columns are ignored.
 
 
 Example: Loading a LAMMPS simulation
@@ -462,6 +463,7 @@ class DumpReader(base.ReaderBase):
     coordinate convention (xs,ys,zs) or scaled unwrapped coordinate convention
     (xsu,ysu,zsu) they will automatically be converted from their
     scaled/fractional representation to their real values.
+    Velocities (vx, vy, vz) can be parsed, too.
 
 
     .. versionchanged:: 2.0.0


### PR DESCRIPTION
Following #3360 (thanks for the great work!) I was implementing a first draft of a parser for the velocities.
Before adding tests I quickly wanted to hear if the way of implementing agrees with your concepts.
Other fields, like e.g. forces, could be added straightforward.

Fixes #

Changes made in this Pull Request:
 - allow LAMMPSDUMP parser to read velocities


PR Checklist
------------
 - [ ] Tests?
 - [ x] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
