### PR TITLE
BLD: improve M1 build support

### DIFF
--- a/package/pyproject.toml
+++ b/package/pyproject.toml
@@ -11,4 +11,7 @@ requires = [
     "numpy==1.21.4; python_version=='3.10' and platform_python_implementation != 'PyPy'",
     "setuptools",
     "wheel",
+    # arm64 on Darwin supports Python 3.8 and above and requires numpy>=1.20.0
+    "numpy==1.20.0; python_version=='3.8' and platform_machine=='arm64' and platform_system=='Darwin'",
+    "numpy==1.20.0; python_version=='3.9' and platform_machine=='arm64' and platform_system=='Darwin'",
 ]

--- a/testsuite/MDAnalysisTests/analysis/test_encore.py
+++ b/testsuite/MDAnalysisTests/analysis/test_encore.py
@@ -446,7 +446,7 @@ class TestEncoreClustering(object):
                                                           "results: {0}".format(cluster_collection)
 
     @pytest.mark.xfail(platform.machine() == "arm64" and platform.system() == "Darwin",
-                       reason="Fails on M1 Mac")
+                       reason="see gh-3599")
     def test_clustering_three_ensembles_two_identical(self, ens1, ens2):
         cluster_collection = encore.cluster([ens1, ens2, ens1])
         expected_value = 40

--- a/testsuite/MDAnalysisTests/analysis/test_encore.py
+++ b/testsuite/MDAnalysisTests/analysis/test_encore.py
@@ -29,6 +29,7 @@ import numpy as np
 import sys
 import os
 import warnings
+import platform
 
 import pytest
 from numpy.testing import assert_equal, assert_almost_equal
@@ -444,6 +445,8 @@ class TestEncoreClustering(object):
         assert len(cluster_collection) == expected_value, "Unexpected " \
                                                           "results: {0}".format(cluster_collection)
 
+    @pytest.mark.xfail(platform.machine() == "arm64" and platform.system() == "Darwin",
+                       reason="Fails on M1 Mac")
     def test_clustering_three_ensembles_two_identical(self, ens1, ens2):
         cluster_collection = encore.cluster([ens1, ens2, ens1])
         expected_value = 40


### PR DESCRIPTION
Deals with part of MDAnalysis/mdanalysis#3592 

* the changes here allow me to build MDAnalysis and its
dependencies on an M1 Mac on the gcc compile farm using
`python3 -m pip install --user .`

* the full test suite passes, except for 1 extra `xfail`
I've added in here--which is also documented by MDAnalysis/mdaencore#38
(it has apparently been failing on "exotic platforms"
for almost 5 years)

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?
