### PR TITLE
Fix OpenMM parser not working when elements is not set

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -75,6 +75,8 @@ Deprecations
  * 2.1.0
 
 Fixes
+  * Fixed OpenMMParser not working when some or none of the elements are set
+    (Issue #3317, PR #3511)
   * Use uint64_t loop counters in C level distance functions to avoid overflow
     for large arrays (Issue #3512, PR #3513).
   * Prevents attempts to close an already closed NamedStream (Issue #3386)

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -16,11 +16,13 @@ The rules for this file:
 ??/??/?? IAlibay, BFedder, inomag, Agorfa, aya9aladdin, shudipto-amin, cbouy,
          HenokB, umak1106, tamandeeps, Mrqeoqqt, megosato, AnirG, rishu235,
          mtiberti, manishsaini6421, Sukeerti1, robotjellyzone, markvrma, alescoulie,
-         mjtadema, PicoCentauri
+         mjtadema, PicoCentauri, Atharva7K
 
  * 2.2.0
 
 Fixes
+  * Fixed `OpenMMTopologyParser` not working when some or none of the elements
+    are present in the openmm topology (Issue #3317, PR #3511).
   * Remove None from filenames in analysis.hole.HoleAnalysis (PR #3650)
   * Fixed Numpy deprecation warnings about elementwise comparisons.
     (Issue #3535, PR #3619)
@@ -57,7 +59,7 @@ Enhancements
     charges.
   * New optimized AnalysisBase derived Watson-Crick distance analysis class in
     analysis.nucleicacids
-  * CRD extended format can now be explicitly requested with the `extended` 
+  * CRD extended format can now be explicitly requested with the `extended`
     keyword (Issue #3605)
 
 Changes
@@ -75,8 +77,6 @@ Deprecations
  * 2.1.0
 
 Fixes
-  * Fixed OpenMMParser not working when some or none of the elements are set
-    (Issue #3317, PR #3511)
   * Use uint64_t loop counters in C level distance functions to avoid overflow
     for large arrays (Issue #3512, PR #3513).
   * Prevents attempts to close an already closed NamedStream (Issue #3386)

--- a/package/MDAnalysis/converters/OpenMMParser.py
+++ b/package/MDAnalysis/converters/OpenMMParser.py
@@ -125,11 +125,12 @@ class OpenMMTopologyParser(TopologyReaderBase):
             atomtypes = [a.element.symbol for a in omm_topology.atoms()]
             masses = [a.element.mass._value for a in omm_topology.atoms()]
 
-        except:
+        except AttributeError:
             attrs = [
                 Atomids(np.array(atomids, dtype=np.int32)),
                 Atomnames(np.array(atomnames, dtype=object)),
-                Bonds(bonds, types=bond_types, order=bond_orders, guessed=False),
+                Bonds(bonds, types=bond_types, order=bond_orders,
+                      guessed=False),
                 ChainIDs(np.array(chainids, dtype=object)),
                 Resids(resids),
                 Resnums(resnums),
@@ -142,7 +143,8 @@ class OpenMMTopologyParser(TopologyReaderBase):
                 Atomids(np.array(atomids, dtype=np.int32)),
                 Atomnames(np.array(atomnames, dtype=object)),
                 Atomtypes(np.array(atomtypes, dtype=object)),
-                Bonds(bonds, types=bond_types, order=bond_orders, guessed=False),
+                Bonds(bonds, types=bond_types, order=bond_orders,
+                      guessed=False),
                 ChainIDs(np.array(chainids, dtype=object)),
                 Elements(np.array(elements, dtype=object)),
                 Masses(np.array(masses, dtype=np.float32)),

--- a/package/MDAnalysis/converters/OpenMMParser.py
+++ b/package/MDAnalysis/converters/OpenMMParser.py
@@ -118,6 +118,9 @@ class OpenMMTopologyParser(TopologyReaderBase):
            * When partial elements are present, values from available elements
              are used whereas the absent elements are assigned an empty string
              with their atomtype set to 'X' and mass set to 0.0.
+           * For abnormal elements (i.e not in SYM2Z) their symbol is
+             used as it is for atomtypes but an empty string is used for
+             elements.
 
         """
         atom_resindex = [a.residue.index for a in omm_topology.atoms()]
@@ -149,10 +152,13 @@ class OpenMMTopologyParser(TopologyReaderBase):
         atomtypes = []
         for a in omm_topology.atoms():
             elem = a.element
-            if elem is not None and elem.symbol.capitalize() in SYMB2Z:
-                validated_elements.append(elem.symbol.capitalize())
-                masses.append(elem.mass._value)
+            if elem is not None:
+                if elem.symbol.capitalize() in SYMB2Z:
+                    validated_elements.append(elem.symbol.capitalize())
+                else:
+                    validated_elements.append('')
                 atomtypes.append(elem.symbol.capitalize())
+                masses.append(elem.mass._value)
             else:
                 wmsg = (f"Unknown element {elem} found for some atoms. "
                         f"These have been given an empty element record "

--- a/package/MDAnalysis/converters/OpenMMParser.py
+++ b/package/MDAnalysis/converters/OpenMMParser.py
@@ -76,11 +76,6 @@ from ..core.topologyattrs import (
     Segids,
 )
 
-try:
-    from openmm.unit import daltons
-except ImportError:
-    from simtk.unit import daltons
-
 
 class OpenMMTopologyParser(TopologyReaderBase):
     format = "OPENMMTOPOLOGY"
@@ -127,6 +122,18 @@ class OpenMMTopologyParser(TopologyReaderBase):
              as it is for atomtypes but an empty string is used for elements.
 
         """
+
+        try:
+            from openmm.unit import daltons
+        except ImportError:
+            try:
+                from simtk.unit import daltons
+            except ImportError:
+                msg = ("OpenMM is required for the OpenMMParser but "
+                       "it's not installed. Try installing it with \n"
+                       "conda install -c conda-forge openmm")
+                raise ImportError(msg)
+
         atom_resindex = [a.residue.index for a in omm_topology.atoms()]
         residue_segindex = [r.chain.index for r in omm_topology.residues()]
         atomids = [a.id for a in omm_topology.atoms()]

--- a/package/MDAnalysis/converters/OpenMMParser.py
+++ b/package/MDAnalysis/converters/OpenMMParser.py
@@ -108,18 +108,22 @@ class OpenMMTopologyParser(TopologyReaderBase):
         -------
         top : MDAnalysis.core.topology.Topology
 
+        Note
+        ----
+        When none of the elements are present in the openmm topolgy, their
+        atomtypes are guessed using their names and their masses are
+        then guessed using their atomtypes.
+
+        When partial elements are present, values from available elements
+        are used whereas the absent elements are assigned an empty string
+        with their atomtype set to 'X' and mass set to 0.0.
+
+        For elements with invalid and unreal symbols, the symbol is used
+        as it is for atomtypes but an empty string is used for elements.
 
         .. versionchanged:: 2.2.0
-           * The parser now works when element attribute is missing in some or
-             all the atoms.
-           * When none of the elements are present their atomtypes are guessed
-             using their names and their masses are then guessed using their
-             atomtypes.
-           * When partial elements are present, values from available elements
-             are used whereas the absent elements are assigned an empty string
-             with their atomtype set to 'X' and mass set to 0.0.
-           * For elements with invalid and unreal symbols, the symbol is used
-             as it is for atomtypes but an empty string is used for elements.
+           The parser now works when element attribute is missing in some or
+           all the atoms.
 
         """
 

--- a/package/MDAnalysis/converters/OpenMMParser.py
+++ b/package/MDAnalysis/converters/OpenMMParser.py
@@ -171,7 +171,6 @@ class OpenMMTopologyParser(TopologyReaderBase):
                 atomtypes.append(elem.symbol)
                 masses.append(elem.mass.value_in_unit(daltons))
             else:
-                warn = True
                 validated_elements.append('')
                 masses.append(0.0)
                 atomtypes.append('X')
@@ -180,7 +179,7 @@ class OpenMMTopologyParser(TopologyReaderBase):
             if any(validated_elements):
                 warnings.warn("Element information missing for some atoms. "
                               "These have been given an empty element record ")
-                if any([i == 'X' for i in atomtypes]):
+                if any(i == 'X' for i in atomtypes):
                     warnings.warn("For absent elements, atomtype has been  "
                                   "set to 'X' and mass has been set to 0.0. "
                                   "If needed these can be guessed using "

--- a/package/MDAnalysis/converters/OpenMMParser.py
+++ b/package/MDAnalysis/converters/OpenMMParser.py
@@ -161,7 +161,6 @@ class OpenMMTopologyParser(TopologyReaderBase):
         validated_elements = []
         masses = []
         atomtypes = []
-        warn = False
         for a in omm_topology.atoms():
             elem = a.element
             if elem is not None:
@@ -177,26 +176,29 @@ class OpenMMTopologyParser(TopologyReaderBase):
                 masses.append(0.0)
                 atomtypes.append('X')
 
-        if warn:
-            wmsg = (f"Element information missing for some atoms. "
-                    f"These have been given an empty element record "
-                    f"with their atomtype set to 'X' "
-                    f"and their mass set to 0.0. "
-                    f"If needed they can be guessed using "
-                    f"MDAnalysis.topology.guessers.")
-            warnings.warn(wmsg)
+        if not all(validated_elements):
+            if any(validated_elements):
+                warnings.warn("Element information missing for some atoms. "
+                              "These have been given an empty element record ")
+                if any([i == 'X' for i in atomtypes]):
+                    warnings.warn("For absent elements, atomtype has been  "
+                                  "set to 'X' and mass has been set to 0.0. "
+                                  "If needed these can be guessed using "
+                                  "MDAnalysis.topology.guessers.")
+                attrs.append(Elements(np.array(validated_elements,
+                                               dtype=object)))
 
-        if not any(validated_elements):
-            atomtypes = guess_types(atomnames)
-            masses = guess_masses(atomtypes)
-            warnings.warn("Element information is missing for all the atoms. "
-                          "Elements attribute will not be populated. "
-                          "Atomtype attribute will be guessed using atom "
-                          "name and mass will be guessed using atomtype."
-                          "See MDAnalysis.topology.guessers.")
+            else:
+                atomtypes = guess_types(atomnames)
+                masses = guess_masses(atomtypes)
+                wmsg = ("Element information is missing for all the atoms. "
+                        "Elements attribute will not be populated. "
+                        "Atomtype attribute will be guessed using atom "
+                        "name and mass will be guessed using atomtype."
+                        "See MDAnalysis.topology.guessers.")
+                warnings.warn(wmsg)
         else:
             attrs.append(Elements(np.array(validated_elements, dtype=object)))
-
         attrs.append(Atomtypes(np.array(atomtypes, dtype=object)))
         attrs.append(Masses(np.array(masses)))
 

--- a/package/MDAnalysis/converters/OpenMMParser.py
+++ b/package/MDAnalysis/converters/OpenMMParser.py
@@ -176,7 +176,7 @@ class OpenMMTopologyParser(TopologyReaderBase):
 
             attrs.append(Elements(np.array(validated_elements, dtype=object)))
             attrs.append(Masses(np.array(masses)))
-            atomtypes = [elem if len(elem) != 0 else 'X'
+            atomtypes = [elem if elem else 'X'
                          for elem in validated_elements]
             attrs.append(Atomtypes(np.array(atomtypes, dtype=object)))
 

--- a/package/MDAnalysis/converters/OpenMMParser.py
+++ b/package/MDAnalysis/converters/OpenMMParser.py
@@ -112,9 +112,6 @@ class OpenMMTopologyParser(TopologyReaderBase):
         atomids = [a.id for a in omm_topology.atoms()]
         atomnames = [a.name for a in omm_topology.atoms()]
         chainids = [a.residue.chain.id for a in omm_topology.atoms()]
-        elements = [a.element.symbol for a in omm_topology.atoms()]
-        atomtypes = [a.element.symbol for a in omm_topology.atoms()]
-        masses = [a.element.mass._value for a in omm_topology.atoms()]
         resnames = [r.name for r in omm_topology.residues()]
         resids = [r.index + 1 for r in omm_topology.residues()]
         resnums = resids.copy()
@@ -123,32 +120,50 @@ class OpenMMTopologyParser(TopologyReaderBase):
         bond_orders = [b.order for b in omm_topology.bonds()]
         bond_types = [b.type for b in omm_topology.bonds()]
 
-        n_atoms = len(atomids)
-        n_residues = len(resids)
-        n_segments = len(segids)
+        try:
+            elements = [a.element.symbol for a in omm_topology.atoms()]
+            atomtypes = [a.element.symbol for a in omm_topology.atoms()]
+            masses = [a.element.mass._value for a in omm_topology.atoms()]
 
-        attrs = [
-            Atomids(np.array(atomids, dtype=np.int32)),
-            Atomnames(np.array(atomnames, dtype=object)),
-            Atomtypes(np.array(atomtypes, dtype=object)),
-            Bonds(bonds, types=bond_types, order=bond_orders, guessed=False),
-            ChainIDs(np.array(chainids, dtype=object)),
-            Elements(np.array(elements, dtype=object)),
-            Masses(np.array(masses, dtype=np.float32)),
-            Resids(resids),
-            Resnums(resnums),
-            Resnames(resnames),
-            Segids(segids),
-        ]
+        except:
+            attrs = [
+                Atomids(np.array(atomids, dtype=np.int32)),
+                Atomnames(np.array(atomnames, dtype=object)),
+                Bonds(bonds, types=bond_types, order=bond_orders, guessed=False),
+                ChainIDs(np.array(chainids, dtype=object)),
+                Resids(resids),
+                Resnums(resnums),
+                Resnames(resnames),
+                Segids(segids),
+            ]
 
-        top = Topology(
-            n_atoms,
-            n_residues,
-            n_segments,
-            attrs=attrs,
-            atom_resindex=atom_resindex,
-            residue_segindex=residue_segindex,
-        )
+        else:
+            attrs = [
+                Atomids(np.array(atomids, dtype=np.int32)),
+                Atomnames(np.array(atomnames, dtype=object)),
+                Atomtypes(np.array(atomtypes, dtype=object)),
+                Bonds(bonds, types=bond_types, order=bond_orders, guessed=False),
+                ChainIDs(np.array(chainids, dtype=object)),
+                Elements(np.array(elements, dtype=object)),
+                Masses(np.array(masses, dtype=np.float32)),
+                Resids(resids),
+                Resnums(resnums),
+                Resnames(resnames),
+                Segids(segids),
+            ]
+
+        finally:
+            n_atoms = len(atomids)
+            n_residues = len(resids)
+            n_segments = len(segids)
+            top = Topology(
+                n_atoms,
+                n_residues,
+                n_segments,
+                attrs=attrs,
+                atom_resindex=atom_resindex,
+                residue_segindex=residue_segindex,
+            )
 
         return top
 

--- a/testsuite/MDAnalysisTests/converters/test_openmm_parser.py
+++ b/testsuite/MDAnalysisTests/converters/test_openmm_parser.py
@@ -159,38 +159,7 @@ class TestOpenMMTopologyParser(OpenMMTopologyBase):
     expected_n_bonds = 1922
 
 
-class TestOpenMMTopologyParserWithNoElements(OpenMMTopologyBase):
-    ref_filename = app.PDBFile(PDB).topology
-    for a in ref_filename.atoms():
-        a.element = None
-
-    expected_n_atoms = 47681
-    expected_n_residues = 11302
-    expected_n_segments = 1
-    expected_n_bonds = 25533
-
-    expected_attrs = [
-        "ids",
-        "names",
-        "resids",
-        "resnames",
-        "masses",
-        "bonds",
-        "chainIDs",
-    ]
-
-    def test_no_elements_warn(self):
-        wmsg = ("Element information is missing for all the atoms. "
-                "Elements attribute will not be populated. "
-                "Atomtype attribute will be guessed using atom "
-                "name and mass will be guessed using atomtype."
-                "See MDAnalysis.topology.guessers.")
-
-        with pytest.warns(UserWarning, match=wmsg):
-            mda_top = self.parser(self.ref_filename).parse()
-
-
-class TestOpenMMTopologyParserWithPartialElements():
+class TestOpenMMTopologyParserWithPartialElements(OpenMMTopologyBase):
     parser = mda.converters.OpenMMParser.OpenMMTopologyParser
     ref_filename = app.PDBFile(PDB).topology
     expected_n_atoms = 47681
@@ -211,6 +180,22 @@ class TestOpenMMTopologyParserWithPartialElements():
             assert mda_top.types.values[3388] == 'X'
             assert mda_top.elements.values[3344] == ''
             assert mda_top.elements.values[3388] == ''
+
+
+def test_no_elements_warn():
+    parser = mda.converters.OpenMMParser.OpenMMTopologyParser
+    omm_top = app.PDBFile(CONECT).topology
+    for a in omm_top.atoms():
+        a.element = None
+
+    wmsg = ("Element information is missing for all the atoms. "
+            "Elements attribute will not be populated. "
+            "Atomtype attribute will be guessed using atom "
+            "name and mass will be guessed using atomtype."
+            "See MDAnalysis.topology.guessers.")
+
+    with pytest.warns(UserWarning, match=wmsg):
+        mda_top = parser(omm_top).parse()
 
 
 def test_invalid_element_symbols():

--- a/testsuite/MDAnalysisTests/converters/test_openmm_parser.py
+++ b/testsuite/MDAnalysisTests/converters/test_openmm_parser.py
@@ -30,13 +30,12 @@ from MDAnalysisTests.datafiles import CONECT, PDBX, PDB
 
 
 try:
-    from openmm.app.element import Element
+    from openmm.app import Element, Topology
     from openmm.unit import daltons
-    from openmm.app import Topology
     from openmm import app
 except ImportError:
     try:
-        from simtk.openmm.app import Topology, Element
+        from simtk.openmm.app import Element, Topology
         from simtk.unit import daltons
         from simtk.openmm import app
     except ImportError:

--- a/testsuite/MDAnalysisTests/converters/test_openmm_parser.py
+++ b/testsuite/MDAnalysisTests/converters/test_openmm_parser.py
@@ -27,14 +27,17 @@ import MDAnalysis as mda
 
 from MDAnalysisTests.topology.base import ParserBase
 from MDAnalysisTests.datafiles import CONECT, PDBX, PDB
-from openmm.app.element import Element
-from openmm.unit import daltons
-from openmm.app import Topology
+
 
 try:
+    from openmm.app.element import Element
+    from openmm.unit import daltons
+    from openmm.app import Topology
     from openmm import app
 except ImportError:
     try:
+        from simtk.openmm.app import Topology, Element
+        from simtk.unit import daltons
         from simtk.openmm import app
     except ImportError:
         pytest.skip(allow_module_level=True)

--- a/testsuite/MDAnalysisTests/converters/test_openmm_parser.py
+++ b/testsuite/MDAnalysisTests/converters/test_openmm_parser.py
@@ -108,7 +108,7 @@ class OpenMMTopologyBase(ParserBase):
             assert isinstance(top.elements.values, np.ndarray)
             assert all(isinstance(elem, str) for elem in top.elements.values)
         else:
-            assert not hasattr(top, 'elemets')
+            assert not hasattr(top, 'elements')
 
     def test_atomtypes(self, top):
         assert len(top.types.values) == self.expected_n_atoms
@@ -171,6 +171,14 @@ class TestOpenMMTopologyParserWithNoElements(OpenMMTopologyBase):
         "bonds",
         "chainIDs",
     ]
+
+    @pytest.fixture()
+    def top(self, filename):
+        omm_topology = self.ref_filename
+        for a in omm_topology.atoms():
+            a.element = None
+        return self.parser(PDB) \
+                   ._mda_topology_from_omm_topology(omm_topology)
 
     def test_no_elements(self, top):
         omm_topology = self.ref_filename

--- a/testsuite/MDAnalysisTests/converters/test_openmm_parser.py
+++ b/testsuite/MDAnalysisTests/converters/test_openmm_parser.py
@@ -107,6 +107,8 @@ class OpenMMTopologyBase(ParserBase):
             assert len(top.elements.values) == self.expected_n_atoms
             assert isinstance(top.elements.values, np.ndarray)
             assert all(isinstance(elem, str) for elem in top.elements.values)
+        else:
+            assert not hasattr(top, 'elemets')
 
     def test_atomtypes(self, top):
         assert len(top.types.values) == self.expected_n_atoms

--- a/testsuite/MDAnalysisTests/converters/test_openmm_parser.py
+++ b/testsuite/MDAnalysisTests/converters/test_openmm_parser.py
@@ -101,6 +101,25 @@ class OpenMMTopologyBase(ParserBase):
         else:
             assert top.segids.values == []
 
+    def test_elements(self, top):
+        if hasattr(top, 'elements'):
+            assert len(top.elements.values) == self.expected_n_atoms
+            assert isinstance(top.elements.values, np.ndarray)
+            assert all(isinstance(elem, str) for elem in top.elements.values)
+
+    def test_atomtypes(self, top):
+        if hasattr(top, 'atomtypes'):
+            assert len(top.atomtypes.values) == self.expected_n_atoms
+            assert isinstance(top, np.ndarray)
+            assert all(isinstance(atomtype, str)
+                       for atomtype in top.atomtypes.values)
+
+    def test_masses(self, top):
+        assert len(top.masses.values) == self.expected_n_atoms
+        assert isinstance(top.masses.values, np.ndarray)
+        assert all(isinstance(mass, np.float64)
+                   for mass in top.masses.values)
+
 
 class OpenMMAppTopologyBase(OpenMMTopologyBase):
     parser = mda.converters.OpenMMParser.OpenMMAppTopologyParser

--- a/testsuite/MDAnalysisTests/converters/test_openmm_parser.py
+++ b/testsuite/MDAnalysisTests/converters/test_openmm_parser.py
@@ -168,18 +168,24 @@ class TestOpenMMTopologyParserWithPartialElements(OpenMMTopologyBase):
     expected_n_bonds = 25533
 
     def test_with_partial_elements(self):
-        wmsg = (f"Element information missing for some atoms. "
-                f"These have been given an empty element record "
-                f"with their atomtype set to 'X' "
-                f"and their mass set to 0.0. "
-                f"If needed they can be guessed using "
-                f"MDAnalysis.topology.guessers.")
-        with pytest.warns(UserWarning, match=wmsg):
+        wmsg1 = ("Element information missing for some atoms. "
+                 "These have been given an empty element record ")
+
+        wmsg2 = ("For absent elements, atomtype has been  "
+                 "set to 'X' and mass has been set to 0.0. "
+                 "If needed these can be guessed using "
+                 "MDAnalysis.topology.guessers.")
+
+        with pytest.warns(UserWarning) as warnings:
             mda_top = self.parser(self.ref_filename).parse()
             assert mda_top.types.values[3344] == 'X'
             assert mda_top.types.values[3388] == 'X'
             assert mda_top.elements.values[3344] == ''
             assert mda_top.elements.values[3388] == ''
+
+            assert len(warnings) == 2
+            assert str(warnings[0].message) == wmsg1
+            assert str(warnings[1].message) == wmsg2
 
 
 def test_no_elements_warn():


### PR DESCRIPTION
Fixes #3317

Changes made in this Pull Request:
 Fixed `OpenMMParser` not working when the elements attribute is not set in the OpenMM topology.



PR Checklist
------------
 - [X] Tests?
 - [X] Docs?
 - [x] CHANGELOG updated?
 - [X] Issue raised/referenced?
