### PR TITLE
Suppress openmm warning

### DIFF
--- a/package/MDAnalysis/__init__.py
+++ b/package/MDAnalysis/__init__.py
@@ -191,6 +191,7 @@ from .exceptions import (
 from .lib import log
 from .lib.log import start_logging, stop_logging
 
+logging.getLogger().setLevel(logging.ERROR)
 logging.getLogger("MDAnalysis").addHandler(log.NullHandler())
 del logging
 


### PR DESCRIPTION
Fixes #3506

Changes made in this Pull Request:
 Suppressed depreciation warning raised by openmm module. Apparently, openmm uses [root logger](https://github.com/openmm/openmm/blob/be19e0222ddf66f612016a3c1f687161a53c2396/wrappers/python/simtk/openmm/__init__.py) for the warnings, so I had to set root logging level to `ERROR` to disable the warning.


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?
