### PR TITLE
CI: add Win 3.10

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,7 +47,7 @@ jobs:
   - script: python -m pip install --upgrade pip setuptools wheel
     displayName: 'Install tools'
   - script: >-
-      python -m pip install
+      python -m pip install --only-binary=h5py
       cython
       hypothesis
       matplotlib
@@ -57,20 +57,17 @@ jobs:
       pytest-xdist
       scikit-learn
       scipy
+      h5py
       tqdm
       threadpoolctl
     displayName: 'Install dependencies'
-  - script: >-
-      python -m pip install --only-binary=h5py
-      "h5py<3.4.0"
-    displayName: 'Install h5py for Python < 3.10'
-    condition: and(succeeded(), ne(variables['PYTHON_VERSION'], '3.10'))
   # TODO: recent rdkit is not on PyPI
   - script: >-
       python -m pip install
       biopython
       chemfiles>=0.9
       duecredit
+      gsd
       joblib
       GridDataFormats
       mmtf-python

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,6 +35,9 @@ jobs:
         Python39-64bit-full:
           PYTHON_VERSION: '3.9'
           PYTHON_ARCH: 'x64'
+        Python310-64bit-full:
+          PYTHON_VERSION: '3.10'
+          PYTHON_ARCH: 'x64'
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -44,7 +47,7 @@ jobs:
   - script: python -m pip install --upgrade pip setuptools wheel
     displayName: 'Install tools'
   - script: >-
-      python -m pip install --only-binary=h5py
+      python -m pip install
       cython
       hypothesis
       matplotlib
@@ -54,17 +57,20 @@ jobs:
       pytest-xdist
       scikit-learn
       scipy
-      "h5py<3.4.0"
       tqdm
       threadpoolctl
     displayName: 'Install dependencies'
+  - script: >-
+      python -m pip install --only-binary=h5py
+      "h5py<3.4.0"
+    displayName: 'Install h5py for Python < 3.10'
+    condition: and(succeeded(), ne(variables['PYTHON_VERSION'], '3.10'))
   # TODO: recent rdkit is not on PyPI
   - script: >-
       python -m pip install
       biopython
       chemfiles>=0.9
       duecredit
-      gsd==1.9.3
       joblib
       GridDataFormats
       mmtf-python

--- a/testsuite/MDAnalysisTests/coordinates/test_chainreader.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_chainreader.py
@@ -354,7 +354,7 @@ class TestChainReaderContinuous(object):
                 # TODO: remove when we no longer have a dependency
                 # that still imports six
                 if (platform.system() == "Windows" and
-                    sys.version_info >= (3, 10)):
+                sys.version_info >= (3, 10)):
                     warnings.filterwarnings(
                             action='ignore',
                             category=ImportWarning)

--- a/testsuite/MDAnalysisTests/coordinates/test_chainreader.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_chainreader.py
@@ -20,6 +20,9 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
+import sys
+import platform
+import warnings
 import numpy as np
 import os
 
@@ -345,7 +348,17 @@ class TestChainReaderContinuous(object):
         sequences = ([0, 1, 2, 3], [2, 3, 4, 5], [4, 5, 6, 7])
         utop, fnames = build_trajectories(folder, sequences=sequences,)
         with no_warning(UserWarning):
-            mda.Universe(utop._topology, fnames, continuous=True)
+            with warnings.catch_warnings():
+                # for windows Python 3.10 ignore:
+                # ImportWarning('_SixMetaPathImporter.find_spec() not found
+                # TODO: remove when we no longer have a dependency
+                # that still imports six
+                if (platform.system() == "Windows" and
+                    sys.version_info >= (3, 10)):
+                    warnings.filterwarnings(
+                            action='ignore',
+                            category=ImportWarning)
+                mda.Universe(utop._topology, fnames, continuous=True)
 
     def test_single_frames(self, tmpdir):
         folder = str(tmpdir)

--- a/testsuite/MDAnalysisTests/coordinates/test_h5md.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_h5md.py
@@ -745,8 +745,8 @@ class TestH5MDWriterWithRealTrajectory(object):
         assert_equal(dset.compression, filter)
         assert_equal(dset.compression_opts, opts)
 
