### PR TITLE
Revert breaking change to OpenMP constructs for self_distance_array OpenMP backend with triclinic boxes (Revert #3706)

### DIFF
--- a/package/MDAnalysis/lib/include/calc_distances.h
+++ b/package/MDAnalysis/lib/include/calc_distances.h
@@ -128,6 +128,9 @@ static void _ortho_pbc(coordinate* coords, uint64_t numcoords, float* box)
         return;
     }
 
+    uint64_t i;
+    int j, s;
+    float crd;
     // inverse box for multi-box shifts:
     const double inverse_box[3] = {1.0 / (double) box[0], \
                                    1.0 / (double) box[1], \
@@ -144,23 +147,23 @@ static void _ortho_pbc(coordinate* coords, uint64_t numcoords, float* box)
     */
 
 #ifdef PARALLEL
-#pragma omp parallel for shared(coords)
+#pragma omp parallel for private(i, j, s, crd) shared(coords)
 #endif
-    for (uint64_t i = 0; i < numcoords; i++) {
-        for (int j = 0; j < 3; j++) {
-            float crd = coords[i][j];
+    for (i=0; i < numcoords; i++) {
+        for (j=0; j < 3; j++) {
+            crd = coords[i][j];
             if (crd < 0.0f) {
                 crd += box[j];
                 // check if multi-box shifts are required:
                 if (crd < 0.0f) {
-                    int s = floor(coords[i][j] * inverse_box[j]);
+                    s = floor(coords[i][j] * inverse_box[j]);
                     coords[i][j] -= s * box[j];
                     // multi-box shifts might be inexact, so check again:
                     if (coords[i][j] < 0.0f) {
                         coords[i][j] += box[j];
                     }
                 }
-                else {
+                else{
                     coords[i][j] = crd;
                 }
             }
@@ -169,14 +172,14 @@ static void _ortho_pbc(coordinate* coords, uint64_t numcoords, float* box)
                 crd -= box[j];
                 // check if multi-box shifts are required:
                 if (crd >= box[j]) {
-                    int s = floor(coords[i][j] * inverse_box[j]);
+                    s = floor(coords[i][j] * inverse_box[j]);
                     coords[i][j] -= s * box[j];
                     // multi-box shifts might be inexact, so check again:
                     if (coords[i][j] >= box[j]) {
                         coords[i][j] -= box[j];
                     }
                 }
-                else {
+                else{
                     coords[i][j] = crd;
                 }
             }
@@ -212,6 +215,9 @@ static void _triclinic_pbc(coordinate* coords, uint64_t numcoords, float* box)
         return;
     }
 
+    uint64_t i;
+    int s, msr;
+    float crd[3];
     // constants for multi-box shifts:
     const double bi0 = 1.0 / (double) box[0];
     const double bi4 = 1.0 / (double) box[4];
@@ -220,6 +226,8 @@ static void _triclinic_pbc(coordinate* coords, uint64_t numcoords, float* box)
     const double bi6 = (-bi3 * box[7] - box[6] * bi0) * bi8;
     const double bi7 = -box[7] * bi4 * bi8;
     // variables and constants for single box shifts:
+    double lbound;
+    double ubound;
     const double a_ax_yfactor = (double) box[3] * bi4;;
     const double a_ax_zfactor = (double) box[6] * bi8;
     const double b_ax_zfactor = (double) box[7] * bi8;
@@ -236,21 +244,18 @@ static void _triclinic_pbc(coordinate* coords, uint64_t numcoords, float* box)
     */
 
 #ifdef PARALLEL
-#pragma omp parallel for shared(coords)
+#pragma omp parallel for private(i, s, msr, crd, lbound, ubound) shared(coords)
 #endif
-    for (uint64_t i = 0; i < numcoords; i++) {
-        int msr = 0;
-        float crd[3];
-        double lbound, ubound;
-        
+    for (i = 0; i < numcoords; i++){
+        msr = 0;
         crd[0] = coords[i][0];
         crd[1] = coords[i][1];
         crd[2] = coords[i][2];
         // translate coords[i] to central cell along c-axis
         if (crd[2] < 0.0f) {
-            crd[0] += box[6];
-            crd[1] += box[7];
-            crd[2] += box[8];
+            crd[0] +=  box[6];
+            crd[1] +=  box[7];
+            crd[2] +=  box[8];
             // check if multi-box shifts are required:
             if (crd[2] < 0.0f) {
                 msr = 1;
@@ -258,12 +263,12 @@ static void _triclinic_pbc(coordinate* coords, uint64_t numcoords, float* box)
         }
         // Don't put an "else" before this! (see note)
         if (crd[2] >= box[8]) {
-            crd[0] -= box[6];
-            crd[1] -= box[7];
-            crd[2] -= box[8];
+            crd[0] -=  box[6];
+            crd[1] -=  box[7];
+            crd[2] -=  box[8];
             // check if multi-box shifts are required:
             if (crd[2] >= box[8]) {
-                msr = 1;
+               msr = 1;
             }
         }
         if (!msr) {
@@ -311,7 +316,7 @@ static void _triclinic_pbc(coordinate* coords, uint64_t numcoords, float* box)
         // multi-box shifts required?
         if (msr) {
             // translate coords[i] to central cell along c-axis
-            int s = floor(coords[i][2] * bi8);
+            s = floor(coords[i][2] * bi8);
             coords[i][2] -= s * box[8];
             coords[i][1] -= s * box[7];
             coords[i][0] -= s * box[6];
@@ -320,7 +325,8 @@ static void _triclinic_pbc(coordinate* coords, uint64_t numcoords, float* box)
             coords[i][1] -= s * box[4];
             coords[i][0] -= s * box[3];
             // translate remainder of coords[i] to central cell along a-axis
-            s = floor(coords[i][0] * bi0 + coords[i][1] * bi3 + coords[i][2] * bi6);
+            s = floor(coords[i][0] * bi0 + coords[i][1] * bi3 + \
+                      coords[i][2] * bi6);
             coords[i][0] -= s * box[0];
             // multi-box shifts might be inexact, so check again:
             crd[0] = coords[i][0];
@@ -328,15 +334,15 @@ static void _triclinic_pbc(coordinate* coords, uint64_t numcoords, float* box)
             crd[2] = coords[i][2];
             // translate coords[i] to central cell along c-axis
             if (crd[2] < 0.0f) {
-                crd[0] += box[6];
-                crd[1] += box[7];
-                crd[2] += box[8];
+                crd[0] +=  box[6];
+                crd[1] +=  box[7];
+                crd[2] +=  box[8];
             }
             // Don't put an "else" before this! (see note)
             if (crd[2] >= box[8]) {
-                crd[0] -= box[6];
-                crd[1] -= box[7];
-                crd[2] -= box[8];
+                crd[0] -=  box[6];
+                crd[1] -=  box[7];
+                crd[2] -=  box[8];
             }
             // translate remainder of crd to central cell along b-axis
             lbound = crd[2] * b_ax_zfactor;
@@ -376,16 +382,19 @@ static void _triclinic_pbc(coordinate* coords, uint64_t numcoords, float* box)
 static void _calc_distance_array(coordinate* ref, uint64_t numref, coordinate* conf,
                                  uint64_t numconf, double* distances)
 {
+  uint64_t i, j;
+  double dx[3];
+  double rsq;
+
 #ifdef PARALLEL
-#pragma omp parallel for shared(distances)
+#pragma omp parallel for private(i, j, dx, rsq) shared(distances)
 #endif
-  for (uint64_t i = 0; i < numref; i++) {
-    for (uint64_t j = 0; j < numconf; j++) {
-      double dx[3];
+  for (i=0; i<numref; i++) {
+    for (j=0; j<numconf; j++) {
       dx[0] = conf[j][0] - ref[i][0];
       dx[1] = conf[j][1] - ref[i][1];
       dx[2] = conf[j][2] - ref[i][2];
-      double rsq = (dx[0]*dx[0]) + (dx[1]*dx[1]) + (dx[2]*dx[2]);
+      rsq = (dx[0]*dx[0]) + (dx[1]*dx[1]) + (dx[2]*dx[2]);
       *(distances+i*numconf+j) = sqrt(rsq);
     }
   }
@@ -394,23 +403,25 @@ static void _calc_distance_array(coordinate* ref, uint64_t numref, coordinate* c
 static void _calc_distance_array_ortho(coordinate* ref, uint64_t numref, coordinate* conf,
                                        uint64_t numconf, float* box, double* distances)
 {
+  uint64_t i, j;
+  double dx[3];
   float inverse_box[3];
+  double rsq;
+
   inverse_box[0] = 1.0 / box[0];
   inverse_box[1] = 1.0 / box[1];
   inverse_box[2] = 1.0 / box[2];
-
 #ifdef PARALLEL
-#pragma omp parallel for shared(distances)
+#pragma omp parallel for private(i, j, dx, rsq) shared(distances)
 #endif
-  for (uint64_t i = 0; i < numref; i++) {
-    for (uint64_t j = 0; j < numconf; j++) {
-      double dx[3];
+  for (i=0; i<numref; i++) {
+    for (j=0; j<numconf; j++) {
       dx[0] = conf[j][0] - ref[i][0];
       dx[1] = conf[j][1] - ref[i][1];
       dx[2] = conf[j][2] - ref[i][2];
       // Periodic boundaries
       minimum_image(dx, box, inverse_box);
-      double rsq = (dx[0]*dx[0]) + (dx[1]*dx[1]) + (dx[2]*dx[2]);
+      rsq = (dx[0]*dx[0]) + (dx[1]*dx[1]) + (dx[2]*dx[2]);
       *(distances+i*numconf+j) = sqrt(rsq);
     }
   }
@@ -420,21 +431,24 @@ static void _calc_distance_array_triclinic(coordinate* ref, uint64_t numref,
                                            coordinate* conf, uint64_t numconf,
                                            float* box, double* distances)
 {
+  uint64_t i, j;
+  double dx[3];
+  double rsq;
+
   // Move coords to inside box
   _triclinic_pbc(ref, numref, box);
   _triclinic_pbc(conf, numconf, box);
 
 #ifdef PARALLEL
-#pragma omp parallel for shared(distances)
+#pragma omp parallel for private(i, j, dx, rsq) shared(distances)
 #endif
-  for (uint64_t i = 0; i < numref; i++) {
-    for (uint64_t j = 0; j < numconf; j++) {
-      double dx[3];
+  for (i=0; i<numref; i++){
+    for (j=0; j<numconf; j++){
       dx[0] = conf[j][0] - ref[i][0];
       dx[1] = conf[j][1] - ref[i][1];
       dx[2] = conf[j][2] - ref[i][2];
       minimum_image_triclinic(dx, box);
-      double rsq = (dx[0]*dx[0] + dx[1]*dx[1] + dx[2]*dx[2]);
+      rsq = (dx[0]*dx[0] + dx[1]*dx[1] + dx[2]*dx[2]);
       *(distances + i*numconf + j) = sqrt(rsq);
     }
   }
@@ -443,22 +457,24 @@ static void _calc_distance_array_triclinic(coordinate* ref, uint64_t numref,
 static void _calc_self_distance_array(coordinate* ref, uint64_t numref,
                                       double* distances)
 {
+  uint64_t i, j, distpos;
+  double dx[3];
+  double rsq;
+
+  distpos = 0;
+
 #ifdef PARALLEL
-#pragma omp parallel for shared(distances)
+#pragma omp parallel for private(i, distpos, j, dx, rsq) shared(distances)
 #endif
-  for (uint64_t i = 0; i < numref; i++) {
+  for (i=0; i<numref; i++) {
 #ifdef PARALLEL
-    uint64_t distpos =
-        i * (2 * numref - i - 1) / 2; // calculates the offset into distances
-#else
-    uint64_t distpos = 0;
+    distpos = i * (2 * numref - i - 1) / 2;  // calculates the offset into distances
 #endif
-    for (uint64_t j = i + 1; j < numref; j++) {
-      double dx[3];
+    for (j=i+1; j<numref; j++) {
       dx[0] = ref[j][0] - ref[i][0];
       dx[1] = ref[j][1] - ref[i][1];
       dx[2] = ref[j][2] - ref[i][2];
-      double rsq = (dx[0]*dx[0]) + (dx[1]*dx[1]) + (dx[2]*dx[2]);
+      rsq = (dx[0]*dx[0]) + (dx[1]*dx[1]) + (dx[2]*dx[2]);
       *(distances+distpos) = sqrt(rsq);
       distpos += 1;
     }
@@ -468,30 +484,30 @@ static void _calc_self_distance_array(coordinate* ref, uint64_t numref,
 static void _calc_self_distance_array_ortho(coordinate* ref, uint64_t numref,
                                             float* box, double* distances)
 {
+  uint64_t i, j, distpos;
+  double dx[3];
   float inverse_box[3];
+  double rsq;
 
   inverse_box[0] = 1.0 / box[0];
   inverse_box[1] = 1.0 / box[1];
   inverse_box[2] = 1.0 / box[2];
+  distpos = 0;
 
 #ifdef PARALLEL
-#pragma omp parallel for shared(distances)
+#pragma omp parallel for private(i, distpos, j, dx, rsq) shared(distances)
 #endif
-  for (uint64_t i = 0; i < numref; i++) {
+  for (i=0; i<numref; i++) {
 #ifdef PARALLEL
-    uint64_t distpos =
-        i * (2 * numref - i - 1) / 2; // calculates the offset into distances
-#else
-    uint64_t distpos = 0;
+    distpos = i * (2 * numref - i - 1) / 2;  // calculates the offset into distances
 #endif
-    for (uint64_t j = i + 1; j < numref; j++) {
-      double dx[3];
+    for (j=i+1; j<numref; j++) {
       dx[0] = ref[j][0] - ref[i][0];
       dx[1] = ref[j][1] - ref[i][1];
       dx[2] = ref[j][2] - ref[i][2];
       // Periodic boundaries
       minimum_image(dx, box, inverse_box);
-      double rsq = (dx[0]*dx[0]) + (dx[1]*dx[1]) + (dx[2]*dx[2]);
+      rsq = (dx[0]*dx[0]) + (dx[1]*dx[1]) + (dx[2]*dx[2]);
       *(distances+distpos) = sqrt(rsq);
       distpos += 1;
     }
@@ -501,25 +517,27 @@ static void _calc_self_distance_array_ortho(coordinate* ref, uint64_t numref,
 static void _calc_self_distance_array_triclinic(coordinate* ref, uint64_t numref,
                                                 float* box, double *distances)
 {
+  uint64_t i, j, distpos;
+  double dx[3];
+  double rsq;
+
   _triclinic_pbc(ref, numref, box);
 
+  distpos = 0;
+
 #ifdef PARALLEL
-#pragma omp parallel for shared(distances)
+#pragma omp parallel for private(i, distpos, j, dx, rsq) shared(distances)
 #endif
-  for (uint64_t i = 0; i < numref; i++) {
+  for (i=0; i<numref; i++){
 #ifdef PARALLEL
-    uint64_t distpos =
-        i * (2 * numref - i - 1) / 2; // calculates the offset into distances
-#else
-    uint64_t distpos = 0;
+    distpos = i * (2 * numref - i - 1) / 2;  // calculates the offset into distances
 #endif
-    for (uint64_t j = i + 1; j < numref; j++) {
-      double dx[3];
+    for (j=i+1; j<numref; j++){
       dx[0] = ref[j][0] - ref[i][0];
       dx[1] = ref[j][1] - ref[i][1];
       dx[2] = ref[j][2] - ref[i][2];
       minimum_image_triclinic(dx, box);
-      double rsq = (dx[0]*dx[0] + dx[1]*dx[1] + dx[2]*dx[2]);
+      rsq = (dx[0]*dx[0] + dx[1]*dx[1] + dx[2]*dx[2]);
       *(distances + distpos) = sqrt(rsq);
       distpos += 1;
     }
@@ -528,19 +546,20 @@ static void _calc_self_distance_array_triclinic(coordinate* ref, uint64_t numref
 
 void _coord_transform(coordinate* coords, uint64_t numCoords, double* box)
 {
+  uint64_t i, j, k;
+  float newpos[3];
   // Matrix multiplication inCoords * box = outCoords
   // Multiplication done in place using temp array 'new'
   // Used to transform coordinates to/from S/R space in trilinic boxes
 #ifdef PARALLEL
-#pragma omp parallel for shared(coords)
+#pragma omp parallel for private(i, j, k, newpos) shared(coords)
 #endif
-  for (uint64_t i = 0; i < numCoords; i++) {
-    float newpos[3];
+  for (i=0; i < numCoords; i++){
     newpos[0] = 0.0;
     newpos[1] = 0.0;
     newpos[2] = 0.0;
-    for (uint64_t j = 0; j < 3; j++) {
-      for (uint64_t k = 0; k < 3; k++) {
+    for (j=0; j<3; j++){
+      for (k=0; k<3; k++){
         newpos[j] += coords[i][k] * box[3 * k + j];
       }
     }
@@ -553,15 +572,18 @@ void _coord_transform(coordinate* coords, uint64_t numCoords, double* box)
 static void _calc_bond_distance(coordinate* atom1, coordinate* atom2,
                                 uint64_t numatom, double* distances)
 {
+  uint64_t i;
+  double dx[3];
+  double rsq;
+
 #ifdef PARALLEL
-#pragma omp parallel for shared(distances)
+#pragma omp parallel for private(i, dx, rsq) shared(distances)
 #endif
-  for (uint64_t i = 0; i < numatom; i++) {
-    double dx[3];
+  for (i=0; i<numatom; i++) {
     dx[0] = atom1[i][0] - atom2[i][0];
     dx[1] = atom1[i][1] - atom2[i][1];
     dx[2] = atom1[i][2] - atom2[i][2];
-    double rsq = (dx[0]*dx[0])+(dx[1]*dx[1])+(dx[2]*dx[2]);
+    rsq = (dx[0]*dx[0])+(dx[1]*dx[1])+(dx[2]*dx[2]);
     *(distances+i) = sqrt(rsq);
   }
 }
@@ -569,23 +591,25 @@ static void _calc_bond_distance(coordinate* atom1, coordinate* atom2,
 static void _calc_bond_distance_ortho(coordinate* atom1, coordinate* atom2,
                                       uint64_t numatom, float* box, double* distances)
 {
+  uint64_t i;
+  double dx[3];
   float inverse_box[3];
+  double rsq;
 
   inverse_box[0] = 1.0/box[0];
   inverse_box[1] = 1.0/box[1];
   inverse_box[2] = 1.0/box[2];
 
 #ifdef PARALLEL
-#pragma omp parallel for shared(distances)
+#pragma omp parallel for private(i, dx, rsq) shared(distances)
 #endif
-  for (uint64_t i = 0; i < numatom; i++) {
-    double dx[3];
+  for (i=0; i<numatom; i++) {
     dx[0] = atom1[i][0] - atom2[i][0];
     dx[1] = atom1[i][1] - atom2[i][1];
     dx[2] = atom1[i][2] - atom2[i][2];
     // PBC time!
     minimum_image(dx, box, inverse_box);
-    double rsq = (dx[0]*dx[0])+(dx[1]*dx[1])+(dx[2]*dx[2]);
+    rsq = (dx[0]*dx[0])+(dx[1]*dx[1])+(dx[2]*dx[2]);
     *(distances+i) = sqrt(rsq);
   }
 }
@@ -593,20 +617,23 @@ static void _calc_bond_distance_triclinic(coordinate* atom1, coordinate* atom2,
                                           uint64_t numatom, float* box,
                                           double* distances)
 {
+  uint64_t i;
+  double dx[3];
+  double rsq;
+
   _triclinic_pbc(atom1, numatom, box);
   _triclinic_pbc(atom2, numatom, box);
 
 #ifdef PARALLEL
-#pragma omp parallel for shared(distances)
+#pragma omp parallel for private(i, dx, rsq) shared(distances)
 #endif
-  for (uint64_t i = 0; i < numatom; i++) {
-    double dx[3];
+  for (i=0; i<numatom; i++) {
     dx[0] = atom1[i][0] - atom2[i][0];
     dx[1] = atom1[i][1] - atom2[i][1];
     dx[2] = atom1[i][2] - atom2[i][2];
     // PBC time!
     minimum_image_triclinic(dx, box);
-    double rsq = (dx[0]*dx[0])+(dx[1]*dx[1])+(dx[2]*dx[2]);
+    rsq = (dx[0]*dx[0])+(dx[1]*dx[1])+(dx[2]*dx[2]);
     *(distances+i) = sqrt(rsq);
   }
 }
@@ -614,12 +641,14 @@ static void _calc_bond_distance_triclinic(coordinate* atom1, coordinate* atom2,
 static void _calc_angle(coordinate* atom1, coordinate* atom2,
                         coordinate* atom3, uint64_t numatom, double* angles)
 {
-#ifdef PARALLEL
-#pragma omp parallel for shared(angles)
-#endif
-  for (uint64_t i=0; i<numatom; i++) {
-    double rji[3], rjk[3], xp[3];
+  uint64_t i;
+  double rji[3], rjk[3];
+  double x, y, xp[3];
 
+#ifdef PARALLEL
+#pragma omp parallel for private(i, rji, rjk, x, xp, y) shared(angles)
+#endif
+  for (i=0; i<numatom; i++) {
     rji[0] = atom1[i][0] - atom2[i][0];
     rji[1] = atom1[i][1] - atom2[i][1];
     rji[2] = atom1[i][2] - atom2[i][2];
@@ -628,13 +657,13 @@ static void _calc_angle(coordinate* atom1, coordinate* atom2,
     rjk[1] = atom3[i][1] - atom2[i][1];
     rjk[2] = atom3[i][2] - atom2[i][2];
 
-    double x = rji[0]*rjk[0] + rji[1]*rjk[1] + rji[2]*rjk[2];
+    x = rji[0]*rjk[0] + rji[1]*rjk[1] + rji[2]*rjk[2];
 
     xp[0] = rji[1]*rjk[2] - rji[2]*rjk[1];
     xp[1] =-rji[0]*rjk[2] + rji[2]*rjk[0];
     xp[2] = rji[0]*rjk[1] - rji[1]*rjk[0];
 
-    double y = sqrt(xp[0]*xp[0] + xp[1]*xp[1] + xp[2]*xp[2]);
+    y = sqrt(xp[0]*xp[0] + xp[1]*xp[1] + xp[2]*xp[2]);
 
     *(angles+i) = atan2(y,x);
   }
@@ -648,6 +677,9 @@ static void _calc_angle_ortho(coordinate* atom1, coordinate* atom2,
   // pbc option ensures that vectors are constructed between atoms in the same image as eachother
   // ie that vectors don't go across a boxlength
   // it doesn't matter if vectors are from different boxes however
+  uint64_t i;
+  double rji[3], rjk[3];
+  double x, y, xp[3];
   float inverse_box[3];
 
   inverse_box[0] = 1.0/box[0];
@@ -655,11 +687,9 @@ static void _calc_angle_ortho(coordinate* atom1, coordinate* atom2,
   inverse_box[2] = 1.0/box[2];
 
 #ifdef PARALLEL
-#pragma omp parallel for shared(angles)
+#pragma omp parallel for private(i, rji, rjk, x, xp, y) shared(angles)
 #endif
-  for (uint64_t i = 0; i < numatom; i++) {
-    double rji[3], rjk[3], xp[3];
-
+  for (i=0; i<numatom; i++) {
     rji[0] = atom1[i][0] - atom2[i][0];
     rji[1] = atom1[i][1] - atom2[i][1];
     rji[2] = atom1[i][2] - atom2[i][2];
@@ -670,13 +700,13 @@ static void _calc_angle_ortho(coordinate* atom1, coordinate* atom2,
     rjk[2] = atom3[i][2] - atom2[i][2];
     minimum_image(rjk, box, inverse_box);
 
-    double x = rji[0]*rjk[0] + rji[1]*rjk[1] + rji[2]*rjk[2];
+    x = rji[0]*rjk[0] + rji[1]*rjk[1] + rji[2]*rjk[2];
 
     xp[0] = rji[1]*rjk[2] - rji[2]*rjk[1];
     xp[1] =-rji[0]*rjk[2] + rji[2]*rjk[0];
     xp[2] = rji[0]*rjk[1] - rji[1]*rjk[0];
 
-    double y = sqrt(xp[0]*xp[0] + xp[1]*xp[1] + xp[2]*xp[2]);
+    y = sqrt(xp[0]*xp[0] + xp[1]*xp[1] + xp[2]*xp[2]);
 
     *(angles+i) = atan2(y,x);
   }
@@ -687,16 +717,18 @@ static void _calc_angle_triclinic(coordinate* atom1, coordinate* atom2,
                                   float* box, double* angles)
 {
   // Triclinic version of min image aware angle calculate, see above
+  uint64_t i;
+  double rji[3], rjk[3];
+  double x, y, xp[3];
+
   _triclinic_pbc(atom1, numatom, box);
   _triclinic_pbc(atom2, numatom, box);
   _triclinic_pbc(atom3, numatom, box);
 
 #ifdef PARALLEL
-#pragma omp parallel for shared(angles)
+#pragma omp parallel for private(i, rji, rjk, x, xp, y) shared(angles)
 #endif
-  for (uint64_t i = 0; i < numatom; i++) {
-    double rji[3], rjk[3], xp[3];
-
+  for (i=0; i<numatom; i++) {
     rji[0] = atom1[i][0] - atom2[i][0];
     rji[1] = atom1[i][1] - atom2[i][1];
     rji[2] = atom1[i][2] - atom2[i][2];
@@ -707,13 +739,13 @@ static void _calc_angle_triclinic(coordinate* atom1, coordinate* atom2,
     rjk[2] = atom3[i][2] - atom2[i][2];
     minimum_image_triclinic(rjk, box);
 
-    double x = rji[0]*rjk[0] + rji[1]*rjk[1] + rji[2]*rjk[2];
+    x = rji[0]*rjk[0] + rji[1]*rjk[1] + rji[2]*rjk[2];
 
     xp[0] = rji[1]*rjk[2] - rji[2]*rjk[1];
     xp[1] =-rji[0]*rjk[2] + rji[2]*rjk[0];
     xp[2] = rji[0]*rjk[1] - rji[1]*rjk[0];
 
-    double y = sqrt(xp[0]*xp[0] + xp[1]*xp[1] + xp[2]*xp[2]);
+    y = sqrt(xp[0]*xp[0] + xp[1]*xp[1] + xp[2]*xp[2]);
 
     *(angles+i) = atan2(y,x);
   }
@@ -761,12 +793,13 @@ static void _calc_dihedral(coordinate* atom1, coordinate* atom2,
                            coordinate* atom3, coordinate* atom4,
                            uint64_t numatom, double* angles)
 {
-#ifdef PARALLEL
-#pragma omp parallel for shared(angles)
-#endif
-  for (uint64_t i = 0; i < numatom; i++) {
-    double va[3], vb[3], vc[3];
+  uint64_t i;
+  double va[3], vb[3], vc[3];
 
+#ifdef PARALLEL
+#pragma omp parallel for private(i, va, vb, vc) shared(angles)
+#endif
+  for (i=0; i<numatom; i++) {
     // connecting vectors between all 4 atoms: 1 -va-> 2 -vb-> 3 -vc-> 4
     va[0] = atom2[i][0] - atom1[i][0];
     va[1] = atom2[i][1] - atom1[i][1];
@@ -788,6 +821,8 @@ static void _calc_dihedral_ortho(coordinate* atom1, coordinate* atom2,
                                  coordinate* atom3, coordinate* atom4,
                                  uint64_t numatom, float* box, double* angles)
 {
+  uint64_t i;
+  double va[3], vb[3], vc[3];
   float inverse_box[3];
 
   inverse_box[0] = 1.0/box[0];
@@ -795,11 +830,9 @@ static void _calc_dihedral_ortho(coordinate* atom1, coordinate* atom2,
   inverse_box[2] = 1.0/box[2];
 
 #ifdef PARALLEL
-#pragma omp parallel for shared(angles)
+#pragma omp parallel for private(i, va, vb, vc) shared(angles)
 #endif
-  for (uint64_t i = 0; i < numatom; i++) {
-    double va[3], vb[3], vc[3];
-
+  for (i=0; i<numatom; i++) {
     // connecting vectors between all 4 atoms: 1 -va-> 2 -vb-> 3 -vc-> 4
     va[0] = atom2[i][0] - atom1[i][0];
     va[1] = atom2[i][1] - atom1[i][1];
@@ -824,17 +857,18 @@ static void _calc_dihedral_triclinic(coordinate* atom1, coordinate* atom2,
                                      coordinate* atom3, coordinate* atom4,
                                      uint64_t numatom, float* box, double* angles)
 {
+  uint64_t i;
+  double va[3], vb[3], vc[3];
+
   _triclinic_pbc(atom1, numatom, box);
   _triclinic_pbc(atom2, numatom, box);
   _triclinic_pbc(atom3, numatom, box);
   _triclinic_pbc(atom4, numatom, box);
 
 #ifdef PARALLEL
-#pragma omp parallel for shared(angles)
+#pragma omp parallel for private(i, va, vb, vc) shared(angles)
 #endif
-  for (uint64_t  i = 0; i < numatom; i++) {
-    double va[3], vb[3], vc[3];
-
+  for (i=0; i<numatom; i++) {
     // connecting vectors between all 4 atoms: 1 -va-> 2 -vb-> 3 -vc-> 4
     va[0] = atom2[i][0] - atom1[i][0];
     va[1] = atom2[i][1] - atom1[i][1];

--- a/package/MDAnalysis/lib/include/calc_distances.h
+++ b/package/MDAnalysis/lib/include/calc_distances.h
@@ -443,14 +443,15 @@ static void _calc_distance_array_triclinic(coordinate* ref, uint64_t numref,
 static void _calc_self_distance_array(coordinate* ref, uint64_t numref,
                                       double* distances)
 {
-    uint64_t distpos = 0;
 #ifdef PARALLEL
-#pragma omp parallel for private(distpos) shared(distances)
+#pragma omp parallel for shared(distances)
 #endif
   for (uint64_t i = 0; i < numref; i++) {
 #ifdef PARALLEL
-    distpos =
+    uint64_t distpos =
         i * (2 * numref - i - 1) / 2; // calculates the offset into distances
+#else
+    uint64_t distpos = 0;
 #endif
     for (uint64_t j = i + 1; j < numref; j++) {
       double dx[3];
@@ -473,15 +474,15 @@ static void _calc_self_distance_array_ortho(coordinate* ref, uint64_t numref,
   inverse_box[1] = 1.0 / box[1];
   inverse_box[2] = 1.0 / box[2];
 
-  uint64_t distpos = 0;
-
 #ifdef PARALLEL
-#pragma omp parallel for private(distpos) shared(distances)
+#pragma omp parallel for shared(distances)
 #endif
   for (uint64_t i = 0; i < numref; i++) {
 #ifdef PARALLEL
-    distpos =
+    uint64_t distpos =
         i * (2 * numref - i - 1) / 2; // calculates the offset into distances
+#else
+    uint64_t distpos = 0;
 #endif
     for (uint64_t j = i + 1; j < numref; j++) {
       double dx[3];
@@ -502,15 +503,15 @@ static void _calc_self_distance_array_triclinic(coordinate* ref, uint64_t numref
 {
   _triclinic_pbc(ref, numref, box);
 
-  uint64_t distpos = 0;
-
 #ifdef PARALLEL
 #pragma omp parallel for shared(distances)
 #endif
   for (uint64_t i = 0; i < numref; i++) {
 #ifdef PARALLEL
-    distpos =
+    uint64_t distpos =
         i * (2 * numref - i - 1) / 2; // calculates the offset into distances
+#else
+    uint64_t distpos = 0;
 #endif
     for (uint64_t j = i + 1; j < numref; j++) {
       double dx[3];


### PR DESCRIPTION
Fixes #3725 

This PR reverts a PR that appears to have broken the OpenMP backend for triclinic boxes. 
Pending some discussion here or on the issue. 

Changes made in this Pull Request:
 - Reverts changes made in #3706 
 - TODO: add tests for triclinic code path in `self_distance_array`

PR Checklist
------------
 - [ ] Tests?
 - [ ] CHANGELOG updated?
 - [X] Issue raised/referenced?
