### PR TITLE
Bat cartesian method modifies input data

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -37,6 +37,7 @@ Fixes
   * Fixed DumpReader triclinic box dimensions reading. (Issue #3386, PR #3403)
   * Updated the badge in README of MDAnalysisTest to point to Github CI Actions
   * Fixed FrameIteratorIndices doesn't rewind. (Issue #3416)
+  * Fixed BAT method Cartesian modifies input data. (Issue #3501)
 
 Enhancements
   * PCA class now has an inverse-PCA function. The inverse transform can

--- a/package/MDAnalysis/analysis/bat.py
+++ b/package/MDAnalysis/analysis/bat.py
@@ -175,6 +175,7 @@ import logging
 import warnings
 
 import numpy as np
+import copy
 
 import MDAnalysis as mda
 from .base import AnalysisBase
@@ -499,7 +500,7 @@ class BAT(AnalysisBase):
         n_torsions = (self._ag.n_atoms - 3)
         bonds = bat_frame[9:n_torsions + 9]
         angles = bat_frame[n_torsions + 9:2 * n_torsions + 9]
-        torsions = bat_frame[2 * n_torsions + 9:]
+        torsions = copy.deepcopy(bat_frame[2 * n_torsions + 9:])
         # When appropriate, convert improper to proper torsions
         shift = torsions[self._primary_torsion_indices]
         shift[self._unique_primary_torsion_indices] = 0.

--- a/testsuite/MDAnalysisTests/analysis/test_bat.py
+++ b/testsuite/MDAnalysisTests/analysis/test_bat.py
@@ -131,10 +131,8 @@ class TestBAT(object):
 
     def test_bat_transformation(self, selected_residues, bat):
         R = BAT(selected_residues)
-        R.run()
-        XYZ = R.results.bat[0]
-        PQR = copy.deepcopy(XYZ)
-        R.Cartesian(R.results.bat[0])
-        assert_almost_equal(PQR, XYZ, 5,
-                            err_msg="error: Bat input data"
-                                    "modified by the Cartesian method")
+        pre_transformation = copy.deepcopy(bat[0])
+        R.Cartesian(bat[0])
+        assert_almost_equal(pre_transformation, bat[0], 5,
+                            err_msg="error: Bat.Cartesian"
+                                    "modified input data")

--- a/testsuite/MDAnalysisTests/analysis/test_bat.py
+++ b/testsuite/MDAnalysisTests/analysis/test_bat.py
@@ -133,7 +133,7 @@ class TestBAT(object):
         XYZ = R.Cartesian(bat[0])
         PQR = R.Cartesian(bat[0])
         assert_almost_equal(PQR, XYZ, 5,
-                           err_msg="error: Reconstructed Cartesian"
-                                   "coordinate after multiple "
-                                   "transformations don't match "
-                                   "original")
+                            err_msg="error: Reconstructed Cartesian"
+                                    "coordinate after multiple "
+                                    "transformations don't match "
+                                    "original")

--- a/testsuite/MDAnalysisTests/analysis/test_bat.py
+++ b/testsuite/MDAnalysisTests/analysis/test_bat.py
@@ -127,11 +127,12 @@ class TestBAT(object):
         errmsg = 'Dimensions of array in loaded file'
         with pytest.raises(ValueError, match=errmsg):
             R = BAT(selected_residues, filename=bat_npz)
-            
-    def test_bat_between_transformations(self, selected_residues, bat):
+
+    def test_bat_transformation(self, selected_residues, bat):
         R = BAT(selected_residues)
         XYZ = R.Cartesian(bat[0])
         PQR = R.Cartesian(bat[0])
         assert_almost_equal(PQR, selected_residues.positions, 5,
-            err_msg="error: Cartesian coordinates after multiple transformation" + \
-                    "don't match original")
+              err_msg="error: Reconstructed Cartesian coordinates"
+                      "after multiple transformations don't match "
+                      "original")

--- a/testsuite/MDAnalysisTests/analysis/test_bat.py
+++ b/testsuite/MDAnalysisTests/analysis/test_bat.py
@@ -127,3 +127,12 @@ class TestBAT(object):
         errmsg = 'Dimensions of array in loaded file'
         with pytest.raises(ValueError, match=errmsg):
             R = BAT(selected_residues, filename=bat_npz)
+            
+    def test_bat_between_transformations(self, selected_residues, bat):
+        R = BAT(selected_residues)
+        XYZ = R.Cartesian(bat[0])
+        PQR = R.Cartesian(bat[0])
+        assert_almost_equal(PQR, selected_residues.positions, 5,
+            err_msg="error: Reconstructed Cartesian coordinates " + \
+                    "after multiple transformations " + \
+                    "don't match original")

