### PR TITLE
Issue #2417: ITPParser should not add angles to SETTLEd waters. 

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -174,6 +174,7 @@ Chronological list of authors
 2022
   - Atharva Kulkarni
   - Yantong Cai
+  - Bjarne Feddersen
 
 External code
 -------------

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -22,6 +22,9 @@ Fixes
 Enhancements
 
 Changes
+  * ITPParser no longer adds an angle for water molecules that have the SETTLE
+    constraint applied to them. This mirrors the way the constraint is handled
+    in AMBER. (Issue #2417, PR #)
 
 Deprecations
 
@@ -36,7 +39,7 @@ Fixes
   * Use uint64_t loop counters in C level distance functions to avoid overflow
     for large arrays (Issue #3512, PR #3513).
   * Prevents attempts to close an already closed NamedStream (Issue #3386)
-  * Added missing exe_err import in hole.py. Fixed a bug in HoleAnalysis where 
+  * Added missing exe_err import in hole.py. Fixed a bug in HoleAnalysis where
     kwarg was passed instead of object to generate path (Issue #3493, PR #3496)
   * Fixes creation of vmd surfaces in hole2 when using non-contiguous frames
     with start/stop/step (Issue #3476)

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -24,7 +24,7 @@ Enhancements
 Changes
   * ITPParser no longer adds an angle for water molecules that have the SETTLE
     constraint applied to them. This mirrors the way the constraint is handled
-    in AMBER. (Issue #2417, PR #)
+    in AMBER. (Issue #2417, PR #3564)
 
 Deprecations
 

--- a/package/MDAnalysis/topology/ITPParser.py
+++ b/package/MDAnalysis/topology/ITPParser.py
@@ -467,6 +467,9 @@ class ITPParser(TopologyReaderBase):
 
     .. _ITP: http://manual.gromacs.org/current/reference-manual/topologies/topology-file-formats.html#molecule-itp-file
     .. _TOP: http://manual.gromacs.org/current/reference-manual/file-formats.html#top
+
+    .. versionchanged:: 2.2.0
+      no longer adds angles for water molecules with SETTLE constraint
     """
     format = 'ITP'
 

--- a/package/MDAnalysis/topology/ITPParser.py
+++ b/package/MDAnalysis/topology/ITPParser.py
@@ -356,7 +356,9 @@ class Molecule:
         # oxygen atom index. The next two atoms are 
         # assumed to be hydrogens. Unlike TPRParser,  
         # the manual only lists this format (as of 2019).
-        # These are treated as 2 bonds and 1 angle.
+        # These are treated as 2 bonds.
+        # No angle component is included to avoid discrepancies 
+        # with water molecules loaded from different MD engines. 
         oxygen, funct, doh, dhh = line.split()
         try:
             base = self.index_ids([oxygen])[0]
@@ -365,7 +367,6 @@ class Molecule:
         else:
             self.bonds[(base, base+1)].append("settles")
             self.bonds[(base, base+2)].append("settles")
-            self.angles[(base+1, base, base+2)].append("settles")
 
     def resolve_residue_attrs(self):
         """Figure out residue borders and assign moltypes and molnums"""

--- a/package/MDAnalysis/topology/ITPParser.py
+++ b/package/MDAnalysis/topology/ITPParser.py
@@ -357,8 +357,8 @@ class Molecule:
         # assumed to be hydrogens. Unlike TPRParser,  
         # the manual only lists this format (as of 2019).
         # These are treated as 2 bonds.
-        # No angle component is included to avoid discrepancies 
-        # with water molecules loaded from different MD engines. 
+        # No angle component is included to avoid discrepancies
+        # with water molecules loaded from different MD engines.
         oxygen, funct, doh, dhh = line.split()
         try:
             base = self.index_ids([oxygen])[0]

--- a/testsuite/MDAnalysisTests/topology/test_itp.py
+++ b/testsuite/MDAnalysisTests/topology/test_itp.py
@@ -279,7 +279,6 @@ class TestITPNoKeywords(BaseITP):
         for b in [(0, 1), (0, 2)]:
             assert b in vals
           
-        print(top.angles.values)
     def test_defines(self, top):
         assert_allclose(top.charges.values[1], 0.241)
         assert_allclose(top.charges.values[2], 0.241)

--- a/testsuite/MDAnalysisTests/topology/test_itp.py
+++ b/testsuite/MDAnalysisTests/topology/test_itp.py
@@ -266,7 +266,7 @@ class TestITPNoKeywords(BaseITP):
 
     expected_n_bonds = 2
     # FLEXIBLE not set -> SETTLE constraint -> water has no angle
-    expected_n_angles = 0   
+    expected_n_angles = 0
     expected_n_dihedrals = 0
     expected_n_impropers = 0
 
@@ -278,7 +278,7 @@ class TestITPNoKeywords(BaseITP):
         vals = top.bonds.values
         for b in [(0, 1), (0, 2)]:
             assert b in vals
-          
+
     def test_defines(self, top):
         assert_allclose(top.charges.values[1], 0.241)
         assert_allclose(top.charges.values[2], 0.241)
@@ -307,7 +307,7 @@ class TestITPKeywords(TestITPNoKeywords):
     def test_whether_settles_types(self, universe):
         for param in list(universe.bonds) + list(universe.angles):
             assert param.type == 1
-    
+
     def test_angles_values(self, top):
         assert (1, 0, 2) in top.angles.values
 

--- a/testsuite/MDAnalysisTests/topology/test_itp.py
+++ b/testsuite/MDAnalysisTests/topology/test_itp.py
@@ -265,7 +265,8 @@ class TestITPNoKeywords(BaseITP):
     guessed_attrs = ['masses']
 
     expected_n_bonds = 2
-    expected_n_angles = 1
+    # FLEXIBLE not set -> SETTLE constraint -> water has no angle
+    expected_n_angles = 0   
     expected_n_dihedrals = 0
     expected_n_impropers = 0
 
@@ -277,10 +278,8 @@ class TestITPNoKeywords(BaseITP):
         vals = top.bonds.values
         for b in [(0, 1), (0, 2)]:
             assert b in vals
-
-    def test_angles_values(self, top):
-        assert (1, 0, 2) in top.angles.values
-
+          
+        print(top.angles.values)
     def test_defines(self, top):
         assert_allclose(top.charges.values[1], 0.241)
         assert_allclose(top.charges.values[2], 0.241)
@@ -292,6 +291,8 @@ class TestITPKeywords(TestITPNoKeywords):
     """
 
     expected_n_atoms = 7
+    # FLEXIBLE is set -> no SETTLE constraint -> water should have angle
+    expected_n_angles = 1
 
     @pytest.fixture
     def universe(self, filename):
@@ -307,6 +308,9 @@ class TestITPKeywords(TestITPNoKeywords):
     def test_whether_settles_types(self, universe):
         for param in list(universe.bonds) + list(universe.angles):
             assert param.type == 1
+    
+    def test_angles_values(self, top):
+        assert (1, 0, 2) in top.angles.values
 
     def test_defines(self, top):
         assert_allclose(top.charges.values[1], 1)
@@ -325,7 +329,7 @@ class TestNestedIfs(BaseITP):
     expected_n_segments = 1
 
     expected_n_bonds = 2
-    expected_n_angles = 1
+    expected_n_angles = 0
     expected_n_dihedrals = 0
     expected_n_impropers = 0
 
@@ -354,7 +358,7 @@ class TestReadTop(BaseITP):
     expected_n_segments = 5
 
     expected_n_bonds = 130
-    expected_n_angles = 185
+    expected_n_angles = 182
     expected_n_dihedrals = 60
     expected_n_impropers = 58
 


### PR DESCRIPTION
Fixes #2417

Changes made in this Pull Request:
 ITPParser no longer adds angles for water molecules with SETTLEd
   geometry. The tests were modified to reflect this.

Changes:
**MDAnalysis/topology/ITPParser.py**
- Molecule.parse_settles changed to no longer add angle

**MDAnalysisTests/topology/test_itp.py**
- TestITPNoKeywords now expects 0 angles
- TestITPKeywords changed to continue to expect 1 angle
- def test_angles_values moved from TestITPNoKeywords to TestITPKeywords
- TestNestedIfs now expects 0 angles
- TestReadTop's topology file has 3 SETTLEd water molecules and now correctly expects three fewer angles than before


PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
