### PR TITLE
formatted unit.py doc

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -188,6 +188,7 @@ Chronological list of authors
   - Rishabh Shukla  
   - Manish Kumar
   - Aditi Tripathi
+  - Robot Jelly
 
 External code
 -------------

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -15,7 +15,7 @@ The rules for this file:
 ------------------------------------------------------------------------------
 ??/??/?? IAlibay, BFedder, inomag, Agorfa, aya9aladdin, shudipto-amin, cbouy,
          HenokB, umak1106, tamandeeps, Mrqeoqqt, megosato, AnirG, rishu235,
-         mtiberti, manishsaini6421
+         mtiberti, manishsaini6421, robotjellyzone
 
  * 2.2.0
 

--- a/package/MDAnalysis/units.py
+++ b/package/MDAnalysis/units.py
@@ -109,15 +109,15 @@ concentration:
     M(H2O) = 18 g/mol   Molar mass of water
 
     factor = 1/(1e-24 * N_Avogadro / M(H2O))
-  
-  from :math:`rho/rho0 = n/(N_A * M^-1) / rho0`
 
-  where :math:`[n] = 1/Volume`, :math:`[rho] = mass/Volume`
+  from :math:`\rho/\rho_0 = n/(N_A * M^{-1}) / \rho_0`
+
+  where :math:`[n] = 1/Volume`, :math:`[\rho] = mass/Volume`
 
 
 Note
 ----
-In the future me might move towards using the Quantities_ package or
+In the future we might move towards using the Quantities_ package or
 :mod:`scipy.constants`.
 
 

--- a/package/MDAnalysis/units.py
+++ b/package/MDAnalysis/units.py
@@ -56,7 +56,7 @@ All conversions with :func:`convert` are carried out in a simple fashion: the
 conversion factor :math:`f_{b,b'}` from the base unit :math:`b` to another unit
 :math:`b'` is precomputed and stored (see :ref:`Data`). The numerical value of
 a quantity in unit :math:`b` is :math:`X/b` (e.g. for :math:`X =
-1.23\,\mathrm{ps}` the numerical value is :math:`X/\mathrm{ps} =
+1.23\,\mathrm{ps}`, the numerical value is :math:`X/\mathrm{ps} =
 1.23`). [#funits]_
 
 The new numerical value :math:`X'/b'` of the quantity (in units of :math:`b'`)
@@ -89,7 +89,7 @@ density:
      n/x = n/A**3 * densityUnit_factor[x]
 
   Example for how to calculate the conversion factor
-  :math:`f_{\mathrm{Å}^{-3},\mathrm{nm}^{-3}}` from :math:`\mathrm{Å^-3}` to
+  :math:`f_{\mathrm{Å}^{-3},\mathrm{nm}^{-3}}` from :math:`\mathrm{Å}^{-3}` to
   :math:`\mathrm{nm}^{-3}`:
 
   .. math::
@@ -104,14 +104,15 @@ concentration:
 
      factor = 1 A**-3 / (N_Avogadro * (10**-9 dm)**-3)
 
-  relative to a density rho0 in g/cm^{3}::
+  relative to a density rho0 in :math:`g/cm^3`::
 
     M(H2O) = 18 g/mol   Molar mass of water
 
     factor = 1/(1e-24 * N_Avogadro / M(H2O))
-  ::
+  
+  from :math:`rho/rho0 = n/(N_A * M^-1) / rho0`
 
-    from rho/rho0 = n/(N_A * M**-1) / rho0   where [n] = 1/Volume, [rho] = mass/Volume
+  where :math:`[n] = 1/Volume`, :math:`[rho] = mass/Volume`
 
 
 Note
@@ -316,9 +317,8 @@ chargeUnit_factor = {
 }
 
 #: :data:`conversion_factor` is used by :func:`get_conversion_factor`
-#: .. note:: 
-#:    any observable with a unit (i.e. one with an entry in
-#:    the :attr:`unit` attribute) needs an entry in :data:`conversion_factor`
+#: NOTE: any observable with a unit (i.e. one with an entry in
+#: the :attr:`unit` attribute) needs an entry in :data:`conversion_factor`
 conversion_factor = {
     'length': lengthUnit_factor,
     'density': densityUnit_factor,
@@ -344,9 +344,9 @@ def get_conversion_factor(unit_type, u1, u2):
 
     f[u1 -> u2] = factor[u2]/factor[u1]
 
-    Conversion of X (in u1) to X' (in u2):
+    Conversion of :math:`X` (in u1) to :math:`X'` (in u2):
 
-        X' = conversion_factor * X
+       :math:`X'` = conversion_factor * :math:`X`
     """
     # x is in u1: from u1 to b:  x'  = x  / factor[u1]
     #             from b  to u2: x'' = x' * factor[u2]

--- a/package/MDAnalysis/units.py
+++ b/package/MDAnalysis/units.py
@@ -104,13 +104,14 @@ concentration:
 
      factor = 1 A**-3 / (N_Avogadro * (10**-9 dm)**-3)
 
-  relative to a density rho0 in g/cm^3::
+  relative to a density rho0 in g/cm^{3}::
 
     M(H2O) = 18 g/mol   Molar mass of water
 
     factor = 1/(1e-24 * N_Avogadro / M(H2O))
+  ::
 
-  from `rho/rho0 = n/(N_A * M**-1) / rho0`  where `[n] = 1/Volume`, `[rho] = mass/Volume`
+    from rho/rho0 = n/(N_A * M**-1) / rho0   where [n] = 1/Volume, [rho] = mass/Volume
 
 
 Note
@@ -219,7 +220,7 @@ water = {
     'MolarMass': 18.016,  # in g mol**-1
 }
 
-#: The basic unit for *densities* is Angstroem**(-3), i.e.
+#: The basic unit for *densities* is Angstrom**(-3), i.e.
 #: the volume per molecule in A**3. Especially for water
 #: it can be convenient to measure the density relative to bulk, and
 #: hence a number of values are pre-stored in :data:`water`.
@@ -314,9 +315,10 @@ chargeUnit_factor = {
     'C': constants['elementary_charge'], 'As': constants['elementary_charge'],
 }
 
-#: :data:`conversion_factor` is used by :func:`get_conversion_factor`:
-#: Note: any observable with a unit (i.e. one with an entry in
-#: the :attr:`unit` attribute) needs an entry in :data:`conversion_factor`
+#: :data:`conversion_factor` is used by :func:`get_conversion_factor`
+#: .. note:: 
+#:    any observable with a unit (i.e. one with an entry in
+#:    the :attr:`unit` attribute) needs an entry in :data:`conversion_factor`
 conversion_factor = {
     'length': lengthUnit_factor,
     'density': densityUnit_factor,


### PR DESCRIPTION
Fixes #3580  - changes done for [unit and conversion page](https://docs.mdanalysis.org/2.1.0-dev0/documentation_pages/units.html?highlight=unit%20conversion#conversions)

Changes made in this Pull Request:
 - Fixed some typos
 - Fixed LaTeX formatting for `rho/rho0 = n/(N_A * M**-1) / rho0 where [n] = 1/Volume, [rho] = mass/Volume`


PR Checklist
------------
 - [ ] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [ ] Issue raised/referenced?
