### PR TITLE
Fix leftover simtk import and fix openmm docs

### DIFF
--- a/package/MDAnalysis/converters/OpenMM.py
+++ b/package/MDAnalysis/converters/OpenMM.py
@@ -26,23 +26,23 @@
 
 
 Read coordinates data from a
-`OpenMM <http://docs.openmm.org/latest/api-python/generated/simtk.openmm.app.simulation.Simulation.html#simtk.openmm.app.simulation.Simulation>`_
-:class:`simtk.openmm.app.simulation.Simulation` with :class:`OpenMMReader`
+`OpenMM <http://docs.openmm.org/latest/api-python/generated/openmm.app.simulation.Simulation.html#openmm.app.simulation.Simulation>`_
+:class:`openmm.app.simulation.Simulation` with :class:`OpenMMReader`
 into a MDAnalysis Universe.
 
 Also converts other objects within the
 `OpenMM Application Layer <http://docs.openmm.org/latest/api-python/app.html>`_:
 
-    - `simtk.openmm.app.pdbfile.PDBFile <http://docs.openmm.org/latest/api-python/generated/simtk.openmm.app.pdbfile.PDBFile.html#simtk.openmm.app.pdbfile.PDBFile>`_
-    - `simtk.openmm.app.modeller.Modeller <http://docs.openmm.org/latest/api-python/generated/simtk.openmm.app.modeller.Modeller.html#simtk.openmm.app.modeller.Modeller>`_
-    - `simtk.openmm.app.pdbxfile.PDBxFile <http://docs.openmm.org/latest/api-python/generated/simtk.openmm.app.pdbxfile.PDBxFile.html#simtk.openmm.app.pdbxfile.PDBxFile>`_
+    - `openmm.app.pdbfile.PDBFile <http://docs.openmm.org/latest/api-python/generated/openmm.app.pdbfile.PDBFile.html#openmm.app.pdbfile.PDBFile>`_
+    - `openmm.app.modeller.Modeller <http://docs.openmm.org/latest/api-python/generated/openmm.app.modeller.Modeller.html#openmm.app.modeller.Modeller>`_
+    - `openmm.app.pdbxfile.PDBxFile <http://docs.openmm.org/latest/api-python/generated/openmm.app.pdbxfile.PDBxFile.html#openmm.app.pdbxfile.PDBxFile>`_
 
 Example
 -------
 OpenMM can read various file formats into OpenMM objects.
 MDAnalysis can then convert some of these OpenMM objects into MDAnalysis Universe objects.
 
-    >>> import simtk.openmm.app as app
+    >>> import openmm.app as app
     >>> import MDAnalysis as mda
     >>> from MDAnalysis.tests.datafiles import PDBX
     >>> pdbxfile = app.PDBxFile(PDBX)
@@ -111,7 +111,10 @@ class OpenMMSimulationReader(base.SingleFrameReaderBase):
 
     def _mda_timestep_from_omm_context(self):
         """ Construct Timestep object from OpenMM context """
-        import simtk.unit as u
+        try:
+            import openmm.unit as u
+        except ImportError:
+            import simtk.unit as u
 
         state = self.filename.context.getState(-1, getVelocities=True,
                 getForces=True, getEnergy=True)
@@ -140,7 +143,7 @@ class OpenMMSimulationReader(base.SingleFrameReaderBase):
 class OpenMMAppReader(base.SingleFrameReaderBase):
     """Reader for OpenMM Application layer objects
 
-    See also `the object definition in the OpenMM Application layer <http://docs.openmm.org/latest/api-python/generated/simtk.openmm.app.simulation.Simulation.html#simtk.openmm.app.simulation.Simulation>`_
+    See also `the object definition in the OpenMM Application layer <http://docs.openmm.org/latest/api-python/generated/openmm.app.simulation.Simulation.html#openmm.app.simulation.Simulation>`_
 
     .. versionadded:: 2.0.0
     """

