### PR TITLE
More details on Dihedral doc

### DIFF
--- a/package/MDAnalysis/analysis/dihedrals.py
+++ b/package/MDAnalysis/analysis/dihedrals.py
@@ -296,7 +296,7 @@ class Dihedral(AnalysisBase):
         """Parameters
         ----------
         atomgroups : list[AtomGroup]
-            a list of :class:`~MDAnalysis.core.groups.AtomGroup` for which 
+            a list of :class:`~MDAnalysis.core.groups.AtomGroup` for which
             the dihedral angles are calculated
 
         Raises

--- a/package/MDAnalysis/analysis/dihedrals.py
+++ b/package/MDAnalysis/analysis/dihedrals.py
@@ -295,8 +295,9 @@ class Dihedral(AnalysisBase):
     def __init__(self, atomgroups, **kwargs):
         """Parameters
         ----------
-        atomgroups : list
-            a list of atomgroups for which the dihedral angles are calculated
+        atomgroups : list[AtomGroup]
+            a list of :class:`~MDAnalysis.core.groups.AtomGroup` for which 
+            the dihedral angles are calculated
 
         Raises
         ------


### PR DESCRIPTION
Improve the doc of the Dihedral module. The changes are cosmetic but allow us to use the Dihedral module in the CLI since [PR82](https://github.com/MDAnalysis/mdacli/pull/82) adds handling of a List of AtomGroups. 

The type of the `atomgroups` attribute follows the [type hint](https://www.python.org/dev/peps/pep-0484/) recommendation.