### PR TITLE
Fixed typos in Aux module docs

### DIFF
--- a/package/MDAnalysis/auxiliary/__init__.py
+++ b/package/MDAnalysis/auxiliary/__init__.py
@@ -63,9 +63,9 @@ Auxiliary readers inherit from the base
 :class:`~MDAnalysis.auxiliary.base.AuxReader`. In stand-alone use they 
 allow iteration over each step in a set of auxiliary data::
 
-    aux = MDAnalysis.auxiliary.xvg.XVGReader('auxdata.xvg')
+    aux = MDAnalysis.auxiliary.XVG.XVGReader('auxdata.xvg')
     for auxstep in aux:
-        print auxstep
+        print(auxstep)
 
 To iterate over only certain sections of the auxiliary::
 
@@ -89,9 +89,9 @@ return an appropriate :class:`~MDAnalysis.auxiliary.base.AuxReader` class for
 a supplied format or set of auxiliary data, guessing the format from the 
 datatype/file extension::
 
-  auxreader = MDAnalysis.auxiliary.code.get_auxreader_for('auxdata.xvg')
+  auxreader = MDAnalysis.auxiliary.core.get_auxreader_for('auxdata.xvg')
   # will return the default XVGReader class
-  auxreader = MDAnalysis.auxiliary.code.get_auxreader_for(format='XVG-F')
+  auxreader = MDAnalysis.auxiliary.core.get_auxreader_for(format='XVG-F')
   # will return the XVGFileReader class
 
 To directly load an instance of the guessed auxiliary reader class given the
@@ -148,7 +148,7 @@ avoid representative values set to ``np.nan``, particularly when auxiliary data
 is less frequent::
 
     u.trajectory.add_auxiliary('low_f', 'low_freq_aux_data.xvg')
-    for ts in u.iter_as_aux('low_f'):
+    for ts in u.trajectory.iter_as_aux('low_f'):
         do_something(ts.aux.low_f) # do something with 'low_f' auxiliary data without
                                    # worrying about having to deal with np.nan
 
@@ -156,20 +156,20 @@ If the auxiliary data are more frequent and the cutoff (if set) is
 sufficiently high, :meth:`~MDAnalysis.coordinates.base.ProtoReader.next_as_aux` 
 and :meth:`~MDAnalysis.coordinates.base.ProtoReader.iter_as_aux` behave the same 
 as the :class:`~MDAnalysis.coordinates.base.ProtoReader` 
-meth:`~MDAnalysis.coordinates.base.ProtoReader.next` and 
+:meth:`~MDAnalysis.coordinates.base.ProtoReader.next` and 
 :meth:`~MDAnalysis.coordinates.base.ProtoReader.__iter__`.
 
-In order to acess auxiliary values at every individual step, including those 
+In order to access auxiliary values at every individual step, including those 
 outside the time range of the trajectory, 
 :meth:`~MDAnalysis.coordinates.base.ProtoReader.iter_auxiliary` allows iteration
 over the auxiliary independent of the trajectory::
 
-    for auxstep in trajectory.iter_auxiliary('pullforce'):
+    for auxstep in u.trajectory.iter_auxiliary('pullforce'):
         do_something(auxstep)
 
 To iterate over only a certain section of the auxiliary::
 
-    for auxstep in trajectory.iter_auxiliary('pullforce', start=100, step=10):
+    for auxstep in u.trajectory.iter_auxiliary('pullforce', start=100, step=10):
         # every 10th step from 100
         do_something(auxstep)
 
@@ -181,17 +181,17 @@ Accessing auxiliary attributes
 To check the values of attributes of an added auxiliary, use 
 :meth:`~MDAnalysis.coordinates.base.ProtoReader.get_aux_attribute`, e.g.::
 
-    pullf_dt = trajectory.get_aux_attribute('pullforce', 'dt')
+    pullf_dt = u.trajectory.get_aux_attribute('pullforce', 'dt')
 
 If attributes are settable, they can be changed using
 :meth:`~MDAnalysis.coordinates.base.ProtoReader.set_aux_attribute`, e.g.::
 
