### PR TITLE
MAINT: update Cython imports

### DIFF
--- a/package/MDAnalysis/analysis/encore/clustering/affinityprop.pyx
+++ b/package/MDAnalysis/analysis/encore/clustering/affinityprop.pyx
@@ -32,6 +32,8 @@ import numpy
 cimport numpy
 cimport cython
 
+numpy.import_array()
+
 cdef extern from "ap.h":
     int CAffinityPropagation(float*, int, float, int, int, bint, long*)
 

--- a/package/MDAnalysis/analysis/encore/cutils.pyx
+++ b/package/MDAnalysis/analysis/encore/cutils.pyx
@@ -36,6 +36,7 @@ cimport numpy as np
 import cython
 from libc.math cimport sqrt
 
+np.import_array()
 
 @cython.boundscheck(False)
 @cython.wraparound(False)

--- a/package/MDAnalysis/analysis/encore/dimensionality_reduction/stochasticproxembed.pyx
+++ b/package/MDAnalysis/analysis/encore/dimensionality_reduction/stochasticproxembed.pyx
@@ -32,6 +32,7 @@ import logging
 import numpy
 cimport numpy
 
+numpy.import_array()
 cimport cython
 
 cdef extern from "spe.h":

--- a/package/MDAnalysis/lib/_augment.pyx
+++ b/package/MDAnalysis/lib/_augment.pyx
@@ -31,6 +31,8 @@ from MDAnalysis.lib._cutil cimport _dot ,_norm, _cross
 
 from libcpp.vector cimport vector
 
+np.import_array()
+
 
 __all__ = ['augment_coordinates', 'undo_augment']
 

--- a/package/MDAnalysis/lib/_cutil.pyx
+++ b/package/MDAnalysis/lib/_cutil.pyx
@@ -35,6 +35,7 @@ from libcpp.vector cimport vector
 from libcpp.utility cimport pair
 from cython.operator cimport dereference as deref
 
+np.import_array()
 
 __all__ = ['unique_int_1d', 'make_whole', 'find_fragments',
            '_sarrus_det_single', '_sarrus_det_multiple']

--- a/package/MDAnalysis/lib/c_distances.pyx
+++ b/package/MDAnalysis/lib/c_distances.pyx
@@ -32,6 +32,7 @@ Serial versions of all distance calculations
 cimport cython
 import numpy
 cimport numpy
+numpy.import_array()
 
 cdef extern from "string.h":
     void* memcpy(void* dst, void* src, int len)

--- a/package/MDAnalysis/lib/c_distances_openmp.pyx
+++ b/package/MDAnalysis/lib/c_distances_openmp.pyx
@@ -32,6 +32,7 @@ Contains OpenMP versions of the contents of "calc_distances.h"
 
 import numpy
 cimport numpy
+numpy.import_array()
 
 cdef extern from "string.h":
     void* memcpy(void* dst, void* src, int len)

--- a/package/MDAnalysis/lib/formats/cython_util.pxd
+++ b/package/MDAnalysis/lib/formats/cython_util.pxd
@@ -21,4 +21,5 @@
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
 cimport numpy as np
+np.import_array()
 cdef np.ndarray ptr_to_ndarray(void* data_ptr, np.int64_t[:] dim, int data_type)

--- a/package/MDAnalysis/lib/formats/libdcd.pyx
+++ b/package/MDAnalysis/lib/formats/libdcd.pyx
@@ -73,6 +73,8 @@ from libc.stdio cimport SEEK_SET, SEEK_CUR, SEEK_END
 from libc.stdint cimport uintptr_t
 from libc.stdlib cimport free
 
+np.import_array()
+
 _whence_vals = {"FIO_SEEK_SET": SEEK_SET,
                 "FIO_SEEK_CUR": SEEK_CUR,
                 "FIO_SEEK_END": SEEK_END}

--- a/package/MDAnalysis/lib/qcprot.pyx
+++ b/package/MDAnalysis/lib/qcprot.pyx
@@ -138,6 +138,7 @@ Users will typically use the :func:`CalcRMSDRotationalMatrix` function.
 
 import numpy as np
 cimport numpy as np
+np.import_array()
 
 from ..due import due, BibTeX, Doi
 


### PR DESCRIPTION
* use `np.import_array()` to prevent convoluted issues with
newer versions of Cython when using `cimport numpy ..` in
Cython sources

* in short, Cython and NumPy try to coordinate to do the right
thing with interwoven header inclusions, but this explicit call
prevents any confusion between the two

Fixes #3455

Changes made in this Pull Request:
 - 


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
