### PR TITLE
MDAnalysisTest badge now points to GH Actions CI instead of Travis

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -174,8 +174,8 @@ Chronological list of authors
 2022
   - Atharva Kulkarni
   - Yantong Cai
-  - Pratik Gupta
   - Bjarne Feddersen
+  - Pratik Gupta
 
 External code
 -------------

--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -174,6 +174,7 @@ Chronological list of authors
 2022
   - Atharva Kulkarni
   - Yantong Cai
+  - Pratik Gupta
 
 External code
 -------------

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,7 +13,7 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-??/??/?? IAlibay, inomag
+??/??/?? IAlibay, BFedder, inomag
 
  * 2.2.0
 

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -19,6 +19,7 @@ The rules for this file:
 
 Fixes
   * Updated the badge in README of MDAnalysisTest to point to Github CI Actions
+
 Enhancements
 
 Changes

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,12 +13,12 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-??/??/?? IAlibay
+??/??/?? IAlibay, inomag
 
  * 2.2.0
 
 Fixes
-
+  * Updated the badge in README of MDAnalysisTest to point to Github CI Actions
 Enhancements
 
 Changes

--- a/testsuite/README
+++ b/testsuite/README
@@ -46,6 +46,7 @@ For questions and discussions for code development, join the developer list http
 .. |build| image:: https://github.com/MDAnalysis/mdanalysis/actions/workflows/gh-ci.yaml/badge.svg
    :alt: Github Actions Build Status
    :target: https://github.com/MDAnalysis/mdanalysis/actions/workflows/gh-ci.yaml
+   
 .. |cov|   image:: https://codecov.io/gh/MDAnalysis/mdanalysis/branch/develop/graph/badge.svg
    :alt: Coverage Status
    :target: https://codecov.io/gh/MDAnalysis/mdanalysis

--- a/testsuite/README
+++ b/testsuite/README
@@ -43,10 +43,10 @@ For questions and discussions for code development, join the developer list http
 
 .. badges
 
-.. |build| image:: https://travis-ci.com/MDAnalysis/mdanalysis.svg?branch=develop
-   :alt: Build Status
-   :target: https://travis-ci.com/MDAnalysis/mdanalysis
-
+.. |build| image:: https://github.com/MDAnalysis/mdanalysis/actions/workflows/gh-ci.yaml/badge.svg
+   :alt: Github Actions Build Status
+   :target: https://github.com/MDAnalysis/mdanalysis/actions/workflows/gh-ci.yaml
+   
 .. |cov|   image:: https://codecov.io/gh/MDAnalysis/mdanalysis/branch/develop/graph/badge.svg
    :alt: Coverage Status
    :target: https://codecov.io/gh/MDAnalysis/mdanalysis

--- a/testsuite/README
+++ b/testsuite/README
@@ -46,7 +46,7 @@ For questions and discussions for code development, join the developer list http
 .. |build| image:: https://github.com/MDAnalysis/mdanalysis/actions/workflows/gh-ci.yaml/badge.svg
    :alt: Github Actions Build Status
    :target: https://github.com/MDAnalysis/mdanalysis/actions/workflows/gh-ci.yaml
-   
+
 .. |cov|   image:: https://codecov.io/gh/MDAnalysis/mdanalysis/branch/develop/graph/badge.svg
    :alt: Coverage Status
    :target: https://codecov.io/gh/MDAnalysis/mdanalysis

--- a/testsuite/README
+++ b/testsuite/README
@@ -46,7 +46,6 @@ For questions and discussions for code development, join the developer list http
 .. |build| image:: https://github.com/MDAnalysis/mdanalysis/actions/workflows/gh-ci.yaml/badge.svg
    :alt: Github Actions Build Status
    :target: https://github.com/MDAnalysis/mdanalysis/actions/workflows/gh-ci.yaml
-   
 .. |cov|   image:: https://codecov.io/gh/MDAnalysis/mdanalysis/branch/develop/graph/badge.svg
    :alt: Coverage Status
    :target: https://codecov.io/gh/MDAnalysis/mdanalysis


### PR DESCRIPTION
Fixes #3557

Changes made in this Pull Request:
 - Updated the badge in README of MDAnalysisTest which first used travis. Now it is point to Github Actions CI similar to the main Readme of repository



PR Checklist
------------
 - [ ] Tests?
 - [x] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
