### PR TITLE
Change code snippets from python 2 to python 3 in the documentation

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -179,6 +179,7 @@ Chronological list of authors
   - Alexander Gorfer
   - Aya M. Alaa
   - Kazi Shudipto Amin
+  - Henok Ademtew
 
 External code
 -------------

--- a/package/doc/sphinx/source/documentation_pages/overview.rst
+++ b/package/doc/sphinx/source/documentation_pages/overview.rst
@@ -35,7 +35,7 @@ of a protein and the radius of gyration of the backbone atoms are calculated::
         r = cterm.pos - nterm.pos  # end-to-end vector from atom positions
         d = numpy.linalg.norm(r)   # end-to-end distance
         rgyr = bb.radius_of_gyration()  # method of a AtomGroup; updates with each frame
-        print "frame = %d: d = %f Angstroem, Rgyr = %f Angstroem" % (ts.frame, d, rgyr)
+        print("frame = %d: d = %f Angstroem, Rgyr = %f Angstroem" % (ts.frame, d, rgyr))
 
 
 .. _NumPy:   http://numpy.scipy.org
@@ -104,7 +104,7 @@ The :class:`~MDAnalysis.core.universe.Universe` contains a number of important a
 the most important ones of which is
 :attr:`~MDAnalysis.core.universe.Universe.atoms`::
 
-  >>> print u.atoms
+  >>> print(u.atoms)
   <AtomGroup with 3341 atoms>
 
 :attr:`Universe.atoms` is a

--- a/package/doc/sphinx/source/documentation_pages/overview.rst
+++ b/package/doc/sphinx/source/documentation_pages/overview.rst
@@ -35,7 +35,7 @@ of a protein and the radius of gyration of the backbone atoms are calculated::
         r = cterm.pos - nterm.pos  # end-to-end vector from atom positions
         d = numpy.linalg.norm(r)   # end-to-end distance
         rgyr = bb.radius_of_gyration()  # method of a AtomGroup; updates with each frame
-        print("frame = %d: d = %f Angstroem, Rgyr = %f Angstroem" % (ts.frame, d, rgyr))
+        print(f"frame = {ts.frame}: d = {d} Angstroem, Rgyr = {rgyr} Angstroem")
 
 
 .. _NumPy:   http://numpy.scipy.org

--- a/package/doc/sphinx/source/documentation_pages/overview.rst
+++ b/package/doc/sphinx/source/documentation_pages/overview.rst
@@ -116,14 +116,14 @@ elementary and fundamental object in MDAnalysis.
 The :attr:`MDAnalysis.Universe.trajectory` attribute gives access to the coordinates
 over time::
 
-  >>> print u.trajectory
+  >>> print(u.trajectory)
   < DCDReader '/..../MDAnalysis/tests/data/adk_dims.dcd' with 98 frames of 3341 atoms (0 fixed) >
 
 Finally, the :meth:`MDAnalysis.Universe.select_atoms` method generates a new
 :class:`~MDAnalysis.core.groups.AtomGroup` according to a selection criterion
 
   >>> calphas = u.select_atoms("name CA")
-  >>> print calphas
+  >>> print(calphas)
   <AtomGroup with 214 atoms>
 
 as described in :ref:`selection-commands-label`.

--- a/package/doc/sphinx/source/documentation_pages/selections.rst
+++ b/package/doc/sphinx/source/documentation_pages/selections.rst
@@ -405,7 +405,7 @@ The most straightforward way to concatentate two AtomGroups is by using the
 ``+`` operator::
 
  >>> ordered = u.select_atoms("segid DMPC and resid 3 and name P") + u.select_atoms("segid DMPC and resid 2 and name P")
- >>> print list(ordered)
+ >>> print(list(ordered))
  [< Atom 570: name 'P' of type '180' of resid 'DMPC', 3 and 'DMPC'>,
  < Atom 452: name 'P' of type '180' of resid 'DMPC', 2 and 'DMPC'>]
 
@@ -413,7 +413,7 @@ A shortcut is to provide *two or more* selections to
 :meth:`~MDAnalysis.core.universe.Universe.select_atoms`, which then
 does the concatenation automatically::
 
- >>> print list(universe.select_atoms("segid DMPC and resid 3 and name P", "segid DMPC and resid 2 and name P"))
+ >>> print(list(universe.select_atoms("segid DMPC and resid 3 and name P", "segid DMPC and resid 2 and name P")))
  [< Atom 570: name 'P' of type '180' of resid 'DMPC', 3 and 'DMPC'>,
  < Atom 452: name 'P' of type '180' of resid 'DMPC', 2 and 'DMPC'>]
 
@@ -421,6 +421,6 @@ Just for comparison to show that a single selection string does not
 work as one might expect::
 
  # WRONG!
- >>> print list(universe.select_atoms("segid DMPC and ( resid 3 or resid 2 ) and name P"))
+ >>> print(list(universe.select_atoms("segid DMPC and ( resid 3 or resid 2 ) and name P")))
  [< Atom 452: name 'P' of type '180' of resid 'DMPC', 2 and 'DMPC'>,
  < Atom 570: name 'P' of type '180' of resid 'DMPC', 3 and 'DMPC'>]

--- a/package/doc/sphinx/source/documentation_pages/selections.rst
+++ b/package/doc/sphinx/source/documentation_pages/selections.rst
@@ -421,6 +421,6 @@ Just for comparison to show that a single selection string does not
 work as one might expect::
 
  # WRONG!
- >>> print(list(universe.select_atoms("segid DMPC and ( resid 3 or resid 2 ) and name P")))
+ >>> print(list(universe.select_atoms("segid DMPC and (resid 3 or resid 2) and name P")))
  [< Atom 452: name 'P' of type '180' of resid 'DMPC', 2 and 'DMPC'>,
  < Atom 570: name 'P' of type '180' of resid 'DMPC', 3 and 'DMPC'>]


### PR DESCRIPTION
Fixes #3582 

Changes made in this Pull Request:
 - Change code snippets from python 2 to python 3 in the documentation
 - Update print statements from python 2 to python 3 


PR Checklist
------------
 - [ ] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
