### PR TITLE
Sort and add intersphinx_mapping

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -15,7 +15,8 @@ The rules for this file:
 ------------------------------------------------------------------------------
 ??/??/?? IAlibay, BFedder, inomag, Agorfa, aya9aladdin, shudipto-amin, cbouy,
          HenokB, umak1106, tamandeeps, Mrqeoqqt, megosato, AnirG, rishu235,
-         mtiberti, manishsaini6421, Sukeerti1, robotjellyzone, markvrma, alescoulie
+         mtiberti, manishsaini6421, Sukeerti1, robotjellyzone, markvrma, alescoulie,
+         PicoCentauri
 
  * 2.2.0
 
@@ -42,6 +43,7 @@ Fixes
   * Fixed BAT method Cartesian modifies input data. (Issue #3501)
 
 Enhancements
+  * Link PMDA in documentation
   * Added MSD example where multiple replicates are combined(Issue #3578
     PR #3633)
   * PCA class now has an inverse-PCA function. The inverse transform can

--- a/package/MDAnalysis/analysis/density.py
+++ b/package/MDAnalysis/analysis/density.py
@@ -233,7 +233,8 @@ class DensityAnalysis(AnalysisBase):
 
     See Also
     --------
-    pmda.density.DensityAnalysis for a parallel version
+    pmda.density.DensityAnalysis
+        A parallel version of :class:`DensityAnalysis`
 
     Notes
     -----

--- a/package/doc/sphinx/source/conf.py
+++ b/package/doc/sphinx/source/conf.py
@@ -338,14 +338,15 @@ epub_copyright = u'2015, '+authors
 
 # Configuration for intersphinx: refer to the Python standard library
 # and other packages used by MDAnalysis
-intersphinx_mapping = {'https://docs.python.org/': None,
-                       'https://docs.scipy.org/doc/numpy/': None,
+intersphinx_mapping = {'https://docs.h5py.org/en/stable': None,
+                       'https://docs.python.org/3/': None,
                        'https://docs.scipy.org/doc/scipy/': None,
-                       'https://matplotlib.org': None,
-                       'https://networkx.github.io/documentation/stable/': None,
-                       'https://www.mdanalysis.org/GridDataFormats/': None,
                        'https://gsd.readthedocs.io/en/stable/': None,
+                       'https://matplotlib.org/stable/': None,
+                       'https://mdanalysis.org/GridDataFormats/': None,
+                       'https://mdanalysis.org/pmda/': None,
+                       'https://networkx.org/documentation/stable/': None,
+                       'https://numpy.org/doc/stable/': None,
                        'https://parmed.github.io/ParmEd/html/': None,
-                       'https://docs.h5py.org/en/stable': None,
-                       'https://www.rdkit.org/docs/': None,
+                       'https://rdkit.org/docs/': None,
                        }


### PR DESCRIPTION
The `See Also` entry for pmda.density.DensityAnalysis was not linked and rendered correctly. Also, the links to external libraries are sorted and updated to their most recent address.

[This](https://mdanalysis--3652.org.readthedocs.build/en/3652/documentation_pages/analysis/density.html?highlight=pmda#MDAnalysis.analysis.density.DensityAnalysis.density) is the new version with a correct link.
