### PR TITLE
Swap equal to allclose for float comparison in StoR test

### DIFF
--- a/testsuite/MDAnalysisTests/lib/test_distances.py
+++ b/testsuite/MDAnalysisTests/lib/test_distances.py
@@ -71,7 +71,7 @@ def test_transform_StoR_pass(coord_dtype):
 
     test_r = distances.transform_StoR(s, box)
 
-    assert_equal(original_r, test_r)
+    assert_allclose(original_r, test_r)
 
 
 def test_capped_distance_noresults():


### PR DESCRIPTION
Fixes #3524

Changes made in this Pull Request:
 - swap from equal to allclose in the one test (_should_ be the only one that was being applied to floats incorrectly)


PR Checklist
------------
 - [x] Tests?
 - Docs?
 - CHANGELOG updated?
 - [x] Issue raised/referenced?
