### PR TITLE
Fix for leftover simtk imports in openmm tests

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -173,6 +173,7 @@ Chronological list of authors
   - Kevin Boyd
 2022
   - Atharva Kulkarni
+  - Yantong Cai
 
 External code
 -------------

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -14,7 +14,8 @@ The rules for this file:
 
 ------------------------------------------------------------------------------
 ??/??/?? IAlibay, melomcr, mdd31, ianmkenney, richardjgowers, hmacdope,
-         orbeckst, scal444, p-j-smith, edisj, Atharva7K, ojeda-e, jbarnoud
+         orbeckst, scal444, p-j-smith, edisj, Atharva7K, ojeda-e, jbarnoud,
+         yangtcai
 
  * 2.1.0
 

--- a/testsuite/MDAnalysisTests/converters/test_openmm.py
+++ b/testsuite/MDAnalysisTests/converters/test_openmm.py
@@ -31,11 +31,22 @@ from MDAnalysisTests.coordinates.base import _SingleFrameReader
 
 import MDAnalysis as mda
 
-mm = pytest.importorskip("simtk.openmm")
-unit = pytest.importorskip("simtk.unit")
-app = pytest.importorskip("simtk.openmm.app")
+try:
+    import openmm as mm
+    from openmm import unit, app
+except ImportError:
+    try:
+        from simtk import openmm as mm
+        from simtk import unit
+        from simtk.openmm import app
+    except ImportError:
+        SKIP_OPENMM = True
 
 
+requires_openmm = pytest.mark.skipif(SKIP_OPENMM, reason="requires OpenMM")
+
+
+@requires_openmm
 class TestOpenMMBasicSimulationReader():
     @pytest.fixture
     def omm_sim_uni(self):
@@ -80,6 +91,7 @@ class TestOpenMMBasicSimulationReader():
         assert len(omm_sim_uni.bonds.indices) == 0
 
 
+@requires_openmm
 class TestOpenMMPDBFileReader(_SingleFrameReader):
     __test__ = True
 
@@ -103,6 +115,7 @@ class TestOpenMMPDBFileReader(_SingleFrameReader):
         assert_almost_equal(up, rp, decimal=3)
 
 
+@requires_openmm
 class TestOpenMMModellerReader(_SingleFrameReader):
     __test__ = True
 
@@ -128,6 +141,7 @@ class TestOpenMMModellerReader(_SingleFrameReader):
         assert_almost_equal(up, rp, decimal=3)
 
 
+@requires_openmm
 class TestOpenMMSimulationReader(_SingleFrameReader):
     __test__ = True
 
@@ -173,6 +187,7 @@ def PDBX_U():
     return mda.Universe(app.PDBxFile(PDBX))
 
 
