### PR TITLE
Make HydrogenBondAnalysis handle empty selection strings

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -18,6 +18,7 @@ The rules for this file:
  * 2.1.0
 
 Fixes
+  * Allow empty strings to be passed to HydrogenBondAnalysis (Issue #3453).
   * Fix ITPParser charge reading (Issue #3419).
   * TRRWriter preserves timestep data (Issue #3350).
   * Fixed Universe creation from a custom object which only provided a topology,

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,7 +13,8 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-??/??/?? IAlibay, melomcr, mdd31, ianmkenney, richardjgowers, hmacdope, orbeckst, scal444
+??/??/?? IAlibay, melomcr, mdd31, ianmkenney, richardjgowers, hmacdope, orbeckst, scal444,
+         p-j-smith
  * 2.1.0
 
 Fixes

--- a/package/MDAnalysis/analysis/hydrogenbonds/hbond_analysis.py
+++ b/package/MDAnalysis/analysis/hydrogenbonds/hbond_analysis.py
@@ -328,6 +328,10 @@ class HydrogenBondAnalysis(AnalysisBase):
         if isinstance(acceptors_sel, str) and not acceptors_sel:
             warnings.warn(msg.format("acceptors_sel"))
 
+        self.donors_sel = donors_sel
+        self.hydrogens_sel = hydrogens_sel
+        self.acceptors_sel = acceptors_sel
+
         # If hydrogen bonding groups are selected, then generate
         # corresponding atom groups
         if between is not None:

--- a/package/MDAnalysis/analysis/hydrogenbonds/hbond_analysis.py
+++ b/package/MDAnalysis/analysis/hydrogenbonds/hbond_analysis.py
@@ -320,7 +320,7 @@ class HydrogenBondAnalysis(AnalysisBase):
         msg = ("{} is an empty selection string - no hydrogen bonds will "
                "be found. This may be intended, but please check your "
                "selection."
-        )
+               )
         if isinstance(donors_sel, str) and not donors_sel:
             warnings.warn(msg.format("donors_sel"))
         if isinstance(hydrogens_sel, str) and not hydrogens_sel:

--- a/package/MDAnalysis/analysis/hydrogenbonds/hbond_analysis.py
+++ b/package/MDAnalysis/analysis/hydrogenbonds/hbond_analysis.py
@@ -317,16 +317,16 @@ class HydrogenBondAnalysis(AnalysisBase):
         self.u = universe
         self._trajectory = self.u.trajectory
 
-        msg = ("{} is an empty selection string - no hydrogen bonds will "
+        msg = ("{}_sel is an empty selection string - no hydrogen bonds will "
                "be found. This may be intended, but please check your "
                "selection."
                )
-        if isinstance(donors_sel, str) and not donors_sel:
-            warnings.warn(msg.format("donors_sel"))
-        if isinstance(hydrogens_sel, str) and not hydrogens_sel:
-            warnings.warn(msg.format("hydrogens_sel"))
-        if isinstance(acceptors_sel, str) and not acceptors_sel:
-            warnings.warn(msg.format("acceptors_sel"))
+        for sel, sel_string in zip(
+            [donors_sel, hydrogens_sel, acceptors_sel],
+            ['donors', 'hydrogens', 'acceptors']
+        ):
+            if isinstance(sel, str) and not sel:
+                warnings.warn(msg.format(sel_string))
 
         self.donors_sel = donors_sel
         self.hydrogens_sel = hydrogens_sel

--- a/package/MDAnalysis/analysis/hydrogenbonds/hbond_analysis.py
+++ b/package/MDAnalysis/analysis/hydrogenbonds/hbond_analysis.py
@@ -316,9 +316,17 @@ class HydrogenBondAnalysis(AnalysisBase):
 
         self.u = universe
         self._trajectory = self.u.trajectory
-        self.donors_sel = donors_sel
-        self.hydrogens_sel = hydrogens_sel
-        self.acceptors_sel = acceptors_sel
+
+        msg = ("{} is an empty selection string - no hydrogen bonds will "
+               "be found. This may be intended, but please check your "
+               "selection."
+        )
+        if isinstance(donors_sel, str) and not donors_sel:
+            warnings.warn(msg.format("donors_sel"))
+        if isinstance(hydrogens_sel, str) and not hydrogens_sel:
+            warnings.warn(msg.format("hydrogens_sel"))
+        if isinstance(acceptors_sel, str) and not acceptors_sel:
+            warnings.warn(msg.format("acceptors_sel"))
 
         # If hydrogen bonding groups are selected, then generate
         # corresponding atom groups

--- a/package/MDAnalysis/analysis/hydrogenbonds/hbond_analysis.py
+++ b/package/MDAnalysis/analysis/hydrogenbonds/hbond_analysis.py
@@ -439,7 +439,7 @@ class HydrogenBondAnalysis(AnalysisBase):
 
         # We need to know `hydrogens_sel` before we can find donors
         # Use a new variable `hydrogens_sel` so that we do not set `self.hydrogens_sel` if it is currently `None`
-        if not self.hydrogens_sel:
+        if self.hydrogens_sel is None:
             hydrogens_sel = self.guess_hydrogens()
         else:
             hydrogens_sel = self.hydrogens_sel
@@ -512,7 +512,7 @@ class HydrogenBondAnalysis(AnalysisBase):
         """
 
         # If donors_sel is not provided, use topology to find d-h pairs
-        if not self.donors_sel:
+        if self.donors_sel is None:
 
             # We're using u._topology.bonds rather than u.bonds as it is a million times faster to access.
             # This is because u.bonds also calculates properties of each bond (e.g bond length).
@@ -583,9 +583,9 @@ class HydrogenBondAnalysis(AnalysisBase):
         self.results.hbonds = [[], [], [], [], [], []]
 
         # Set atom selections if they have not been provided
-        if not self.acceptors_sel:
+        if self.acceptors_sel is None:
             self.acceptors_sel = self.guess_acceptors()
-        if not self.hydrogens_sel:
+        if self.hydrogens_sel is None:
             self.hydrogens_sel = self.guess_hydrogens()
 
         # Select atom groups

--- a/package/MDAnalysis/analysis/hydrogenbonds/hbond_analysis.py
+++ b/package/MDAnalysis/analysis/hydrogenbonds/hbond_analysis.py
@@ -317,9 +317,9 @@ class HydrogenBondAnalysis(AnalysisBase):
         self.u = universe
         self._trajectory = self.u.trajectory
 
-        self.donors_sel = donors_sel.strip()
-        self.hydrogens_sel = hydrogens_sel.strip()
-        self.acceptors_sel = acceptors_sel.strip()
+        self.donors_sel = donors_sel.strip() if donors_sel is not None else donors_sel
+        self.hydrogens_sel = hydrogens_sel.strip() if hydrogens_sel is not None else hydrogens_sel
+        self.acceptors_sel = acceptors_sel.strip() if acceptors_sel is not None else acceptors_sel
 
         msg = ("{} is an empty selection string - no hydrogen bonds will "
                "be found. This may be intended, but please check your "

--- a/package/MDAnalysis/analysis/hydrogenbonds/hbond_analysis.py
+++ b/package/MDAnalysis/analysis/hydrogenbonds/hbond_analysis.py
@@ -317,9 +317,9 @@ class HydrogenBondAnalysis(AnalysisBase):
         self.u = universe
         self._trajectory = self.u.trajectory
 
-        self.donors_sel = donors_sel
-        self.hydrogens_sel = hydrogens_sel
-        self.acceptors_sel = acceptors_sel
+        self.donors_sel = donors_sel.strip()
+        self.hydrogens_sel = hydrogens_sel.strip()
+        self.acceptors_sel = acceptors_sel.strip()
 
         msg = ("{} is an empty selection string - no hydrogen bonds will "
                "be found. This may be intended, but please check your "

--- a/package/MDAnalysis/analysis/hydrogenbonds/hbond_analysis.py
+++ b/package/MDAnalysis/analysis/hydrogenbonds/hbond_analysis.py
@@ -317,20 +317,18 @@ class HydrogenBondAnalysis(AnalysisBase):
         self.u = universe
         self._trajectory = self.u.trajectory
 
-        msg = ("{}_sel is an empty selection string - no hydrogen bonds will "
-               "be found. This may be intended, but please check your "
-               "selection."
-               )
-        for sel, sel_string in zip(
-            [donors_sel, hydrogens_sel, acceptors_sel],
-            ['donors', 'hydrogens', 'acceptors']
-        ):
-            if isinstance(sel, str) and not sel:
-                warnings.warn(msg.format(sel_string))
-
         self.donors_sel = donors_sel
         self.hydrogens_sel = hydrogens_sel
         self.acceptors_sel = acceptors_sel
+
+        msg = ("{} is an empty selection string - no hydrogen bonds will "
+               "be found. This may be intended, but please check your "
+               "selection."
+               )
+        for sel in ['donors_sel', 'hydrogens_sel', 'acceptors_sel']:
+            val = getattr(self, sel)
+            if isinstance(val, str) and not val:
+                warnings.warn(msg.format(sel))
 
         # If hydrogen bonding groups are selected, then generate
         # corresponding atom groups

--- a/testsuite/MDAnalysisTests/analysis/test_hydrogenbonds_analysis.py
+++ b/testsuite/MDAnalysisTests/analysis/test_hydrogenbonds_analysis.py
@@ -556,24 +556,19 @@ class TestHydrogenBondAnalysisTIP3PStartStep(object):
 
 class TestHydrogenBondAnalysisEmptySelections:
 
-    @pytest.fixture()
-    def h(self):
+    universe = MDAnalysis.Universe(waterPSF, waterDCD)
+    kwargs = {
+        'donors_sel': '',
+        'hydrogens_sel': '',
+        'acceptors_sel': '',
+    }
 
-        universe = MDAnalysis.Universe(waterPSF, waterDCD)
-        kwargs = {
-            'donors_sel': '',
-            'hydrogens_sel': '',
-            'acceptors_sel': '',
-        }
+    h = HydrogenBondAnalysis(universe, **kwargs)
+    h.run()
 
-        h = HydrogenBondAnalysis(universe, **kwargs)
-        h.run()
+    def test_hbond_analysis(self):
 
-        return h
-
-    def test_hbond_analysis(self, h):
-
-        assert h.donors_sel == ''
-        assert h.hydrogens_sel == ''
-        assert h.acceptors_sel == ''
-        assert h.results.hbonds.size == 0
+        assert self.h.donors_sel == ''
+        assert self.h.hydrogens_sel == ''
+        assert self.h.acceptors_sel == ''
+        assert self.h.results.hbonds.size == 0

--- a/testsuite/MDAnalysisTests/analysis/test_hydrogenbonds_analysis.py
+++ b/testsuite/MDAnalysisTests/analysis/test_hydrogenbonds_analysis.py
@@ -561,40 +561,22 @@ class TestHydrogenBondAnalysisEmptySelections:
     def universe():
         return MDAnalysis.Universe(waterPSF, waterDCD)
 
-    kwargs = {
-        'donors_sel': ' ',
-        'hydrogens_sel': ' ',
-        'acceptors_sel': ' ',
-    }
     msg = ("{} is an empty selection string - no hydrogen bonds will "
            "be found. This may be intended, but please check your "
            "selection."
            )
 
-    def test_empty_donors_sel(self, universe):
-        with pytest.warns(UserWarning, match=self.msg.format("donors_sel")):
-            HydrogenBondAnalysis(
-                universe,
-                donors_sel=self.kwargs['donors_sel'],
-            )
-
-    def test_empty_hydrogens_sel(self, universe):
-        with pytest.warns(UserWarning, match=self.msg.format("hydrogens_sel")):
-            HydrogenBondAnalysis(
-                universe,
-                hydrogens_sel=self.kwargs['hydrogens_sel'],
-            )
-
-    def test_empty_acceptors_sel(self, universe):
-        with pytest.warns(UserWarning, match=self.msg.format("acceptors_sel")):
-            HydrogenBondAnalysis(
-                universe,
-                acceptors_sel=self.kwargs['acceptors_sel'],
-            )
+    @pytest.mark.parametrize('seltype',
+            ['donors_sel', 'hydrogens_sel', 'acceptors_sel'])
+    def test_empty_sel(self, universe, seltype):
+        sel_kwarg = {seltype: ' '}
+        with pytest.warns(UserWarning, match=self.msg.format(seltype)):
+            HydrogenBondAnalysis(universe, **sel_kwarg)
 
     def test_hbond_analysis(self, universe):
 
-        h = HydrogenBondAnalysis(universe, **self.kwargs)
+        h = HydrogenBondAnalysis(universe, donors_sel=' ', hydrogens_sel=' ',
+                                 acceptors_sel=' ')
         h.run()
 
         assert h.donors_sel == ''

--- a/testsuite/MDAnalysisTests/analysis/test_hydrogenbonds_analysis.py
+++ b/testsuite/MDAnalysisTests/analysis/test_hydrogenbonds_analysis.py
@@ -556,19 +556,48 @@ class TestHydrogenBondAnalysisTIP3PStartStep(object):
 
 class TestHydrogenBondAnalysisEmptySelections:
 
-    universe = MDAnalysis.Universe(waterPSF, waterDCD)
+    @staticmethod
+    @pytest.fixture(scope='class')
+    def universe():
+        return MDAnalysis.Universe(waterPSF, waterDCD)
+
     kwargs = {
         'donors_sel': '',
         'hydrogens_sel': '',
         'acceptors_sel': '',
     }
+    msg = ("{} is an empty selection string - no hydrogen bonds will "
+           "be found. This may be intended, but please check your "
+           "selection."
+           )
 
-    h = HydrogenBondAnalysis(universe, **kwargs)
-    h.run()
+    def test_empty_donors_sel(self, universe):
+        with pytest.warns(UserWarning, match=self.msg.format("donors_sel")):
+            HydrogenBondAnalysis(
+                universe,
+                donors_sel=self.kwargs['donors_sel'],
+            )
 
-    def test_hbond_analysis(self):
+    def test_empty_hydrogens_sel(self, universe):
+        with pytest.warns(UserWarning, match=self.msg.format("hydrogens_sel")):
+            HydrogenBondAnalysis(
+                universe,
+                hydrogens_sel=self.kwargs['hydrogens_sel'],
+            )
 
-        assert self.h.donors_sel == ''
-        assert self.h.hydrogens_sel == ''
-        assert self.h.acceptors_sel == ''
-        assert self.h.results.hbonds.size == 0
+    def test_empty_acceptors_sel(self, universe):
+        with pytest.warns(UserWarning, match=self.msg.format("acceptors_sel")):
+            HydrogenBondAnalysis(
+                universe,
+                acceptors_sel=self.kwargs['acceptors_sel'],
+            )
+
+    def test_hbond_analysis(self, universe):
+
+        h = HydrogenBondAnalysis(universe, **self.kwargs)
+        h.run()
+
+        assert h.donors_sel == ''
+        assert h.hydrogens_sel == ''
+        assert h.acceptors_sel == ''
+        assert h.results.hbonds.size == 0

--- a/testsuite/MDAnalysisTests/analysis/test_hydrogenbonds_analysis.py
+++ b/testsuite/MDAnalysisTests/analysis/test_hydrogenbonds_analysis.py
@@ -552,3 +552,28 @@ class TestHydrogenBondAnalysisTIP3PStartStep(object):
 
         counts = h.count_by_type()
         assert int(counts[0, 2]) == ref_count
+
+
+class TestHydrogenBondAnalysisEmptySelections:
+
+    @pytest.fixture()
+    def h(self):
+
+        universe = MDAnalysis.Universe(waterPSF, waterDCD)
+        kwargs = {
+            'donors_sel': '',
+            'hydrogens_sel': '',
+            'acceptors_sel': '',
+        }
+
+        h = HydrogenBondAnalysis(universe, **kwargs)
+        h.run()
+
+        return h
+
+    def test_hbond_analysis(self, h):
+
+        assert h.donors_sel == ''
+        assert h.hydrogens_sel == ''
+        assert h.acceptors_sel == ''
+        assert h.results.hbonds.size == 0

--- a/testsuite/MDAnalysisTests/analysis/test_hydrogenbonds_analysis.py
+++ b/testsuite/MDAnalysisTests/analysis/test_hydrogenbonds_analysis.py
@@ -562,9 +562,9 @@ class TestHydrogenBondAnalysisEmptySelections:
         return MDAnalysis.Universe(waterPSF, waterDCD)
 
     kwargs = {
-        'donors_sel': '',
-        'hydrogens_sel': '',
-        'acceptors_sel': '',
+        'donors_sel': ' ',
+        'hydrogens_sel': ' ',
+        'acceptors_sel': ' ',
     }
     msg = ("{} is an empty selection string - no hydrogen bonds will "
            "be found. This may be intended, but please check your "


### PR DESCRIPTION
Fixes #3453

Changes made in this Pull Request:
 - in `HydrogenBondAnalysis`, acceptors and donors are guessed `if self.acceptors_sel is None` and `if self.donors_sel is None`, rather than e.g. `if not self.acceptors_sel`.
- tests added that pass empty selection strings to `HydrogenBondAnalysis`

PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
