### PR TITLE
DOC: fix SciPy intersphinx link.

### DIFF
--- a/package/doc/sphinx/source/conf.py
+++ b/package/doc/sphinx/source/conf.py
@@ -340,7 +340,7 @@ epub_copyright = u'2015, '+authors
 # and other packages used by MDAnalysis
 intersphinx_mapping = {'https://docs.python.org/': None,
                        'https://docs.scipy.org/doc/numpy/': None,
-                       'https://docs.scipy.org/doc/scipy/reference/': None,
+                       'https://docs.scipy.org/doc/scipy/': None,
                        'https://matplotlib.org': None,
                        'https://networkx.github.io/documentation/stable/': None,
                        'https://www.mdanalysis.org/GridDataFormats/': None,


### PR DESCRIPTION
See: https://github.com/scipy/scipy/issues/15545#issuecomment-1032825234

Fixup intersphinx link after new SciPy doc theme in `1.8.0` release and `.htaccess` changes on our docs server upstream.
