### PR TITLE
Issue 3659 fixed loading for MOL2 and PDB edge cases

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -193,6 +193,7 @@ Chronological list of authors
   - Kavya Bisht
   - Mark Verma
   - Marcelo D. Poleto
+  - Zachary Smith
   - Ricky Sexton
   - Rafael R. Pappalardo
   - Tengyu Xie

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -28,6 +28,8 @@ Fixes
     RMSD of None
   * Fixes hydrogenbonds tutorial path to point to hbonds (Issue #4285, PR #4286)
   * Fix atom charge reading in PDBQT parser (Issue #4282, PR #4283)
+  * Universe keyword to correctly parse repeated resnames in PDB and MOL2
+    (Issue #3659, PR #3662)
 
 Enhancements
   * Add faster nucleic acid Major and Minor pair distance calculators using

--- a/package/MDAnalysis/topology/MOL2Parser.py
+++ b/package/MDAnalysis/topology/MOL2Parser.py
@@ -253,7 +253,7 @@ class MOL2Parser(TopologyReaderBase):
 
         if np.all(resnames):
             residx, (resids, resnames,), _ = squash_by_attributes(
-                [resids, resnames])
+                (resids, resnames))
             n_residues = len(resids)
             attrs.append(Resids(resids))
             attrs.append(Resnums(resids.copy()))

--- a/package/MDAnalysis/topology/MOL2Parser.py
+++ b/package/MDAnalysis/topology/MOL2Parser.py
@@ -132,8 +132,14 @@ class MOL2Parser(TopologyReaderBase):
     """
     format = 'MOL2'
 
-    def parse(self, **kwargs):
+    def parse(self, repeated_resids: bool = False, **kwargs):
         """Parse MOL2 file *filename* and return the dict `structure`.
+
+        Parameters
+        ----------
+        repeated_resids: bool
+          Whether the same resid is used for multiple residues.
+          This option will perceive residues using the resid/resname pair.
 
         Returns
         -------
@@ -252,8 +258,14 @@ class MOL2Parser(TopologyReaderBase):
         resnames = np.array(resnames, dtype=object)
 
         if np.all(resnames):
-            residx, (resids, resnames,), _ = squash_by_attributes(
-                (resids, resnames))
+            if repeated_resids:
+                (
+                    residx,
+                    (resids, resnames,),
+                    _,
+                ) = squash_by_attributes((resids, resnames))
+            else:
+                residx, resids, (resnames,) = squash_by(resids, resnames)
             n_residues = len(resids)
             attrs.append(Resids(resids))
             attrs.append(Resnums(resids.copy()))

--- a/package/MDAnalysis/topology/MOL2Parser.py
+++ b/package/MDAnalysis/topology/MOL2Parser.py
@@ -46,7 +46,7 @@ import numpy as np
 
 from . import guessers
 from ..lib.util import openany
-from .base import TopologyReaderBase, squash_by
+from .base import TopologyReaderBase, squash_by, squash_by_attributes
 from ..core.topologyattrs import (
     Atomids,
     Atomnames,
@@ -252,9 +252,8 @@ class MOL2Parser(TopologyReaderBase):
         resnames = np.array(resnames, dtype=object)
 
         if np.all(resnames):
-            squash_ids = resnames + resids.astype(str)
-            residx, squash_ids, (resids, resnames,) = squash_by(
-                squash_ids, resids, resnames)
+            residx, _, (resids, resnames,), _ = squash_by_attributes(
+                [resids, resnames])
             n_residues = len(resids)
             attrs.append(Resids(resids))
             attrs.append(Resnums(resids.copy()))

--- a/package/MDAnalysis/topology/MOL2Parser.py
+++ b/package/MDAnalysis/topology/MOL2Parser.py
@@ -252,8 +252,9 @@ class MOL2Parser(TopologyReaderBase):
         resnames = np.array(resnames, dtype=object)
 
         if np.all(resnames):
-            residx, resids, (resnames,) = squash_by(
-                resids, resnames)
+            squash_ids = resnames + resids.astype(str)
+            residx, squash_ids, (resids, resnames,) = squash_by(
+                squash_ids, resids, resnames)
             n_residues = len(resids)
             attrs.append(Resids(resids))
             attrs.append(Resnums(resids.copy()))

--- a/package/MDAnalysis/topology/MOL2Parser.py
+++ b/package/MDAnalysis/topology/MOL2Parser.py
@@ -252,7 +252,7 @@ class MOL2Parser(TopologyReaderBase):
         resnames = np.array(resnames, dtype=object)
 
         if np.all(resnames):
-            residx, _, (resids, resnames,), _ = squash_by_attributes(
+            residx, (resids, resnames,), _ = squash_by_attributes(
                 [resids, resnames])
             n_residues = len(resids)
             attrs.append(Resids(resids))

--- a/package/MDAnalysis/topology/MOL2Parser.py
+++ b/package/MDAnalysis/topology/MOL2Parser.py
@@ -261,7 +261,10 @@ class MOL2Parser(TopologyReaderBase):
             if repeated_resids:
                 (
                     residx,
-                    (resids, resnames,),
+                    (
+                        resids,
+                        resnames,
+                    ),
                     _,
                 ) = squash_by_attributes((resids, resnames))
             else:

--- a/package/MDAnalysis/topology/PDBParser.py
+++ b/package/MDAnalysis/topology/PDBParser.py
@@ -386,8 +386,8 @@ class PDBParser(TopologyReaderBase):
         resnums = resids.copy()
         segids = np.array(segids, dtype=object)
 
-        residx, (resids, resnames, icodes, segids), (resnums,) = squash_by_attributes(
-            (resids, resnames, icodes, segids), resnums)
+        residx, (resids, resnames, icodes, segids), (resnums,) =\
+            squash_by_attributes((resids, resnames, icodes, segids), resnums)
         n_residues = len(resids)
         attrs.append(Resnums(resnums))
         attrs.append(Resids(resids))

--- a/package/MDAnalysis/topology/PDBParser.py
+++ b/package/MDAnalysis/topology/PDBParser.py
@@ -64,7 +64,7 @@ import warnings
 from .guessers import guess_masses, guess_types
 from .tables import SYMB2Z
 from ..lib import util
-from .base import TopologyReaderBase, change_squash
+from .base import TopologyReaderBase, squash_by_attributes
 from ..core.topology import Topology
 from ..core.topologyattrs import (
     Atomnames,
@@ -386,8 +386,8 @@ class PDBParser(TopologyReaderBase):
         resnums = resids.copy()
         segids = np.array(segids, dtype=object)
 
-        residx, (resids, resnames, icodes, resnums, segids) = change_squash(
-            (resids, resnames, icodes, segids), (resids, resnames, icodes, resnums, segids))
+        residx, (resids, resnames, icodes, segids), (resnums,) = squash_by_attributes(
+            (resids, resnames, icodes, segids), resnums)
         n_residues = len(resids)
         attrs.append(Resnums(resnums))
         attrs.append(Resids(resids))
@@ -396,7 +396,7 @@ class PDBParser(TopologyReaderBase):
         attrs.append(Resnames(resnames))
 
         if any(segids) and not any(val is None for val in segids):
-            segidx, (segids,) = change_squash((segids,), (segids,))
+            segidx, (segids,), _ = squash_by_attributes((segids,))
             n_segments = len(segids)
             attrs.append(Segids(segids))
         else:

--- a/package/MDAnalysis/topology/PDBParser.py
+++ b/package/MDAnalysis/topology/PDBParser.py
@@ -406,7 +406,13 @@ class PDBParser(TopologyReaderBase):
         resnums = resids.copy()
         segids = np.array(segids, dtype=object)
         if contiguous_resids:
-            residx, (resids, resnames, icodes, resnums, segids) = change_squash(
+            residx, (
+                resids,
+                resnames,
+                icodes,
+                resnums,
+                segids,
+            ) = change_squash(
                 (resids, resnames, icodes, segids),
                 (resids, resnames, icodes, resnums, segids),
             )
@@ -415,7 +421,9 @@ class PDBParser(TopologyReaderBase):
                 residx,
                 (resids, resnames, icodes, segids),
                 (resnums,),
-            ) = squash_by_attributes((resids, resnames, icodes, segids), resnums)
+            ) = squash_by_attributes(
+                (resids, resnames, icodes, segids), resnums
+            )
         n_residues = len(resids)
         attrs.append(Resnums(resnums))
         attrs.append(Resids(resids))

--- a/package/MDAnalysis/topology/base.py
+++ b/package/MDAnalysis/topology/base.py
@@ -37,6 +37,7 @@ Classes
 
 """
 from functools import reduce
+from typing import List
 
 import itertools
 import numpy as np
@@ -142,27 +143,33 @@ def squash_by(child_parent_ids, *attributes):
     return atom_idx, unique_resids, [attr[sort_mask] for attr in attributes]
 
 
-def squash_by_attributes(squash_attributes, *other_attributes):
+def squash_by_attributes(
+    squash_attributes: List[np.ndarray], *other_attributes: np.ndarray
+):
     """Squash a child-parent relationship using combinations of attributes
     parents will retain their order of appearance
 
-    Arguments
-    ---------
-    squash_attributes - list of attribute arrays (attributes used to
-                        identify the parent)
-    *other_attributes - other arrays that need to follow the sorting of ids
+    Parameters
+    ----------
+    squash_attributes: list of numpy ndarray
+      list of attribute arrays (attributes used to identify the parent)
+      Their unique combinations will set child-parent relationships
+    *other_attributes: numpy ndarrays
+      other arrays that need to follow the sorting of ids
 
     Returns
     -------
-    child_parents_idx - an array of len(child) which points to the index of
-                        parent
-    parent_combos - len(parent) of the unique combinations
-    squashed_attrs - len(parent) of the attributes used for squashing
-    *other_attrs - len(parent) of the other attributes
+    sorted_atom_idx: numpy ndarray
+      an array of len(child) which points to the index of the parent
+    squashed_attrs: list of numpy ndarray
+      List of re-ordered squash_attributes
+    *other_attrs: list of numpy ndarray
+      List of re-ordered other_attributes
     """
     squash_array = np.column_stack(squash_attributes).astype(str)
     unique_combos, sort_mask, atom_idx = np.unique(
-        squash_array, return_index=True, return_inverse=True, axis=0)
+        squash_array, return_index=True, return_inverse=True, axis=0
+    )
 
     appearance_order = np.argsort(sort_mask)
     new_index = np.arange(0, len(appearance_order))

--- a/package/MDAnalysis/topology/base.py
+++ b/package/MDAnalysis/topology/base.py
@@ -142,6 +142,38 @@ def squash_by(child_parent_ids, *attributes):
     return atom_idx, unique_resids, [attr[sort_mask] for attr in attributes]
 
 
+def squash_by_attributes(squash_attributes, *other_attributes):
+    """Squash a child-parent relationship using combinations of attributes
+    parents will retain their order of appearance 
+
+    Arguments
+    ---------
+    squash_attributes - list of attribute arrays (attributes used to identify the parent)
+    *other_attributes - other arrays that need to follow the sorting of ids
+
+    Returns
+    -------
+    child_parents_idx - an array of len(child) which points to the index of parent
+    parent_combos - len(parent) of the unique combinations
+    squashed_attrs - len(parent) of the attributes used for squashing
+    *other_attrs - len(parent) of the other attributes
+    """
+    squash_array = np.column_stack(squash_attributes).astype(str)
+    unique_combos, sort_mask, atom_idx = np.unique(squash_array, return_index=True, return_inverse=True, axis=0)
+
+
+    appearance_order = np.argsort(sort_mask)
+    new_index = np.arange(0,len(appearance_order))
+    resort_pairs = np.column_stack((appearance_order, new_index))
+    atom_idx_mapping = dict(resort_pairs)
+
+    sorted_atom_idx = np.vectorize(atom_idx_mapping.get)(atom_idx).astype(int)
+    sorted_unique_combos = unique_combos[appearance_order]
+    sorted_mask = np.sort(sort_mask)
+    
+    return sorted_atom_idx, sorted_unique_combos, [attr[sorted_mask] for attr in squash_attributes], [attr[sorted_mask] for attr in other_attributes]
+
+
 def change_squash(criteria, to_squash):
     """Squash per atom data to per residue according to changes in resid
 

--- a/package/MDAnalysis/topology/base.py
+++ b/package/MDAnalysis/topology/base.py
@@ -148,18 +148,21 @@ def squash_by_attributes(squash_attributes, *other_attributes):
 
     Arguments
     ---------
-    squash_attributes - list of attribute arrays (attributes used to identify the parent)
+    squash_attributes - list of attribute arrays (attributes used to 
+                        identify the parent)
     *other_attributes - other arrays that need to follow the sorting of ids
 
     Returns
     -------
-    child_parents_idx - an array of len(child) which points to the index of parent
+    child_parents_idx - an array of len(child) which points to the index of
+                        parent
     parent_combos - len(parent) of the unique combinations
     squashed_attrs - len(parent) of the attributes used for squashing
     *other_attrs - len(parent) of the other attributes
     """
     squash_array = np.column_stack(squash_attributes).astype(str)
-    unique_combos, sort_mask, atom_idx = np.unique(squash_array, return_index=True, return_inverse=True, axis=0)
+    unique_combos, sort_mask, atom_idx = np.unique(
+        squash_array, return_index=True, return_inverse=True, axis=0)
 
 
     appearance_order = np.argsort(sort_mask)
@@ -170,7 +173,10 @@ def squash_by_attributes(squash_attributes, *other_attributes):
     sorted_atom_idx = np.vectorize(atom_idx_mapping.get)(atom_idx).astype(int)
     sorted_mask = np.sort(sort_mask)
     
-    return sorted_atom_idx, [attr[sorted_mask] for attr in squash_attributes], [attr[sorted_mask] for attr in other_attributes]
+    squashed_attrs = [attr[sorted_mask] for attr in squash_attributes]
+    other_attrs = [attr[sorted_mask] for attr in other_attributes]
+    
+    return sorted_atom_idx, squashed_attrs, other_attrs
 
 
 def change_squash(criteria, to_squash):

--- a/package/MDAnalysis/topology/base.py
+++ b/package/MDAnalysis/topology/base.py
@@ -144,11 +144,11 @@ def squash_by(child_parent_ids, *attributes):
 
 def squash_by_attributes(squash_attributes, *other_attributes):
     """Squash a child-parent relationship using combinations of attributes
-    parents will retain their order of appearance 
+    parents will retain their order of appearance
 
     Arguments
     ---------
-    squash_attributes - list of attribute arrays (attributes used to 
+    squash_attributes - list of attribute arrays (attributes used to
                         identify the parent)
     *other_attributes - other arrays that need to follow the sorting of ids
 
@@ -164,18 +164,17 @@ def squash_by_attributes(squash_attributes, *other_attributes):
     unique_combos, sort_mask, atom_idx = np.unique(
         squash_array, return_index=True, return_inverse=True, axis=0)
 
-
     appearance_order = np.argsort(sort_mask)
-    new_index = np.arange(0,len(appearance_order))
+    new_index = np.arange(0, len(appearance_order))
     resort_pairs = np.column_stack((appearance_order, new_index))
     atom_idx_mapping = dict(resort_pairs)
 
     sorted_atom_idx = np.vectorize(atom_idx_mapping.get)(atom_idx).astype(int)
     sorted_mask = np.sort(sort_mask)
-    
+
     squashed_attrs = [attr[sorted_mask] for attr in squash_attributes]
     other_attrs = [attr[sorted_mask] for attr in other_attributes]
-    
+
     return sorted_atom_idx, squashed_attrs, other_attrs
 
 

--- a/package/MDAnalysis/topology/base.py
+++ b/package/MDAnalysis/topology/base.py
@@ -168,10 +168,9 @@ def squash_by_attributes(squash_attributes, *other_attributes):
     atom_idx_mapping = dict(resort_pairs)
 
     sorted_atom_idx = np.vectorize(atom_idx_mapping.get)(atom_idx).astype(int)
-    sorted_unique_combos = unique_combos[appearance_order]
     sorted_mask = np.sort(sort_mask)
     
-    return sorted_atom_idx, sorted_unique_combos, [attr[sorted_mask] for attr in squash_attributes], [attr[sorted_mask] for attr in other_attributes]
+    return sorted_atom_idx, [attr[sorted_mask] for attr in squash_attributes], [attr[sorted_mask] for attr in other_attributes]
 
 
 def change_squash(criteria, to_squash):

--- a/testsuite/MDAnalysisTests/topology/test_mol2.py
+++ b/testsuite/MDAnalysisTests/topology/test_mol2.py
@@ -317,7 +317,7 @@ def test_unformat():
                        match='Some atoms in the mol2 file'):
         u = mda.Universe(StringIO(mol2_resname_unformat), format='MOL2')
 
-def test_resname_changed():
+def test_repeat_resid():
     u = mda.Universe(StringIO(mol2_repeat_resid), format='MOL2')
 
     expected_resnames = np.array(['LYS', 'SER', 'LEU'], dtype=object)

--- a/testsuite/MDAnalysisTests/topology/test_mol2.py
+++ b/testsuite/MDAnalysisTests/topology/test_mol2.py
@@ -319,9 +319,12 @@ def test_unformat():
 
 
 def test_repeat_resid():
-    u = mda.Universe(StringIO(mol2_repeat_resid), format='MOL2')
+    """
+    Test parsing re-used resids with different resnames
+    """
+    u = mda.Universe(StringIO(mol2_repeat_resid), format="MOL2", repeated_resids=True)
 
-    expected_resnames = np.array(['LYS', 'SER', 'LEU'], dtype=object)
+    expected_resnames = np.array(["LYS", "SER", "LEU"], dtype=object)
     assert_equal(u.residues.resnames, expected_resnames)
 
     expected_resids = np.array([1, 2, 1])

--- a/testsuite/MDAnalysisTests/topology/test_mol2.py
+++ b/testsuite/MDAnalysisTests/topology/test_mol2.py
@@ -322,7 +322,9 @@ def test_repeat_resid():
     """
     Test parsing re-used resids with different resnames
     """
-    u = mda.Universe(StringIO(mol2_repeat_resid), format="MOL2", repeated_resids=True)
+    u = mda.Universe(
+        StringIO(mol2_repeat_resid), format="MOL2", repeated_resids=True
+    )
 
     expected_resnames = np.array(["LYS", "SER", "LEU"], dtype=object)
     assert_equal(u.residues.resnames, expected_resnames)

--- a/testsuite/MDAnalysisTests/topology/test_mol2.py
+++ b/testsuite/MDAnalysisTests/topology/test_mol2.py
@@ -172,6 +172,20 @@ USER_CHARGES
 """
 
 
+mol2_repeat_resid = """\
+@<TRIPOS>MOLECULE
+mol2_repeat_resid
+ 3 0 0 0 0
+SMALL
+GASTEIGER
+
+@<TRIPOS>ATOM
+    1  CA        65.9780   40.8660   -0.1830 C.3     1  LYS        0.0532
+    2  CA        64.3240   40.0060    3.1640 C.3     2  SER        0.1227
+    3  CA        64.0000   39.2360    8.6480 C.3     1  LEU        0.0996
+"""
+
+
 class TestMOL2Base(ParserBase):
     parser = mda.topology.MOL2Parser.MOL2Parser
     expected_attrs = [
@@ -301,3 +315,9 @@ def test_unformat():
     with pytest.raises(ValueError,
                        match='Some atoms in the mol2 file'):
         u = mda.Universe(StringIO(mol2_resname_unformat), format='MOL2')
+
+def test_resname_changed():
+    u = mda.Universe(StringIO(mol2_repeat_resid), format='MOL2')
+
+    expected = np.array(['LYS', 'SER', 'LEU'], dtype=object)
+    assert_equal(u.residues.resnames, expected)

--- a/testsuite/MDAnalysisTests/topology/test_mol2.py
+++ b/testsuite/MDAnalysisTests/topology/test_mol2.py
@@ -317,6 +317,7 @@ def test_unformat():
                        match='Some atoms in the mol2 file'):
         u = mda.Universe(StringIO(mol2_resname_unformat), format='MOL2')
 
+
 def test_repeat_resid():
     u = mda.Universe(StringIO(mol2_repeat_resid), format='MOL2')
 

--- a/testsuite/MDAnalysisTests/topology/test_mol2.py
+++ b/testsuite/MDAnalysisTests/topology/test_mol2.py
@@ -183,6 +183,7 @@ GASTEIGER
     1  CA        65.9780   40.8660   -0.1830 C.3     1  LYS        0.0532
     2  CA        64.3240   40.0060    3.1640 C.3     2  SER        0.1227
     3  CA        64.0000   39.2360    8.6480 C.3     1  LEU        0.0996
+    4  N         66.1350   42.0990   -1.0070 N.4     1  LYS        0.2273
 """
 
 
@@ -319,5 +320,8 @@ def test_unformat():
 def test_resname_changed():
     u = mda.Universe(StringIO(mol2_repeat_resid), format='MOL2')
 
-    expected = np.array(['LYS', 'SER', 'LEU'], dtype=object)
-    assert_equal(u.residues.resnames, expected)
+    expected_resnames = np.array(['LYS', 'SER', 'LEU'], dtype=object)
+    assert_equal(u.residues.resnames, expected_resnames)
+
+    expected_resids = np.array([1, 2, 1])
+    assert_equal(u.residues.resids, expected_resids)

--- a/testsuite/MDAnalysisTests/topology/test_pdb.py
+++ b/testsuite/MDAnalysisTests/topology/test_pdb.py
@@ -330,10 +330,11 @@ def test_nobonds_error():
 
 pdb_repeat_resid = """\
 ATOM      1  CA  LYS A   1      65.978  40.866  -0.183  1.00  0.00           C
-ATOM      2  CA  SER A   2      64.324  40.006   3.164  1.00  0.00           C  
-ATOM      3  CA  LEU A   1      64.000  39.236   8.648  1.00  0.00           C  
-ATOM      4  N   LYS A   1      66.135  42.099  -1.007  1.00  0.00           N1+
+ATOM      2  CA  SER A   2      64.324  40.006   3.164  1.00  0.00           C
+ATOM      3  CA  LEU A   1      64.000  39.236   8.648  1.00  0.00           C
+ATOM      4  N   LYS A   1      66.135  42.099  -1.007  1.00  0.00           N
 """
+
 
 def test_repeat_resid():
     u = mda.Universe(StringIO(pdb_repeat_resid), format='PDB')

--- a/testsuite/MDAnalysisTests/topology/test_pdb.py
+++ b/testsuite/MDAnalysisTests/topology/test_pdb.py
@@ -328,6 +328,51 @@ def test_nobonds_error():
         u.atoms.bonds
 
 
+def test_PDB_charges():
+    """The test checks whether formalcharges attribute are assigned
+    properly given a PDB file with a valid formal charges record.
+    """
+    u = mda.Universe(PDB_charges)
+    formal_charges = np.array([0, 0, 0, 0, 0, 0, 0, -1, 0, 0, 0, 0, 0, 0, 0,
+                               0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,
+                               0, 0, 0, 0, 0], dtype=int)
+    assert_equal(u.atoms.formalcharges, formal_charges)
+
+
+PDB_charges_nosign = """\
+REMARK Invalid charge assignment - no sign for MG2+
+HETATM    1 CU    CU A   1      03.000  00.000  00.000  1.00 00.00          CU2+
+HETATM    2 FE    FE A   2      00.000  03.000  00.000  1.00 00.00          Fe2+
+HETATM    3 Mg    Mg A   3      03.000  03.000  03.000  1.00 00.00          MG2
+END
+"""
+
+
+PDB_charges_invertsign = """\
+REMARK Invalid charge format for MG2+
+HETATM    1 CU    CU A   1      03.000  00.000  00.000  1.00 00.00          CU2+
+HETATM    2 FE    FE A   2      00.000  03.000  00.000  1.00 00.00          Fe2+
+HETATM    3 Mg    Mg A   3      03.000  03.000  03.000  1.00 00.00          MG+2
+END
+"""
+
+
+@pytest.mark.parametrize('infile,entry', [
+        [PDB_charges_nosign, r'2'],
+        [PDB_charges_invertsign, r'\+2']
+])
+def test_PDB_bad_charges(infile, entry):
+    """
+    Test that checks that a warning is raised and formal charges are not set:
+        * If there are missing signs for a given formal charge entry
+        * If there is an unrecognised formal charge entry
+    """
+    wmsg = f"Unknown entry {entry} encountered in formal charge field."
+    with pytest.warns(UserWarning, match=wmsg):
+        u = mda.Universe(StringIO(infile), format='PDB')
+        assert not hasattr(u, 'formalcharges')
+
+
 pdb_repeat_resid = """\
 ATOM      1  CA  LYS A   1      65.978  40.866  -0.183  1.00  0.00           C
 ATOM      2  CA  SER A   2      64.324  40.006   3.164  1.00  0.00           C

--- a/testsuite/MDAnalysisTests/topology/test_pdb.py
+++ b/testsuite/MDAnalysisTests/topology/test_pdb.py
@@ -328,46 +328,18 @@ def test_nobonds_error():
         u.atoms.bonds
 
 
-def test_PDB_charges():
-    """The test checks whether formalcharges attribute are assigned
-    properly given a PDB file with a valid formal charges record.
-    """
-    u = mda.Universe(PDB_charges)
-    formal_charges = np.array([0, 0, 0, 0, 0, 0, 0, -1, 0, 0, 0, 0, 0, 0, 0,
-                               0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,
-                               0, 0, 0, 0, 0], dtype=int)
-    assert_equal(u.atoms.formalcharges, formal_charges)
-
-
-PDB_charges_nosign = """\
-REMARK Invalid charge assignment - no sign for MG2+
-HETATM    1 CU    CU A   1      03.000  00.000  00.000  1.00 00.00          CU2+
-HETATM    2 FE    FE A   2      00.000  03.000  00.000  1.00 00.00          Fe2+
-HETATM    3 Mg    Mg A   3      03.000  03.000  03.000  1.00 00.00          MG2
-END
+pdb_repeat_resid = """\
+ATOM      1  CA  LYS A   1      65.978  40.866  -0.183  1.00  0.00           C
+ATOM      2  CA  SER A   2      64.324  40.006   3.164  1.00  0.00           C  
+ATOM      3  CA  LEU A   1      64.000  39.236   8.648  1.00  0.00           C  
+ATOM      4  N   LYS A   1      66.135  42.099  -1.007  1.00  0.00           N1+
 """
 
+def test_repeat_resid():
+    u = mda.Universe(StringIO(pdb_repeat_resid), format='PDB')
 
-PDB_charges_invertsign = """\
-REMARK Invalid charge format for MG2+
-HETATM    1 CU    CU A   1      03.000  00.000  00.000  1.00 00.00          CU2+
-HETATM    2 FE    FE A   2      00.000  03.000  00.000  1.00 00.00          Fe2+
-HETATM    3 Mg    Mg A   3      03.000  03.000  03.000  1.00 00.00          MG+2
-END
-"""
+    expected_resnames = np.array(['LYS', 'SER', 'LEU'], dtype=object)
+    assert_equal(u.residues.resnames, expected_resnames)
 
-
-@pytest.mark.parametrize('infile,entry', [
-        [PDB_charges_nosign, r'2'],
-        [PDB_charges_invertsign, r'\+2']
-])
-def test_PDB_bad_charges(infile, entry):
-    """
-    Test that checks that a warning is raised and formal charges are not set:
-        * If there are missing signs for a given formal charge entry
-        * If there is an unrecognised formal charge entry
-    """
-    wmsg = f"Unknown entry {entry} encountered in formal charge field."
-    with pytest.warns(UserWarning, match=wmsg):
-        u = mda.Universe(StringIO(infile), format='PDB')
-        assert not hasattr(u, 'formalcharges')
+    expected_resids = np.array([1, 2, 1])
+    assert_equal(u.residues.resids, expected_resids)

--- a/testsuite/MDAnalysisTests/topology/test_pdb.py
+++ b/testsuite/MDAnalysisTests/topology/test_pdb.py
@@ -382,9 +382,12 @@ ATOM      4  N   LYS A   1      66.135  42.099  -1.007  1.00  0.00           N
 
 
 def test_repeat_resid():
-    u = mda.Universe(StringIO(pdb_repeat_resid), format='PDB')
+    """
+    Test parsing re-used resids with differeent resnames
+    """
+    u = mda.Universe(StringIO(pdb_repeat_resid), format="PDB", contiguous_resids=False)
 
-    expected_resnames = np.array(['LYS', 'SER', 'LEU'], dtype=object)
+    expected_resnames = np.array(["LYS", "SER", "LEU"], dtype=object)
     assert_equal(u.residues.resnames, expected_resnames)
 
     expected_resids = np.array([1, 2, 1])

--- a/testsuite/MDAnalysisTests/topology/test_pdb.py
+++ b/testsuite/MDAnalysisTests/topology/test_pdb.py
@@ -385,7 +385,9 @@ def test_repeat_resid():
     """
     Test parsing re-used resids with differeent resnames
     """
-    u = mda.Universe(StringIO(pdb_repeat_resid), format="PDB", contiguous_resids=False)
+    u = mda.Universe(
+        StringIO(pdb_repeat_resid), format="PDB", contiguous_resids=False
+    )
 
     expected_resnames = np.array(["LYS", "SER", "LEU"], dtype=object)
     assert_equal(u.residues.resnames, expected_resnames)


### PR DESCRIPTION
Fixes #3659 

Changes made in this Pull Request:
 - New squash function `squash_by_attributes` that uses unique combinations of attributes to determine residues
 - `MOL2Parser` and `PDBParser` now use this function to avoid issues when loading non-unique resids and non-contiguous residues  (#3659)


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
