### PR TITLE
[proposal / MAINT] Update to python>=3.8, numpy>=1.9.0, gsd>=1.9.3, networkx>=2.0, and scipy>=1.5.0

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -28,7 +28,7 @@ jobs:
         fail-fast: false
         matrix:
           os: [ubuntu-latest, ]
-          python-version: [3.8, 3.9, "3.10"]
+          python-version: [3.8, 3.9]
           full-deps: [true, ]
           install_hole: [true, ]
           codecov: [true, ]

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -45,7 +45,7 @@ jobs:
               full-deps: true
               install_hole: true
               codecov: true
-            - name: macOS_catalina_py37
+            - name: macOS_catalina_py38
               os: macOS-10.15
               python-version: 3.8
               full-deps: true

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -28,7 +28,7 @@ jobs:
         fail-fast: false
         matrix:
           os: [ubuntu-latest, ]
-          python-version: [3.8, 3.9]
+          python-version: [3.8, 3.9, "3.10"]
           full-deps: [true, ]
           install_hole: [true, ]
           codecov: [true, ]

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -28,7 +28,7 @@ jobs:
         fail-fast: false
         matrix:
           os: [ubuntu-latest, ]
-          python-version: [3.7, 3.8, 3.9]
+          python-version: [3.8, 3.9]
           full-deps: [true, ]
           install_hole: [true, ]
           codecov: [true, ]
@@ -47,26 +47,26 @@ jobs:
               codecov: true
             - name: macOS_catalina_py37
               os: macOS-10.15
-              python-version: 3.7
+              python-version: 3.8
               full-deps: true
               install_hole: true
               codecov: false
             - name: minimal-ubuntu
               os: ubuntu-latest
-              python-version: 3.7
+              python-version: 3.8
               full-deps: false
               install_hole: false
               codecov: true
             - name: numpy_min
               os: ubuntu-latest
-              python-version: 3.7
+              python-version: 3.8
               full-deps: false
               install_hole: false
               codecov: false
-              numpy: numpy=1.18.1
+              numpy: numpy=1.19.0
             - name: asv_check
               os: ubuntu-latest
-              python-version: 3.7
+              python-version: 3.8
               full-deps: true
               install_hole: false
               codecov: false
@@ -148,7 +148,7 @@ jobs:
     - name: setup_miniconda
       uses: conda-incubator/setup-miniconda@v2
       with:
-        python-version: 3.7
+        python-version: 3.8
         auto-update-conda: true
         channel-priority: flexible
         channels: conda-forge, bioconda
@@ -235,7 +235,7 @@ jobs:
     - name: setup_miniconda
       uses: conda-incubator/setup-miniconda@v2
       with:
-        python-version: 3.7
+        python-version: 3.8
         auto-update-conda: true
         channel-priority: flexible
         channels: conda-forge
@@ -265,7 +265,7 @@ jobs:
     - name: setup_miniconda
       uses: conda-incubator/setup-miniconda@v2
       with:
-        python-version: 3.7
+        python-version: 3.8
         auto-update-conda: true
         channel-priority: flexible
         channels: conda-forge

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,16 +21,10 @@ jobs:
     MPLBACKEND: agg
   strategy:
     matrix:
-        Win-Python37-32bit-full:
-          PYTHON_VERSION: '3.7'
+        Win-Python38-32bit-full:
+          PYTHON_VERSION: '3.8'
           PYTHON_ARCH: 'x86'
           BUILD_TYPE: 'normal'
-          imageName: 'windows-2019'
-        Win-Python37-64bit-full-wheel:
-          PYTHON_VERSION: '3.7'
-          PYTHON_ARCH: 'x64'
-          BUILD_TYPE: 'wheel'
-          NUMPY_MIN: '1.18.0'
           imageName: 'windows-2019'
         Win-Python38-64bit-full:
           PYTHON_VERSION: '3.8'
@@ -52,7 +46,7 @@ jobs:
           PYTHON_VERSION: '3.8'
           PYTHON_ARCH: 'x64'
           BUILD_TYPE: 'wheel'
-          NUMPY_MIN: '1.18.0'
+          NUMPY_MIN: '1.19.0'
           imageName: 'windows-2019'
         Linux-Python39-64bit-full-wheel:
           PYTHON_VERSION: '3.9'
@@ -60,8 +54,8 @@ jobs:
           BUILD_TYPE: 'wheel'
           NUMPY_MIN: '1.19.3'
           imageName: 'ubuntu-latest'
