### PR TITLE
 add typo issue

### DIFF
--- a/package/MDAnalysis/units.py
+++ b/package/MDAnalysis/units.py
@@ -236,7 +236,7 @@ densityUnit_factor = {
 
 
 #: For *time*, the basic unit is ps; in particular CHARMM's
-#: 1 AKMA_ time unit = 4.888821E-14 sec is supported.
+#: 1 AKMA_ time unit = 4.888821e-14 sec is supported.
 timeUnit_factor = {
     'ps': 1.0, 'picosecond': 1.0,  # 1/1.0
     'fs': 1e3, 'femtosecond': 1e3,  # 1/1e-3,

--- a/package/doc/sphinx/source/documentation_pages/units.rst
+++ b/package/doc/sphinx/source/documentation_pages/units.rst
@@ -11,14 +11,11 @@
 > - units and conversions [page](https://docs.mdanalysis.org/2.1.0-dev0/documentation_pages/units.html?highlight=unit%20conversion#conversions), `MDAnalysis.units.timeUnit_factor`: fix scientific notation in **time unit** = 4.888821`E-14` sec to 4.888821`e-14` sec
 
 
-![image](https://user-images.githubusercontent.com/36210723/163504826-76e845f5-2bbe-40ca-a3ef-a8b2c447e709.png)
 
 
 > - units and conversions [page](https://docs.mdanalysis.org/2.1.0-dev0/documentation_pages/units.html?highlight=unit%20conversion#conversions), `MDAnalysis.units.densityUnit_factor`: fix scientific notation in **Example for how to calculate the conversion factor** where `Å−3 `  to  ` A**-3 `
 
-.
 
-![image](https://user-images.githubusercontent.com/36210723/163504221-1b7cd27e-3627-4942-97ff-81a0466bb0c7.png)
 
 
 .

--- a/package/doc/sphinx/source/documentation_pages/units.rst
+++ b/package/doc/sphinx/source/documentation_pages/units.rst
@@ -1,2 +1,3 @@
 .. automodule:: MDAnalysis.units
 
+Can I work in this issue as typo

--- a/package/doc/sphinx/source/documentation_pages/units.rst
+++ b/package/doc/sphinx/source/documentation_pages/units.rst
@@ -1,11 +1,13 @@
 .. automodule:: MDAnalysis.units
 
+
+
 .
 
-## I work in this issue for below typos
 
+Changes made in this Pull Request:
 
-=============================================
+- Fixed some typos : 
 
 
 > - units and conversions [page](https://docs.mdanalysis.org/2.1.0-dev0/documentation_pages/units.html?highlight=unit%20conversion#conversions), `MDAnalysis.units.timeUnit_factor`: fix scientific notation in **time unit** = 4.888821`E-14` sec to 4.888821`e-14` sec
@@ -14,6 +16,7 @@
 
 
 > - units and conversions [page](https://docs.mdanalysis.org/2.1.0-dev0/documentation_pages/units.html?highlight=unit%20conversion#conversions), `MDAnalysis.units.densityUnit_factor`: fix scientific notation in **Example for how to calculate the conversion factor** where `Å−3 `  to  ` A**-3 `
+
 
 
 

--- a/package/doc/sphinx/source/documentation_pages/units.rst
+++ b/package/doc/sphinx/source/documentation_pages/units.rst
@@ -1,3 +1,27 @@
 .. automodule:: MDAnalysis.units
 
-Can I work in this issue as typo
+.
+
+## I work in this issue for below typos
+
+
+=============================================
+
+
+> - units and conversions [page](https://docs.mdanalysis.org/2.1.0-dev0/documentation_pages/units.html?highlight=unit%20conversion#conversions), `MDAnalysis.units.timeUnit_factor`: fix scientific notation in **time unit** = 4.888821`E-14` sec to 4.888821`e-14` sec
+
+
+![image](https://user-images.githubusercontent.com/36210723/163504826-76e845f5-2bbe-40ca-a3ef-a8b2c447e709.png)
+
+
+> - units and conversions [page](https://docs.mdanalysis.org/2.1.0-dev0/documentation_pages/units.html?highlight=unit%20conversion#conversions), `MDAnalysis.units.densityUnit_factor`: fix scientific notation in **Example for how to calculate the conversion factor** where `Å−3 `  to  ` A**-3 `
+
+.
+
+![image](https://user-images.githubusercontent.com/36210723/163504221-1b7cd27e-3627-4942-97ff-81a0466bb0c7.png)
+
+
+.
+
+
+


### PR DESCRIPTION

> Fixes #3639- changes done for [unit and conversion page](https://docs.mdanalysis.org/2.1.0-dev0/documentation_pages/units.html?highlight=unit%20conversion#conversions)



> Changes made in this Pull Request:
> 
> * Fixed some typos
> * Fixed MDAnalysis.units formatting for charge = `4.888821E-14 sec` to `4.888821e-14 sec`
> * Fixed MDAnalysis.units.densityUnit_factor formatting for charge = `Å−3` to `A**-3`
> 
> ## PR Checklist
> * [ ]  Tests?
> * [x]  Docs?
> * [x]  CHANGELOG updated?
> * [ ]  Issue raised/referenced?


