### PR TITLE
Reorganize dependencies

### DIFF
--- a/.github/actions/setup-deps/action.yaml
+++ b/.github/actions/setup-deps/action.yaml
@@ -83,24 +83,36 @@ runs:
   steps:
     - name: conda_install
       shell: bash -l {0}
+      env:
+        CONDA_MIN_DEPS: |
+          ${{ inputs.biopython }}
+          ${{ inputs.codecov }}
+          ${{ inputs.cython }}
+          ${{ inputs.griddataformats }}
+          ${{ inputs.gsd }}
+          ${{ inputs.hypothesis }}
+          ${{ inputs.matplotlib }}
+          ${{ inputs.mmtf-python }}
+          ${{ inputs.networkx }}
+          ${{ inputs.numpy }}
+          ${{ inputs.pip }}
+          ${{ inputs.pytest }}
+          ${{ inputs.scipy }}
+          ${{ inputs.threadpoolctl }}
+          ${{ inputs.tqdm }}
+        CONDA_OPT_DEPS: |
+          ${{ inputs.chemfiles-python }}
+          ${{ inputs.clustalw }}
+          ${{ inputs.h5py }}
+          ${{ inputs.joblib }}
+          ${{ inputs.netcdf4 }}
+          ${{ inputs.openmm }}
+          ${{ inputs.rdkit }}
+          ${{ inputs.scikit-learn }}
+          ${{ inputs.seaborn }}
+          ${{ inputs.tidynamics }}
+
       run: |
-        # setup env variable for the minimum deps
-        CONDA_MIN_DEPS="${{ inputs.biopython }} ${{ inputs.codecov }} "
-        CONDA_MIN_DEPS+="${{ inputs.cython }} ${{ inputs.griddataformats }} "
-        CONDA_MIN_DEPS+="${{ inputs.gsd }} ${{ inputs.hypothesis }} "
-        CONDA_MIN_DEPS+="${{ inputs.matplotlib }} ${{ inputs.mmtf-python }} "
-        CONDA_MIN_DEPS+="${{ inputs.networkx }} ${{ inputs.numpy }} "
-        CONDA_MIN_DEPS+="${{ inputs.pip }} ${{ inputs.pytest }} "
-        CONDA_MIN_DEPS+="${{ inputs.scipy }} ${{ inputs.threadpoolctl }} "
-        CONDA_MIN_DEPS+="${{ inputs.tqdm }} "
-
-        # setup env variable for optional deps
-        CONDA_OPT_DEPS="${{ inputs.chemfiles-python }} ${{ inputs.clustalw }} "
-        CONDA_OPT_DEPS+="${{ inputs.h5py }} ${{ inputs.joblib }} "
-        CONDA_OPT_DEPS+="${{ inputs.netcdf4 }} ${{ inputs.openmm }} "
-        CONDA_OPT_DEPS+="${{ inputs.rdkit }} ${{ inputs.scikit-learn }} "
-        CONDA_OPT_DEPS+="${{ inputs.seaborn }} ${{ inputs.tidynamics }} "
-
         # setup full variable
         if [ ${{ inputs.full-deps }} = "true" ]; then
           CONDA_DEPS="${CONDA_MIN_DEPS} ${CONDA_OPT_DEPS} ${{ inputs.extra-conda-deps }}"
@@ -117,14 +129,15 @@ runs:
           
     - name: pip_install
       shell: bash -l {0}
+      env:
+        PIP_MIN_DEPS: |
+          ${{ inputs.coverage }}
+          ${{ inputs.pytest-cov }}
+          ${{ inputs.pytest-xdist }}
+        PIP_OPT_DEPS: |
+          ${{ inputs.duecredit }}
+          ${{ inputs.parmed }}
       run: |
-        # setup env variable for the minimum deps
-        PIP_MIN_DEPS="${{ inputs.coverage }} ${{ inputs.pytest-cov }} "
-        PIP_MIN_DEPS+="${{ inputs.pytest-xdist }} "
-
-        # setup env variable for optional deps
-        PIP_OPT_DEPS="${{ inputs.duecredit }} ${{ inputs.parmed }} "
-
         # setup full variable
         if [ ${{ inputs.full-deps }} = "true" ]; then
           PIP_DEPS="${PIP_MIN_DEPS} ${PIP_OPT_DEPS} ${{ inputs.extra-pip-deps }}"

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -4,6 +4,7 @@ on:
     branches:
       - develop
       - master
+      - pr3490-reorg
   pull_request:
     branches:
       - develop
@@ -22,7 +23,6 @@ defaults:
 
 jobs:
   main_tests:
-    if: "github.repository == 'MDAnalysis/mdanalysis'"
     runs-on: ${{ matrix.os }}
     strategy:
         fail-fast: false
@@ -136,7 +136,6 @@ jobs:
 
 
   build_docs:
-    if: "github.repository == 'MDAnalysis/mdanalysis'"
     runs-on: ubuntu-latest
     env:
       CYTHON_TRACE_NOGIL: 1
@@ -226,7 +225,6 @@ jobs:
 
 
   pylint_check:
-    if: "github.repository == 'MDAnalysis/mdanalysis'"
     runs-on: ubuntu-latest
 
     steps:
@@ -256,7 +254,6 @@ jobs:
 
 
   pypi_check:
-    if: "github.repository == 'MDAnalysis/mdanalysis'"
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -4,7 +4,6 @@ on:
     branches:
       - develop
       - master
-      - pr3490-reorg
   pull_request:
     branches:
       - develop
@@ -23,6 +22,7 @@ defaults:
 
 jobs:
   main_tests:
+    if: "github.repository == 'MDAnalysis/mdanalysis'"
     runs-on: ${{ matrix.os }}
     strategy:
         fail-fast: false
@@ -136,6 +136,7 @@ jobs:
 
 
   build_docs:
+    if: "github.repository == 'MDAnalysis/mdanalysis'"
     runs-on: ubuntu-latest
     env:
       CYTHON_TRACE_NOGIL: 1
@@ -225,6 +226,7 @@ jobs:
 
 
   pylint_check:
+    if: "github.repository == 'MDAnalysis/mdanalysis'"
     runs-on: ubuntu-latest
 
     steps:
@@ -254,6 +256,7 @@ jobs:
 
 
   pypi_check:
+    if: "github.repository == 'MDAnalysis/mdanalysis'"
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Changes made in this Pull Request:
 - Reorganizes dependencies in setup-deps/action.yaml to move the `CONDA_MIN_DEPS`, `CONDA_OPT_DEPS` etc. into environment variables
 
This is just a cosmetic change and shouldn't change anything. Tests are failing because I haven't rebased yet to fix #3494.

Test run here: https://github.com/lilyminium/mdanalysis/runs/4725421554?check_suite_focus=true

Link specifically goes to a run where full dependencies are *not* installed; you can click on `install_deps` > `Run # setup full variable` > `env` to inspect `CONDA_MIN_DEPS`, `CONDA_OPT_DEPS`, and so on.


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
