### PR TITLE
switch awk call, temporarily disable guards for tests

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -238,7 +238,7 @@ jobs:
 
       - name: pip_install_mda
         run: |
-          grep "__version__ =" package/MDAnalysis/version.py | awk '{print $3}' > version.dat
+          grep "__version__ =" package/MDAnalysis/version.py | awk '{print $3}' | tr -d \" > version.dat
           ver=$(python maintainer/norm_version.py --file version.dat)
           pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple MDAnalysis==$ver
           pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple MDAnalysisTests==$ver

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,6 +3,7 @@ name: Build and upload to PyPI
 on:
   pull_request:
     branches:
+      - develop
       - "package-*"
   push:
     branches:
@@ -179,12 +180,12 @@ jobs:
           packages_dir: testsuite/dist
 
   check_testpypi:
-    if: |
-      github.repository == 'MDAnalysis/mdanalysis' &&
-      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/package'))
+    #if: |
+    #  github.repository == 'MDAnalysis/mdanalysis' &&
+    #  (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/package'))
     name: testpypi check
     runs-on: ${{ matrix.os }}
-    needs: upload_testpypi
+    #needs: upload_testpypi
     strategy:
       fail-fast: false
       matrix:
@@ -237,7 +238,7 @@ jobs:
 
       - name: pip_install_mda
         run: |
-          awk '/__version__ =/ {print $3; quit}' package/MDAnalysis/version.py | tr -d \" > version.dat
+          grep "__version__ =" package/MDAnalysis/version.py | awk '{print $3}' > version.dat
           ver=$(python maintainer/norm_version.py --file version.dat)
           pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple MDAnalysis==$ver
           pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple MDAnalysisTests==$ver

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,7 +3,6 @@ name: Build and upload to PyPI
 on:
   pull_request:
     branches:
-      - develop
       - "package-*"
   push:
     branches:
@@ -180,12 +179,12 @@ jobs:
           packages_dir: testsuite/dist
 
   check_testpypi:
-    #if: |
-    #  github.repository == 'MDAnalysis/mdanalysis' &&
-    #  (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/package'))
+    if: |
+      github.repository == 'MDAnalysis/mdanalysis' &&
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/package'))
     name: testpypi check
     runs-on: ${{ matrix.os }}
-    #needs: upload_testpypi
+    needs: upload_testpypi
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -238,7 +238,7 @@ jobs:
 
       - name: pip_install_mda
         run: |
-          grep "__version__ =" package/MDAnalysis/version.py | awk '{print $3}' | tr -d \" > version.dat
+          awk '/__version__ =/ {print $3; exit}' package/MDAnalysis/version.py | tr -d \" > version.dat
           ver=$(python maintainer/norm_version.py --file version.dat)
           pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple MDAnalysis==$ver
           pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple MDAnalysisTests==$ver

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -75,7 +75,6 @@ Fixes
 Enhancements
   * Add smarts_kwargs to allow greater flexiblity with smarts atom selection
     (Issue #3469, PR #3470).
-  * Added `frames` argument to AnalysisBase.run to allow analysis to run on
   * Added DL_POLY Classic support. Now HISTORY files from DL_POLY Classic can be
   * used. (Issue #3678)
   * Wheels and dist now get automatically built and deployed on release

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -18,6 +18,7 @@ The rules for this file:
  * 2.3.0
 
 Fixes
+  * Fixes awk call in deploy.yaml tests for macos runners (Issue #3693)
 
 Enhancements
 


### PR DESCRIPTION
Fixes #3693 #3696 

Opening this now so that we can see the macos tests pass for testpypi's 2.2.0 build. Once we are 2.3.0 we can move towards merging this.

Changes made in this Pull Request:
 - switch out the awk call


PR Checklist
------------
 - Tests?
 - Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
