### PR TITLE
Fix deprecation warnings from Issue #3535

### DIFF
--- a/testsuite/MDAnalysisTests/core/test_topologyattrs.py
+++ b/testsuite/MDAnalysisTests/core/test_topologyattrs.py
@@ -185,12 +185,17 @@ class TestAtomnames(TestAtomAttr):
         return mda.Universe(PSF, DCD)
 
     def test_prev_emptyresidue(self, u):
-        assert_equal(u.residues[[]]._get_prev_residues_by_resid(),
-                     u.residues[[]])
+        # Checking group size rather than doing
+        # array comparison on zero-sized arrays (Issue #3535)
+        groupsize = len(u.residues[[]]._get_prev_residues_by_resid().atoms)
+        assert groupsize == 0
+        assert groupsize == len(u.residues[[]].atoms)
 
     def test_next_emptyresidue(self, u):
-        assert_equal(u.residues[[]]._get_next_residues_by_resid(),
-                     u.residues[[]])
+        # See above re: checking size for zero-sized arrays
+        groupsize = len(u.residues[[]]._get_next_residues_by_resid().atoms)
+        assert groupsize == 0
+        assert groupsize == len(u.residues[[]].atoms)
 
 
 class AggregationMixin(TestAtomAttr):

--- a/testsuite/MDAnalysisTests/utils/test_pickleio.py
+++ b/testsuite/MDAnalysisTests/utils/test_pickleio.py
@@ -164,8 +164,8 @@ def test_pickle_with_write_mode(unpicklable_f, tmpdir):
 def test_GSD_pickle():
     gsd_io = gsd_pickle_open(GSD, mode='rb')
     gsd_io_pickled = pickle.loads(pickle.dumps(gsd_io))
-    assert_equal(gsd_io.read_frame(0).particles.position,
-                 gsd_io_pickled.read_frame(0).particles.position)
+    assert_equal(gsd_io[0].particles.position,
+                 gsd_io_pickled[0].particles.position)
 
 
 def test_GSD_with_write_mode(tmpdir):


### PR DESCRIPTION
Fixes #3535 #3534

Changes made in this Pull Request:
 - fix GSD read_frames being deprecated (just index)
 - assert on size rather than comparing arrays for empty residuegroups in test_topologyattr
   - Note: we can probably just do an assert on the residuegroups themselves (which uses np.array_equal), but doing this probably avoids us kicking the bucket down the road.


PR Checklist
------------
 - [x] Tests?
 - Docs?
 - CHANGELOG updated?
 - [x] Issue raised/referenced?
