### PR TITLE
Modified MOL2Parser.py and MOL2.py to unpack only compulsory keywords for MOL2 format

### DIFF
--- a/package/MDAnalysis/coordinates/MOL2.py
+++ b/package/MDAnalysis/coordinates/MOL2.py
@@ -203,7 +203,7 @@ class MOL2Reader(base.ReaderBase):
 
         coords = np.zeros((self.n_atoms, 3), dtype=np.float32)
         for i, a in enumerate(atom_lines):
-            aid, name, x, y, z, atom_type, resid, resname, charge = a.split()[:9]
+            aid, name, x, y, z, atom_type = a.split()[:6]
 
             #x, y, z = float(x), float(y), float(z)
             coords[i, :] = x, y, z

--- a/package/MDAnalysis/topology/MOL2Parser.py
+++ b/package/MDAnalysis/topology/MOL2Parser.py
@@ -153,7 +153,7 @@ class MOL2Parser(TopologyReaderBase):
 
         for a in atom_lines:
             columns = a.split()
-            opt_values = [1, '', 0.0]
+            opt_values = ['1', 'UNK', '0.0']
             opt_fields = ['subst_id', 'subst_name', 'charge']
             if len(columns) < 6:
                 raise ValueError("The @<TRIPOS>ATOM block in mol2 file {0}"

--- a/package/MDAnalysis/topology/MOL2Parser.py
+++ b/package/MDAnalysis/topology/MOL2Parser.py
@@ -157,14 +157,17 @@ class MOL2Parser(TopologyReaderBase):
             opt_fields = ['subst_id', 'subst_name', 'charge']
             if len(columns) < 6:
                 raise ValueError("The @<TRIPOS>ATOM block in mol2 file {0}"
-                " should contain at least 6 fields to be unpacked:"
-                " atom_id atom_name x y z atom_type [subst_id[subst_name [charge [status_bit]]]]".format(os.path.basename(self.filename)))
+                                 " should contain at least 6 fields to be unpacked:"
+                                 " atom_id atom_name x y z atom_type"
+                                 " [subst_id[subst_name [charge [status_bit]]]]".format(
+                    os.path.basename(self.filename)))
             aid, name, x, y, z, atom_type = columns[:6]
             for i in range(6, len(columns)):
                 opt_values[i-6] = columns[i]
             for i in range(len(columns), 9):
                 warnings.warn("Not enough values to unpack."
-                          " {0} has been given value {1}.".format(opt_fields[i-6], opt_values[i-6]))
+                              " {0} has been given value {1}.".format(
+                    opt_fields[i-6], opt_values[i-6]))
             resid, resname, charge = opt_values
             ids.append(aid)
             names.append(name)


### PR DESCRIPTION
Fixes #3385 

Changes made in this Pull Request:
 - Modified MOL2Parser: when optional fields are not provided: '1' assigned to 'subst_id', 'UNK' assigned to 'subst_name', and '0.0' assigned to 'charge' by default. Therefore the situation described in #3385 can be properly handled.
 -  Modified MOL2.py to unpack only compulsory keywords as well.


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced
