### PR TITLE
Provide ability to use AtomGroup as selection for Contact

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -178,6 +178,7 @@ Chronological list of authors
   - Pratik Gupta
   - Alexander Gorfer
   - Aya M. Alaa
+  - Kazi Shudipto Amin
 
 External code
 -------------

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,14 +13,16 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-??/??/?? IAlibay, BFedder, inomag, Agorfa, aya9aladdin
+??/??/?? IAlibay, BFedder, inomag, Agorfa, aya9aladdin, shudipto-amin
 
  * 2.2.0
 
 Fixes
   * Fixed DumpReader triclinic box dimensions reading. (Issue #3386, PR #3403)
   * Updated the badge in README of MDAnalysisTest to point to Github CI Actions
-
+  * Provides Contacts ability to use static AtomGroups as well as selection 
+    texts.
+  
 Enhancements
 
 Changes

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -22,7 +22,7 @@ Fixes
     (Issue #2666, PR #3565)
   * Fixed DumpReader triclinic box dimensions reading. (Issue #3386, PR #3403)
   * Updated the badge in README of MDAnalysisTest to point to Github CI Actions
-  
+ 
 Enhancements
 
 Changes

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -22,6 +22,10 @@ Fixes
   * Updated the badge in README of MDAnalysisTest to point to Github CI Actions
   * Provides Contacts ability to use static AtomGroups as well as selection 
     texts.
+  * Contacts can now accepts static AtomGroup as well as selection text. 
+    (Issue #2666, PR #3565)
+  * Helper function  `_new_selections()` in `contacts.py` now simply uses 
+    `Universe.copy()`. (Issue #2666, PR #3565)   
   
 Enhancements
 

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -22,7 +22,7 @@ Fixes
   * Updated the badge in README of MDAnalysisTest to point to Github CI Actions
   * Provides Contacts ability to use static AtomGroups as well as selection 
     texts.
-  * Contacts can now accepts static AtomGroup as well as selection text. 
+  * Contacts can now accept static AtomGroups as well as selection texts.
     (Issue #2666, PR #3565)
   * Helper function  `_new_selections()` in `contacts.py` now simply uses 
     `Universe.copy()`. (Issue #2666, PR #3565)   

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -18,14 +18,12 @@ The rules for this file:
  * 2.2.0
 
 Fixes
+  * Contacts can now accept static AtomGroups as well as selection texts.
+    (Issue #2666, PR #3565)
   * Fixed DumpReader triclinic box dimensions reading. (Issue #3386, PR #3403)
   * Updated the badge in README of MDAnalysisTest to point to Github CI Actions
   * Provides Contacts ability to use static AtomGroups as well as selection 
     texts.
-  * Contacts can now accept static AtomGroups as well as selection texts.
-    (Issue #2666, PR #3565)
-  * Helper function  `_new_selections()` in `contacts.py` now simply uses 
-    `Universe.copy()`. (Issue #2666, PR #3565)   
   
 Enhancements
 

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -22,8 +22,6 @@ Fixes
     (Issue #2666, PR #3565)
   * Fixed DumpReader triclinic box dimensions reading. (Issue #3386, PR #3403)
   * Updated the badge in README of MDAnalysisTest to point to Github CI Actions
-  * Provides Contacts ability to use static AtomGroups as well as selection 
-    texts.
   
 Enhancements
 

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -22,7 +22,7 @@ Fixes
     (Issue #2666, PR #3565)
   * Fixed DumpReader triclinic box dimensions reading. (Issue #3386, PR #3403)
   * Updated the badge in README of MDAnalysisTest to point to Github CI Actions
- 
+
 Enhancements
 
 Changes

--- a/package/MDAnalysis/analysis/contacts.py
+++ b/package/MDAnalysis/analysis/contacts.py
@@ -386,6 +386,8 @@ class Contacts(AnalysisBase):
     .. versionchanged:: 2.0.0
        :attr:`timeseries` results are now stored in a
        :class:`MDAnalysis.analysis.base.Results` instance.
+    .. versionchanged:: 2.2.0
+       :class: `Contacts` accepts both AtomGroup and string for `select`
     """
     # Error message for wrong selection type:
     _select_error_message = ("selection must be either string or a "

--- a/package/MDAnalysis/analysis/contacts.py
+++ b/package/MDAnalysis/analysis/contacts.py
@@ -389,7 +389,7 @@ class Contacts(AnalysisBase):
     """
     # Error message for wrong selection type:
     select_error_message = "selection must be either string or a " \
-                                    "static AtomGroup"
+                           "static AtomGroup"
 
     def __init__(self, u, select, refgroup, method="hard_cut", radius=4.5,
                  pbc=True, kwargs=None, **basekwargs):

--- a/package/MDAnalysis/analysis/contacts.py
+++ b/package/MDAnalysis/analysis/contacts.py
@@ -28,7 +28,7 @@ Native contacts analysis --- :mod:`MDAnalysis.analysis.contacts`
 This module contains classes to analyze native contacts *Q* over a
 trajectory. Native contacts of a conformation are contacts that exist
 in a reference structure and in the conformation. Contacts in the
-reference structure are always defined as being closer then a distance
+reference structure are always defined as being closer than a distance
 `radius`. The fraction of native contacts for a conformation can be
 calculated in different ways. This module supports 3 different metrics
 listed below, as well as custom metrics.
@@ -394,7 +394,7 @@ class Contacts(AnalysisBase):
         ----------
         u : Universe
             trajectory
-        select : tuple(string, string)
+        select : tuple(AtomGroup, AtomGroup) | tuple(string, string)
             two contacting groups that change over time
         refgroup : tuple(AtomGroup, AtomGroup)
             two contacting atomgroups in their reference conformation. This
@@ -437,8 +437,22 @@ class Contacts(AnalysisBase):
             self.fraction_contacts = method
 
         self.select = select
-        self.grA = u.select_atoms(select[0])
-        self.grB = u.select_atoms(select[1])
+        
+        select_error_message = "selection must be either string or AtomGroup"
+
+        if isinstance(select[0], str):
+            self.grA = u.select_atoms(select[0])
+        elif isinstance(select[0], AtomGroup):
+            self.grA = select[0]
+        else:
+            raise TypeError(select_error_message)
+
+        if isinstance(select[1], str):
+            self.grB = u.select_atoms(select[1])
+        elif isinstance(select[1], AtomGroup):
+            self.grB = select[1]
+        else:
+            raise TypeError(select_error_message)
         self.pbc = pbc
         
         # contacts formed in reference

--- a/package/MDAnalysis/analysis/contacts.py
+++ b/package/MDAnalysis/analysis/contacts.py
@@ -389,10 +389,6 @@ class Contacts(AnalysisBase):
     .. versionchanged:: 2.2.0
        :class: `Contacts` accepts both AtomGroup and string for `select`
     """
-    # Error message for wrong selection type:
-    _select_error_message = ("selection must be either string or a "
-                             "static AtomGroup. Updating AtomGroups "
-                             "are not supported.")
 
     def __init__(self, u, select, refgroup, method="hard_cut", radius=4.5,
                  pbc=True, kwargs=None, **basekwargs):
@@ -473,15 +469,18 @@ class Contacts(AnalysisBase):
 
     @staticmethod
     def _get_atomgroup(u, sel):
+        select_error_message = ("selection must be either string or a "
+                                "static AtomGroup. Updating AtomGroups "
+                                "are not supported.")
         if isinstance(sel, str):
             return u.select_atoms(sel)
         elif isinstance(sel, AtomGroup):
             if isinstance(sel, UpdatingAtomGroup):
-                raise TypeError(Contacts._select_error_message)
+                raise TypeError(select_error_message)
             else:
                 return sel
         else:
-            raise TypeError(Contacts._select_error_message)
+            raise TypeError(select_error_message)
 
     def _prepare(self):
         self.results.timeseries = np.empty((self.n_frames, len(self.r0)+1))

--- a/package/MDAnalysis/analysis/contacts.py
+++ b/package/MDAnalysis/analysis/contacts.py
@@ -392,18 +392,6 @@ class Contacts(AnalysisBase):
                              "static AtomGroup. Updating AtomGroups "
                              "are not supported.")
 
-    @staticmethod
-    def _get_atomgroup(u, sel):
-        if isinstance(sel, str):
-            return u.select_atoms(sel)
-        elif isinstance(sel, AtomGroup):
-            if isinstance(sel, UpdatingAtomGroup):
-                raise TypeError(Contacts._select_error_message)
-            else:
-                return sel
-        else:
-            raise TypeError(Contacts._select_error_message)
-
     def __init__(self, u, select, refgroup, method="hard_cut", radius=4.5,
                  pbc=True, kwargs=None, **basekwargs):
         """
@@ -480,6 +468,18 @@ class Contacts(AnalysisBase):
                 self.r0.append(distance_array(refA.positions, refB.positions,
                                                 box=self._get_box(refA.universe)))
                 self.initial_contacts.append(contact_matrix(self.r0[-1], radius))
+
+    @staticmethod
+    def _get_atomgroup(u, sel):
+        if isinstance(sel, str):
+            return u.select_atoms(sel)
+        elif isinstance(sel, AtomGroup):
+            if isinstance(sel, UpdatingAtomGroup):
+                raise TypeError(Contacts._select_error_message)
+            else:
+                return sel
+        else:
+            raise TypeError(Contacts._select_error_message)
 
     def _prepare(self):
         self.results.timeseries = np.empty((self.n_frames, len(self.r0)+1))

--- a/package/MDAnalysis/analysis/contacts.py
+++ b/package/MDAnalysis/analysis/contacts.py
@@ -387,7 +387,7 @@ class Contacts(AnalysisBase):
        :attr:`timeseries` results are now stored in a
        :class:`MDAnalysis.analysis.base.Results` instance.
     .. versionchanged:: 2.2.0
-       :class: `Contacts` accepts both AtomGroup and string for `select`
+       :class:`Contacts` accepts both AtomGroup and string for `select`
     """
 
     def __init__(self, u, select, refgroup, method="hard_cut", radius=4.5,

--- a/package/MDAnalysis/analysis/contacts.py
+++ b/package/MDAnalysis/analysis/contacts.py
@@ -510,7 +510,7 @@ class Contacts(AnalysisBase):
 
 def _new_selections(u_orig, selections, frame):
     """create stand alone AGs from selections at frame"""
-    u = u_orig.copy()
+    u = MDAnalysis.Universe(u_orig.filename, u_orig.trajectory.filename)
     u.trajectory[frame]
     return [u.select_atoms(s) for s in selections]
 

--- a/package/MDAnalysis/analysis/contacts.py
+++ b/package/MDAnalysis/analysis/contacts.py
@@ -387,6 +387,10 @@ class Contacts(AnalysisBase):
        :attr:`timeseries` results are now stored in a
        :class:`MDAnalysis.analysis.base.Results` instance.
     """
+    # Error message for wrong selection type:
+    select_error_message = "selection must be either string or a " \
+                                    "static AtomGroup"
+
     def __init__(self, u, select, refgroup, method="hard_cut", radius=4.5,
                  pbc=True, kwargs=None, **basekwargs):
         """
@@ -437,27 +441,25 @@ class Contacts(AnalysisBase):
             self.fraction_contacts = method
 
         self.select = select
-        
-        select_error_message = "selection must be either string or a static AtomGroup"
 
         if isinstance(select[0], str):
             self.grA = u.select_atoms(select[0])
         elif isinstance(select[0], AtomGroup):
             if isinstance(select[0], UpdatingAtomGroup):
-                raise TypeError(select_error_message)
+                raise TypeError(self.select_error_message)
             else:
                 self.grA = select[0]
         else:
-            raise TypeError(select_error_message)
+            raise TypeError(self.select_error_message)
 
         if isinstance(select[1], str):
             self.grB = u.select_atoms(select[1])
         elif isinstance(select[1], AtomGroup):
             if isinstance(select[1], UpdatingAtomGroup):
-                raise TypeError(select_error_message)
+                raise TypeError(self.select_error_message)
             self.grB = select[1]
         else:
-            raise TypeError(select_error_message)
+            raise TypeError(self.select_error_message)
 
         self.pbc = pbc
         

--- a/testsuite/MDAnalysisTests/analysis/test_contacts.py
+++ b/testsuite/MDAnalysisTests/analysis/test_contacts.py
@@ -177,7 +177,6 @@ class TestContacts(object):
     ):
         acidic = universe.select_atoms(self.sel_acidic)
         basic = universe.select_atoms(self.sel_basic)
-
         return contacts.Contacts(
             universe,
             select=(self.sel_acidic, self.sel_basic),

--- a/testsuite/MDAnalysisTests/analysis/test_contacts.py
+++ b/testsuite/MDAnalysisTests/analysis/test_contacts.py
@@ -187,7 +187,8 @@ class TestContacts(object):
 
     @pytest.mark.parametrize("seltxt", [sel_acidic, sel_basic])
     def test_select_valid_types(self, universe, seltxt):
-        """Test if Contact can take both string and AtomGroup as selections.
+        """Test if Contacts._get_atomgroup() can take both string and AtomGroup
+         as selections.
         """
         ag = universe.select_atoms(seltxt)
 
@@ -195,6 +196,27 @@ class TestContacts(object):
         ag_from_ag = contacts.Contacts._get_atomgroup(universe, ag)
 
         assert_equal(ag_from_string, ag_from_ag)
+
+    def test_contacts_selections(self, universe):
+        """Test if Contacts can take both string and AtomGroup as selections.
+        """
+        aga = universe.select_atoms(self.sel_acidic)
+        agb = universe.select_atoms(self.sel_basic)
+
+        cag = contacts.Contacts(
+            universe,
+            select=(aga, agb),
+            refgroup=(aga, agb),
+        ).run()
+
+        csel = contacts.Contacts(
+            universe,
+            select=(self.sel_acidic, self.sel_basic),
+            refgroup=(aga, agb)
+        ).run()
+
+        assert cag.grA == csel.grA
+        assert cag.grB == csel.grB
 
     @pytest.mark.parametrize("ag", [1, [2], mda.Universe, "USE UPDATING AG"])
     def test_select_wrong_types(self, universe, ag):

--- a/testsuite/MDAnalysisTests/analysis/test_contacts.py
+++ b/testsuite/MDAnalysisTests/analysis/test_contacts.py
@@ -204,12 +204,15 @@ class TestContacts(object):
 
         cag = contacts.Contacts(
             universe, select=(aga, agb), refgroup=(aga, agb)
-        ).run()
+        )
 
         csel = contacts.Contacts(
             universe, select=(self.sel_acidic, self.sel_basic),
             refgroup=(aga, agb)
-        ).run()
+        )
+
+        cag.run()
+        csel.run()
 
         assert cag.grA == csel.grA
         assert cag.grB == csel.grB

--- a/testsuite/MDAnalysisTests/analysis/test_contacts.py
+++ b/testsuite/MDAnalysisTests/analysis/test_contacts.py
@@ -173,36 +173,28 @@ class TestContacts(object):
 
     def _run_Contacts(
         self, universe,
-        ag_acidic=None, ag_basic=None,
         start=None, stop=None, step=None, **kwargs
     ):
         acidic = universe.select_atoms(self.sel_acidic)
         basic = universe.select_atoms(self.sel_basic)
-        if ag_acidic is None:
-            ag_acidic = self.sel_acidic
-        if ag_basic is None:
-            ag_basic = self.sel_basic
 
         return contacts.Contacts(
             universe,
-            select=(ag_acidic, ag_basic),
+            select=(self.sel_acidic, self.sel_basic),
             refgroup=(acidic, basic),
             radius=6.0,
             **kwargs).run(start=start, stop=stop, step=step)
 
-    def test_select_valid_types(self, universe):
+    @pytest.mark.parametrize("seltxt", [sel_acidic, sel_basic])
+    def test_select_valid_types(self, universe, seltxt):
         """Test if Contact can take both string and AtomGroup as selections.
         """
-        acidic = universe.select_atoms(self.sel_acidic)
-        basic = universe.select_atoms(self.sel_basic)
+        ag = universe.select_atoms(seltxt)
 
-        with_string = self._run_Contacts(universe)
-        with_atomgroup = self._run_Contacts(
-            universe, ag_acidic=acidic, ag_basic=basic
-        )
-
-        assert_equal(with_atomgroup.grA, with_string.grA)
-        assert_equal(with_atomgroup.grB, with_string.grB)
+        ag_from_string = contacts.Contacts._get_atomgroup(universe, seltxt)
+        ag_from_ag = contacts.Contacts._get_atomgroup(universe, ag)
+        
+        assert_equal(ag_from_string, ag_from_ag)
 
     @pytest.mark.parametrize("ag", [1, [2], mda.Universe, "USE UPDATING AG"])
     def test_select_wrong_types(self, universe, ag):

--- a/testsuite/MDAnalysisTests/analysis/test_contacts.py
+++ b/testsuite/MDAnalysisTests/analysis/test_contacts.py
@@ -205,7 +205,7 @@ class TestContacts(object):
         assert_equal(with_atomgroup.grB, with_string.grB)
 
     @pytest.mark.parametrize(
-        "ag1, ag2", 
+        "ag1, ag2",
         [
             (1, 2),
             ([1], [2]),
@@ -222,8 +222,9 @@ class TestContacts(object):
         if ag2 == "USE UPDATING AG":
             ag2 = universe.select_atoms(self.sel_basic, updating=True)
 
-        sel_err_msg = contacts.Contacts.select_error_message
-        with pytest.raises(TypeError, match=sel_err_msg) as te: 
+        with pytest.raises(
+            TypeError, match=contacts.Contacts.select_error_message
+        ) as te:
             C = self._run_Contacts(universe, ag_acidic=ag1, ag_basic=ag2)
 
     def test_startframe(self, universe):

--- a/testsuite/MDAnalysisTests/analysis/test_contacts.py
+++ b/testsuite/MDAnalysisTests/analysis/test_contacts.py
@@ -208,6 +208,27 @@ class TestContacts(object):
         uag = universe.select_atoms(self.sel_basic, updating=True)
         self._run_Contacts(universe, sel_basic=uag)
 
+    @pytest.mark.xfail
+    def test_select_wrong_type(self, universe):
+        """test that Contacts fails if selection types are wrong"""
+        selections = [
+            (1, 2), 
+            ([1], [2]), 
+            (mda.Universe, mda.Universe),
+            (AtomGroup, 2)
+        ]
+        fails = True
+        for sel_acid, self_basic in selections:
+            try:
+                self._run_Contacts(universe, sel_acid=sel_acid, sel_basic=sel_basic)
+                fails = False
+                break
+            except:
+                pass
+        if fails:
+            raise TypeError
+            
+
     def test_startframe(self, universe):
         """test_startframe: TestContactAnalysis1: start frame set to 0 (resolution of
         Issue #624)

--- a/testsuite/MDAnalysisTests/analysis/test_contacts.py
+++ b/testsuite/MDAnalysisTests/analysis/test_contacts.py
@@ -204,28 +204,17 @@ class TestContacts(object):
         assert_equal(with_atomgroup.grA, with_string.grA)
         assert_equal(with_atomgroup.grB, with_string.grB)
 
-    @pytest.mark.parametrize(
-        "ag1, ag2",
-        [
-            (1, 2),
-            ([1], [2]),
-            (mda.Universe, sel_basic),
-            (sel_acidic, 2),
-            ("USE UPDATING AG", sel_basic),
-            (sel_acidic, "USE UPDATING AG")
-        ]
-    )
-    def test_select_wrong_types(self, universe, ag1, ag2):
-        """test that Contacts fails if selection types are wrong"""
-        if ag1 == "USE UPDATING AG":
-            ag1 = universe.select_atoms(self.sel_acidic, updating=True)
-        if ag2 == "USE UPDATING AG":
-            ag2 = universe.select_atoms(self.sel_basic, updating=True)
+    @pytest.mark.parametrize("ag", [1, [2], mda.Universe, "USE UPDATING AG"])
+    def test_select_wrong_types(self, universe, ag):
+        """Test that Contacts._get_atomgroup(u, sel) fails if sel is of the
+        wrong type"""
+        if ag == "USE UPDATING AG":
+            ag = universe.select_atoms(self.sel_acidic, updating=True)
 
         with pytest.raises(
-            TypeError, match=contacts.Contacts.select_error_message
+            TypeError, match=contacts.Contacts._select_error_message
         ) as te:
-            C = self._run_Contacts(universe, ag_acidic=ag1, ag_basic=ag2)
+            contacts.Contacts._get_atomgroup(universe, ag)
 
     def test_startframe(self, universe):
         """test_startframe: TestContactAnalysis1: start frame set to 0 (resolution of

--- a/testsuite/MDAnalysisTests/analysis/test_contacts.py
+++ b/testsuite/MDAnalysisTests/analysis/test_contacts.py
@@ -194,7 +194,7 @@ class TestContacts(object):
         ag_from_string = contacts.Contacts._get_atomgroup(universe, seltxt)
         ag_from_ag = contacts.Contacts._get_atomgroup(universe, ag)
 
-        assert_equal(ag_from_string, ag_from_ag)
+        assert ag_from_string == ag_from_ag
 
     def test_contacts_selections(self, universe):
         """Test if Contacts can take both string and AtomGroup as selections.

--- a/testsuite/MDAnalysisTests/analysis/test_contacts.py
+++ b/testsuite/MDAnalysisTests/analysis/test_contacts.py
@@ -193,7 +193,7 @@ class TestContacts(object):
 
         ag_from_string = contacts.Contacts._get_atomgroup(universe, seltxt)
         ag_from_ag = contacts.Contacts._get_atomgroup(universe, ag)
-        
+
         assert_equal(ag_from_string, ag_from_ag)
 
     @pytest.mark.parametrize("ag", [1, [2], mda.Universe, "USE UPDATING AG"])

--- a/testsuite/MDAnalysisTests/analysis/test_contacts.py
+++ b/testsuite/MDAnalysisTests/analysis/test_contacts.py
@@ -203,14 +203,11 @@ class TestContacts(object):
         agb = universe.select_atoms(self.sel_basic)
 
         cag = contacts.Contacts(
-            universe,
-            select=(aga, agb),
-            refgroup=(aga, agb),
+            universe, select=(aga, agb), refgroup=(aga, agb)
         ).run()
 
         csel = contacts.Contacts(
-            universe,
-            select=(self.sel_acidic, self.sel_basic),
+            universe, select=(self.sel_acidic, self.sel_basic),
             refgroup=(aga, agb)
         ).run()
 
@@ -225,7 +222,7 @@ class TestContacts(object):
             ag = universe.select_atoms(self.sel_acidic, updating=True)
 
         with pytest.raises(
-            TypeError, match=contacts.Contacts._select_error_message
+            TypeError, match="must be either string or a static AtomGroup"
         ) as te:
             contacts.Contacts._get_atomgroup(universe, ag)
 


### PR DESCRIPTION
Fixes #2666

Summary
Solves the GSoC starter issue [#2666](https://github.com/MDAnalysis/mdanalysis/issues/2666)

Changes made in this Pull Request:
 - the class `mdanalysis/package/MDAnalysis/analysis/contacts.py::Contacts` is modified to accept static AtomGroups
 - the helper function `_new_selections()` in the same script is modified to use `Universe.copy()` **UPDATE: this has now been raised in new Issue #3570. This PR has reverted it back to the original.**
 - tests were added to `test_contacts.py` to ensure Contacts successfully uses static AtomGroups as well as selection texts.
 - tests were also added to ensure it fails when wrong types are provided for selection, including updating AtomGroups.

PR Checklist
------------
 - [x] Codecov coverage?
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