+@requires_openmm
 def test_pdbx_coordinates(PDBX_U):
     ref_pos = 10 * np.array(
         [

--- a/testsuite/MDAnalysisTests/converters/test_openmm.py
+++ b/testsuite/MDAnalysisTests/converters/test_openmm.py
@@ -40,13 +40,9 @@ except ImportError:
         from simtk import unit
         from simtk.openmm import app
     except ImportError:
-        SKIP_OPENMM = True
+        pytest.skip(allow_module_level=True)
 
 
-requires_openmm = pytest.mark.skipif(SKIP_OPENMM, reason="requires OpenMM")
-
-
-@requires_openmm
 class TestOpenMMBasicSimulationReader():
     @pytest.fixture
     def omm_sim_uni(self):
@@ -91,7 +87,6 @@ class TestOpenMMBasicSimulationReader():
         assert len(omm_sim_uni.bonds.indices) == 0
 
 
-@requires_openmm
 class TestOpenMMPDBFileReader(_SingleFrameReader):
     __test__ = True
 
@@ -115,7 +110,6 @@ class TestOpenMMPDBFileReader(_SingleFrameReader):
         assert_almost_equal(up, rp, decimal=3)
 
 
-@requires_openmm
 class TestOpenMMModellerReader(_SingleFrameReader):
     __test__ = True
 
@@ -141,7 +135,6 @@ class TestOpenMMModellerReader(_SingleFrameReader):
         assert_almost_equal(up, rp, decimal=3)
 
 
-@requires_openmm
 class TestOpenMMSimulationReader(_SingleFrameReader):
     __test__ = True
 
@@ -187,7 +180,6 @@ def PDBX_U():
     return mda.Universe(app.PDBxFile(PDBX))
 
 
-@requires_openmm
 def test_pdbx_coordinates(PDBX_U):
     ref_pos = 10 * np.array(
         [

--- a/testsuite/MDAnalysisTests/converters/test_openmm_parser.py
+++ b/testsuite/MDAnalysisTests/converters/test_openmm_parser.py
@@ -28,10 +28,19 @@ import MDAnalysis as mda
 from MDAnalysisTests.topology.base import ParserBase
 from MDAnalysisTests.datafiles import CONECT, PDBX
 
+try:
+    from openmm import app
+except ImportError:
+    try:
+        from simtk.openmm import app
+    except ImportError:
+        SKIP_OPENMM = True
 
-app = pytest.importorskip('simtk.openmm.app')
+
+requires_openmm = pytest.mark.skipif(SKIP_OPENMM, reason="requires OpenMM")
 
 
+@requires_openmm
 class OpenMMTopologyBase(ParserBase):
     parser = mda.converters.OpenMMParser.OpenMMTopologyParser
     expected_attrs = [
@@ -97,6 +106,7 @@ class OpenMMTopologyBase(ParserBase):
             assert top.segids.values == []
 
 
+@requires_openmm
 class OpenMMAppTopologyBase(OpenMMTopologyBase):
     parser = mda.converters.OpenMMParser.OpenMMAppTopologyParser
     expected_attrs = [
@@ -117,6 +127,7 @@ class OpenMMAppTopologyBase(OpenMMTopologyBase):
         assert isinstance(u, mda.Universe)
 
 
+@requires_openmm
 class TestOpenMMTopologyParser(OpenMMTopologyBase):
     ref_filename = app.PDBFile(CONECT).topology
     expected_n_atoms = 1890
@@ -125,6 +136,7 @@ class TestOpenMMTopologyParser(OpenMMTopologyBase):
     expected_n_bonds = 1922
 
 
+@requires_openmm
 class TestOpenMMPDBFileParser(OpenMMAppTopologyBase):
     ref_filename = app.PDBFile(CONECT)
     expected_n_atoms = 1890
@@ -133,6 +145,7 @@ class TestOpenMMPDBFileParser(OpenMMAppTopologyBase):
     expected_n_bonds = 1922
 
 
+@requires_openmm
 class TestOpenMMPDBxFileParser(OpenMMAppTopologyBase):
     ref_filename = app.PDBxFile(PDBX)
     expected_n_atoms = 60

--- a/testsuite/MDAnalysisTests/converters/test_openmm_parser.py
+++ b/testsuite/MDAnalysisTests/converters/test_openmm_parser.py
@@ -34,13 +34,9 @@ except ImportError:
     try:
         from simtk.openmm import app
     except ImportError:
-        SKIP_OPENMM = True
+        pytest.skip(allow_module_level=True)
 
 
-requires_openmm = pytest.mark.skipif(SKIP_OPENMM, reason="requires OpenMM")
-
-
-@requires_openmm
 class OpenMMTopologyBase(ParserBase):
     parser = mda.converters.OpenMMParser.OpenMMTopologyParser
     expected_attrs = [
@@ -106,7 +102,6 @@ class OpenMMTopologyBase(ParserBase):
             assert top.segids.values == []
 
 
-@requires_openmm
 class OpenMMAppTopologyBase(OpenMMTopologyBase):
     parser = mda.converters.OpenMMParser.OpenMMAppTopologyParser
     expected_attrs = [
@@ -127,7 +122,6 @@ class OpenMMAppTopologyBase(OpenMMTopologyBase):
         assert isinstance(u, mda.Universe)
 
 
-@requires_openmm
 class TestOpenMMTopologyParser(OpenMMTopologyBase):
     ref_filename = app.PDBFile(CONECT).topology
     expected_n_atoms = 1890
@@ -136,7 +130,6 @@ class TestOpenMMTopologyParser(OpenMMTopologyBase):
     expected_n_bonds = 1922
 
 
-@requires_openmm
 class TestOpenMMPDBFileParser(OpenMMAppTopologyBase):
     ref_filename = app.PDBFile(CONECT)
     expected_n_atoms = 1890
@@ -145,7 +138,6 @@ class TestOpenMMPDBFileParser(OpenMMAppTopologyBase):
     expected_n_bonds = 1922
 
 
-@requires_openmm
 class TestOpenMMPDBxFileParser(OpenMMAppTopologyBase):
     ref_filename = app.PDBxFile(PDBX)
     expected_n_atoms = 60

--- a/testsuite/setup.cfg
+++ b/testsuite/setup.cfg
@@ -18,6 +18,7 @@ filterwarnings=
     ignore:Failed to guess the mass:UserWarning
     # Coordinates
     ignore:No coordinate reader found:UserWarning
+    ignore:Reader has no dt information, set to 1.0 ps
     # NamedStream warnings
     ignore:Constructed NamedStream:RuntimeWarning
 


### PR DESCRIPTION
Follow up to #3518 - we forgot about the test imports for openmm

Changes made in this Pull Request:
 - try/else around tests with fallback to a pytest.skip()
 - Also add missing author information for #3518 - I guess I got distracted over the whole license thing

Notes:
 - Originally attempted to do a bit more of a fine-grained pytest.mark.skipif, but had some issues with `test_openmm_parser` with some weird pytest behaviour that just hated the decorator. Given that we don't really need the fine-grained behaviour here I'm defaulting to just doing the pytest.skip().


PR Checklist
------------
 - Tests?
 - Docs?
 - CHANGELOG updated?
 - [x] Issue raised/referenced?
