### PR TITLE
Prevent flush on closed NamedStream

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -19,6 +19,7 @@ The rules for this file:
  * 2.1.0
 
 Fixes
+  * Prevents attempts to close an already closed NamedStream (Issue #3386)
   * Added missing exe_err import in hole.py. Fixed a bug in HoleAnalysis where 
     kwarg was passed instead of object to generate path (Issue #3493, PR #3496)
   * Fixes creation of vmd surfaces in hole2 when using non-contiguous frames

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -724,6 +724,11 @@ class NamedStream(io.IOBase, os.PathLike):
         .. Note:: This ``close()`` method is non-standard. ``del NamedStream``
                   always closes the underlying stream.
 
+
+        .. versionchanged:: 2.1.0
+           Calls to ``close()`` will no longer attempt to close or flush the
+           stream if :attr:`closed` is `True`.
+
         """
         if self.closed:
             return

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -724,11 +724,6 @@ class NamedStream(io.IOBase, os.PathLike):
         .. Note:: This ``close()`` method is non-standard. ``del NamedStream``
                   always closes the underlying stream.
 
-
-        .. versionchanged:: 2.1.0
-           Calls to ``close()`` will no longer attempt to close or flush the
-           stream if :attr:`closed` is `True`.
-
         """
         if self.closed:
             return

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -725,6 +725,9 @@ class NamedStream(io.IOBase, os.PathLike):
                   always closes the underlying stream.
 
         """
+        if self.closed:
+            return
+
         if self.close_stream or force:
             try:
                 return self.stream.close()

--- a/testsuite/MDAnalysisTests/utils/test_streamio.py
+++ b/testsuite/MDAnalysisTests/utils/test_streamio.py
@@ -96,6 +96,8 @@ class TestNamedStream(object):
         assert_equal(ns.closed, False)
         ns.close(force=True)
         assert_equal(ns.closed, True)
+        # Issue 3386 - calling close again shouldn't raise an error
+        ns.close()
 
     def test_StringIO_read(self):
         obj = StringIO("".join(self.text))
@@ -329,7 +331,6 @@ class TestStreamIO(RefAdKSmall):
     def test_PrimitivePDBReader(self):
         u = MDAnalysis.Universe(streamData.as_NamedStream('PDB'))
         assert_equal(u.atoms.n_atoms, self.ref_n_atoms)
-
 
     def test_PDBReader(self):
         try:


### PR DESCRIPTION
Fixes #3386

Changes made in this Pull Request:
 - Prevents trying to close (or seek) an already closed stream.


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
