### PR TITLE
Defaults TRZReader timestep to 1.0 ps

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -36,6 +36,8 @@ Enhancements
   * Added R/S Chirality support to RDKit parsed molecules
 
 Changes
+  * TRZReader now defaults to a `dt` of 1.0 (instead of 0.0 previously) when
+    it cannot be obtained from file (Issue #3257)
   * Dropped python 3.6 support and raised minimum numpy version to 1.18.0
     (NEP29)
 

--- a/package/MDAnalysis/coordinates/TRZ.py
+++ b/package/MDAnalysis/coordinates/TRZ.py
@@ -268,10 +268,7 @@ class TRZReader(base.ReaderBase):
             t1 = self.ts.time
             dt = t1 - t0
         except StopIteration:
-            msg = ('dt information could not be obtained, defaulting to 0 ps. '
-                   'Note: in MDAnalysis 2.1.0 this default will change 1 ps.')
-            warnings.warn(msg)
-            return 0
+            raise AttributeError
         else:
             return dt
         finally:

--- a/package/MDAnalysis/coordinates/TRZ.py
+++ b/package/MDAnalysis/coordinates/TRZ.py
@@ -80,6 +80,9 @@ class TRZReader(base.ReaderBase):
     .. versionchanged:: 1.0.1
        Now checks for the correct `n_atoms` on reading
        and can raise :exc:`ValueError`.
+    .. versionchanged:: 2.1.0
+       TRZReader now returns a default :attr:`dt` of 1.0 when it cannot be
+       obtained from the difference between two frames.
     """
 
     format = "TRZ"
@@ -257,9 +260,14 @@ class TRZReader(base.ReaderBase):
     def _get_dt(self):
         """The amount of time between frames in ps
 
-        Assumes that this step is constant (ie. 2 trajectories with different steps haven't been
-        stitched together)
-        Returns 0 in case of IOError
+        Assumes that this step is constant (ie. 2 trajectories with different
+        steps haven't been stitched together).
+        Returns ``AttributeError`` in case of ``StopIteration``
+        (which makes :attr:`dt` return 1.0).
+
+        .. versionchanged:: 2.1.0
+           Now returns an ``AttributeError`` if dt can't be obtained from the
+           time difference between two frames.
         """
         curr_frame = self.ts.frame
         try:

--- a/testsuite/MDAnalysisTests/coordinates/test_trz.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_trz.py
@@ -26,7 +26,8 @@ import os
 
 from numpy.testing import (
     assert_equal,
-    assert_almost_equal
+    assert_almost_equal,
+    assert_allclose
 )
 import numpy as np
 
@@ -233,10 +234,9 @@ class TestTRZWriter2(object):
 
         u2 = mda.Universe(two_water_gro, outfile)
 
-        wmsg = ('dt information could not be obtained, defaulting to 0 ps. '
-                'Note: in MDAnalysis 2.1.0 this default will change 1 ps.')
+        wmsg = ('Reader has no dt information, set to 1.0 ps')
         with pytest.warns(UserWarning, match=wmsg):
-            assert_almost_equal(u2.trajectory.dt, 0)
+            assert_allclose(u2.trajectory.dt, 1.0)
 
 
 class TestWrite_Partial_Timestep(object):


### PR DESCRIPTION
Fixes #3257

Changes made in this Pull Request:
 - Completes the previously warned changes to the TRZReader's `dt` default (i.e. if it cannot be obtained from file).
 - `_get_dt` raises an AttributeError in the same way that the NetCDFReader does (the only other trajectory reader that uses `dt` in this way).


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
