### PR TITLE
Switch from deprecated scipy.io.netcdf to scipy.io

### DIFF
--- a/package/MDAnalysis/coordinates/TRJ.py
+++ b/package/MDAnalysis/coordinates/TRJ.py
@@ -419,7 +419,7 @@ class NCDFReader(base.ReaderBase):
     to memory (using the :class:`~mmap.mmap`); ``mmap=False`` may consume large
     amounts of memory because it loads the whole trajectory into memory but it
     might be faster. The default is ``mmap=None`` and then default behavior of
-    :class:`scipy.io.netcdf.netcdf_file` prevails, i.e. ``True`` when
+    :class:`scipy.io.netcdf_file` prevails, i.e. ``True`` when
     *filename* is a file name, ``False`` when *filename* is a file-like object.
 
     .. _AMBER NETCDF format: http://ambermd.org/netcdf/nctraj.xhtml
@@ -448,7 +448,7 @@ class NCDFReader(base.ReaderBase):
        Support for reading `degrees` units for `cell_angles` has now been
        removed (Issue #2327)
     .. versionchanged:: 2.0.0
-       Now use a picklable :class:`scipy.io.netcdf.netcdf_file`--
+       Now use a picklable :class:`scipy.io.netcdf_file`--
        :class:`NCDFPicklable`.
        Reading of `dt` now defaults to 1.0 ps if `dt` cannot be extracted from
        the first two frames of the trajectory.
@@ -639,7 +639,7 @@ class NCDFReader(base.ReaderBase):
 
     @staticmethod
     def parse_n_atoms(filename, **kwargs):
-        with scipy.io.netcdf.netcdf_file(filename, mmap=None) as f:
+        with scipy.io.netcdf_file(filename, mmap=None) as f:
             n_atoms = f.dimensions['atom']
         return n_atoms
 
@@ -980,9 +980,9 @@ class NCDFWriter(base.WriterBase):
             ncfile = netCDF4.Dataset(self.filename, 'w',
                                      format='NETCDF3_64BIT')
         else:
-            ncfile = scipy.io.netcdf.netcdf_file(self.filename,
-                                                 mode='w', version=2,
-                                                 maskandscale=False)
+            ncfile = scipy.io.netcdf_file(self.filename,
+                                          mode='w', version=2,
+                                          maskandscale=False)
             wmsg = ("Could not find netCDF4 module. Falling back to MUCH "
                     "slower scipy.io.netcdf implementation for writing.")
             logger.warning(wmsg)
@@ -1206,11 +1206,11 @@ class NCDFWriter(base.WriterBase):
             self.trjfile = None
 
 
-class NCDFPicklable(scipy.io.netcdf.netcdf_file):
+class NCDFPicklable(scipy.io.netcdf_file):
     """NetCDF file object (read-only) that can be pickled.
 
     This class provides a file-like object (as returned by
-    :class:`scipy.io.netcdf.netcdf_file`) that,
+    :class:`scipy.io.netcdf_file`) that,
     unlike standard Python file objects,
     can be pickled. Only read mode is supported.
 
@@ -1222,7 +1222,7 @@ class NCDFPicklable(scipy.io.netcdf.netcdf_file):
 
 
     .. note::
-        This class subclasses :class:`scipy.io.netcdf.netcdf_file`, please
+        This class subclasses :class:`scipy.io.netcdf_file`, please
         see the `scipy netcdf API documentation`_ for more information on
         the parameters and how the class behaviour.
 

--- a/testsuite/MDAnalysisTests/coordinates/test_netcdf.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_netcdf.py
@@ -24,7 +24,7 @@ import MDAnalysis as mda
 import numpy as np
 import sys
 
-from scipy.io import netcdf
+from scipy.io import netcdf_file
 
 import pytest
 from numpy.testing import (
@@ -306,8 +306,8 @@ class _NCDFGenerator(object):
     def create_ncdf(self, params):
         """A basic modular ncdf writer based on :class:`NCDFWriter`"""
         # Create under context manager
-        with netcdf.netcdf_file(params['filename'], mode='w',
-                                version=params['version_byte']) as ncdf:
+        with netcdf_file(params['filename'], mode='w',
+                         version=params['version_byte']) as ncdf:
             # Top level attributes
             if params['Conventions']:
                 setattr(ncdf, 'Conventions', params['Conventions'])
@@ -656,7 +656,7 @@ class _NCDFWriterTest(object):
         #       which should be "float32".
         #       See http://docs.scipy.org/doc/numpy-1.10.0/reference/arrays.dtypes.html
         #       and https://github.com/MDAnalysis/mdanalysis/pull/503
-        dataset = netcdf.netcdf_file(outfile, 'r')
+        dataset = netcdf_file(outfile, 'r')
         coords = dataset.variables['coordinates']
         time = dataset.variables['time']
         assert_equal(coords[:].dtype.name, np.dtype(np.float32).name,
@@ -908,7 +908,7 @@ class TestNCDFWriterScaleFactors:
         sfactors = {}
         # being overly cautious by setting mmap to False, probably would
         # be faster & ok to set it to True
-        with netcdf.netcdf_file(ncdfile, mmap=False) as f:
+        with netcdf_file(ncdfile, mmap=False) as f:
             for var in f.variables:
                 if hasattr(f.variables[var], 'scale_factor'):
                     sfactors[var] = f.variables[var].scale_factor
@@ -917,7 +917,7 @@ class TestNCDFWriterScaleFactors:
 
     def get_variable(self, ncdfile, variable, frame):
         """Return a variable array from netcdf file"""
-        with netcdf.netcdf_file(ncdfile, mmap=False) as f:
+        with netcdf_file(ncdfile, mmap=False) as f:
             return f.variables[variable][frame]
 
     def test_write_read_factors_default(self, outfile, universe):
@@ -1038,7 +1038,7 @@ class TestNCDFWriterUnits(object):
             for ts in trr.trajectory:
                 W.write(trr)
 
-        with netcdf.netcdf_file(outfile, mode='r') as ncdf:
+        with netcdf_file(outfile, mode='r') as ncdf:
             unit = ncdf.variables[var].units.decode('utf-8')
             assert_equal(unit, expected)
 


### PR DESCRIPTION
Fixes #3529 

Changes made in this Pull Request:
 - switches imports for netcdf_file (as per title)


PR Checklist
------------
 - Tests?
 - Docs?
 - CHANGELOG updated?
 - [x] Issue raised/referenced?
