### PR TITLE
Enable automated wheel and dist uploads on releases

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -129,13 +129,13 @@ jobs:
           mv dist/MDAnalysisTests-* dist-test/dist
 
       - name: upload_source
-        uses: pypa/gh-action-pypi-publish@release/v1.5.0
+        uses: pypa/gh-action-pypi-publish@v1.5.0
         with:
           user: __token__
           password: ${{ secrets.TESTPYPI_API_TOKEN_SRC }}
 
       - name: upload_tests
-        uses: pypa/gh-action-pypi-publish@release/v1.5.0
+        uses: pypa/gh-action-pypi-publish@v1.5.0
         with:
           user: __token__
           password: ${{ secrets.TESTPYPI_API_TOKEN_TEST }}
@@ -161,13 +161,13 @@ jobs:
           mv dist/MDAnalysisTests-* dist-test/dist
 
       - name: upload_source
-        uses: pypa/gh-action-pypi-publish@release/v1.5.0
+        uses: pypa/gh-action-pypi-publish@v1.5.0
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN_SRC }}
 
       - name: upload_tests
-        uses: pypa/gh-action-pypi-publish@release/v1.5.0
+        uses: pypa/gh-action-pypi-publish@v1.5.0
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN_TEST }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -161,7 +161,13 @@ jobs:
         exclude:
           # Multiple deps don't like windows
           - os: windows-latest
-            python-version: ['3.8', '3.9', '3.10']
+            python-version: "3.8"
+            type: "FULL"
+          - os: windows-latest
+            python-version: "3.9"
+            type: "FULL"
+          - os: windows-latest
+            python-version: "3.10"
             type: "FULL"
           # OpenMM isn't available for this yet
           - os: macos-latest

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -73,7 +73,7 @@ jobs:
   upload_testpypi:
     if: |
       github.repository == 'MDAnalysis/mdanalysis' &&
-      github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
     name: testpypi upload
     environment: deploy
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -125,8 +125,8 @@ jobs:
 
       - name: move_test_dist
         run: |
-          mkdir -p dist-test/dist
-          mv dist/MDAnalysisTests-* dist-test/dist
+          mkdir -p testsuite/dist
+          mv dist/MDAnalysisTests-* testsuite/dist
 
       - name: upload_source
         uses: pypa/gh-action-pypi-publish@v1.5.0
@@ -141,7 +141,7 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.TESTPYPI_API_TOKEN_TEST }}
-          packages_dir: dist-test/
+          packages_dir: testsuite/
           skip_existing: true
           repository_url: https://test.pypi.org/legacy/
  

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -120,11 +120,23 @@ jobs:
           name: artifact
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@v1.5
+      - name: move_test_dist
+        run: |
+          mkdir -p dist-test/dist
+          mv dist/MDAnalysisTests-* dist-test/dist
+
+      - name: upload_source
+        uses: pypa/gh-action-pypi-publish@v1.5
         with:
           user: __token__
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
+          password: ${{ secrets.TESTPYPI_API_TOKEN_SRC }}
+
+      - name: upload_tests
+        uses: pypa/gh-action-pypi-publish@v1.5
+        with:
+          user: __token__
+          password: ${{ secrets.TESTPYPI_API_TOKEN_TEST }}
+          packages_dir: dist-test/
  
   upload_pypi:
     if: |
@@ -140,10 +152,23 @@ jobs:
           name: artifact
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@v1.5
+      - name: move_test_dist
+        run: |
+          mkdir -p dist-test/dist
+          mv dist/MDAnalysisTests-* dist-test/dist
+
+      - name: upload_source
+        uses: pypa/gh-action-pypi-publish@v1.5
         with:
           user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
+          password: ${{ secrets.PYPI_API_TOKEN_SRC }}
+
+      - name: upload_tests
+        uses: pypa/gh-action-pypi-publish@v1.5
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN_TEST }}
+          packages_dir: dist-test/
 
   check_testpypi:
     # if: |