-#    @pytest.mark.xfail(os.name == 'nt',
-#                       reason="occasional PermissionError on windows")
+    @pytest.mark.xfail(os.name == 'nt',
+                       reason="occasional PermissionError on windows")
     @pytest.mark.parametrize('driver', ('core', 'stdio'))
     def test_write_with_drivers(self, universe, outfile, Writer, driver):
         with Writer(outfile,

--- a/testsuite/MDAnalysisTests/topology/test_top.py
+++ b/testsuite/MDAnalysisTests/topology/test_top.py
@@ -499,7 +499,7 @@ class TestErrorsAndWarnings(object):
                 # TODO: remove when we no longer have a dependency
                 # that still imports six
                 if (platform.system() == "Windows" and
-                    sys.version_info >= (3, 10)):
+                sys.version_info >= (3, 10)):
                     warnings.filterwarnings(
                             action='ignore',
                             category=ImportWarning)

--- a/testsuite/MDAnalysisTests/topology/test_top.py
+++ b/testsuite/MDAnalysisTests/topology/test_top.py
@@ -20,6 +20,9 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
+import sys
+import platform
+import warnings
 import MDAnalysis as mda
 import pytest
 import numpy as np
@@ -490,7 +493,17 @@ class TestErrorsAndWarnings(object):
     ))
     def test_warning(self, parm, errmsgs):
         with pytest.warns(UserWarning) as record:
-            u = mda.Universe(parm)
+            with warnings.catch_warnings():
+                # for windows Python 3.10 ignore:
+                # ImportWarning('_SixMetaPathImporter.find_spec() not found
+                # TODO: remove when we no longer have a dependency
+                # that still imports six
+                if (platform.system() == "Windows" and
+                    sys.version_info >= (3, 10)):
+                    warnings.filterwarnings(
+                            action='ignore',
+                            category=ImportWarning)
+                u = mda.Universe(parm)
 
         assert len(record) == len(errmsgs)
         # Assumes errmsgs list is in order of occurence

--- a/testsuite/MDAnalysisTests/utils/test_duecredit.py
+++ b/testsuite/MDAnalysisTests/utils/test_duecredit.py
@@ -29,6 +29,7 @@ import importlib
 # (if set to 'no', the tests will be SKIPPED; has to be yes, true, or 1 for duecredit
 # to work; duecredit must also be installed)
 import MDAnalysis as mda
+from MDAnalysis.coordinates.H5MD import HAS_H5PY
 from MDAnalysisTests.datafiles import MMTF, TPR_xvf, H5MD_xvf
 
 # duecredit itself is not needed in the name space but this is a
@@ -95,6 +96,7 @@ class TestDuecredit(object):
         assert mda.due.citations[('MDAnalysis.topology.MMTFParser',
                                   '10.1371/journal.pcbi.1005575')].cites_module
 
+    @pytest.mark.skipif(not HAS_H5PY, reason="h5py not installed")
     def test_duecredit_h5md(self):
         # doesn't trigger on import but on use of either reader or writer
         u = mda.Universe(TPR_xvf, H5MD_xvf)


### PR DESCRIPTION
Deals with the Windows portion of gh-3457

Changes made in this Pull Request:
 - adds Windows Python 3.10 testing to Azure CI to prevent any regressions there moving forward
 - for the moment, we skip `h5py` install on Python 3.10 and we no longer pin the version of `gsd`
 - we temporarily suppress the following Python 3.10 warning observed on Windows for a third-party library that is still importing `six`: `ImportWarning('_SixMetaPathImporter.find_spec() not found`
 - add the option to skip one test that had an obligate requirement for `h5py`, which seems more consistent anyway because we already have a bunch of tests that skip conditionally with `HAS_H5PY`
 - in my hands, this allows the test suite to pass on Windows w/ Python `3.10`; I do suggest that we open an issue to revert any of the minor workarounds in use here as the `3.10` dependencies/ecosystem matures in the future


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
