### PR TITLE
BAT method Cartesian modifies input data issue resolved

### DIFF
--- a/package/MDAnalysis/analysis/bat.py
+++ b/package/MDAnalysis/analysis/bat.py
@@ -501,7 +501,7 @@ class BAT(AnalysisBase):
         bonds = bat_frame[9:n_torsions + 9]
         angles = bat_frame[n_torsions + 9:2 * n_torsions + 9]
         torsions = bat_frame[2 * n_torsions + 9:]
-        torsions=copy.deepcopy(torsions)
+        torsions = copy.deepcopy(torsions)
         # When appropriate, convert improper to proper torsions
         shift = torsions[self._primary_torsion_indices]
         shift[self._unique_primary_torsion_indices] = 0.

--- a/package/MDAnalysis/analysis/bat.py
+++ b/package/MDAnalysis/analysis/bat.py
@@ -501,7 +501,7 @@ class BAT(AnalysisBase):
         bonds = bat_frame[9:n_torsions + 9]
         angles = bat_frame[n_torsions + 9:2 * n_torsions + 9]
         torsions = bat_frame[2 * n_torsions + 9:]
-        copy.deepcopy()
+        torsions=copy.deepcopy(torsions)
         # When appropriate, convert improper to proper torsions
         shift = torsions[self._primary_torsion_indices]
         shift[self._unique_primary_torsion_indices] = 0.

--- a/package/MDAnalysis/analysis/bat.py
+++ b/package/MDAnalysis/analysis/bat.py
@@ -173,8 +173,9 @@ References
 """
 import logging
 import warnings
-import copy
+
 import numpy as np
+import copy
 
 import MDAnalysis as mda
 from .base import AnalysisBase

--- a/package/MDAnalysis/analysis/bat.py
+++ b/package/MDAnalysis/analysis/bat.py
@@ -173,7 +173,7 @@ References
 """
 import logging
 import warnings
-
+import copy
 import numpy as np
 
 import MDAnalysis as mda
@@ -500,6 +500,7 @@ class BAT(AnalysisBase):
         bonds = bat_frame[9:n_torsions + 9]
         angles = bat_frame[n_torsions + 9:2 * n_torsions + 9]
         torsions = bat_frame[2 * n_torsions + 9:]
+        copy.deepcopy()
         # When appropriate, convert improper to proper torsions
         shift = torsions[self._primary_torsion_indices]
         shift[self._unique_primary_torsion_indices] = 0.

--- a/testsuite/MDAnalysisTests/analysis/test_bat.py
+++ b/testsuite/MDAnalysisTests/analysis/test_bat.py
@@ -127,3 +127,8 @@ class TestBAT(object):
         errmsg = 'Dimensions of array in loaded file'
         with pytest.raises(ValueError, match=errmsg):
             R = BAT(selected_residues, filename=bat_npz)
+
+    def test_bat_input_data(self,torsions,bat_frame):
+        arr1 = np.array(torsions)
+        arr2 = np.array(bat_frame)
+        return np.may_share_memory(arr1,arr2)


### PR DESCRIPTION
Fixes #3501 

Changes made in this Pull Request:
 - "Non-primary" torsions in the original input BAT data are modified due to issues with scope and pass-by-reference.I have just called the `copy.deepcopy()` method to resolve this error.


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
