### PR TITLE
Issue #3580 Fix typo units and conersion page

### DIFF
--- a/package/doc/html/html/documentation_pages/units.html
+++ b/package/doc/html/html/documentation_pages/units.html
@@ -1,0 +1,439 @@
+<!DOCTYPE html>
+<html class="writer-html5" lang="en" >
+<head>
+  <meta charset="utf-8" /><meta name="generator" content="Docutils 0.17.1: http://docutils.sourceforge.net/" />
+
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>15. Constants and unit conversion — MDAnalysis.units &mdash; MDAnalysis 2.2.0-dev0 documentation</title>
+      <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
+      <link rel="stylesheet" href="../_static/css/msmb.css" type="text/css" />
+      <link rel="stylesheet" href="../_static/custom.css" type="text/css" />
+    <link rel="shortcut icon" href="../_static/mdanalysis-logo.ico"/>
+  <!--[if lt IE 9]>
+    <script src="../_static/js/html5shiv.min.js"></script>
+  <![endif]-->
+  
+        <script data-url_root="../" id="documentation_options" src="../_static/documentation_options.js"></script>
+        <script src="../_static/jquery.js"></script>
+        <script src="../_static/underscore.js"></script>
+        <script src="../_static/doctools.js"></script>
+        <script async="async" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+        <script src="../_static/js/versions.js"></script>
+    <script src="../_static/js/theme.js"></script>
+    <link rel="search" type="application/opensearchdescription+xml"
+          title="Search within MDAnalysis 2.2.0-dev0 documentation"
+          href="../_static/opensearch.xml"/>
+    <link rel="index" title="Index" href="../genindex.html" />
+    <link rel="search" title="Search" href="../search.html" />
+    <link rel="next" title="16. Custom exceptions and warnings — MDAnalysis.exceptions" href="exceptions.html" />
+    <link rel="prev" title="14. Version information for MDAnalysis - MDAnalysis.version" href="version.html" /> 
+</head>
+
+<body class="wy-body-for-nav"> 
+  <div class="wy-grid-for-nav">
+    <nav data-toggle="wy-nav-shift" class="wy-nav-side">
+      <div class="wy-side-scroll">
+        <div class="wy-side-nav-search"  style="background: white" >
+            <a href="../index.html">
+            <img src="../_static/mdanalysis-logo-thin.png" class="logo" alt="Logo"/>
+          </a>
+              <div class="version">
+                2.2.0-dev0
+              </div>
+<div role="search">
+  <form id="rtd-search-form" class="wy-form" action="../search.html" method="get">
+    <input type="text" name="q" placeholder="Search docs" />
+    <input type="hidden" name="check_keywords" value="yes" />
+    <input type="hidden" name="area" value="default" />
+  </form>
+</div>
+        </div><div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="Navigation menu">
+              <ul class="current">
+<li class="toctree-l1"><a class="reference internal" href="overview.html">1. Overview over MDAnalysis</a></li>
+<li class="toctree-l1"><a class="reference internal" href="topology.html">2. The topology system</a></li>
+<li class="toctree-l1"><a class="reference internal" href="selections.html">3. Selection commands</a></li>
+<li class="toctree-l1"><a class="reference internal" href="analysis_modules.html">4. Analysis modules</a></li>
+<li class="toctree-l1"><a class="reference internal" href="topology_modules.html">5. Topology modules</a></li>
+<li class="toctree-l1"><a class="reference internal" href="coordinates_modules.html">6. Coordinates modules</a></li>
+<li class="toctree-l1"><a class="reference internal" href="converters.html">7. Converter modules</a></li>
+<li class="toctree-l1"><a class="reference internal" href="trajectory_transformations.html">8. Trajectory transformations (“on-the-fly” transformations)</a></li>
+<li class="toctree-l1"><a class="reference internal" href="selections_modules.html">9. Selection exporters</a></li>
+<li class="toctree-l1"><a class="reference internal" href="auxiliary_modules.html">10. Auxiliary modules</a></li>
+<li class="toctree-l1"><a class="reference internal" href="core_modules.html">11. Core modules</a></li>
+<li class="toctree-l1"><a class="reference internal" href="visualization_modules.html">12. Visualization modules</a></li>
+<li class="toctree-l1"><a class="reference internal" href="lib_modules.html">13. Library functions — <code class="xref py py-mod docutils literal notranslate"><span class="pre">MDAnalysis.lib</span></code></a></li>
+<li class="toctree-l1"><a class="reference internal" href="version.html">14. Version information for MDAnalysis - <code class="xref py py-mod docutils literal notranslate"><span class="pre">MDAnalysis.version</span></code></a></li>
+<li class="toctree-l1 current"><a class="current reference internal" href="#">15. Constants and unit conversion — <code class="xref py py-mod docutils literal notranslate"><span class="pre">MDAnalysis.units</span></code></a><ul>
+<li class="toctree-l2"><a class="reference internal" href="#implementation-notes">15.1. Implementation notes</a><ul>
+<li class="toctree-l3"><a class="reference internal" href="#conversions">15.1.1. Conversions</a></li>
+</ul>
+</li>
+<li class="toctree-l2"><a class="reference internal" href="#functions">15.2. Functions</a></li>
+<li class="toctree-l2"><a class="reference internal" href="#data">15.3. Data</a></li>
+<li class="toctree-l2"><a class="reference internal" href="#references-and-footnotes">15.4. References and footnotes</a></li>
+</ul>
+</li>
+<li class="toctree-l1"><a class="reference internal" href="exceptions.html">16. Custom exceptions and warnings — <code class="xref py py-mod docutils literal notranslate"><span class="pre">MDAnalysis.exceptions</span></code></a></li>
+<li class="toctree-l1"><a class="reference internal" href="references.html">17. References</a></li>
+</ul>
+
+        </div>
+      </div>
+    </nav>
+
+    <section data-toggle="wy-nav-shift" class="wy-nav-content-wrap"><nav class="wy-nav-top" aria-label="Mobile navigation menu"  style="background: white" >
+          <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
+          <a href="../index.html">MDAnalysis</a>
+      </nav>
+
+      <div class="wy-nav-content">
+        <div class="rst-content">
+          <div role="navigation" aria-label="Page navigation">
+  <ul class="wy-breadcrumbs">
+      <li><a href="../index.html" class="icon icon-home"></a> &raquo;</li>
+      <li><span class="section-number">15. </span>Constants and unit conversion — <code class="xref py py-mod docutils literal notranslate"><span class="pre">MDAnalysis.units</span></code></li>
+      <li class="wy-breadcrumbs-aside">
+            <a href="../_sources/documentation_pages/units.rst.txt" rel="nofollow"> View page source</a>
+      </li>
+  </ul>
+  <hr/>
+</div>
+          <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div itemprop="articleBody">
+             
+  <span class="target" id="module-MDAnalysis.units"></span><section id="constants-and-unit-conversion-mdanalysis-units">
+<h1><span class="section-number">15. </span>Constants and unit conversion — <a class="reference internal" href="#module-MDAnalysis.units" title="MDAnalysis.units"><code class="xref py py-mod docutils literal notranslate"><span class="pre">MDAnalysis.units</span></code></a><a class="headerlink" href="#constants-and-unit-conversion-mdanalysis-units" title="Permalink to this headline"></a></h1>
+<p>The base units of MDAnalysis trajectories are the <strong>Å</strong> (<strong>ångström</strong>) for
+<strong>length</strong> and <strong>ps</strong> (<strong>pico second</strong>) for <strong>time</strong>. By default, all positions
+are in Å and all times are in ps, regardless of how the MD code stored
+trajectory data. By default, MDAnalysis converts automatically to the
+MDAnalysis units when reading trajectories and converts back when writing. This
+makes it possible to write scripts that can be agnostic of the specifics of how
+a particular MD code stores trajectory data. Other base units are listed in the
+table on <a class="reference internal" href="#table-baseunits"><span class="std std-ref">Base units in MDAnalysis</span></a>.</p>
+<span id="table-baseunits"></span><table class="docutils align-default" id="id4">
+<caption><span class="caption-text">Base units in MDAnalysis</span><a class="headerlink" href="#id4" title="Permalink to this table"></a></caption>
+<colgroup>
+<col style="width: 15%" />
+<col style="width: 19%" />
+<col style="width: 65%" />
+</colgroup>
+<thead>
+<tr class="row-odd"><th class="head"><p>quantity</p></th>
+<th class="head"><p>unit</p></th>
+<th class="head"><p>SI units</p></th>
+</tr>
+</thead>
+<tbody>
+<tr class="row-even"><td><p>length</p></td>
+<td><p>Å</p></td>
+<td><p><span class="math notranslate nohighlight">\(10^{-10}\)</span> m</p></td>
+</tr>
+<tr class="row-odd"><td><p>time</p></td>
+<td><p>ps</p></td>
+<td><p><span class="math notranslate nohighlight">\(10^{-12}\)</span> s</p></td>
+</tr>
+<tr class="row-even"><td><p>energy</p></td>
+<td><p>kJ/mol</p></td>
+<td><p><span class="math notranslate nohighlight">\(1.66053892103219 \times 10^{-21}\)</span> J</p></td>
+</tr>
+<tr class="row-odd"><td><p>charge</p></td>
+<td><p><span class="math notranslate nohighlight">\(e\)</span></p></td>
+<td><p><span class="math notranslate nohighlight">\(1.602176565 \times 10^{-19}\)</span> As</p></td>
+</tr>
+<tr class="row-even"><td><p>force</p></td>
+<td><p>kJ/(mol·Å)</p></td>
+<td><p><span class="math notranslate nohighlight">\(1.66053892103219 \times 10^{-11}\)</span> J/m</p></td>
+</tr>
+<tr class="row-odd"><td><p>speed</p></td>
+<td><p>Å/ps</p></td>
+<td><p><span class="math notranslate nohighlight">\(100\)</span> m/s</p></td>
+</tr>
+</tbody>
+</table>
+<section id="implementation-notes">
+<h2><span class="section-number">15.1. </span>Implementation notes<a class="headerlink" href="#implementation-notes" title="Permalink to this headline"></a></h2>
+<p>All conversions with <a class="reference internal" href="#MDAnalysis.units.convert" title="MDAnalysis.units.convert"><code class="xref py py-func docutils literal notranslate"><span class="pre">convert()</span></code></a> are carried out in a simple fashion: the
+conversion factor <span class="math notranslate nohighlight">\(f_{b,b'}\)</span> from the base unit <span class="math notranslate nohighlight">\(b\)</span> to another unit
+<span class="math notranslate nohighlight">\(b'\)</span> is precomputed and stored (see <a class="reference internal" href="#data"><span class="std std-ref">Data</span></a>). The numerical value of
+a quantity in unit <span class="math notranslate nohighlight">\(b\)</span> is <span class="math notranslate nohighlight">\(X/b\)</span> (e.g. for <span class="math notranslate nohighlight">\(X =
+1.23\,\mathrm{ps}\)</span> the numerical value is <span class="math notranslate nohighlight">\(X/\mathrm{ps} =
+1.23\)</span>). <a class="footnote-reference brackets" href="#funits" id="id1">1</a></p>
+<p>The new numerical value <span class="math notranslate nohighlight">\(X'/b'\)</span> of the quantity (in units of <span class="math notranslate nohighlight">\(b'\)</span>)
+is then</p>
+<div class="math notranslate nohighlight">
+\[X'/b' = f_{b,b'} X/b\]</div>
+<p>The function <a class="reference internal" href="#MDAnalysis.units.get_conversion_factor" title="MDAnalysis.units.get_conversion_factor"><code class="xref py py-func docutils literal notranslate"><span class="pre">get_conversion_factor()</span></code></a> returns the appropriate factor
+<span class="math notranslate nohighlight">\(f_{b,b'}\)</span>.</p>
+<p>Conversion between different units is always carried out via the base unit as
+an intermediate step:</p>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">x</span> <span class="ow">is</span> <span class="ow">in</span> <span class="n">u1</span><span class="p">:</span> <span class="kn">from</span> <span class="nn">u1</span> <span class="n">to</span> <span class="n">b</span><span class="p">:</span>  <span class="n">x</span><span class="s1">&#39;  = x  / factor[u1]</span>
+            <span class="kn">from</span> <span class="nn">b</span>  <span class="n">to</span> <span class="n">u2</span><span class="p">:</span> <span class="n">x</span><span class="s1">&#39;&#39;</span> <span class="o">=</span> <span class="n">x</span><span class="s1">&#39; * factor[u2]</span>
+<span class="n">so</span> <span class="n">f</span><span class="p">[</span><span class="n">u1</span><span class="p">,</span><span class="n">u2</span><span class="p">]</span> <span class="o">=</span> <span class="n">factor</span><span class="p">[</span><span class="n">u2</span><span class="p">]</span><span class="o">/</span><span class="n">factor</span><span class="p">[</span><span class="n">u1</span><span class="p">]</span>
+</pre></div>
+</div>
+<section id="conversions">
+<h3><span class="section-number">15.1.1. </span>Conversions<a class="headerlink" href="#conversions" title="Permalink to this headline"></a></h3>
+<p>Examples for how to calculate some of the conversion factors that are
+hard-coded in <a class="reference internal" href="#module-MDAnalysis.units" title="MDAnalysis.units"><code class="xref py py-mod docutils literal notranslate"><span class="pre">units</span></code></a> (see <a class="reference internal" href="#data"><span class="std std-ref">Data</span></a>).</p>
+<dl>
+<dt>density:</dt><dd><p>Base unit is <span class="math notranslate nohighlight">\(\mathrm{Å}^{-3}\)</span>:</p>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">n</span><span class="o">/</span><span class="n">x</span> <span class="o">=</span> <span class="n">n</span><span class="o">/</span><span class="n">A</span><span class="o">**</span><span class="mi">3</span> <span class="o">*</span> <span class="n">densityUnit_factor</span><span class="p">[</span><span class="n">x</span><span class="p">]</span>
+</pre></div>
+</div>
+<p>Example for how to calculate the conversion factor
+<span class="math notranslate nohighlight">\(f_{\mathrm{Å}^{-3},\mathrm{nm}^{-3}}\)</span> from <span class="math notranslate nohighlight">\(\mathrm{Å^-3}\)</span> to
+<span class="math notranslate nohighlight">\(\mathrm{nm}^{-3}\)</span>:</p>
+<div class="math notranslate nohighlight">
+\[f_{\mathrm{Å}^{-3},\mathrm{nm}^{-3}}
+      = \frac{1\,\mathrm{nm}^{-3}}{1\,\mathrm{Å}^{-3}}
+      = \frac{(10\,\mathrm{Å})^{-3}}{1\,\mathrm{Å}^{-3}}
+      = 10^{-3}\]</div>
+</dd>
+<dt>concentration:</dt><dd><p>Example for how to convert the conversion factor to Molar (mol/l):</p>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">factor</span> <span class="o">=</span> <span class="mi">1</span> <span class="n">A</span><span class="o">**-</span><span class="mi">3</span> <span class="o">/</span> <span class="p">(</span><span class="n">N_Avogadro</span> <span class="o">*</span> <span class="p">(</span><span class="mi">10</span><span class="o">**-</span><span class="mi">9</span> <span class="n">dm</span><span class="p">)</span><span class="o">**-</span><span class="mi">3</span><span class="p">)</span>
+</pre></div>
+</div>
+<p>relative to a density rho0 in g/cm^3:</p>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">M</span><span class="p">(</span><span class="n">H2O</span><span class="p">)</span> <span class="o">=</span> <span class="mi">18</span> <span class="n">g</span><span class="o">/</span><span class="n">mol</span>   <span class="n">Molar</span> <span class="n">mass</span> <span class="n">of</span> <span class="n">water</span>
+
+<span class="n">factor</span> <span class="o">=</span> <span class="mi">1</span><span class="o">/</span><span class="p">(</span><span class="mf">1e-24</span> <span class="o">*</span> <span class="n">N_Avogadro</span> <span class="o">/</span> <span class="n">M</span><span class="p">(</span><span class="n">H2O</span><span class="p">))</span>
+</pre></div>
+</div>
+<p>from <cite>rho/rho0 = n/(N_A * M**-1) / rho0</cite>  where <cite>[n] = 1/Volume</cite>, <cite>[rho] = mass/Volume</cite></p>
+</dd>
+</dl>
+<div class="admonition note">
+<p class="admonition-title">Note</p>
+<p>In the future, we might move towards using the <a class="reference external" href="http://packages.python.org/quantities/">Quantities</a> package or
+<a class="reference external" href="https://docs.scipy.org/doc/scipy/reference/constants.html#module-scipy.constants" title="(in SciPy v1.8.0)"><code class="xref py py-mod docutils literal notranslate"><span class="pre">scipy.constants</span></code></a>.</p>
+</div>
+</section>
+</section>
+<section id="functions">
+<h2><span class="section-number">15.2. </span>Functions<a class="headerlink" href="#functions" title="Permalink to this headline"></a></h2>
+<dl class="py function">
+<dt class="sig sig-object py" id="MDAnalysis.units.get_conversion_factor">
+<span class="sig-prename descclassname"><span class="pre">MDAnalysis.units.</span></span><span class="sig-name descname"><span class="pre">get_conversion_factor</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">unit_type</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">u1</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">u2</span></span></em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/MDAnalysis/units.html#get_conversion_factor"><span class="viewcode-link"><span class="pre">[source]</span></span></a><a class="headerlink" href="#MDAnalysis.units.get_conversion_factor" title="Permalink to this definition"></a></dt>
+<dd><p>generate the conversion factor u1 -&gt; u2 by using the base unit as an intermediate</p>
+<p>f[u1 -&gt; u2] = factor[u2]/factor[u1]</p>
+<p>Conversion of X (in u1) to X’ (in u2):</p>
+<blockquote>
+<div><p>X’ = conversion_factor * X</p>
+</div></blockquote>
+</dd></dl>
+
+<dl class="py function">
+<dt class="sig sig-object py" id="MDAnalysis.units.convert">
+<span class="sig-prename descclassname"><span class="pre">MDAnalysis.units.</span></span><span class="sig-name descname"><span class="pre">convert</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">x</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">u1</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">u2</span></span></em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/MDAnalysis/units.html#convert"><span class="viewcode-link"><span class="pre">[source]</span></span></a><a class="headerlink" href="#MDAnalysis.units.convert" title="Permalink to this definition"></a></dt>
+<dd><p>Convert value <em>x</em> in unit <em>u1</em> to new value in <em>u2</em>.</p>
+<dl class="field-list simple">
+<dt class="field-odd">Returns</dt>
+<dd class="field-odd"><p>Converted value.</p>
+</dd>
+<dt class="field-even">Return type</dt>
+<dd class="field-even"><p><a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.10)">float</a></p>
+</dd>
+<dt class="field-odd">Raises</dt>
+<dd class="field-odd"><p><a class="reference external" href="https://docs.python.org/3/library/exceptions.html#ValueError" title="(in Python v3.10)"><strong>ValueError</strong></a> – The units are not known or if one attempts to convert between
+    incompatible units.</p>
+</dd>
+</dl>
+</dd></dl>
+
+</section>
+<section id="data">
+<span id="id2"></span><h2><span class="section-number">15.3. </span>Data<a class="headerlink" href="#data" title="Permalink to this headline"></a></h2>
+<dl class="py data">
+<dt class="sig sig-object py" id="MDAnalysis.units.constants">
+<span class="sig-prename descclassname"><span class="pre">MDAnalysis.units.</span></span><span class="sig-name descname"><span class="pre">constants</span></span><em class="property"><span class="w"> </span><span class="p"><span class="pre">=</span></span><span class="w"> </span><span class="pre">{'Boltzman_constant':</span> <span class="pre">0.008314462159,</span> <span class="pre">'N_Avogadro':</span> <span class="pre">6.02214129e+23,</span> <span class="pre">'calorie':</span> <span class="pre">4.184,</span> <span class="pre">'electric_constant':</span> <span class="pre">0.00552635,</span> <span class="pre">'elementary_charge':</span> <span class="pre">1.602176565e-19}</span></em><a class="headerlink" href="#MDAnalysis.units.constants" title="Permalink to this definition"></a></dt>
+<dd><p>Values of physical constants are taken from <a class="reference external" href="http://physics.nist.gov/cuu/Constants/">CODATA 2010 at NIST</a>. The
+thermochemical calorie is defined in the <a class="reference external" href="http://www.iso.org/iso/catalogue_detail?csnumber=31890">ISO 80000-5:2007</a> standard
+and is also listed in the <a class="reference external" href="http://physics.nist.gov/Pubs/SP811/appenB8.html#C">NIST Guide to SI: Appendix B.8: Factors for Units</a>.</p>
+<div class="versionadded">
+<p><span class="versionmodified added">New in version 0.9.0.</span></p>
+</div>
+</dd></dl>
+
+<dl class="py data">
+<dt class="sig sig-object py" id="MDAnalysis.units.lengthUnit_factor">
+<span class="sig-prename descclassname"><span class="pre">MDAnalysis.units.</span></span><span class="sig-name descname"><span class="pre">lengthUnit_factor</span></span><em class="property"><span class="w"> </span><span class="p"><span class="pre">=</span></span><span class="w"> </span><span class="pre">{'A':</span> <span class="pre">1.0,</span> <span class="pre">'Angstrom':</span> <span class="pre">1.0,</span> <span class="pre">'angstrom':</span> <span class="pre">1.0,</span> <span class="pre">'femtometer':</span> <span class="pre">100000.0,</span> <span class="pre">'fm':</span> <span class="pre">100000.0,</span> <span class="pre">'nanometer':</span> <span class="pre">0.1,</span> <span class="pre">'nm':</span> <span class="pre">0.1,</span> <span class="pre">'picometer':</span> <span class="pre">100.0,</span> <span class="pre">'pm':</span> <span class="pre">100.0,</span> <span class="pre">'Å':</span> <span class="pre">1.0}</span></em><a class="headerlink" href="#MDAnalysis.units.lengthUnit_factor" title="Permalink to this definition"></a></dt>
+<dd><p>The basic unit of <em>length</em> in MDAnalysis is the Angstrom.
+Conversion factors between the base unit and other lengthUnits <em>x</em> are stored.
+Conversions follow <cite>L/x = L/Angstrom * lengthUnit_factor[x]</cite>.
+<em>x</em> can be <em>nm</em>/<em>nanometer</em> or <em>fm</em>.</p>
+</dd></dl>
+
+<dl class="py data">
+<dt class="sig sig-object py" id="MDAnalysis.units.water">
+<span class="sig-prename descclassname"><span class="pre">MDAnalysis.units.</span></span><span class="sig-name descname"><span class="pre">water</span></span><em class="property"><span class="w"> </span><span class="p"><span class="pre">=</span></span><span class="w"> </span><span class="pre">{'MolarMass':</span> <span class="pre">18.016,</span> <span class="pre">'SPC':</span> <span class="pre">0.985,</span> <span class="pre">'TIP3P':</span> <span class="pre">1.002,</span> <span class="pre">'TIP4P':</span> <span class="pre">1.001,</span> <span class="pre">'exp':</span> <span class="pre">0.997}</span></em><a class="headerlink" href="#MDAnalysis.units.water" title="Permalink to this definition"></a></dt>
+<dd><dl>
+<dt>water density values at T=298K, P=1atm <a class="reference internal" href="#jorgensen1998" id="id3"><span>[Jorgensen1998]</span></a></dt><dd><table class="docutils align-default">
+<colgroup>
+<col style="width: 47%" />
+<col style="width: 53%" />
+</colgroup>
+<thead>
+<tr class="row-odd"><th class="head"><p>model</p></th>
+<th class="head"><p>g cm**-3</p></th>
+</tr>
+</thead>
+<tbody>
+<tr class="row-even"><td><p>SPC</p></td>
+<td><p>0.985(1)</p></td>
+</tr>
+<tr class="row-odd"><td><p>TIP3P</p></td>
+<td><p>1.002(1)</p></td>
+</tr>
+<tr class="row-even"><td><p>TIP4P</p></td>
+<td><p>1.001(1)</p></td>
+</tr>
+<tr class="row-odd"><td><p>exp</p></td>
+<td><p>0.997</p></td>
+</tr>
+</tbody>
+</table>
+</dd>
+</dl>
+<p>and molar mass 18.016 g mol**-1.</p>
+</dd></dl>
+
+<dl class="py data">
+<dt class="sig sig-object py" id="MDAnalysis.units.densityUnit_factor">
+<span class="sig-prename descclassname"><span class="pre">MDAnalysis.units.</span></span><span class="sig-name descname"><span class="pre">densityUnit_factor</span></span><em class="property"><span class="w"> </span><span class="p"><span class="pre">=</span></span><span class="w"> </span><span class="pre">{'A^{-3}':</span> <span class="pre">1.0,</span> <span class="pre">'Angstrom^{-3}':</span> <span class="pre">1.0,</span> <span class="pre">'Molar':</span> <span class="pre">1660.5389210321898,</span> <span class="pre">'SPC':</span> <span class="pre">30.37184690488927,</span> <span class="pre">'TIP3P':</span> <span class="pre">29.85655608913766,</span> <span class="pre">'TIP4P':</span> <span class="pre">29.886382818497438,</span> <span class="pre">'nanometer^{-3}':</span> <span class="pre">1000.0,</span> <span class="pre">'nm^{-3}':</span> <span class="pre">1000.0,</span> <span class="pre">'water':</span> <span class="pre">30.00628806551247,</span> <span class="pre">'Å^{-3}':</span> <span class="pre">1.0}</span></em><a class="headerlink" href="#MDAnalysis.units.densityUnit_factor" title="Permalink to this definition"></a></dt>
+<dd><p>The basic unit for <em>densities</em> is Angstroem**(-3), i.e.
+the volume per molecule in A**3. Especially for water
+it can be convenient to measure the density relative to bulk, and
+hence a number of values are pre-stored in <a class="reference internal" href="#MDAnalysis.units.water" title="MDAnalysis.units.water"><code class="xref py py-data docutils literal notranslate"><span class="pre">water</span></code></a>.</p>
+</dd></dl>
+
+<dl class="py data">
+<dt class="sig sig-object py" id="MDAnalysis.units.timeUnit_factor">
+<span class="sig-prename descclassname"><span class="pre">MDAnalysis.units.</span></span><span class="sig-name descname"><span class="pre">timeUnit_factor</span></span><em class="property"><span class="w"> </span><span class="p"><span class="pre">=</span></span><span class="w"> </span><span class="pre">{'AKMA':</span> <span class="pre">20.45482949774598,</span> <span class="pre">'femtosecond':</span> <span class="pre">1000.0,</span> <span class="pre">'fs':</span> <span class="pre">1000.0,</span> <span class="pre">'microsecond':</span> <span class="pre">1e-06,</span> <span class="pre">'millisecond':</span> <span class="pre">1e-09,</span> <span class="pre">'ms':</span> <span class="pre">1e-09,</span> <span class="pre">'nanosecond':</span> <span class="pre">0.001,</span> <span class="pre">'ns':</span> <span class="pre">0.001,</span> <span class="pre">'picosecond':</span> <span class="pre">1.0,</span> <span class="pre">'ps':</span> <span class="pre">1.0,</span> <span class="pre">'s':</span> <span class="pre">1e-12,</span> <span class="pre">'sec':</span> <span class="pre">1e-12,</span> <span class="pre">'second':</span> <span class="pre">1e-12,</span> <span class="pre">'us':</span> <span class="pre">1e-06,</span> <span class="pre">'μs':</span> <span class="pre">1e-06}</span></em><a class="headerlink" href="#MDAnalysis.units.timeUnit_factor" title="Permalink to this definition"></a></dt>
+<dd><p>For <em>time</em>, the basic unit is ps; in particular CHARMM’s
+1 <a class="reference external" href="http://www.charmm.org/documentation/c37b1/usage.html#%20AKMA">AKMA</a> time unit = 4.888821E-14 sec is supported.</p>
+</dd></dl>
+
+<dl class="py data">
+<dt class="sig sig-object py" id="MDAnalysis.units.speedUnit_factor">
+<span class="sig-prename descclassname"><span class="pre">MDAnalysis.units.</span></span><span class="sig-name descname"><span class="pre">speedUnit_factor</span></span><em class="property"><span class="w"> </span><span class="p"><span class="pre">=</span></span><span class="w"> </span><span class="pre">{'A/AKMA':</span> <span class="pre">0.04888821,</span> <span class="pre">'A/fs':</span> <span class="pre">1000.0,</span> <span class="pre">'A/ms':</span> <span class="pre">1e-09,</span> <span class="pre">'A/ps':</span> <span class="pre">1.0,</span> <span class="pre">'A/us':</span> <span class="pre">1e-06,</span> <span class="pre">'Angstrom/AKMA':</span> <span class="pre">0.04888821,</span> <span class="pre">'Angstrom/femtosecond':</span> <span class="pre">1000.0,</span> <span class="pre">'Angstrom/fs':</span> <span class="pre">1000.0,</span> <span class="pre">'Angstrom/microsecond':</span> <span class="pre">1e-06,</span> <span class="pre">'Angstrom/millisecond':</span> <span class="pre">1e-09,</span> <span class="pre">'Angstrom/ms':</span> <span class="pre">1e-09,</span> <span class="pre">'Angstrom/picosecond':</span> <span class="pre">1.0,</span> <span class="pre">'Angstrom/ps':</span> <span class="pre">1.0,</span> <span class="pre">'Angstrom/us':</span> <span class="pre">1e-06,</span> <span class="pre">'Angstrom/μs':</span> <span class="pre">1e-06,</span> <span class="pre">'angstrom/femtosecond':</span> <span class="pre">1000.0,</span> <span class="pre">'angstrom/fs':</span> <span class="pre">1000.0,</span> <span class="pre">'angstrom/microsecond':</span> <span class="pre">1e-06,</span> <span class="pre">'angstrom/millisecond':</span> <span class="pre">1e-09,</span> <span class="pre">'angstrom/ms':</span> <span class="pre">1e-09,</span> <span class="pre">'angstrom/picosecond':</span> <span class="pre">1.0,</span> <span class="pre">'angstrom/us':</span> <span class="pre">1e-06,</span> <span class="pre">'angstrom/μs':</span> <span class="pre">1e-06,</span> <span class="pre">'m/s':</span> <span class="pre">100.0,</span> <span class="pre">'nanometer/picosecond':</span> <span class="pre">0.1,</span> <span class="pre">'nanometer/ps':</span> <span class="pre">0.1,</span> <span class="pre">'nm/ns':</span> <span class="pre">100.0,</span> <span class="pre">'nm/ps':</span> <span class="pre">0.1,</span> <span class="pre">'pm/ps':</span> <span class="pre">100.0,</span> <span class="pre">'Å/ps':</span> <span class="pre">1.0}</span></em><a class="headerlink" href="#MDAnalysis.units.speedUnit_factor" title="Permalink to this definition"></a></dt>
+<dd><p>For <em>speed</em>, the basic unit is Angstrom/ps.</p>
+</dd></dl>
+
+<dl class="py data">
+<dt class="sig sig-object py" id="MDAnalysis.units.forceUnit_factor">
+<span class="sig-prename descclassname"><span class="pre">MDAnalysis.units.</span></span><span class="sig-name descname"><span class="pre">forceUnit_factor</span></span><em class="property"><span class="w"> </span><span class="p"><span class="pre">=</span></span><span class="w"> </span><span class="pre">{'J/m':</span> <span class="pre">1.66053892103219e-11,</span> <span class="pre">'N':</span> <span class="pre">1.66053892103219e-11,</span> <span class="pre">'Newton':</span> <span class="pre">1.66053892103219e-11,</span> <span class="pre">'kJ/(mol*A)':</span> <span class="pre">1.0,</span> <span class="pre">'kJ/(mol*Angstrom)':</span> <span class="pre">1.0,</span> <span class="pre">'kJ/(mol*nm)':</span> <span class="pre">10.0,</span> <span class="pre">'kJ/(mol*Å)':</span> <span class="pre">1.0,</span> <span class="pre">'kcal/(mol*Angstrom)':</span> <span class="pre">0.2390057361376673}</span></em><a class="headerlink" href="#MDAnalysis.units.forceUnit_factor" title="Permalink to this definition"></a></dt>
+<dd><p>For <em>force</em> the basic unit is kJ/(mol*Angstrom).</p>
+</dd></dl>
+
+<dl class="py data">
+<dt class="sig sig-object py" id="MDAnalysis.units.chargeUnit_factor">
+<span class="sig-prename descclassname"><span class="pre">MDAnalysis.units.</span></span><span class="sig-name descname"><span class="pre">chargeUnit_factor</span></span><em class="property"><span class="w"> </span><span class="p"><span class="pre">=</span></span><span class="w"> </span><span class="pre">{'Amber':</span> <span class="pre">18.2223,</span> <span class="pre">'As':</span> <span class="pre">1.602176565e-19,</span> <span class="pre">'C':</span> <span class="pre">1.602176565e-19,</span> <span class="pre">'e':</span> <span class="pre">1.0}</span></em><a class="headerlink" href="#MDAnalysis.units.chargeUnit_factor" title="Permalink to this definition"></a></dt>
+<dd><p><em>Charge</em> is measured in multiples of the <a class="reference external" href="http://physics.nist.gov/cgi-bin/cuu/Value?e">electron charge</a> <em>e</em>, with the value
+<em>elementary_charge</em> in <a class="reference internal" href="#MDAnalysis.units.constants" title="MDAnalysis.units.constants"><code class="xref py py-data docutils literal notranslate"><span class="pre">constants</span></code></a>.
+The <a class="reference external" href="http://ambermd.org/formats.html#parm">conversion factor to Amber charge units</a> is 18.2223.</p>
+<div class="versionchanged">
+<p><span class="versionmodified changed">Changed in version 0.9.0: </span>Use CODATA 2010 value for <em>elementary charge</em>, which differs from the previously used value
+<em>e</em> =  1.602176487 x 10**(-19) C by 7.8000000e-27 C.</p>
+</div>
+</dd></dl>
+
+<dl class="py data">
+<dt class="sig sig-object py" id="MDAnalysis.units.conversion_factor">
+<span class="sig-prename descclassname"><span class="pre">MDAnalysis.units.</span></span><span class="sig-name descname"><span class="pre">conversion_factor</span></span><em class="property"><span class="w"> </span><span class="p"><span class="pre">=</span></span><span class="w"> </span><span class="pre">{'charge':</span> <span class="pre">{'Amber':</span> <span class="pre">18.2223,</span> <span class="pre">'As':</span> <span class="pre">1.602176565e-19,</span> <span class="pre">'C':</span> <span class="pre">1.602176565e-19,</span> <span class="pre">'e':</span> <span class="pre">1.0},</span> <span class="pre">'density':</span> <span class="pre">{'A^{-3}':</span> <span class="pre">1.0,</span> <span class="pre">'Angstrom^{-3}':</span> <span class="pre">1.0,</span> <span class="pre">'Molar':</span> <span class="pre">1660.5389210321898,</span> <span class="pre">'SPC':</span> <span class="pre">30.37184690488927,</span> <span class="pre">'TIP3P':</span> <span class="pre">29.85655608913766,</span> <span class="pre">'TIP4P':</span> <span class="pre">29.886382818497438,</span> <span class="pre">'nanometer^{-3}':</span> <span class="pre">1000.0,</span> <span class="pre">'nm^{-3}':</span> <span class="pre">1000.0,</span> <span class="pre">'water':</span> <span class="pre">30.00628806551247,</span> <span class="pre">'Å^{-3}':</span> <span class="pre">1.0},</span> <span class="pre">'energy':</span> <span class="pre">{'J':</span> <span class="pre">1.66053892103219e-21,</span> <span class="pre">'eV':</span> <span class="pre">0.01036426919046959,</span> <span class="pre">'kJ/mol':</span> <span class="pre">1.0,</span> <span class="pre">'kcal/mol':</span> <span class="pre">0.2390057361376673},</span> <span class="pre">'force':</span> <span class="pre">{'J/m':</span> <span class="pre">1.66053892103219e-11,</span> <span class="pre">'N':</span> <span class="pre">1.66053892103219e-11,</span> <span class="pre">'Newton':</span> <span class="pre">1.66053892103219e-11,</span> <span class="pre">'kJ/(mol*A)':</span> <span class="pre">1.0,</span> <span class="pre">'kJ/(mol*Angstrom)':</span> <span class="pre">1.0,</span> <span class="pre">'kJ/(mol*nm)':</span> <span class="pre">10.0,</span> <span class="pre">'kJ/(mol*Å)':</span> <span class="pre">1.0,</span> <span class="pre">'kcal/(mol*Angstrom)':</span> <span class="pre">0.2390057361376673},</span> <span class="pre">'length':</span> <span class="pre">{'A':</span> <span class="pre">1.0,</span> <span class="pre">'Angstrom':</span> <span class="pre">1.0,</span> <span class="pre">'angstrom':</span> <span class="pre">1.0,</span> <span class="pre">'femtometer':</span> <span class="pre">100000.0,</span> <span class="pre">'fm':</span> <span class="pre">100000.0,</span> <span class="pre">'nanometer':</span> <span class="pre">0.1,</span> <span class="pre">'nm':</span> <span class="pre">0.1,</span> <span class="pre">'picometer':</span> <span class="pre">100.0,</span> <span class="pre">'pm':</span> <span class="pre">100.0,</span> <span class="pre">'Å':</span> <span class="pre">1.0},</span> <span class="pre">'speed':</span> <span class="pre">{'A/AKMA':</span> <span class="pre">0.04888821,</span> <span class="pre">'A/fs':</span> <span class="pre">1000.0,</span> <span class="pre">'A/ms':</span> <span class="pre">1e-09,</span> <span class="pre">'A/ps':</span> <span class="pre">1.0,</span> <span class="pre">'A/us':</span> <span class="pre">1e-06,</span> <span class="pre">'Angstrom/AKMA':</span> <span class="pre">0.04888821,</span> <span class="pre">'Angstrom/femtosecond':</span> <span class="pre">1000.0,</span> <span class="pre">'Angstrom/fs':</span> <span class="pre">1000.0,</span> <span class="pre">'Angstrom/microsecond':</span> <span class="pre">1e-06,</span> <span class="pre">'Angstrom/millisecond':</span> <span class="pre">1e-09,</span> <span class="pre">'Angstrom/ms':</span> <span class="pre">1e-09,</span> <span class="pre">'Angstrom/picosecond':</span> <span class="pre">1.0,</span> <span class="pre">'Angstrom/ps':</span> <span class="pre">1.0,</span> <span class="pre">'Angstrom/us':</span> <span class="pre">1e-06,</span> <span class="pre">'Angstrom/μs':</span> <span class="pre">1e-06,</span> <span class="pre">'angstrom/femtosecond':</span> <span class="pre">1000.0,</span> <span class="pre">'angstrom/fs':</span> <span class="pre">1000.0,</span> <span class="pre">'angstrom/microsecond':</span> <span class="pre">1e-06,</span> <span class="pre">'angstrom/millisecond':</span> <span class="pre">1e-09,</span> <span class="pre">'angstrom/ms':</span> <span class="pre">1e-09,</span> <span class="pre">'angstrom/picosecond':</span> <span class="pre">1.0,</span> <span class="pre">'angstrom/us':</span> <span class="pre">1e-06,</span> <span class="pre">'angstrom/μs':</span> <span class="pre">1e-06,</span> <span class="pre">'m/s':</span> <span class="pre">100.0,</span> <span class="pre">'nanometer/picosecond':</span> <span class="pre">0.1,</span> <span class="pre">'nanometer/ps':</span> <span class="pre">0.1,</span> <span class="pre">'nm/ns':</span> <span class="pre">100.0,</span> <span class="pre">'nm/ps':</span> <span class="pre">0.1,</span> <span class="pre">'pm/ps':</span> <span class="pre">100.0,</span> <span class="pre">'Å/ps':</span> <span class="pre">1.0},</span> <span class="pre">'time':</span> <span class="pre">{'AKMA':</span> <span class="pre">20.45482949774598,</span> <span class="pre">'femtosecond':</span> <span class="pre">1000.0,</span> <span class="pre">'fs':</span> <span class="pre">1000.0,</span> <span class="pre">'microsecond':</span> <span class="pre">1e-06,</span> <span class="pre">'millisecond':</span> <span class="pre">1e-09,</span> <span class="pre">'ms':</span> <span class="pre">1e-09,</span> <span class="pre">'nanosecond':</span> <span class="pre">0.001,</span> <span class="pre">'ns':</span> <span class="pre">0.001,</span> <span class="pre">'picosecond':</span> <span class="pre">1.0,</span> <span class="pre">'ps':</span> <span class="pre">1.0,</span> <span class="pre">'s':</span> <span class="pre">1e-12,</span> <span class="pre">'sec':</span> <span class="pre">1e-12,</span> <span class="pre">'second':</span> <span class="pre">1e-12,</span> <span class="pre">'us':</span> <span class="pre">1e-06,</span> <span class="pre">'μs':</span> <span class="pre">1e-06}}</span></em><a class="headerlink" href="#MDAnalysis.units.conversion_factor" title="Permalink to this definition"></a></dt>
+<dd><p><a class="reference internal" href="#MDAnalysis.units.conversion_factor" title="MDAnalysis.units.conversion_factor"><code class="xref py py-data docutils literal notranslate"><span class="pre">conversion_factor</span></code></a> is used by <a class="reference internal" href="#MDAnalysis.units.get_conversion_factor" title="MDAnalysis.units.get_conversion_factor"><code class="xref py py-func docutils literal notranslate"><span class="pre">get_conversion_factor()</span></code></a>:
+Note: any observable with a unit (i.e. one with an entry in
+the <code class="xref py py-attr docutils literal notranslate"><span class="pre">unit</span></code> attribute) needs an entry in <a class="reference internal" href="#MDAnalysis.units.conversion_factor" title="MDAnalysis.units.conversion_factor"><code class="xref py py-data docutils literal notranslate"><span class="pre">conversion_factor</span></code></a></p>
+</dd></dl>
+
+<dl class="py data">
+<dt class="sig sig-object py" id="MDAnalysis.units.unit_types">
+<span class="sig-prename descclassname"><span class="pre">MDAnalysis.units.</span></span><span class="sig-name descname"><span class="pre">unit_types</span></span><em class="property"><span class="w"> </span><span class="p"><span class="pre">=</span></span><span class="w"> </span><span class="pre">{'A':</span> <span class="pre">'length',</span> <span class="pre">'A/AKMA':</span> <span class="pre">'speed',</span> <span class="pre">'A/fs':</span> <span class="pre">'speed',</span> <span class="pre">'A/ms':</span> <span class="pre">'speed',</span> <span class="pre">'A/ps':</span> <span class="pre">'speed',</span> <span class="pre">'A/us':</span> <span class="pre">'speed',</span> <span class="pre">'AKMA':</span> <span class="pre">'time',</span> <span class="pre">'A^{-3}':</span> <span class="pre">'density',</span> <span class="pre">'Amber':</span> <span class="pre">'charge',</span> <span class="pre">'Angstrom':</span> <span class="pre">'length',</span> <span class="pre">'Angstrom/AKMA':</span> <span class="pre">'speed',</span> <span class="pre">'Angstrom/femtosecond':</span> <span class="pre">'speed',</span> <span class="pre">'Angstrom/fs':</span> <span class="pre">'speed',</span> <span class="pre">'Angstrom/microsecond':</span> <span class="pre">'speed',</span> <span class="pre">'Angstrom/millisecond':</span> <span class="pre">'speed',</span> <span class="pre">'Angstrom/ms':</span> <span class="pre">'speed',</span> <span class="pre">'Angstrom/picosecond':</span> <span class="pre">'speed',</span> <span class="pre">'Angstrom/ps':</span> <span class="pre">'speed',</span> <span class="pre">'Angstrom/us':</span> <span class="pre">'speed',</span> <span class="pre">'Angstrom/μs':</span> <span class="pre">'speed',</span> <span class="pre">'Angstrom^{-3}':</span> <span class="pre">'density',</span> <span class="pre">'As':</span> <span class="pre">'charge',</span> <span class="pre">'C':</span> <span class="pre">'charge',</span> <span class="pre">'J':</span> <span class="pre">'energy',</span> <span class="pre">'J/m':</span> <span class="pre">'force',</span> <span class="pre">'Molar':</span> <span class="pre">'density',</span> <span class="pre">'N':</span> <span class="pre">'force',</span> <span class="pre">'Newton':</span> <span class="pre">'force',</span> <span class="pre">'SPC':</span> <span class="pre">'density',</span> <span class="pre">'TIP3P':</span> <span class="pre">'density',</span> <span class="pre">'TIP4P':</span> <span class="pre">'density',</span> <span class="pre">'angstrom':</span> <span class="pre">'length',</span> <span class="pre">'angstrom/femtosecond':</span> <span class="pre">'speed',</span> <span class="pre">'angstrom/fs':</span> <span class="pre">'speed',</span> <span class="pre">'angstrom/microsecond':</span> <span class="pre">'speed',</span> <span class="pre">'angstrom/millisecond':</span> <span class="pre">'speed',</span> <span class="pre">'angstrom/ms':</span> <span class="pre">'speed',</span> <span class="pre">'angstrom/picosecond':</span> <span class="pre">'speed',</span> <span class="pre">'angstrom/us':</span> <span class="pre">'speed',</span> <span class="pre">'angstrom/μs':</span> <span class="pre">'speed',</span> <span class="pre">'e':</span> <span class="pre">'charge',</span> <span class="pre">'eV':</span> <span class="pre">'energy',</span> <span class="pre">'femtometer':</span> <span class="pre">'length',</span> <span class="pre">'femtosecond':</span> <span class="pre">'time',</span> <span class="pre">'fm':</span> <span class="pre">'length',</span> <span class="pre">'fs':</span> <span class="pre">'time',</span> <span class="pre">'kJ/(mol*A)':</span> <span class="pre">'force',</span> <span class="pre">'kJ/(mol*Angstrom)':</span> <span class="pre">'force',</span> <span class="pre">'kJ/(mol*nm)':</span> <span class="pre">'force',</span> <span class="pre">'kJ/(mol*Å)':</span> <span class="pre">'force',</span> <span class="pre">'kJ/mol':</span> <span class="pre">'energy',</span> <span class="pre">'kcal/(mol*Angstrom)':</span> <span class="pre">'force',</span> <span class="pre">'kcal/mol':</span> <span class="pre">'energy',</span> <span class="pre">'m/s':</span> <span class="pre">'speed',</span> <span class="pre">'microsecond':</span> <span class="pre">'time',</span> <span class="pre">'millisecond':</span> <span class="pre">'time',</span> <span class="pre">'ms':</span> <span class="pre">'time',</span> <span class="pre">'nanometer':</span> <span class="pre">'length',</span> <span class="pre">'nanometer/picosecond':</span> <span class="pre">'speed',</span> <span class="pre">'nanometer/ps':</span> <span class="pre">'speed',</span> <span class="pre">'nanometer^{-3}':</span> <span class="pre">'density',</span> <span class="pre">'nanosecond':</span> <span class="pre">'time',</span> <span class="pre">'nm':</span> <span class="pre">'length',</span> <span class="pre">'nm/ns':</span> <span class="pre">'speed',</span> <span class="pre">'nm/ps':</span> <span class="pre">'speed',</span> <span class="pre">'nm^{-3}':</span> <span class="pre">'density',</span> <span class="pre">'ns':</span> <span class="pre">'time',</span> <span class="pre">'picometer':</span> <span class="pre">'length',</span> <span class="pre">'picosecond':</span> <span class="pre">'time',</span> <span class="pre">'pm':</span> <span class="pre">'length',</span> <span class="pre">'pm/ps':</span> <span class="pre">'speed',</span> <span class="pre">'ps':</span> <span class="pre">'time',</span> <span class="pre">'s':</span> <span class="pre">'time',</span> <span class="pre">'sec':</span> <span class="pre">'time',</span> <span class="pre">'second':</span> <span class="pre">'time',</span> <span class="pre">'us':</span> <span class="pre">'time',</span> <span class="pre">'water':</span> <span class="pre">'density',</span> <span class="pre">'μs':</span> <span class="pre">'time',</span> <span class="pre">'Å':</span> <span class="pre">'length',</span> <span class="pre">'Å/ps':</span> <span class="pre">'speed',</span> <span class="pre">'Å^{-3}':</span> <span class="pre">'density'}</span></em><a class="headerlink" href="#MDAnalysis.units.unit_types" title="Permalink to this definition"></a></dt>
+<dd><p>returns the type of unit for a known input unit.
+Note: Any unit must be <em>unique</em> because this dict is used to guess the
+unit type.</p>
+<dl class="field-list simple">
+<dt class="field-odd">Type</dt>
+<dd class="field-odd"><p>Generated lookup table (<a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#dict" title="(in Python v3.10)">dict</a>)</p>
+</dd>
+</dl>
+</dd></dl>
+
+</section>
+<section id="references-and-footnotes">
+<h2><span class="section-number">15.4. </span>References and footnotes<a class="headerlink" href="#references-and-footnotes" title="Permalink to this headline"></a></h2>
+<dl class="citation">
+<dt class="label" id="jorgensen1998"><span class="brackets"><a class="fn-backref" href="#id3">Jorgensen1998</a></span></dt>
+<dd><ol class="upperalpha simple" start="23">
+<li><p>Jorgensen, C. Jenson, J Comp Chem 19 (1998), 1179-1186</p></li>
+</ol>
+</dd>
+</dl>
+<p class="rubric">Footnotes</p>
+<dl class="footnote brackets">
+<dt class="label" id="funits"><span class="brackets"><a class="fn-backref" href="#id1">1</a></span></dt>
+<dd><p>One can also consider the conversion factor to carry
+units <span class="math notranslate nohighlight">\(b'/b\)</span>, in which case the conversion formula would
+become</p>
+<div class="math notranslate nohighlight">
+\[X' = f_{b,b'} X\]</div>
+</dd>
+</dl>
+</section>
+</section>
+
+
+           </div>
+          </div>
+          <footer><div class="rst-footer-buttons" role="navigation" aria-label="Footer">
+        <a href="version.html" class="btn btn-neutral float-left" title="14. Version information for MDAnalysis - MDAnalysis.version" accesskey="p" rel="prev"><span class="fa fa-arrow-circle-left" aria-hidden="true"></span> Previous</a>
+        <a href="exceptions.html" class="btn btn-neutral float-right" title="16. Custom exceptions and warnings — MDAnalysis.exceptions" accesskey="n" rel="next">Next <span class="fa fa-arrow-circle-right" aria-hidden="true"></span></a>
+    </div>
+
+  <hr/>
+
+  <div role="contentinfo">
+    <p>&#169; Copyright 2005-2022, Naveen Michaud-Agrawal, Elizabeth J. Denning, Christian Beckstein (logo), Joshua L. Adelman, Henok Ademtew, Shobhit Agarwal, Aya M. Alaa, Irfan Alibay, Kazi Shudipto Amin, Anshul Angaria, Luís Pedro Borges Araújo, Balasubramanian, Utkarsh Bansal, Leonardo Barneschi, Jonathan Barnoud, Estefania Barreto-Ojeda, Tone Bengtsen, Alejandro Bernardin, Ninad Bhat, Mateusz Bieniek, Wouter Boomsma, Jose Borreguero, Cédric Bouysset, Kevin Boyd, Bart Bruininks, Sébastien Buchoux, Sören von Bülow, Yantong Cai, David Caplan, Yuanyu Chang, Matthieu Chavent, Haochuan Chen, Kathleen Clark, Orion Cohen, Charlie Cook, Ruggero Cortini, Nicholas Craven, Ramon Crehuet, Davide Cruz, Robert Delgado, John Detlefs, Xavier Deupi, Jan Domanski, David L. Dotson, Mark D. Driver, Ali Ehlen, Shujie Fan, Bjarne Feddersen, Lennard van der Feltz, Philip Fowler, Guillaume Fraux, William Glass, Joseph Goose, Alexander Gorfer, Richard J. Gowers, Lukas Grossar, Abhinav Gupta, Akshay Gupta, Pratik Gupta, Benjamin Hall, Ameya Harmalkar, Ivan Hristov, Eugen Hruska, Kyle J. Huston, Siddharth Jain, Edis Jakupovic, Joe Jordan, Henrik Jäger, Uma D Kadam, Aditya Kamath, Jon Kapla, Navya Khare, Andrew William King, Henry Kobin, Abhishek A. Kognole, Kosuke Kudo, Atharva Kulkarni, Max Linke, Philip Loche, Jinju Lu, Hugo MacDermott-Opeskin, Micaela Matta, Andrew R. McCluskey, Robert McGibbon, Rocco Meli, Manuel Nuno Melo, Marcelo C. R. Melo, Dominik &#39;Rathann&#39; Mierzejewski, Henry Mull, Morgan L. Nance, Fiona B. Naughton, Alex Nesterenko, Hai Nguyen, Sang Young Noh, Daniele Padula, Nabarun Pal, Mattia F. Palermo, Dimitrios Papageorgiou, Danny Parton, Shakul Pathak, Joshua L. Phillips, Hannah Pollak, Kashish Punjani, Michael Quevillon, Vedant Rathore, Tyler Reddy, Pedro Reis, Paul Rigor, Andrea Rizzi, Carlos Yanez S., Utkarsh Saxena, Marcello Sega, Sean L. Seyler, Faraaz Shah, Sulay Shah, Abhishek Shandilya, Shubham Sharma, Karthikeyan Singaravelan, Tamandeep Singh, Paul Smith, Andy Somogyi, Caio S. Souza, Shantanu Srivastava, Lukas Stelzl, Jan Stevens, Gorman Stock, Fenil Suchak, Ayush Suhane, Filip T. Szczypiński, Matthijs Tadema, Joao Miguel Correia Teixeira, Xiki Tempula, Paarth Thadani, Matthew W. Thompson, Hao Tian, Matteo Tiberti, Wiep van der Toorn, Mieczyslaw Torchala, Isaac Virshup, Lily Wang, Nestor Wendt, Zhiyi Wu, Zhuyi Xue, Alexander Yang, Juan Eiros Zamora, Johannes Zeman, Yibo Zhang, Yuxuan Zhuang, and Oliver Beckstein.</p>
+  </div>
+
+  
+ 
+<div class="footer"><p>Please see
+    our <a href="https://www.mdanalysis.org/pages/privacy/">Privacy Policy</a>
+    to learn how <a href="https://www.mdanalysis.org">MDAnalysis</a> collects data.</p>
+    <script data-goatcounter="https://mdanalysis.goatcounter.com/count"
+        async src="//gc.zgo.at/count.js"></script>
+</div>
+
+
+</footer>
+        </div>
+      </div>
+    </section>
+  </div>
+  <script>
+    var versions_json_url = 'https://docs.mdanalysis.org/versions.json'
+</script>
+
+<div class="rst-versions" data-toggle="rst-versions" role="note"
+     aria-label="versions">
+    <span class="rst-current-version" data-toggle="rst-current-version">
+      <span class="fa fa-book"></span>
+        2.2.0-dev0
+      <span class="fa fa-caret-down"></span>
+    </span>
+
+    <div class="rst-other-versions">
+        <dl id="versionselector">
+            <dt>Other Versions</dt>
+        </dl>
+
+    </div>
+</div><script>
+      jQuery(function () {
+          SphinxRtdTheme.Navigation.enable(true);
+      });
+  </script> 
+
+</body>
+</html>


### PR DESCRIPTION
- Part of #3580

- Fix typo units and conversions page, note box: "`In the future me might`" to "`In the future, we might`"

Fixes #

Changes made in this Pull Request:
 - 


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