--- a/testsuite/MDAnalysisTests/analysis/test_bat.py
+++ b/testsuite/MDAnalysisTests/analysis/test_bat.py
@@ -132,7 +132,8 @@ class TestBAT(object):
         R = BAT(selected_residues)
         XYZ = R.Cartesian(bat[0])
         PQR = R.Cartesian(bat[0])
-        assert_almost_equal(PQR, selected_residues.positions, 5,
-              err_msg="error: Reconstructed Cartesian coordinates"
-                      "after multiple transformations don't match "
-                      "original")
+        assert_almost_equal(PQR, XYZ, 5,
+                           err_msg="error: Reconstructed Cartesian"
+                                   "coordinate after multiple "
+                                   "transformations don't match "
+                                   "original")

--- a/testsuite/MDAnalysisTests/analysis/test_bat.py
+++ b/testsuite/MDAnalysisTests/analysis/test_bat.py
@@ -132,12 +132,9 @@ class TestBAT(object):
     def test_bat_transformation(self, selected_residues, bat):
         R = BAT(selected_residues)
         R.run()
-        R.Cartesian(R.results.bat[0])
         XYZ = R.results.bat[0]
         PQR = copy.deepcopy(XYZ)
         R.Cartesian(R.results.bat[0])
         assert_almost_equal(PQR, XYZ, 5,
-                            err_msg="error: Reconstructed Cartesian"
-                                    "coordinate after multiple "
-                                    "transformations don't match "
-                                    "original")
+                            err_msg="error: Bat input data"
+                                    "modified by the Cartesian method")

--- a/testsuite/MDAnalysisTests/analysis/test_bat.py
+++ b/testsuite/MDAnalysisTests/analysis/test_bat.py
@@ -25,6 +25,7 @@ from __future__ import absolute_import
 import numpy as np
 from numpy.testing import assert_equal, assert_almost_equal
 import pytest
+import copy
 
 import MDAnalysis as mda
 from MDAnalysisTests.datafiles import (PSF, DCD, mol2_comments_header, XYZ_mini,
@@ -130,8 +131,11 @@ class TestBAT(object):
 
     def test_bat_transformation(self, selected_residues, bat):
         R = BAT(selected_residues)
-        XYZ = R.Cartesian(bat[0])
-        PQR = R.Cartesian(bat[0])
+        R.run()
+        R.Cartesian(R.results.bat[0])
+        XYZ = R.results.bat[0]
+        PQR = copy.deepcopy(XYZ)
+        R.Cartesian(R.results.bat[0])
         assert_almost_equal(PQR, XYZ, 5,
                             err_msg="error: Reconstructed Cartesian"
                                     "coordinate after multiple "

--- a/testsuite/MDAnalysisTests/analysis/test_bat.py
+++ b/testsuite/MDAnalysisTests/analysis/test_bat.py
@@ -129,10 +129,11 @@ class TestBAT(object):
         with pytest.raises(ValueError, match=errmsg):
             R = BAT(selected_residues, filename=bat_npz)
 
-    def test_bat_transformation(self, selected_residues, bat):
+    def test_Cartesian_does_not_modify_input(self, selected_residues, bat):
         R = BAT(selected_residues)
         pre_transformation = copy.deepcopy(bat[0])
         R.Cartesian(bat[0])
-        assert_almost_equal(pre_transformation, bat[0], 5,
-                            err_msg="error: Bat.Cartesian"
-                                    "modified input data")
+        assert_almost_equal(
+            pre_transformation, bat[0],
+            err_msg="BAT.Cartesian modified input data"
+        )

--- a/testsuite/MDAnalysisTests/analysis/test_bat.py
+++ b/testsuite/MDAnalysisTests/analysis/test_bat.py
@@ -133,6 +133,5 @@ class TestBAT(object):
         XYZ = R.Cartesian(bat[0])
         PQR = R.Cartesian(bat[0])
         assert_almost_equal(PQR, selected_residues.positions, 5,
-            err_msg="error: Reconstructed Cartesian coordinates " + \
-                    "after multiple transformations " + \
+            err_msg="error: Cartesian coordinates after multiple transformation" + \
                     "don't match original")


### PR DESCRIPTION
Fixes #3501 

Changes made in this Pull Request:
 - Use copy.deepcopy() to sort the issue caused by scope and pass-by-reference resulting addition of non-primary torsions in the input of BAT data
 - Wrote a regression test for the same


PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
