### PR TITLE
Addd center_of_charge attribute

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -57,6 +57,9 @@ Fixes
   * Fixed BAT method Cartesian modifies input data. (Issue #3501)
 
 Enhancements
+  * Added equations for `center_of_mass` and `center_of_geometry`to
+    documentation (PR #3671)
+  * Added `center_of_charge` attribute (PR #3671)
   * LinearDensity now works with updating AtomGroups (Issue #2508, PR #3617)
   * Link PMDA in documentation (PR #3652)
   * Added MSD example where multiple replicates are combined(Issue #3578

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -1106,12 +1106,14 @@ class GroupBase(_MutableBase):
     @_pbc_to_wrap
     @check_wrap_and_unwrap
     def center_of_geometry(self, wrap=False, unwrap=False, compound='group'):
-        """Center of geometry of (compounds of) the group.
+        r"""Computes the center of geometry (a.k.a. centroid)
 
-        Computes the center of geometry (a.k.a. centroid) of
-        :class:`Atoms<Atom>` in the group. Centers of geometry per
-        :class:`Residue`, :class:`Segment`, molecule, or fragment can be
-        obtained by setting the `compound` parameter accordingly.
+        .. math::
+            \boldsymbol R = \frac{\sum_i \boldsymbol r_i}{\sum i} 
+
+        where :math:`\boldsymbol r_i` of :class:`Atoms<Atom>` :math:`i`.
+        Centers of geometry per :class:`Residue` or per :class:`Segment` can
+        be obtained by setting the `compound` parameter accordingly.
 
         Parameters
         ----------

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -1106,10 +1106,10 @@ class GroupBase(_MutableBase):
     @_pbc_to_wrap
     @check_wrap_and_unwrap
     def center_of_geometry(self, wrap=False, unwrap=False, compound='group'):
-        r"""Computes the center of geometry (a.k.a. centroid)
+        r"""Center of geometry of (compounds of) the group
 
         .. math::
-            \boldsymbol R = \frac{\sum_i \boldsymbol r_i}{\sum i} 
+            \boldsymbol R = \frac{\sum_i \boldsymbol r_i}{\sum i}
 
         where :math:`\boldsymbol r_i` of :class:`Atoms<Atom>` :math:`i`.
         Centers of geometry per :class:`Residue` or per :class:`Segment` can

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -1109,7 +1109,7 @@ class GroupBase(_MutableBase):
         r"""Center of geometry of (compounds of) the group
 
         .. math::
-            \boldsymbol R = \frac{\sum_i \boldsymbol r_i}{\sum i}
+            \boldsymbol R = \frac{\sum_i \boldsymbol r_i}{\sum_i 1}
 
         where :math:`\boldsymbol r_i` of :class:`Atoms<Atom>` :math:`i`.
         Centers of geometry per :class:`Residue` or per :class:`Segment` can

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -1454,9 +1454,17 @@ class Masses(AtomAttr):
     @_pbc_to_wrap
     @check_wrap_and_unwrap
     def center_of_mass(group, wrap=False, unwrap=False, compound='group'):
-        """Center of mass of (compounds of) the group.
+        r"""Center of mass of (compounds of) the group.
 
-        Computes the center of mass of :class:`Atoms<Atom>` in the group.
+        Computes the center of mass
+
+        .. math::
+            \boldsymbol R = \frac{\sum_i \vert m_i \vert \boldsymbol r_i}
+                                 {\sum \vert m_i \vert}
+
+        where :math:`m_i` is the mass and :math:`\boldsymbol r_i` the
+        position of atom :math:`i` in the given
+        :class:`MDAnalysis.core.groups.AtomGroup`.
         Centers of mass per :class:`Residue`, :class:`Segment`, molecule, or
         fragment can be obtained by setting the `compound` parameter
         accordingly. If the masses of a compound sum up to zero, the
@@ -1921,6 +1929,75 @@ class Charges(AtomAttr):
             charges = np.array([self.values[row].sum() for row in segatoms])
 
         return charges
+
+    @warn_if_not_unique
+    @_pbc_to_wrap
+    @check_wrap_and_unwrap
+    def center_of_charge(group, wrap=False, unwrap=False, compound='group'):
+        r"""Center of (absolute) charge of (compounds of) the group.
+
+        Computes the center of charge
+
+        .. math::
+            \boldsymbol R = \frac{\sum_i \vert q_i \vert \boldsymbol r_i}
+                                 {\sum_i \vert q_i \vert}
+
+        where :math:`q_i` is the charge and :math:`\boldsymbol r_i` the
+        position of atom :math:`i` in the given
+        :class:`MDAnalysis.core.groups.AtomGroup`.
+        Centers of charge per :class:`Residue`, :class:`Segment`, molecule, or
+        fragment can be obtained by setting the `compound` parameter
+        accordingly. If the charges of a compound sum up to zero, the
+        center of mass coordinates of that compound will be ``nan`` (not a
+        number).
+
+        Parameters
+        ----------
+        wrap : bool, optional
+            If ``True`` and `compound` is ``'group'``, move all atoms to the
+            primary unit cell before calculation.
+            If ``True`` and `compound` is not ``group``, the
+            centers of mass of each compound will be calculated without moving
+            any atoms to keep the compounds intact. Instead, the resulting
+            center-of-mass position vectors will be moved to the primary unit
+            cell after calculation.
+        unwrap : bool, optional
+            If ``True``, compounds will be unwrapped before computing their
+            centers.
+        compound : {'group', 'segments', 'residues', 'molecules', \
+                    'fragments'}, optional
+            If ``'group'``, the center of mass of all atoms in the group will
+            be returned as a single position vector. Otherwise, the centers of
+            mass of each :class:`Segment`, :class:`Residue`, molecule, or
+            fragment will be returned as an array of position vectors, i.e. 
+            a 2d array.
+            Note that, in any case, *only* the positions of
+            :class:`Atoms<Atom>` *belonging to the group* will be taken into
+            account.
+
+        Returns
+        -------
+        center : numpy.ndarray
+            Position vector(s) of the center(s) of charge of the group.
+            If `compound` was set to ``'group'``, the output will be a single
+            position vector.
+            If `compound` was set to ``'segments'`` or ``'residues'``, the
+            output will be a 2d coordinate array of shape ``(n, 3)`` where ``n``
+            is the number of compounds.
+
+        Note
+        ----
+        This method can only be accessed if the underlying topology has
+        information about atomic charges.
+        """
+        atoms = group.atoms
+        return atoms.center(weights=atoms.charges.__abs__(),
+                            wrap=wrap,
+                            compound=compound,
+                            unwrap=unwrap)
+
+    transplants[GroupBase].append(
+        ('center_of_charge', center_of_charge))
 
     @warn_if_not_unique
     def total_charge(group, compound='group'):

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -1984,6 +1984,8 @@ class Charges(AtomAttr):
         ----
         This method can only be accessed if the underlying topology has
         information about atomic charges.
+
+        .. versionadded:: 2.2.0
         """
         atoms = group.atoms
         return atoms.center(weights=atoms.charges.__abs__(),

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -1454,13 +1454,10 @@ class Masses(AtomAttr):
     @_pbc_to_wrap
     @check_wrap_and_unwrap
     def center_of_mass(group, wrap=False, unwrap=False, compound='group'):
-        r"""Center of mass of (compounds of) the group.
-
-        Computes the center of mass
+        r"""Center of mass of (compounds of) the group
 
         .. math::
-            \boldsymbol R = \frac{\sum_i \vert m_i \vert \boldsymbol r_i}
-                                 {\sum \vert m_i \vert}
+            \boldsymbol R = \frac{\sum_i m_i \boldsymbol r_i}{\sum m_i}
 
         where :math:`m_i` is the mass and :math:`\boldsymbol r_i` the
         position of atom :math:`i` in the given
@@ -1934,9 +1931,7 @@ class Charges(AtomAttr):
     @_pbc_to_wrap
     @check_wrap_and_unwrap
     def center_of_charge(group, wrap=False, unwrap=False, compound='group'):
-        r"""Center of (absolute) charge of (compounds of) the group.
-
-        Computes the center of charge
+        r"""Center of (absolute) charge of (compounds of) the group
 
         .. math::
             \boldsymbol R = \frac{\sum_i \vert q_i \vert \boldsymbol r_i}
@@ -1969,7 +1964,7 @@ class Charges(AtomAttr):
             If ``'group'``, the center of mass of all atoms in the group will
             be returned as a single position vector. Otherwise, the centers of
             mass of each :class:`Segment`, :class:`Residue`, molecule, or
-            fragment will be returned as an array of position vectors, i.e. 
+            fragment will be returned as an array of position vectors, i.e.
             a 2d array.
             Note that, in any case, *only* the positions of
             :class:`Atoms<Atom>` *belonging to the group* will be taken into
@@ -1982,8 +1977,8 @@ class Charges(AtomAttr):
             If `compound` was set to ``'group'``, the output will be a single
             position vector.
             If `compound` was set to ``'segments'`` or ``'residues'``, the
-            output will be a 2d coordinate array of shape ``(n, 3)`` where ``n``
-            is the number of compounds.
+            output will be a 2d coordinate array of shape ``(n, 3)`` where
+            ``n`` is the number of compounds.
 
         Note
         ----

--- a/testsuite/MDAnalysisTests/core/test_topologyattrs.py
+++ b/testsuite/MDAnalysisTests/core/test_topologyattrs.py
@@ -31,14 +31,13 @@ from numpy.testing import (
 )
 import pytest
 from MDAnalysisTests.datafiles import PSF, DCD, PDB_CHECK_RIGHTHAND_PA, MMTF
-from MDAnalysisTests import make_Universe, no_deprecated_call
+from MDAnalysisTests import make_Universe
 
 import MDAnalysis as mda
 import MDAnalysis.core.topologyattrs as tpattrs
 from MDAnalysis.core._get_readers import get_reader_for
 from MDAnalysis.core.topology import Topology
 from MDAnalysis.exceptions import NoDataError
-from soupsieve import escape
 
 
 class DummyGroup(object):


### PR DESCRIPTION
Added a `center_of_charge` attribute to groups. Also added the equations for `center_of_mass` and `center_of_geometry` to the documentation.

Is there an additional spot in the docs to mention that a `center_of_charge` exists?

PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
