### PR TITLE
Remove deprecated np.object

### DIFF
--- a/testsuite/MDAnalysisTests/core/test_topologyattrs.py
+++ b/testsuite/MDAnalysisTests/core/test_topologyattrs.py
@@ -176,7 +176,7 @@ class TestIndicesClasses(object):
 
 class TestAtomnames(TestAtomAttr):
     values = np.array(['O', 'C', 'CA', 'N', 'CB', 'CG', 'CD', 'NA', 'CL', 'OW'],
-                      dtype=np.object)
+                      dtype=object)
     single_value = 'Ca2'
     attrclass = tpattrs.Atomnames
 


### PR DESCRIPTION
Partially address #3535

Changes made in this Pull Request:
 - Remove deprecated `np.object`

PR Checklist
------------
 - ~[ ] Tests?~
 - ~[ ] Docs?~
 - ~[ ] CHANGELOG updated?~
 - [X] Issue raised/referenced?