-    trajectory.set_aux_attribute('pullforce', 'data_selector', [1])
+    u.trajectory.set_aux_attribute('pullforce', 'data_selector', [1])
 
 The auxiliary may be renamed using ``set_aux_attribute`` with 'auxname', or more
 directly by using :meth:`~MDAnalysis.coordinates.base.ProtoReader.rename_aux`::
 
-    trajectory.rename_aux('pullforce', 'pullf')
+    u.trajectory.rename_aux('pullforce', 'pullf')
 
 
 Recreating auxiliaries
@@ -204,21 +204,21 @@ original auxiliary reader::
 
     description = aux.get_description()
     del(aux)
-    reload_aux = auxiliary.auxreader(**description)
+    reload_aux = MDAnalysis.auxiliary.auxreader(**description)
 
 The 'description' of any or all the auxiliaries added to a trajectory can be
 obtained using :meth:`~MDAnalysis.coordinates.base.ProtoReader.get_aux_descriptions`::
 
-    descriptions = trajectory.get_aux_descriptions()
+    descriptions = u.trajectory.get_aux_descriptions()
 
 Get descriptions for selected auxiliaries only::
 
-    descriptions = trajectory.get_aux_descriptions(['pullf', 'pullx'])
+    descriptions = u.trajectory.get_aux_descriptions(['pullf', 'pullx'])
 
 And to reload::
 
     for descr in descriptions:
-        new_trajectory.add_auxiliary(**descr)
+        new_u.new_trajectory.add_auxiliary(**descr)
 
 
 .. _AuxStep API:
@@ -226,7 +226,7 @@ And to reload::
 AuxStep class
 ~~~~~~~~~~~~~
 An AuxStep instance holds the auxiliary data for the current step. It is
-updated whenever the a new auxiliary step is read.
+updated whenever a new auxiliary step is read.
 
 AuxStep classes are derived from the base class 
 :class:`~MDAnalysis.auxiliary.base.AuxStep`. The appropriate AuxStep class for
@@ -250,8 +250,9 @@ The following are inherited from :class:`~MDAnalysis.auxiliary.base.AuxStep`:
       Determined from ``_data`` id data selection is enabled at a valid 
       ``data_selector`` is provided; otherwise set to ``_data``.
 
-The following are stored in AuxStep but can be accessed through the parent 
-auxiliary reader (see :ref:`AuxReader API` below). 
+The following are stored in AuxStep. The parent 
+auxiliary reader has the equivalent attributes, though non-private (no _)
+(see :ref:`AuxReader API` below). 
 
   ``_dt``
       Change in time between auxiliary steps (in ps). If not specified, will
@@ -271,7 +272,7 @@ auxiliary reader (see :ref:`AuxReader API` below).
       read with each step (``_data``) (ignored if data selection is not enabled
       by the reader). As for ``time_selector``, type depends on the auxiliary 
       format. If ``None`` (default value), ``_data`` is returned.
-  ``constant_dt``
+  ``_constant_dt``
       Boolean of whether dt is constant throughout auxiliary data. Default is 
       ``True``.
 
@@ -354,8 +355,8 @@ The following attributes are inherited from
       Representative value(s) of auxiliary data for last-read trajectory
       timestep.
 
-The following are stored in ``auxstep`` but may be accessed from the auxiliary
-reader; see the :ref:`AuxStep API` above.
+The following are stored in ``auxstep`` as private attributes (with _)
+but may be accessed from the auxiliary reader; see the :ref:`AuxStep API` above.
 
   ``step``
 
@@ -494,8 +495,8 @@ define/overwrite the following:
 
   ``close()``
 
-For convenience, when reading auxiliary data from an open file, step at a time,
-:class:`~MDAnalysis.auxiliary.base.AuxFileReader`
+For convenience, when reading auxiliary data from an open file, one step at a
+time, :class:`~MDAnalysis.auxiliary.base.AuxFileReader`
 extends :class:`~MDAnalysis.auxiliary.base.AuxReader` by providing the
 following (these may be overwritten by subclasses as appropriate):
 


### PR DESCRIPTION
Changes made in this Pull Request:
 - Fixed typos in MDAnalysis.auxiliary.__init__.py


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
