### PR TITLE
BLD, MAINT: hoist packaging import

### DIFF
--- a/package/setup.py
+++ b/package/setup.py
@@ -46,6 +46,7 @@ Google groups forbids any name that contains the string `anal'.)
 from setuptools import setup, Extension, find_packages
 from distutils.ccompiler import new_compiler
 from distutils.sysconfig import customize_compiler
+from packaging.version import Version
 import codecs
 import os
 import sys
@@ -83,7 +84,6 @@ try:
     import Cython
     from Cython.Build import cythonize
     cython_found = True
-    from packaging.version import Version
 
     required_version = "0.16"
     if not Version(Cython.__version__) >= Version(required_version):


### PR DESCRIPTION
* hoist the import of `packaging` outside of a Cython-focused
`try`/`except` block to avoid a deceptive error message when
`packaging` is missing, per discussion at:
https://github.com/MDAnalysis/mdanalysis/pull/3398#issuecomment-1037371853

* we may also want to consider removing the external dependency
completely and vendoring the pertinent code since it is so small, but
maybe not this close to a release; an example:
https://github.com/scipy/scipy/blob/main/scipy/_lib/_pep440.py


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