@@ -204,8 +229,9 @@ jobs:
 
       - name: pip_install_mda
         run: |
-          pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple MDAnalysis
-          pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple MDAnalysisTests
+          ver=$(grep "__version__ =" package/MDAnalysis/version.py | awk '{print $3}')
+          pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple MDAnalysis==$ver
+          pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple MDAnalysisTests==$ver
 
       - name: run_tests
         run: |

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -133,6 +133,8 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.TESTPYPI_API_TOKEN_SRC }}
+          skip_existing: true
+          repository_url: https://test.pypi.org/legacy/
 
       - name: upload_tests
         uses: pypa/gh-action-pypi-publish@v1.5.0
@@ -140,6 +142,8 @@ jobs:
           user: __token__
           password: ${{ secrets.TESTPYPI_API_TOKEN_TEST }}
           packages_dir: dist-test/
+          skip_existing: true
+          repository_url: https://test.pypi.org/legacy/
  
   upload_pypi:
     if: |

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -44,6 +44,8 @@ jobs:
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.6.0
+        with:
+          package-dir: package
 
       - name: upload artifacts
         if: |
@@ -51,7 +53,7 @@ jobs:
           (github.event_name == 'release' && github.event.action == 'published')
         uses: actions/upload-artifact@v2
         with:
