### PR TITLE
References are formatted properly #2837 

### DIFF
--- a/package/MDAnalysis/analysis/contacts.py
+++ b/package/MDAnalysis/analysis/contacts.py
@@ -254,7 +254,7 @@ def soft_cut_q(r, r0, beta=5.0, lambda_constant=1.8):
     Q : float
       fraction of native contacts
 
-    References
+    """ References
     ----------
     .. [Best2013] RB Best, G Hummer, and WA Eaton, "Native contacts determine protein
        folding mechanisms in atomistic simulations" _PNAS_ **110** (2013),

--- a/package/MDAnalysis/analysis/contacts.py
+++ b/package/MDAnalysis/analysis/contacts.py
@@ -254,6 +254,7 @@ def soft_cut_q(r, r0, beta=5.0, lambda_constant=1.8):
     Q : float
       fraction of native contacts
 
+    The native contact function is defined as :cite:p:`best2013native`
     """ References
     ----------
     .. [Best2013] RB Best, G Hummer, and WA Eaton, "Native contacts determine protein

--- a/package/MDAnalysis/analysis/md.bib
+++ b/package/MDAnalysis/analysis/md.bib
@@ -16,8 +16,8 @@
 		title = {Maximum likelihood trajectory for large-scale structural transitions in a coarse-grained locally harmonic energy landscape},  
 		journal= {Nucleic Acids Research}, 
 		volume = {35},
-        pages{477–482},
-        doi= {`10.1093/nar/gkm342},
-        url= {http://doi.org/10.1093/nar/gkm342}
+        	pages{477–482},
+       		doi= {`10.1093/nar/gkm342},
+        	url= {http://doi.org/10.1093/nar/gkm342}
 }
 

--- a/package/MDAnalysis/analysis/md.bib
+++ b/package/MDAnalysis/analysis/md.bib
@@ -1,23 +1,21 @@
-@article{[Best2013],
-		author= {RB Best, G Hummer, and WA Eaton,},
-		title = {"Native contacts determine protein folding mechanisms in atomistic simulations"}, 				
-		 _PNAS_ **110** 
-		year= {(2013)},
-		pages = {17874–17879}, 
-		doi= {10.1073/pnas.1311599110},
-		url= {http://doi.org/10.1073/pnas.1311599110}
+@article{best2013native,
+  title={Native contacts determine protein folding mechanisms in atomistic simulations},
+  author={Best, Robert B and Hummer, Gerhard and Eaton, William A},
+  journal={Proceedings of the National Academy of Sciences},
+  volume={110},
+  number={44},
+  pages={17874--17879},
+  year={2013},
+  publisher={National Acad Sciences}
 }
-
       
-@article{[Franklin2007],
-		author = {Franklin, J., Koehl, P., Doniach, S., & Delarue, M.},
-		year= {(2007)}, 
-		shorttitle= {Min Action Path},
-		title = {Maximum likelihood trajectory for large-scale structural transitions in a coarse-grained locally harmonic energy landscape},  
-		journal= {Nucleic Acids Research}, 
-		volume = {35},
-        	pages{477–482},
-       		doi= {`10.1093/nar/gkm342},
-        	url= {http://doi.org/10.1093/nar/gkm342}
+@article{franklin2007minactionpath,
+  title={MinActionPath: maximum likelihood trajectory for large-scale structural transitions in a coarse-grained locally harmonic energy landscape},
+  author={Franklin, Joel and Koehl, Patrice and Doniach, Sebastian and Delarue, Marc},
+  journal={Nucleic acids research},
+  volume={35},
+  number={suppl\_2},
+  pages={W477--W482},
+  year={2007},
+  publisher={Oxford University Press}
 }
-

--- a/package/MDAnalysis/analysis/md.bib
+++ b/package/MDAnalysis/analysis/md.bib
@@ -1,0 +1,23 @@
+@article{[Best2013],
+		author= {RB Best, G Hummer, and WA Eaton,},
+		title = {"Native contacts determine protein folding mechanisms in atomistic simulations"}, 				
+		 _PNAS_ **110** 
+		year= {(2013)},
+		pages = {17874–17879}, 
+		doi= {10.1073/pnas.1311599110},
+		url= {http://doi.org/10.1073/pnas.1311599110}
+}
+
+      
+@article{[Franklin2007],
+		author = {Franklin, J., Koehl, P., Doniach, S., & Delarue, M.},
+		year= {(2007)}, 
+		shorttitle= {Min Action Path},
+		title = {Maximum likelihood trajectory for large-scale structural transitions in a coarse-grained locally harmonic energy landscape},  
+		journal= {Nucleic Acids Research}, 
+		volume = {35},
+        pages{477–482},
+        doi= {`10.1093/nar/gkm342},
+        url= {http://doi.org/10.1093/nar/gkm342}
+}
+


### PR DESCRIPTION
Fixes #2837


Changes made in this Pull Request:
A docstring was added to line 257 so as to properly cite the reference.