### PR TITLE
temporarily pin openmm to 7.7.0 build 0 for macos

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -52,7 +52,6 @@ jobs:
               full-deps: true
               openmm: openmm=7.7.0=py37hf0bdc88_0_khronos
               install_hole: true
-              openmm:
               codecov: false
             - name: minimal-ubuntu
               os: ubuntu-latest
@@ -104,6 +103,7 @@ jobs:
         full-deps: ${{ matrix.full-deps }}
         # in most cases will just default to empty, i.e. pick up max version from other deps
         numpy: ${{ matrix.numpy }}
+        openmm: ${{ matrix.openmm }}
         extra-pip-deps: ${{ matrix.extra-pip-deps }}
 
     - name: build_srcs

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -103,7 +103,7 @@ jobs:
         full-deps: ${{ matrix.full-deps }}
         # in most cases will just default to empty, i.e. pick up max version from other deps
         numpy: ${{ matrix.numpy }}
-        openmm: ${{ matrix.openmm }}
+        extra-conda-deps: ${{ matrix.openmm }}
         extra-pip-deps: ${{ matrix.extra-pip-deps }}
 
     - name: build_srcs

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -44,12 +44,15 @@ jobs:
               python-version: 3.9
               full-deps: true
               install_hole: true
+              openmm: openmm=7.7.0=py39h8d72adf_0_khronos
               codecov: true
             - name: macOS_catalina_py37
               os: macOS-10.15
               python-version: 3.7
               full-deps: true
+              openmm: openmm=7.7.0=py37hf0bdc88_0_khronos
               install_hole: true
+              openmm:
               codecov: false
             - name: minimal-ubuntu
               os: ubuntu-latest


### PR DESCRIPTION
Temporary solution for #3550

Changes made in this Pull Request:
 - Pin macos runners to 7.7.0 build 0 (build 1 is causing the failures). 


PR Checklist
------------
 - Tests?
 - Docs?
 - CHANGELOG updated?
 - Issue raised/referenced?
