### PR TITLE
add parse_n_atoms() to H5MDReader

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,7 +13,9 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-??/??/?? IAlibay, melomcr, mdd31, ianmkenney, richardjgowers, hmacdope, orbeckst, scal444
+??/??/?? IAlibay, melomcr, mdd31, ianmkenney, richardjgowers, hmacdope,
+         orbeckst, scal444, edisj
+
  * 2.1.0
 
 Fixes
@@ -27,6 +29,7 @@ Fixes
     created using add_Residue and add_Segment (Issue #3437)
 
 Enhancements
+  * Adds :meth:`parse_n_atoms` to H5MD reader (Issue #3465)
   * Add option for custom compiler flags for C/C++ on build and remove march
     option from setup.cfg (Issue #3428, PR #3429).
 

--- a/package/MDAnalysis/coordinates/H5MD.py
+++ b/package/MDAnalysis/coordinates/H5MD.py
@@ -565,6 +565,17 @@ class H5MDReader(base.ReaderBase):
         # format='H5MD' is used
         return HAS_H5PY and isinstance(thing, h5py.File)
 
+    @staticmethod
+    def parse_n_atoms(filename):
+        with h5py.File(filename, 'r') as f:
+            for group in ('position', 'velocity', 'force'):
+                try:
+                    n_atoms = f[f'particles/trajectory/{group}/value'].shape[1]
+                    return n_atoms
+                except KeyError:
+                    pass
+
+
     def open_trajectory(self):
         """opens the trajectory file using h5py library"""
         self._frame = -1

--- a/package/MDAnalysis/coordinates/H5MD.py
+++ b/package/MDAnalysis/coordinates/H5MD.py
@@ -568,13 +568,15 @@ class H5MDReader(base.ReaderBase):
     @staticmethod
     def parse_n_atoms(filename):
         with h5py.File(filename, 'r') as f:
-            for group in ('position', 'velocity', 'force'):
-                try:
+            for group in f['particles/trajectory']:
+                if group in ('position', 'velocity', 'force'):
                     n_atoms = f[f'particles/trajectory/{group}/value'].shape[1]
                     return n_atoms
-                except KeyError:
-                    pass
-
+            else:
+                raise NoDataError("Could not construct minimal topology from the "
+                                  "H5MD trajectory file, as it did not contain a "
+                                  "'position', 'velocity', or 'force' group. "
+                                  "You must include a topology file.")
 
     def open_trajectory(self):
         """opens the trajectory file using h5py library"""

--- a/package/MDAnalysis/coordinates/H5MD.py
+++ b/package/MDAnalysis/coordinates/H5MD.py
@@ -327,6 +327,10 @@ class H5MDReader(base.ReaderBase):
 
 
     .. versionadded:: 2.0.0
+    .. versionchanged:: 2.1.0
+       Adds :meth:`parse_n_atoms` method to obtain the number of atoms directly
+       from the trajectory by evaluating the shape of the ``position``,
+       ``velocity``, or ``force`` groups.
 
     """
 
@@ -573,10 +577,11 @@ class H5MDReader(base.ReaderBase):
                     n_atoms = f[f'particles/trajectory/{group}/value'].shape[1]
                     return n_atoms
             else:
-                raise NoDataError("Could not construct minimal topology from the "
-                                  "H5MD trajectory file, as it did not contain a "
-                                  "'position', 'velocity', or 'force' group. "
-                                  "You must include a topology file.")
+                raise NoDataError("Could not construct minimal topology from "
+                                  "the H5MD trajectory file, as it did not "
+                                  "contain a 'position', 'velocity', or "
+                                  "'force' group. You must include a "
+                                  "topology file.")
 
     def open_trajectory(self):
         """opens the trajectory file using h5py library"""

--- a/package/MDAnalysis/coordinates/H5MD.py
+++ b/package/MDAnalysis/coordinates/H5MD.py
@@ -576,7 +576,7 @@ class H5MDReader(base.ReaderBase):
                 if group in ('position', 'velocity', 'force'):
                     n_atoms = f[f'particles/trajectory/{group}/value'].shape[1]
                     return n_atoms
-            
+
             raise NoDataError("Could not construct minimal topology from the "
                               "H5MD trajectory file, as it did not contain a "
                               "'position', 'velocity', or 'force' group. "

--- a/package/MDAnalysis/coordinates/H5MD.py
+++ b/package/MDAnalysis/coordinates/H5MD.py
@@ -576,12 +576,11 @@ class H5MDReader(base.ReaderBase):
                 if group in ('position', 'velocity', 'force'):
                     n_atoms = f[f'particles/trajectory/{group}/value'].shape[1]
                     return n_atoms
-            else:
-                raise NoDataError("Could not construct minimal topology from "
-                                  "the H5MD trajectory file, as it did not "
-                                  "contain a 'position', 'velocity', or "
-                                  "'force' group. You must include a "
-                                  "topology file.")
+            
+            raise NoDataError("Could not construct minimal topology from the "
+                              "H5MD trajectory file, as it did not contain a "
+                              "'position', 'velocity', or 'force' group. "
+                              "You must include a topology file.")
 
     def open_trajectory(self):
         """opens the trajectory file using h5py library"""

--- a/testsuite/MDAnalysisTests/coordinates/test_h5md.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_h5md.py
@@ -415,6 +415,7 @@ class TestH5MDReaderWithRealTrajectory(object):
         with pytest.raises(ValueError):
             u = mda.Universe(outfile)
 
+
 @pytest.mark.skipif(not HAS_H5PY, reason="h5py not installed")
 class TestH5MDWriterWithRealTrajectory(object):
 

--- a/testsuite/MDAnalysisTests/coordinates/test_h5md.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_h5md.py
@@ -413,7 +413,8 @@ class TestH5MDReaderWithRealTrajectory(object):
                 del traj_group['velocity']
                 del traj_group['force']
 
-        with pytest.raises(ValueError):
+        errmsg = "Could not construct minimal topology"
+        with pytest.raises(ValueError, match=errmsg):
             u = mda.Universe(outfile)
 
 

--- a/testsuite/MDAnalysisTests/coordinates/test_h5md.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_h5md.py
@@ -381,6 +381,39 @@ class TestH5MDReaderWithRealTrajectory(object):
         u = mda.Universe(TPR_xvf, H5MD_xvf, driver="core")
         assert_equal(u.trajectory._file.driver, "core")
 
+    @pytest.mark.parametrize('group1, group2', (('velocity', 'force'),
+                                                ('position', 'force'),
+                                                ('position', 'velocity')))
+    def test_parse_n_atoms(self, h5md_file, outfile, group1, group2):
+        with h5md_file as f:
+            with h5py.File(outfile, 'w') as g:
+                f.copy(source='particles', dest=g)
+                f.copy(source='h5md', dest=g)
+                traj_group = g['particles/trajectory']
+                del traj_group[group1]
+                del traj_group[group2]
+                for dset in ('position/value', 'velocity/value', 'force/value'):
+                    try:
+                        n_atoms_in_dset = traj_group[dset].shape[1]
+                        break
+                    except KeyError:
+                        continue
+
+        u = mda.Universe(outfile)
+        assert_equal(u.atoms.n_atoms, n_atoms_in_dset)
+
+    def test_parse_n_atoms_error(self, h5md_file, outfile):
+        with h5md_file as f:
+            with h5py.File(outfile, 'w') as g:
+                f.copy(source='particles', dest=g)
+                f.copy(source='h5md', dest=g)
+                traj_group = g['particles/trajectory']
+                del traj_group['position']
+                del traj_group['velocity']
+                del traj_group['force']
+
+        with pytest.raises(ValueError):
+            u = mda.Universe(outfile)
 
 @pytest.mark.skipif(not HAS_H5PY, reason="h5py not installed")
 class TestH5MDWriterWithRealTrajectory(object):

--- a/testsuite/MDAnalysisTests/coordinates/test_h5md.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_h5md.py
@@ -392,7 +392,8 @@ class TestH5MDReaderWithRealTrajectory(object):
                 traj_group = g['particles/trajectory']
                 del traj_group[group1]
                 del traj_group[group2]
-                for dset in ('position/value', 'velocity/value', 'force/value'):
+                for dset in ('position/value', 'velocity/value',
+                             'force/value'):
                     try:
                         n_atoms_in_dset = traj_group[dset].shape[1]
                         break


### PR DESCRIPTION
Fixes #3465

Changes made in this Pull Request:
 - add the `parse_n_atoms` method to H5MDReader so you can load a trajectory without a topology


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