-          path: ./wheelhouse/*.whl
+          path: ./package/wheelhouse/*.whl
 
   build_sdist:
     if: "github.repository == 'MDAnalysis/mdanalysis'"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -62,7 +62,7 @@ jobs:
 
   build_sdist:
     if: "github.repository == 'MDAnalysis/mdanalysis'"
-    name: build source distribution
+    name: build package source distribution
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -85,7 +85,7 @@ jobs:
 
   build_sdist_tests:
     if: "github.repository == 'MDAnalysis/mdanalysis'"
-    name: build source distribution
+    name: build test source distribution
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -162,6 +162,8 @@ jobs:
       MPLBACKEND: agg
 
     steps:
+      - uses: actions/checkout@v3
+
       - name: setup_miniconda
         uses: conda-incubator/setup-miniconda@v2
         with:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -6,9 +6,9 @@ on:
       - develop
   push:
     branches:
-      - develop
+      - "package-*"
     tags:
-      - "*"
+      - "package-*"
   release:
     types:
       - published
@@ -33,15 +33,13 @@ jobs:
       fail-fast: false
       matrix:
         buildplat:
-          - [ubuntu-latest, manylinux_x86_64]
+          - [ubuntu-18.04, manylinux_x86_64]
           - [macos-10.15, macosx_*]
           - [windows-2019, win_amd64]
-          - [windows-2019, win32]
         python: ["cp38", "cp39", "cp310"]
     defaults:
       run:
         working-directory: ./package
-
     steps:
       - uses: actions/checkout@v3
         with:
@@ -69,7 +67,6 @@ jobs:
     defaults:
       run:
         working-directory: ./package
-
     steps:
       - uses: actions/checkout@v3
         with:
@@ -84,7 +81,7 @@ jobs:
           (github.event_name == 'release' && github.event.action == 'published')
         uses: actions/upload-artifact@v2
         with:
-          path: dist/*.tar.gz
+          path: package/dist/*.tar.gz
 
   build_sdist_tests:
     if: "github.repository == 'MDAnalysis/mdanalysis'"
@@ -93,7 +90,6 @@ jobs:
     defaults:
       run:
         working-directory: ./testsuite
-
     steps:
       - uses: actions/checkout@v3
         with:
@@ -108,7 +104,7 @@ jobs:
           (github.event_name == 'release' && github.event.action == 'published')
         uses: actions/upload-artifact@v2
         with:
-          path: dist/*.tar.gz
+          path: testsuite/dist/*.tar.gz
 
   upload_testpypi:
     if: |
@@ -148,3 +144,52 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
+
+  check_testpypi:
+    # if: |
+    #  github.repository == 'MDAnalysis/mdanalysis' &&
+    #  (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
+    name: testpypi check
+    runs-on: ${{ matrix.os }}
+    # needs: upload_testpypi
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.8", "3.9", "3.10"]
+        type: ["FULL", "MIN"]
+    env:
+      MPLBACKEND: agg
+
+    steps:
+      - name: setup_miniconda
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+          auto-update-conda: true
+          channel-priority: flexible
+          channels: conda-forge, bioconda
+          add-pip-as-python-dependency: true
+          mamba-version: "*"
+          architecture: x64
+
+      - name: install_full_deps
+        uses: ./.github/actions/setup-deps
+        if: "matrix.type == 'FULL'"
+        with:
+          mamba: true
+          full-deps: true
+
+      - name: install_min_deps
+        if: "matrix.type == 'MIN'"
+        run: |
+          pip install pytest pytest-xdist
+
+      - name: pip_install_mda
+        run: |
+          pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple MDAnalysis
+          pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple MDAnalysisTests
+
+      - name: run_tests
+        run: |
+          pytest -n2 --pyargs MDAnalysisTests

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -129,13 +129,13 @@ jobs:
           mv dist/MDAnalysisTests-* dist-test/dist
 
       - name: upload_source
-        uses: pypa/gh-action-pypi-publish@v1.5
+        uses: pypa/gh-action-pypi-publish@release/v1.5.0
         with:
           user: __token__
           password: ${{ secrets.TESTPYPI_API_TOKEN_SRC }}
 
       - name: upload_tests
-        uses: pypa/gh-action-pypi-publish@v1.5
+        uses: pypa/gh-action-pypi-publish@release/v1.5.0
         with:
           user: __token__
           password: ${{ secrets.TESTPYPI_API_TOKEN_TEST }}
@@ -161,13 +161,13 @@ jobs:
           mv dist/MDAnalysisTests-* dist-test/dist
 
       - name: upload_source
-        uses: pypa/gh-action-pypi-publish@v1.5
+        uses: pypa/gh-action-pypi-publish@release/v1.5.0
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN_SRC }}
 
       - name: upload_tests
-        uses: pypa/gh-action-pypi-publish@v1.5
+        uses: pypa/gh-action-pypi-publish@release/v1.5.0
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN_TEST }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -236,7 +236,9 @@ jobs:
 
       - name: pip_install_mda
         run: |
-          ver=$(grep "__version__ =" package/MDAnalysis/version.py | awk '{print $3}')
+          grep "__version__ =" package/MDAnalysis/version.py | awk '{print $3}' > version.dat
+          sed -i "s/-dev0/.dev0/g" version.dat
+          ver=$(cat version.dat)
           pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple MDAnalysis==$ver
           pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple MDAnalysisTests==$ver
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -28,10 +28,14 @@ jobs:
   build_wheels:
     if: "github.repository == 'MDAnalysis/mdanalysis'"
     name: Build wheels
+    fail-fast: false
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+    defaults:
+      run:
+        working-directory: ./package
 
     steps:
       - uses: actions/checkout@v3
@@ -53,6 +57,9 @@ jobs:
     if: "github.repository == 'MDAnalysis/mdanalysis'"
     name: build source distribution
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./package
 
     steps:
       - uses: actions/checkout@v3
@@ -82,7 +89,7 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: artifact
-          path: dist
+          path: package/dist
 
       - uses: pypa/gh-action-pypi-publish@v1.5
         with:
@@ -102,7 +109,7 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: artifact
-          path: dist
+          path: package/dist
 
       - uses: pypa/gh-action-pypi-publish@v1.5
         with:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -141,7 +141,7 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.TESTPYPI_API_TOKEN_TEST }}
-          packages_dir: testsuite/
+          packages_dir: testsuite/dist
           skip_existing: true
           repository_url: https://test.pypi.org/legacy/
  
@@ -161,8 +161,8 @@ jobs:
 
       - name: move_test_dist
         run: |
-          mkdir -p dist-test/dist
-          mv dist/MDAnalysisTests-* dist-test/dist
+          mkdir -p testsuite/dist
+          mv dist/MDAnalysisTests-* testsuite/dist
 
       - name: upload_source
         uses: pypa/gh-action-pypi-publish@v1.5.0
@@ -175,7 +175,7 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN_TEST }}
-          packages_dir: dist-test/
+          packages_dir: testsuite/dist
 
   check_testpypi:
     #if: |

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,110 @@
+name: Build and upload to PyPI
+
+on:
+  pull_request:
+    branches:
+      - develop
+  push:
+    branches:
+      - develop
+    tags:
+      - "*"
+  release:
+    types:
+      - published
+
+
+concurrency:
+  group: "${{ github.ref }}-${{ github.head_ref }}-${{ github.workflow }}"
+  cancel-in-progress: true
+
+
+defaults:
+  run:
+    shell: bash -l {0}
+
+
+jobs:
+  build_wheels:
+    if: "github.repository == 'MDAnalysis/mdanalysis'"
+    name: Build wheels
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.6.0
+
+      - name: upload artifacts
+        if: |
+          (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
+          (github.event_name == 'release' && github.event.action == 'published')
+        uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl
+
+  build_sdist:
+    if: "github.repository == 'MDAnalysis/mdanalysis'"
+    name: build source distribution
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Build sdist
+        run: pipx run build --sdist
+
+      - name: upload artifacts
+        if: |
+          (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
+          (github.event_name == 'release' && github.event.action == 'published')
+        uses: actions/upload-artifact@v2
+        with:
+          path: dist/*.tar.gz
+
+  upload_testpypi:
+    if: |
+      github.repository == 'MDAnalysis/mdanalysis' &&
+      github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'
+    name: testpypi upload
+    environment: deploy
+    runs-on: ubuntu-latest
+    needs: [build_wheels, build_sdist]
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: artifact
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@v1.5
+        with:
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+ 
+  upload_pypi:
+    if: |
+      github.repository == 'MDAnalysis/mdanalysis' &&
+      github.event_name == 'release' && github.event.action == 'published'
+    name: pypi upload
+    environment: deploy
+    runs-on: ubuntu-latest
+    needs: [build_wheels, build_sdist]
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: artifact
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@v1.5
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -28,11 +28,17 @@ jobs:
   build_wheels:
     if: "github.repository == 'MDAnalysis/mdanalysis'"
     name: Build wheels
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.buildplat[0] }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+        buildplat:
+          - [ubuntu-latest, manylinux_x86_64]
+          - [macos-10.15, macosx_*]
+          - [windows-2019, win_amd64]
+          - [windows-2019, win32]
+        python: ["cp38", "cp39", "cp310"]
     defaults:
       run:
         working-directory: ./package
@@ -46,6 +52,8 @@ jobs:
         uses: pypa/cibuildwheel@v2.6.0
         with:
           package-dir: package
+        env:
+          CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
 
       - name: upload artifacts
         if: |

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -58,7 +58,8 @@ jobs:
         #  (github.event_name == 'release' && github.event.action == 'published')
         uses: actions/upload-artifact@v2
         with:
-          path: ./package/wheelhouse/*.whl
+          path: wheelhouse/*.whl
+          retention-days: 7
 
   build_sdist:
     if: "github.repository == 'MDAnalysis/mdanalysis'"
@@ -82,6 +83,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           path: package/dist/*.tar.gz
+          retention-days: 7
 
   build_sdist_tests:
     if: "github.repository == 'MDAnalysis/mdanalysis'"
@@ -105,6 +107,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           path: testsuite/dist/*.tar.gz
+          retention-days: 7
 
   upload_testpypi:
     if: |
@@ -113,7 +116,7 @@ jobs:
     name: testpypi upload
     environment: deploy
     runs-on: ubuntu-latest
-    needs: [build_wheels, build_sdist]
+    needs: [build_wheels, build_sdist, build_sdist_tests]
     steps:
       - uses: actions/download-artifact@v2
         with:
@@ -145,7 +148,7 @@ jobs:
     name: pypi upload
     environment: deploy
     runs-on: ubuntu-latest
-    needs: [build_wheels, build_sdist]
+    needs: [build_wheels, build_sdist, build_sdist_tests]
     steps:
       - uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,7 +3,7 @@ name: Build and upload to PyPI
 on:
   pull_request:
     branches:
-      - develop
+      - "package-*"
   push:
     branches:
       - "package-*"
@@ -53,9 +53,9 @@ jobs:
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
 
       - name: upload artifacts
-        #if: |
-        #  (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
-        #  (github.event_name == 'release' && github.event.action == 'published')
+        if: |
+          (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/package')) ||
+          (github.event_name == 'release' && github.event.action == 'published')
         uses: actions/upload-artifact@v2
         with:
           path: wheelhouse/*.whl
@@ -77,9 +77,9 @@ jobs:
         run: pipx run build --sdist
 
       - name: upload artifacts
-        #if: |
-        #  (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
-        #  (github.event_name == 'release' && github.event.action == 'published')
+        if: |
+          (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/package')) ||
+          (github.event_name == 'release' && github.event.action == 'published')
         uses: actions/upload-artifact@v2
         with:
           path: package/dist/*.tar.gz
@@ -101,18 +101,18 @@ jobs:
         run: pipx run build --sdist
 
       - name: upload artifacts
-        #if: |
-        #  (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
-        #  (github.event_name == 'release' && github.event.action == 'published')
+        if: |
+          (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/package')) ||
+          (github.event_name == 'release' && github.event.action == 'published')
         uses: actions/upload-artifact@v2
         with:
           path: testsuite/dist/*.tar.gz
           retention-days: 7
 
   upload_testpypi:
-    #if: |
-    #  github.repository == 'MDAnalysis/mdanalysis' &&
-    #  (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
+    if: |
+      github.repository == 'MDAnalysis/mdanalysis' &&
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/package'))
     name: testpypi upload
     environment: deploy
     runs-on: ubuntu-latest
@@ -178,9 +178,9 @@ jobs:
           packages_dir: testsuite/dist
 
   check_testpypi:
-    #if: |
-    #  github.repository == 'MDAnalysis/mdanalysis' &&
-    #  (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
+    if: |
+      github.repository == 'MDAnalysis/mdanalysis' &&
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/package'))
     name: testpypi check
     runs-on: ${{ matrix.os }}
     needs: upload_testpypi

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -110,9 +110,9 @@ jobs:
           retention-days: 7
 
   upload_testpypi:
-    if: |
-      github.repository == 'MDAnalysis/mdanalysis' &&
-      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
+    #if: |
+    #  github.repository == 'MDAnalysis/mdanalysis' &&
+    #  (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
     name: testpypi upload
     environment: deploy
     runs-on: ubuntu-latest
@@ -174,9 +174,9 @@ jobs:
           packages_dir: dist-test/
 
   check_testpypi:
-    if: |
-      github.repository == 'MDAnalysis/mdanalysis' &&
-      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
+    #if: |
+    #  github.repository == 'MDAnalysis/mdanalysis' &&
+    #  (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
     name: testpypi check
     runs-on: ${{ matrix.os }}
     needs: upload_testpypi

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -158,6 +158,15 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.8", "3.9", "3.10"]
         type: ["FULL", "MIN"]
+        exclude:
+          # Multiple deps don't like windows
+          - os: windows-latest
+            python-version: ['3.8', '3.9', '3.10']
+            type: "FULL"
+          # OpenMM isn't available for this yet
+          - os: macos-latest
+            python-version: "3.10"
+            type: "FULL"
     env:
       MPLBACKEND: agg
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -28,9 +28,9 @@ jobs:
   build_wheels:
     if: "github.repository == 'MDAnalysis/mdanalysis'"
     name: Build wheels
-    fail-fast: false
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     defaults:
@@ -77,6 +77,30 @@ jobs:
         with:
           path: dist/*.tar.gz
 
+  build_sdist_tests:
+    if: "github.repository == 'MDAnalysis/mdanalysis'"
+    name: build source distribution
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./testsuite
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Build sdist
+        run: pipx run build --sdist
+
+      - name: upload artifacts
+        if: |
+          (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
+          (github.event_name == 'release' && github.event.action == 'published')
+        uses: actions/upload-artifact@v2
+        with:
+          path: dist/*.tar.gz
+
   upload_testpypi:
     if: |
       github.repository == 'MDAnalysis/mdanalysis' &&
@@ -89,7 +113,7 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: artifact
-          path: package/dist
+          path: dist
 
       - uses: pypa/gh-action-pypi-publish@v1.5
         with:
@@ -109,7 +133,7 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: artifact
-          path: package/dist
+          path: dist
 
       - uses: pypa/gh-action-pypi-publish@v1.5
         with:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -236,7 +236,7 @@ jobs:
 
       - name: pip_install_mda
         run: |
-          grep "__version__ =" package/MDAnalysis/version.py | awk '{print $3}' | tr -d \" > version.dat
+          awk '/__version__ =/ {print $3; quit}' package/MDAnalysis/version.py | tr -d \" > version.dat
           ver=$(python maintainer/norm_version.py --file version.dat)
           pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple MDAnalysis==$ver
           pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple MDAnalysisTests==$ver

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,6 +3,7 @@ name: Build and upload to PyPI
 on:
   pull_request:
     branches:
+      - develop
       - "package-*"
   push:
     branches:
@@ -51,6 +52,7 @@ jobs:
           package-dir: package
         env:
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
+          CIBW_BUILD_VERBOSITY: 1
 
       - name: upload artifacts
         if: |

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -128,7 +128,7 @@ jobs:
           mkdir -p testsuite/dist
           mv dist/MDAnalysisTests-* testsuite/dist
 
-      - name: upload_source
+      - name: upload_source_and_wheels
         uses: pypa/gh-action-pypi-publish@v1.5.0
         with:
           user: __token__
@@ -164,7 +164,7 @@ jobs:
           mkdir -p testsuite/dist
           mv dist/MDAnalysisTests-* testsuite/dist
 
-      - name: upload_source
+      - name: upload_source_and_wheels
         uses: pypa/gh-action-pypi-publish@v1.5.0
         with:
           user: __token__

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -236,9 +236,8 @@ jobs:
 
       - name: pip_install_mda
         run: |
-          grep "__version__ =" package/MDAnalysis/version.py | awk '{print $3}' > version.dat
-          sed -i "s/-dev0/.dev0/g" version.dat
-          ver=$(cat version.dat)
+          grep "__version__ =" package/MDAnalysis/version.py | awk '{print $3}' | tr -d \" > version.dat
+          ver=$(python maintainer/norm_version.py --file version.dat)
           pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple MDAnalysis==$ver
           pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple MDAnalysisTests==$ver
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,7 +3,6 @@ name: Build and upload to PyPI
 on:
   pull_request:
     branches:
-      - develop
       - "package-*"
   push:
     branches:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -53,9 +53,9 @@ jobs:
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
 
       - name: upload artifacts
-        if: |
-          (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
-          (github.event_name == 'release' && github.event.action == 'published')
+        #if: |
+        #  (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
+        #  (github.event_name == 'release' && github.event.action == 'published')
         uses: actions/upload-artifact@v2
         with:
           path: ./package/wheelhouse/*.whl
@@ -76,9 +76,9 @@ jobs:
         run: pipx run build --sdist
 
       - name: upload artifacts
-        if: |
-          (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
-          (github.event_name == 'release' && github.event.action == 'published')
+        #if: |
+        #  (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
+        #  (github.event_name == 'release' && github.event.action == 'published')
         uses: actions/upload-artifact@v2
         with:
           path: package/dist/*.tar.gz
@@ -99,9 +99,9 @@ jobs:
         run: pipx run build --sdist
 
       - name: upload artifacts
-        if: |
-          (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
-          (github.event_name == 'release' && github.event.action == 'published')
+        #if: |
+        #  (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
+        #  (github.event_name == 'release' && github.event.action == 'published')
         uses: actions/upload-artifact@v2
         with:
           path: testsuite/dist/*.tar.gz
@@ -171,12 +171,12 @@ jobs:
           packages_dir: dist-test/
 
   check_testpypi:
-    # if: |
-    #  github.repository == 'MDAnalysis/mdanalysis' &&
-    #  (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
+    if: |
+      github.repository == 'MDAnalysis/mdanalysis' &&
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
     name: testpypi check
     runs-on: ${{ matrix.os }}
-    # needs: upload_testpypi
+    needs: upload_testpypi
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -32,7 +32,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
         buildplat:
           - [ubuntu-latest, manylinux_x86_64]
           - [macos-10.15, macosx_*]

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -28,7 +28,7 @@ jobs:
         fail-fast: false
         matrix:
           os: [ubuntu-latest, ]
-          python-version: [3.8, 3.9, 3.10]
+          python-version: [3.8, 3.9, "3.10"]
           full-deps: [true, ]
           install_hole: [true, ]
           codecov: [true, ]

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -28,17 +28,11 @@ jobs:
         fail-fast: false
         matrix:
           os: [ubuntu-latest, ]
-          python-version: [3.8, 3.9]
+          python-version: [3.8, 3.9, 3.10]
           full-deps: [true, ]
           install_hole: [true, ]
           codecov: [true, ]
           include:
-            - name: linux_mindeps_py3_10
-              os: ubuntu-latest
-              python-version: "3.10"
-              full-deps: false
-              install_hole: true
-              codecov: true
             - name: macOS_bigsur_py39
               os: macOS-11
               python-version: 3.9

--- a/maintainer/norm_version.py
+++ b/maintainer/norm_version.py
@@ -1,0 +1,32 @@
+from packaging.version import Version
+
+
+def norm_version(version_str: str):
+    """
+    Normalize an input version string in the same way that setuptools' dist
+    does.
+
+    Parameters
+    ----------
+    version_str : str
+      A version string to normalize.
+
+    Returns
+    -------
+    str
+      Normalised version string
+    """
+    return str(Version(version_str))
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--file', type=str, help="file with version to parse")
+    args = parser.parse_args()
+
+    with open(args.file) as filed:
+        ver = filed.readlines()[0].strip("\n")
+
+    print(norm_version(version_str=ver))

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -58,6 +58,8 @@ Fixes
   * Fixed BAT method Cartesian modifies input data. (Issue #3501)
 
 Enhancements
+  * Wheels and dist now get automatically built and deployed on release
+    triggers (Issue #1300, PR #3680)
   * Added `frames` argument to AnalysisBase.run to allow analysis to run on 
     arbitrary list of frames (Issue #1985)  
   * LinearDensity now works with updating AtomGroups (Issue #2508, PR #3617)


### PR DESCRIPTION
Fixes #1300

Changes made in this Pull Request:
 - Added a deploy action that should build wheels using cibuildwheel, and sdist and then upload them to testpypi / pypi on specific triggers
 - Action runs on every push (so we can notice if something goes wrong), but push to testpypi only happens when you create a tag, and push to pypi only happens when you create a release
 - Created a deploy environment with the necessary pypi / testpypi API token secrets
 - Added maintainer script to normalize release versions in the same way setuptools does (so we can pick it up from testpypi)
 - Standard CI has been expanded to do a full deps check of py3.10 (instead of the minimum deps check done previously)

TODO:
  - Docs

PR Checklist
------------
 - Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