-        Linux-Python37-64bit-full-wheel:
-          PYTHON_VERSION: '3.7'
+        Linux-Python38-64bit-full-wheel:
+          PYTHON_VERSION: '3.8'
           PYTHON_ARCH: 'x64'
           BUILD_TYPE: 'wheel'
           NUMPY_MIN: '1.19.3'

--- a/maintainer/conda/environment.yml
+++ b/maintainer/conda/environment.yml
@@ -15,13 +15,13 @@ dependencies:
   - mmtf-python
   - mock
   - networkx
-  - numpy>=1.17.3
+  - numpy>=1.19
   - pytest
   - python==3.7
   - scikit-learn
   - scipy
   - pip
-  - sphinx==1.8.5
+  - sphinx
   - tidynamics>=1.0.0
   - tqdm>=4.43.0
   - sphinxcontrib-bibtex

--- a/maintainer/conda/environment.yml
+++ b/maintainer/conda/environment.yml
@@ -17,7 +17,7 @@ dependencies:
   - networkx
   - numpy>=1.19
   - pytest
-  - python==3.7
+  - python==3.8
   - scikit-learn
   - scipy
   - pip

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -53,6 +53,8 @@ Fixes
   * Fixed BAT method Cartesian modifies input data. (Issue #3501)
 
 Enhancements
+  * The minimm Python, NumPy, and SciPy versions are now 3.8, 1.19, and 1.5.0,
+    GSD now also have a minimum version of 1.9.3.
   * LinearDensity now works with updating AtomGroups (Issue #2508, PR #3617)
   * Link PMDA in documentation (PR #3652)
   * Added MSD example where multiple replicates are combined(Issue #3578

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -54,7 +54,7 @@ Fixes
 
 Enhancements
   * The minimm Python, NumPy, and SciPy versions are now 3.8, 1.19, and 1.5.0,
-    GSD now also have a minimum version of 1.9.3.
+    GSD now also have a minimum version of 1.9.3 (Issue #3665)
   * LinearDensity now works with updating AtomGroups (Issue #2508, PR #3617)
   * Link PMDA in documentation (PR #3652)
   * Added MSD example where multiple replicates are combined(Issue #3578

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -53,8 +53,6 @@ Fixes
   * Fixed BAT method Cartesian modifies input data. (Issue #3501)
 
 Enhancements
-  * The minimm Python, NumPy, and SciPy versions are now 3.8, 1.19, and 1.5.0,
-    GSD now also have a minimum version of 1.9.3 (Issue #3665)
   * LinearDensity now works with updating AtomGroups (Issue #2508, PR #3617)
   * Link PMDA in documentation (PR #3652)
   * Added MSD example where multiple replicates are combined(Issue #3578
@@ -73,6 +71,9 @@ Enhancements
     keyword (Issue #3605)
 
 Changes
+  * The minimm Python, NumPy, and SciPy versions (following NEP29) are now 3.8, 
+    1.19, and 1.5.0; GSD now also has a minimum version of 1.9.3 and networkx
+    has minimum version 2.0 (Issue #3665)
   * LinearDensity now saves the histogram bin edges for easier plotting as 
     "hist_bin_edges" for each dimension xyz in the results dictionary.
     (Issue #2508, PR #3617)

--- a/package/pyproject.toml
+++ b/package/pyproject.toml
@@ -5,8 +5,7 @@ requires = [
     "packaging",
     # lowest NumPy we can use for a given Python,
     # except for more exotic platforms (linux/Mac ARM flavors)
-    "numpy==1.18; python_version=='3.7' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='aarch64'",
-    "numpy==1.18; python_version=='3.8' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='aarch64'",
+    "numpy==1.19; python_version=='3.8' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='aarch64'",
     "numpy==1.19.3; python_version=='3.9' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='aarch64'",
     "numpy==1.21.4; python_version=='3.10' and platform_python_implementation != 'PyPy'",
     "setuptools",

--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -10,7 +10,7 @@ mmtf-python
 msmb_theme==1.2.0
 netcdf4
 networkx
-numpy>=1.16.0
+numpy>=1.19.0
 packaging
 parmed
 pytest

--- a/package/setup.py
+++ b/package/setup.py
@@ -57,8 +57,8 @@ import warnings
 import platform
 
 # Make sure I have the right Python version.
-if sys.version_info[:2] < (3, 7):
-    print('MDAnalysis requires Python 3.7 or better. Python {0:d}.{1:d} detected'.format(*
+if sys.version_info[:2] < (3, 8):
+    print('MDAnalysis requires Python 3.8 or better. Python {0:d}.{1:d} detected'.format(*
           sys.version_info[:2]))
     print('Please upgrade your version of Python.')
     sys.exit(-1)
@@ -81,11 +81,12 @@ is_release = 'dev' not in RELEASE
 # Handle cython modules
 try:
     # cython has to be >=0.16 <0.28 to support cython.parallel
+    # minimum cython version now set to 0.28 to match pyproject.toml
     import Cython
     from Cython.Build import cythonize
     cython_found = True
 
-    required_version = "0.16"
+    required_version = "0.28"
     if not Version(Cython.__version__) >= Version(required_version):
         # We don't necessarily die here. Maybe we already have
         #  the cythonized '.c' files.
@@ -189,7 +190,7 @@ def get_numpy_include():
         import numpy as np
     except ImportError:
         print('*** package "numpy" not found ***')
-        print('MDAnalysis requires a version of NumPy (>=1.18.0), even for setup.')
+        print('MDAnalysis requires a version of NumPy (>=1.19.0), even for setup.')
         print('Please get it from http://numpy.scipy.org/ or install it through '
               'your package manager.')
         sys.exit(-1)
@@ -576,7 +577,6 @@ if __name__ == '__main__':
         'Operating System :: Microsoft :: Windows ',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
@@ -590,23 +590,19 @@ if __name__ == '__main__':
     exts, cythonfiles = extensions(config)
 
     install_requires = [
-          'numpy>=1.18.0',
+          'numpy>=1.19.0',
           'biopython>=1.71',
-          'networkx>=1.0',
+          'networkx>=2.0',
           'GridDataFormats>=0.4.0',
           'mmtf-python>=1.0.0',
           'joblib>=0.12',
-          'scipy>=1.0.0',
+          'scipy>=1.5.0',
           'matplotlib>=1.5.1',
           'tqdm>=4.43.0',
           'threadpoolctl',
           'packaging',
+          'gsd>=1.9.3',
     ]
-
-    if not os.name == 'nt':
-        install_requires.append('gsd>=1.4.0')
-    else:
-        install_requires.append('gsd>=1.9.3')
 
     setup(name='MDAnalysis',
           version=RELEASE,
@@ -638,11 +634,11 @@ if __name__ == '__main__':
                         ],
           },
           ext_modules=exts,
-          python_requires='>=3.7',
+          python_requires='>=3.8',
           # all standard requirements are available through PyPi and
           # typically can be installed without difficulties through setuptools
           setup_requires=[
-              'numpy>=1.18.0',
+              'numpy>=1.19.0',
               'packaging',
           ],
           install_requires=install_requires,

--- a/testsuite/setup.py
+++ b/testsuite/setup.py
@@ -78,8 +78,8 @@ class MDA_SDist(sdist.sdist):
 
 
 # Make sure I have the right Python version.
-if sys.version_info[:2] < (3, 7):
-    print("MDAnalysis requires Python 3.7 or better. "
+if sys.version_info[:2] < (3, 8):
+    print("MDAnalysis requires Python 3.8 or better. "
           "Python {0:d}.{1:d} detected".format(*sys.version_info[:2]))
     print("Please upgrade your version of Python.")
     sys.exit(-1)
@@ -101,7 +101,6 @@ if __name__ == '__main__':
         'Operating System :: Microsoft :: Windows ',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
@@ -181,6 +180,7 @@ if __name__ == '__main__':
                          'data/*.sdf',
                         ],
           },
+          python_requires='>=3.8',
           install_requires=[
               'MDAnalysis=={0!s}'.format(RELEASE),  # same as this release!
               'pytest>=3.3.0', # Raised to 3.3.0 due to Issue 2329


### PR DESCRIPTION
Changes made in this Pull Request:
- More closely follow NEP29, scipy bump is to match ~ release of numpy 1.9.0.
- GSD 1.9.3 is now rather old, we can make it the minimum version so as not to have a difference between *nix/macOS and windows
- As requested by @RMeli networkx 1.0 is very old and so is 2.0. We should at the very least set the minimum version at 2.0.
- Various maintenance changes to track the new dependency versions we use

PR Checklist
------------
 - Tests?
 - Docs?
 - [x] CHANGELOG updated?
 - Issue raised/referenced?
