### PR TITLE
Accepts AtomGroup in place of Universe in DistanceMatrix

### DIFF
--- a/package/MDAnalysis/analysis/diffusionmap.py
+++ b/package/MDAnalysis/analysis/diffusionmap.py
@@ -249,7 +249,8 @@ class DistanceMatrix(AnalysisBase):
     def __init__(self, atomGroup, select='all', metric=rmsd, cutoff=1E0-5,
                  weights=None, **kwargs):
         # remember that this must be called before referencing self.n_frames
-        super(DistanceMatrix, self).__init__(atomGroup.universe.trajectory, **kwargs)
+        super(DistanceMatrix, self).__init__(atomGroup.universe.trajectory, 
+                                             **kwargs)
 
         print("testing")
 

--- a/package/MDAnalysis/analysis/diffusionmap.py
+++ b/package/MDAnalysis/analysis/diffusionmap.py
@@ -249,7 +249,7 @@ class DistanceMatrix(AnalysisBase):
     def __init__(self, atomGroup, select='all', metric=rmsd, cutoff=1E0-5,
                  weights=None, **kwargs):
         # remember that this must be called before referencing self.n_frames
-        super(DistanceMatrix, self).__init__(atomGroup.universe.trajectory, 
+        super(DistanceMatrix, self).__init__(atomGroup.universe.trajectory,
                                              **kwargs)
 
         print("testing")

--- a/package/MDAnalysis/analysis/diffusionmap.py
+++ b/package/MDAnalysis/analysis/diffusionmap.py
@@ -152,6 +152,7 @@ module in published work please cite [Theobald2005]_.
 """
 import logging
 import warnings
+from MDAnalysis import AtomGroup
 
 import numpy as np
 
@@ -245,12 +246,14 @@ class DistanceMatrix(AnalysisBase):
          :class:`MDAnalysis.analysis.base.Results` instance.
 
     """
-    def __init__(self, universe, select='all', metric=rmsd, cutoff=1E0-5,
+    def __init__(self, atomGroup, select='all', metric=rmsd, cutoff=1E0-5,
                  weights=None, **kwargs):
         # remember that this must be called before referencing self.n_frames
-        super(DistanceMatrix, self).__init__(universe.trajectory, **kwargs)
+        super(DistanceMatrix, self).__init__(atomGroup.universe.trajectory, **kwargs)
 
-        self.atoms = universe.select_atoms(select)
+        print("testing")
+
+        self.atoms = atomGroup.select_atoms(select)
         self._metric = metric
         self._cutoff = cutoff
         self._weights = weights
@@ -328,12 +331,12 @@ class DiffusionMap(object):
             Parameters to be passed for the initialization of a
             :class:`DistanceMatrix`.
         """
-        if isinstance(u, Universe):
+        if isinstance(u, AtomGroup):
             self._dist_matrix = DistanceMatrix(u, **kwargs)
         elif isinstance(u, DistanceMatrix):
             self._dist_matrix = u
         else:
-            raise ValueError("U is not a Universe or DistanceMatrix and"
+            raise ValueError("U is not a AtomGroup or DistanceMatrix and"
                              " so the DiffusionMap has no data to work with.")
         self._epsilon = epsilon
 
@@ -353,6 +356,7 @@ class DiffusionMap(object):
         .. versionchanged:: 0.19.0
            Added start/stop/step kwargs
         """
+
         # run only if distance matrix not already calculated
         if not self._dist_matrix._calculated:
             self._dist_matrix.run(start=start, stop=stop, step=step)


### PR DESCRIPTION
Fixes #3486

Changes made in this Pull Request:
 - Remove Universe as an input parameter and replace it with AtomGroup for DistanceMatrix class.

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?