--- a/package/MDAnalysis/converters/OpenMM.py
+++ b/package/MDAnalysis/converters/OpenMM.py
@@ -87,7 +87,7 @@ class OpenMMSimulationReader(base.SingleFrameReaderBase):
         try:
             from openmm.app import Simulation
         except ImportError:
-            try:  # pragma no cover
+            try:  # pragma: no cover
                 from simtk.openmm.app import Simulation
             except ImportError:
                 return False
@@ -113,7 +113,7 @@ class OpenMMSimulationReader(base.SingleFrameReaderBase):
         """ Construct Timestep object from OpenMM context """
         try:
             import openmm.unit as u
-        except ImportError:  # pragma no cover
+        except ImportError:  # pragma: no cover
             import simtk.unit as u
 
         state = self.filename.context.getState(-1, getVelocities=True,
@@ -158,7 +158,7 @@ class OpenMMAppReader(base.SingleFrameReaderBase):
         try:
             from openmm import app
         except ImportError:
-            try:  # pragma no cover
+            try:  # pragma: no cover
                 from simtk.openmm import app
             except ImportError:
                 return False

--- a/package/MDAnalysis/converters/OpenMM.py
+++ b/package/MDAnalysis/converters/OpenMM.py
@@ -87,7 +87,7 @@ class OpenMMSimulationReader(base.SingleFrameReaderBase):
         try:
             from openmm.app import Simulation
         except ImportError:
-            try:
+            try:  # pragma no cover
                 from simtk.openmm.app import Simulation
             except ImportError:
                 return False
@@ -113,7 +113,7 @@ class OpenMMSimulationReader(base.SingleFrameReaderBase):
         """ Construct Timestep object from OpenMM context """
         try:
             import openmm.unit as u
-        except ImportError:
+        except ImportError:  # pragma no cover
             import simtk.unit as u
 
         state = self.filename.context.getState(-1, getVelocities=True,
@@ -158,7 +158,7 @@ class OpenMMAppReader(base.SingleFrameReaderBase):
         try:
             from openmm import app
         except ImportError:
-            try:
+            try:  # pragma no cover
                 from simtk.openmm import app
             except ImportError:
                 return False

--- a/package/MDAnalysis/converters/OpenMMParser.py
+++ b/package/MDAnalysis/converters/OpenMMParser.py
@@ -28,16 +28,16 @@
 
 
 Converts an
-`OpenMM topology <http://docs.openmm.org/latest/api-python/generated/simtk.openmm.app.topology.Topology.html#simtk.openmm.app.topology.Topology>`_
-:class:`simtk.openmm.app.topology.Topology` into a :class:`MDAnalysis.core.Topology`.
+`OpenMM topology <http://docs.openmm.org/latest/api-python/generated/openmm.app.topology.Topology.html#openmm.app.topology.Topology>`_
+:class:`openmm.app.topology.Topology` into a :class:`MDAnalysis.core.Topology`.
 
 Also converts some objects within the
 `OpenMM Application layer <http://docs.openmm.org/latest/api-python/app.html>`_
 
-    - `simtk.openmm.app.pdbfile.PDBFile <http://docs.openmm.org/latest/api-python/generated/simtk.openmm.app.pdbfile.PDBFile.html#simtk.openmm.app.pdbfile.PDBFile>`_
-    - `simtk.openmm.app.simulation.Simulation <http://docs.openmm.org/latest/api-python/generated/simtk.openmm.app.simulation.Simulation.html#simtk.openmm.app.simulation.Simulation>`_
-    - `simtk.openmm.app.modeller.Modeller <http://docs.openmm.org/latest/api-python/generated/simtk.openmm.app.modeller.Modeller.html#simtk.openmm.app.modeller.Modeller>`_
-    - `simtk.openmm.app.pdbxfile.PDBxFile <http://docs.openmm.org/latest/api-python/generated/simtk.openmm.app.pdbxfile.PDBxFile.html#simtk.openmm.app.pdbxfile.PDBxFile>`_
+    - `openmm.app.pdbfile.PDBFile <http://docs.openmm.org/latest/api-python/generated/openmm.app.pdbfile.PDBFile.html#openmm.app.pdbfile.PDBFile>`_
+    - `openmm.app.simulation.Simulation <http://docs.openmm.org/latest/api-python/generated/openmm.app.simulation.Simulation.html#openmm.app.simulation.Simulation>`_
+    - `openmm.app.modeller.Modeller <http://docs.openmm.org/latest/api-python/generated/openmm.app.modeller.Modeller.html#openmm.app.modeller.Modeller>`_
+    - `openmm.app.pdbxfile.PDBxFile <http://docs.openmm.org/latest/api-python/generated/openmm.app.pdbxfile.PDBxFile.html#openmm.app.pdbxfile.PDBxFile>`_
 
 The :class:`OpenMMTopologyParser` generates a topology from an OpenMM Topology object.
 
@@ -83,9 +83,12 @@ class OpenMMTopologyParser(TopologyReaderBase):
 
         """
         try:
-            from simtk.openmm import app
+            from openmm import app
         except ImportError:
-            return False
+            try:
+                from simtk.openmm import app
+            except ImportError:
+                return False
         else:
             return isinstance(thing, app.Topology)
 
@@ -96,7 +99,7 @@ class OpenMMTopologyParser(TopologyReaderBase):
 
         Parameters
         ----------
-        omm_topology: simtk.openmm.Topology
+        omm_topology: openmm.Topology
 
         Returns
         -------
@@ -165,9 +168,12 @@ class OpenMMAppTopologyParser(OpenMMTopologyParser):
 
         """
         try:
-            from simtk.openmm import app
+            from openmm import app
         except ImportError:
-            return False
+            try:
+                from simtk.openmm import app
+            except ImportError:
+                return False
         else:
             return isinstance(
                 thing,

--- a/package/MDAnalysis/converters/OpenMMParser.py
+++ b/package/MDAnalysis/converters/OpenMMParser.py
@@ -85,7 +85,7 @@ class OpenMMTopologyParser(TopologyReaderBase):
         try:
             from openmm import app
         except ImportError:
-            try:
+            try:  # pragma no cover
                 from simtk.openmm import app
             except ImportError:
                 return False
@@ -170,7 +170,7 @@ class OpenMMAppTopologyParser(OpenMMTopologyParser):
         try:
             from openmm import app
         except ImportError:
-            try:
+            try:  # pragma no cover
                 from simtk.openmm import app
             except ImportError:
                 return False

--- a/package/MDAnalysis/converters/OpenMMParser.py
+++ b/package/MDAnalysis/converters/OpenMMParser.py
@@ -85,7 +85,7 @@ class OpenMMTopologyParser(TopologyReaderBase):
         try:
             from openmm import app
         except ImportError:
-            try:  # pragma no cover
+            try:  # pragma: no cover
                 from simtk.openmm import app
             except ImportError:
                 return False
@@ -170,7 +170,7 @@ class OpenMMAppTopologyParser(OpenMMTopologyParser):
         try:
             from openmm import app
         except ImportError:
-            try:  # pragma no cover
+            try:  # pragma: no cover
                 from simtk.openmm import app
             except ImportError:
                 return False

--- a/package/MDAnalysis/converters/ParmEdParser.py
+++ b/package/MDAnalysis/converters/ParmEdParser.py
@@ -57,8 +57,8 @@ protein atoms, and then convert it back to ParmEd. ::
 From here you can create an OpenMM simulation system and minimize the
 energy. ::
 
-    >>> import simtk.openmm as mm
-    >>> import simtk.openmm.app as app
+    >>> import openmm as mm
+    >>> import openmm.app as app
     >>> from parmed import unit as u
     >>> system = prm_prot.createSystem(nonbondedMethod=app.NoCutoff,
     ...                                constraints=app.HBonds,


### PR DESCRIPTION
Not sure why I was paying so little attention in previous PRs, but there were still import warnings being through & all the docs hadn't been suitably updated.

`git grep` now reports no other instances for simtk (other than those we are keeping for backwards compatibility).

The warning is annoying enough that this needs to make it in for 2.1.0.

PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - CHANGELOG updated?
 - Issue raised/referenced?
