### PR TITLE
Allow distance routines to accept an NumPy Array or AtomGroup [Core]

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -21,7 +21,8 @@ Fixes
   * Fixes awk call in deploy.yaml tests for macos runners (Issue #3693)
 
 Enhancements
-  * 
+  * Change functions in `lib.distances` to accept AtomGroups as well as NumPy
+    arrays (CZI Performance track PR #3730)
   * Add `norm` parameter to InterRDF, InterRDF_s to normalize as rdf,
     number density or do not normalize at all. (Issue #3687)
   * Additional logger.info output when per-frame analysis starts (PR #3710)

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -21,6 +21,7 @@ Fixes
   * Fixes awk call in deploy.yaml tests for macos runners (Issue #3693)
 
 Enhancements
+  * 
   * Add `norm` parameter to InterRDF, InterRDF_s to normalize as rdf,
     number density or do not normalize at all. (Issue #3687)
   * Additional logger.info output when per-frame analysis starts (PR #3710)

--- a/package/MDAnalysis/lib/distances.py
+++ b/package/MDAnalysis/lib/distances.py
@@ -73,7 +73,6 @@ Functions
 """
 import numpy as np
 from numpy.lib.utils import deprecate
-import numpy.typing as npt
 
 from typing import Union, Optional, Callable
 from typing import TYPE_CHECKING
@@ -140,7 +139,7 @@ from .c_distances import (_UINT64_MAX,
 from .c_distances_openmp import OPENMP_ENABLED as USED_OPENMP
 
 
-def _check_result_array(result: npt.NDArray, shape: tuple) -> npt.NDArray:
+def _check_result_array(result: np.ndarray, shape: tuple) -> np.ndarray:
     """Check if the result array is ok to use.
 
     The `result` array must meet the following requirements:
@@ -183,11 +182,11 @@ def _check_result_array(result: npt.NDArray, shape: tuple) -> npt.NDArray:
 
 @check_coords('reference', 'configuration', reduce_result_if_single=False,
               check_lengths_match=False, allow_atomgroup=True)
-def distance_array(reference: Union[npt.NDArray, 'AtomGroup'],
-                   configuration: Union[npt.NDArray, 'AtomGroup'],
-                   box: Optional[npt.NDArray] = None,
-                   result: Optional[npt.NDArray] = None,
-                   backend: str = "serial") -> npt.NDArray:
+def distance_array(reference: Union[np.ndarray, 'AtomGroup'],
+                   configuration: Union[np.ndarray, 'AtomGroup'],
+                   box: Optional[np.ndarray] = None,
+                   result: Optional[np.ndarray] = None,
+                   backend: str = "serial") -> np.ndarray:
     """Calculate all possible distances between a reference set and another
     configuration.
 
@@ -271,10 +270,10 @@ def distance_array(reference: Union[npt.NDArray, 'AtomGroup'],
 
 
 @check_coords('reference', reduce_result_if_single=False, allow_atomgroup=True)
-def self_distance_array(reference: Union[npt.NDArray, 'AtomGroup'],
-                        box: Optional[npt.NDArray] = None,
-                        result: Optional[npt.NDArray] = None,
-                        backend: str = "serial") -> npt.NDArray:
+def self_distance_array(reference: Union[np.ndarray, 'AtomGroup'],
+                        box: Optional[np.ndarray] = None,
+                        result: Optional[np.ndarray] = None,
+                        backend: str = "serial") -> np.ndarray:
     """Calculate all possible distances within a configuration `reference`.
 
     If the optional argument `box` is supplied, the minimum image convention is
@@ -1268,11 +1267,11 @@ def transform_StoR(coords, box, backend="serial"):
 
 
 @check_coords('coords1', 'coords2', allow_atomgroup=True)
-def calc_bonds(coords1: Union[npt.NDArray, 'AtomGroup'],
-               coords2: Union[npt.NDArray, 'AtomGroup'],
-               box: Optional[npt.NDArray] = None,
-               result: Optional[npt.NDArray] = None,
-               backend: str = "serial") -> npt.NDArray:
+def calc_bonds(coords1: Union[np.ndarray, 'AtomGroup'],
+               coords2: Union[np.ndarray, 'AtomGroup'],
+               box: Optional[np.ndarray] = None,
+               result: Optional[np.ndarray] = None,
+               backend: str = "serial") -> np.ndarray:
     """Calculates the bond lengths between pairs of atom positions from the two
     coordinate arrays `coords1` and `coords2`, which must contain the same
     number of coordinates. ``coords1[i]`` and ``coords2[i]`` represent the
@@ -1359,12 +1358,12 @@ def calc_bonds(coords1: Union[npt.NDArray, 'AtomGroup'],
 
 
 @check_coords('coords1', 'coords2', 'coords3', allow_atomgroup=True)
-def calc_angles(coords1: Union[npt.NDArray, 'AtomGroup'],
-                coords2: Union[npt.NDArray, 'AtomGroup'],
-                coords3: Union[npt.NDArray, 'AtomGroup'],
-                box: Optional[npt.NDArray] = None,
-                result: Optional[npt.NDArray] = None,
-                backend: str = "serial") -> npt.NDArray:
+def calc_angles(coords1: Union[np.ndarray, 'AtomGroup'],
+                coords2: Union[np.ndarray, 'AtomGroup'],
+                coords3: Union[np.ndarray, 'AtomGroup'],
+                box: Optional[np.ndarray] = None,
+                result: Optional[np.ndarray] = None,
+                backend: str = "serial") -> np.ndarray:
     """Calculates the angles formed between triplets of atom positions from the
     three coordinate arrays `coords1`, `coords2`, and `coords3`. All coordinate
     arrays must contain the same number of coordinates.
@@ -1461,13 +1460,13 @@ def calc_angles(coords1: Union[npt.NDArray, 'AtomGroup'],
 
 
 @check_coords('coords1', 'coords2', 'coords3', 'coords4', allow_atomgroup=True)
-def calc_dihedrals(coords1: Union[npt.NDArray, 'AtomGroup'],
-                   coords2: Union[npt.NDArray, 'AtomGroup'],
-                   coords3: Union[npt.NDArray, 'AtomGroup'],
-                   coords4: Union[npt.NDArray, 'AtomGroup'],
-                   box: Optional[npt.NDArray] = None,
-                   result: Optional[npt.NDArray] = None,
-                   backend: str = "serial") -> npt.NDArray:
+def calc_dihedrals(coords1: Union[np.ndarray, 'AtomGroup'],
+                   coords2: Union[np.ndarray, 'AtomGroup'],
+                   coords3: Union[np.ndarray, 'AtomGroup'],
+                   coords4: Union[np.ndarray, 'AtomGroup'],
+                   box: Optional[np.ndarray] = None,
+                   result: Optional[np.ndarray] = None,
+                   backend: str = "serial") -> np.ndarray:
     r"""Calculates the dihedral angles formed between quadruplets of positions
     from the four coordinate arrays `coords1`, `coords2`, `coords3`, and
     `coords4`, which must contain the same number of coordinates.
@@ -1578,9 +1577,9 @@ def calc_dihedrals(coords1: Union[npt.NDArray, 'AtomGroup'],
 
 
 @check_coords('coords', allow_atomgroup=True)
-def apply_PBC(coords: Union[npt.NDArray, 'AtomGroup'],
-              box: Optional[npt.NDArray] = None,
-              backend: str = "serial") -> npt.NDArray:
+def apply_PBC(coords: Union[np.ndarray, 'AtomGroup'],
+              box: Optional[np.ndarray] = None,
+              backend: str = "serial") -> np.ndarray:
     """Moves coordinates into the primary unit cell.
 
     Parameters
@@ -1626,7 +1625,7 @@ def apply_PBC(coords: Union[npt.NDArray, 'AtomGroup'],
 
 
 @check_coords('vectors', enforce_copy=False, enforce_dtype=False)
-def minimize_vectors(vectors: npt.NDArray, box: npt.NDArray) -> npt.NDArray:
+def minimize_vectors(vectors: np.ndarray, box: np.ndarray) -> np.ndarray:
     """Apply minimum image convention to an array of vectors
 
     This function is required for calculating the correct vectors between two

--- a/package/MDAnalysis/lib/distances.py
+++ b/package/MDAnalysis/lib/distances.py
@@ -1491,22 +1491,26 @@ def calc_dihedrals(coords1: Union[np.ndarray, AtomGroup],
 
     Parameters
     ----------
-    coords1 : numpy.ndarray
+    coords1 : numpy.ndarray or :class:`~MDAnalysis.core.groups.AtomGroup`
         Coordinate array of shape ``(3,)`` or ``(n, 3)`` containing the 1st
         positions in dihedrals (dtype is arbitrary, will be converted to
-        ``numpy.float32`` internally)
-    coords2 : numpy.ndarray
+        ``numpy.float32`` internally).  Also accepts an 
+        :class:`~MDAnalysis.core.groups.AtomGroup`.
+    coords2 : numpy.ndarray or :class:`~MDAnalysis.core.groups.AtomGroup`
         Coordinate array of shape ``(3,)`` or ``(n, 3)`` containing the 2nd
         positions in dihedrals (dtype is arbitrary, will be converted to
-        ``numpy.float32`` internally)
-    coords3 : numpy.ndarray
+        ``numpy.float32`` internally).  Also accepts an 
+        :class:`~MDAnalysis.core.groups.AtomGroup`.
+    coords3 : numpy.ndarray or :class:`~MDAnalysis.core.groups.AtomGroup`
         Coordinate array of shape ``(3,)`` or ``(n, 3)`` containing the 3rd
         positions in dihedrals (dtype is arbitrary, will be converted to
-        ``numpy.float32`` internally)
-    coords4 : numpy.ndarray
+        ``numpy.float32`` internally).  Also accepts an 
+        :class:`~MDAnalysis.core.groups.AtomGroup`.
+    coords4 : numpy.ndarray or :class:`~MDAnalysis.core.groups.AtomGroup`
         Coordinate array of shape ``(3,)`` or ``(n, 3)`` containing the 4th
         positions in dihedrals (dtype is arbitrary, will be converted to
-        ``numpy.float32`` internally)
+        ``numpy.float32`` internally).  Also accepts an 
+        :class:`~MDAnalysis.core.groups.AtomGroup`.
     box : numpy.ndarray, optional
         The unitcell dimensions of the system, which can be orthogonal or
         triclinic and must be provided in the same format as returned by

--- a/package/MDAnalysis/lib/distances.py
+++ b/package/MDAnalysis/lib/distances.py
@@ -70,7 +70,7 @@ Functions
 import numpy as np
 from numpy.lib.utils import deprecate
 
-from typing import Union, Optional
+from typing import Union, Optional, Callable
 from ..core.groups import AtomGroup
 from .util import check_coords, check_box
 from .mdamath import triclinic_vectors
@@ -93,7 +93,8 @@ except ImportError:
     pass
 del importlib
 
-def _run(funcname, args=None, kwargs=None, backend="serial"):
+def _run(funcname: Callable, args: Optional[tuple] = None,
+         kwargs: Optional[dict] = None, backend: str = "serial"):
     """Helper function to select a backend function `funcname`."""
     args = args if args is not None else tuple()
     kwargs = kwargs if kwargs is not None else dict()
@@ -131,7 +132,7 @@ from .c_distances import (_UINT64_MAX,
 from .c_distances_openmp import OPENMP_ENABLED as USED_OPENMP
 
 
-def _check_result_array(result, shape):
+def _check_result_array(result: np.ndarray, shape: tuple):
     """Check if the result array is ok to use.
 
     The `result` array must meet the following requirements:
@@ -195,10 +196,10 @@ def distance_array(reference: Union[np.ndarray, AtomGroup],
 
     Parameters
     ----------
-    reference : numpy.ndarray
+    reference :numpy.ndarray or :class:`~MDAnalysis.core.groups.AtomGroup`
         Reference coordinate array of shape ``(3,)`` or ``(n, 3)`` (dtype is
         arbitrary, will be converted to ``numpy.float32`` internally).
-    configuration : numpy.ndarray
+    configuration : numpy.ndarray or :class:`~MDAnalysis.core.groups.AtomGroup`
         Configuration coordinate array of shape ``(3,)`` or ``(m, 3)`` (dtype is
         arbitrary, will be converted to ``numpy.float32`` internally).
     box : array_like, optional
@@ -275,7 +276,7 @@ def self_distance_array(reference: Union[np.ndarray, AtomGroup],
 
     Parameters
     ----------
-    reference : numpy.ndarray
+    reference : numpy.ndarray or :class:`~MDAnalysis.core.groups.AtomGroup`
         Reference coordinate array of shape ``(3,)`` or ``(n, 3)`` (dtype is
         arbitrary, will be converted to ``numpy.float32`` internally).
     box : array_like, optional

--- a/package/MDAnalysis/lib/distances.py
+++ b/package/MDAnalysis/lib/distances.py
@@ -77,7 +77,7 @@ import numpy.typing as npt
 
 from typing import Union, Optional, Callable
 from typing import TYPE_CHECKING
-if TYPE_CHECKING:
+if TYPE_CHECKING: # pragma: no cover
     from ..core.groups import AtomGroup
 from .util import check_coords, check_box
 from .mdamath import triclinic_vectors

--- a/package/MDAnalysis/lib/distances.py
+++ b/package/MDAnalysis/lib/distances.py
@@ -176,7 +176,8 @@ def _check_result_array(result, shape):
               check_lengths_match=False)
 def distance_array(reference: Union[np.ndarray, AtomGroup],
                    configuration: Union[np.ndarray, AtomGroup],
-                   box: Optional[np.ndarray] = None, result=None,
+                   box: Optional[np.ndarray] = None,
+                   result: Optional[np.ndarray] = None,
                    backend: str = "serial") -> None:
     """Calculate all possible distances between a reference set and another
     configuration.
@@ -225,6 +226,8 @@ def distance_array(reference: Union[np.ndarray, AtomGroup],
     .. versionchanged:: 0.19.0
        Internal dtype conversion of input coordinates to ``numpy.float32``.
        Now also accepts single coordinates as input.
+    .. versionchanged:: 2.3.0
+       Now accepts AtomGroups as input and checks types using type hinting.
     """
     confnum = configuration.shape[0]
     refnum = reference.shape[0]
@@ -256,7 +259,10 @@ def distance_array(reference: Union[np.ndarray, AtomGroup],
 
 
 @check_coords('reference', reduce_result_if_single=False)
-def self_distance_array(reference, box=None, result=None, backend="serial"):
+def self_distance_array(reference: Union[np.ndarray, AtomGroup],
+                        box: Optional[np.ndarray] = None,
+                        result: Optional[np.ndarray] = None,
+                        backend: str = "serial") -> None:
     """Calculate all possible distances within a configuration `reference`.
 
     If the optional argument `box` is supplied, the minimum image convention is
@@ -302,6 +308,8 @@ def self_distance_array(reference, box=None, result=None, backend="serial"):
        Added *backend* keyword.
     .. versionchanged:: 0.19.0
        Internal dtype conversion of input coordinates to ``numpy.float32``.
+    .. versionchanged:: 2.3.0
+       Now accepts AtomGroups as input and checks types using type hinting.
     """
     refnum = reference.shape[0]
     distnum = refnum * (refnum - 1) // 2

--- a/package/MDAnalysis/lib/distances.py
+++ b/package/MDAnalysis/lib/distances.py
@@ -1255,7 +1255,11 @@ def transform_StoR(coords, box, backend="serial"):
 
 
 @check_coords('coords1', 'coords2')
-def calc_bonds(coords1, coords2, box=None, result=None, backend="serial"):
+def calc_bonds(coords1: Union[np.ndarray, AtomGroup],
+               coords2: Union[np.ndarray, AtomGroup],
+               box: Optional[np.ndarray] = None,
+               result: Optional[np.ndarray] = None,
+               backend: str = "serial") -> None:
     """Calculates the bond lengths between pairs of atom positions from the two
     coordinate arrays `coords1` and `coords2`, which must contain the same
     number of coordinates. ``coords1[i]`` and ``coords2[i]`` represent the
@@ -1337,8 +1341,12 @@ def calc_bonds(coords1, coords2, box=None, result=None, backend="serial"):
 
 
 @check_coords('coords1', 'coords2', 'coords3')
-def calc_angles(coords1, coords2, coords3, box=None, result=None,
-                backend="serial"):
+def calc_angles(coords1: Union[np.ndarray, AtomGroup],
+                coords2: Union[np.ndarray, AtomGroup],
+                coords3: Union[np.ndarray, AtomGroup],
+                box: Optional[np.ndarray] = None,
+                result: Optional[np.ndarray] = None,
+                backend: str = "serial") -> None:
     """Calculates the angles formed between triplets of atom positions from the
     three coordinate arrays `coords1`, `coords2`, and `coords3`. All coordinate
     arrays must contain the same number of coordinates.
@@ -1429,8 +1437,13 @@ def calc_angles(coords1, coords2, coords3, box=None, result=None,
 
 
 @check_coords('coords1', 'coords2', 'coords3', 'coords4')
-def calc_dihedrals(coords1, coords2, coords3, coords4, box=None, result=None,
-                   backend="serial"):
+def calc_dihedrals(coords1: Union[np.ndarray, AtomGroup],
+                   coords2: Union[np.ndarray, AtomGroup],
+                   coords3: Union[np.ndarray, AtomGroup],
+                   coords4: Union[np.ndarray, AtomGroup],
+                   box: Optional[np.ndarray] = None,
+                   result: Optional[np.ndarray] = None,
+                   backend: str = "serial") -> None:
     r"""Calculates the dihedral angles formed between quadruplets of positions
     from the four coordinate arrays `coords1`, `coords2`, `coords3`, and
     `coords4`, which must contain the same number of coordinates.

--- a/package/MDAnalysis/lib/distances.py
+++ b/package/MDAnalysis/lib/distances.py
@@ -178,7 +178,7 @@ def _check_result_array(result: np.ndarray, shape: tuple) -> np.ndarray:
 
 
 @check_coords('reference', 'configuration', reduce_result_if_single=False,
-              check_lengths_match=False)
+              check_lengths_match=False, allow_atomgroup=True)
 def distance_array(reference: Union[np.ndarray, AtomGroup],
                    configuration: Union[np.ndarray, AtomGroup],
                    box: Optional[np.ndarray] = None,
@@ -266,7 +266,7 @@ def distance_array(reference: Union[np.ndarray, AtomGroup],
     return distances
 
 
-@check_coords('reference', reduce_result_if_single=False)
+@check_coords('reference', reduce_result_if_single=False, allow_atomgroup=True)
 def self_distance_array(reference: Union[np.ndarray, AtomGroup],
                         box: Optional[np.ndarray] = None,
                         result: Optional[np.ndarray] = None,
@@ -1263,7 +1263,7 @@ def transform_StoR(coords, box, backend="serial"):
     return coords
 
 
-@check_coords('coords1', 'coords2')
+@check_coords('coords1', 'coords2', allow_atomgroup=True)
 def calc_bonds(coords1: Union[np.ndarray, AtomGroup],
                coords2: Union[np.ndarray, AtomGroup],
                box: Optional[np.ndarray] = None,
@@ -1354,7 +1354,7 @@ def calc_bonds(coords1: Union[np.ndarray, AtomGroup],
     return bondlengths
 
 
-@check_coords('coords1', 'coords2', 'coords3')
+@check_coords('coords1', 'coords2', 'coords3', allow_atomgroup=True)
 def calc_angles(coords1: Union[np.ndarray, AtomGroup],
                 coords2: Union[np.ndarray, AtomGroup],
                 coords3: Union[np.ndarray, AtomGroup],
@@ -1456,7 +1456,7 @@ def calc_angles(coords1: Union[np.ndarray, AtomGroup],
     return angles
 
 
-@check_coords('coords1', 'coords2', 'coords3', 'coords4')
+@check_coords('coords1', 'coords2', 'coords3', 'coords4', allow_atomgroup=True)
 def calc_dihedrals(coords1: Union[np.ndarray, AtomGroup],
                    coords2: Union[np.ndarray, AtomGroup],
                    coords3: Union[np.ndarray, AtomGroup],

--- a/package/MDAnalysis/lib/distances.py
+++ b/package/MDAnalysis/lib/distances.py
@@ -138,7 +138,7 @@ from .c_distances import (_UINT64_MAX,
 
 from .c_distances_openmp import OPENMP_ENABLED as USED_OPENMP
 
-
+# typing: numpy
 def _check_result_array(result: np.ndarray, shape: tuple) -> np.ndarray:
     """Check if the result array is ok to use.
 
@@ -179,7 +179,7 @@ def _check_result_array(result: np.ndarray, shape: tuple) -> np.ndarray:
 #        raise ValueError("{0} is not C-contiguous.".format(desc))
     return result
 
-
+# typing: numpy
 @check_coords('reference', 'configuration', reduce_result_if_single=False,
               check_lengths_match=False, allow_atomgroup=True)
 def distance_array(reference: Union[np.ndarray, 'AtomGroup'],
@@ -268,7 +268,7 @@ def distance_array(reference: Union[np.ndarray, 'AtomGroup'],
 
     return distances
 
-
+# typing: numpy
 @check_coords('reference', reduce_result_if_single=False, allow_atomgroup=True)
 def self_distance_array(reference: Union[np.ndarray, 'AtomGroup'],
                         box: Optional[np.ndarray] = None,
@@ -1265,7 +1265,7 @@ def transform_StoR(coords, box, backend="serial"):
     _run("coord_transform", args=(coords, box), backend=backend)
     return coords
 
-
+# typing: numpy
 @check_coords('coords1', 'coords2', allow_atomgroup=True)
 def calc_bonds(coords1: Union[np.ndarray, 'AtomGroup'],
                coords2: Union[np.ndarray, 'AtomGroup'],
@@ -1356,7 +1356,7 @@ def calc_bonds(coords1: Union[np.ndarray, 'AtomGroup'],
 
     return bondlengths
 
-
+# typing: numpy
 @check_coords('coords1', 'coords2', 'coords3', allow_atomgroup=True)
 def calc_angles(coords1: Union[np.ndarray, 'AtomGroup'],
                 coords2: Union[np.ndarray, 'AtomGroup'],
@@ -1458,7 +1458,7 @@ def calc_angles(coords1: Union[np.ndarray, 'AtomGroup'],
 
     return angles
 
-
+# typing: numpy
 @check_coords('coords1', 'coords2', 'coords3', 'coords4', allow_atomgroup=True)
 def calc_dihedrals(coords1: Union[np.ndarray, 'AtomGroup'],
                    coords2: Union[np.ndarray, 'AtomGroup'],
@@ -1575,7 +1575,7 @@ def calc_dihedrals(coords1: Union[np.ndarray, 'AtomGroup'],
 
     return dihedrals
 
-
+# typing: numpy
 @check_coords('coords', allow_atomgroup=True)
 def apply_PBC(coords: Union[np.ndarray, 'AtomGroup'],
               box: Optional[np.ndarray] = None,
@@ -1623,7 +1623,7 @@ def apply_PBC(coords: Union[np.ndarray, 'AtomGroup'],
 
     return coords
 
-
+# typing: numpy
 @check_coords('vectors', enforce_copy=False, enforce_dtype=False)
 def minimize_vectors(vectors: np.ndarray, box: np.ndarray) -> np.ndarray:
     """Apply minimum image convention to an array of vectors

--- a/package/MDAnalysis/lib/distances.py
+++ b/package/MDAnalysis/lib/distances.py
@@ -77,7 +77,7 @@ import numpy.typing as npt
 
 from typing import Union, Optional, Callable
 from typing import TYPE_CHECKING
-if TYPE_CHECKING: # pragma: no cover
+if TYPE_CHECKING:  # pragma: no cover
     from ..core.groups import AtomGroup
 from .util import check_coords, check_box
 from .mdamath import triclinic_vectors

--- a/package/MDAnalysis/lib/distances.py
+++ b/package/MDAnalysis/lib/distances.py
@@ -73,6 +73,7 @@ Functions
 """
 import numpy as np
 from numpy.lib.utils import deprecate
+import numpy.typing as npt
 
 from typing import Union, Optional, Callable
 from ..core.groups import AtomGroup
@@ -137,7 +138,7 @@ from .c_distances import (_UINT64_MAX,
 from .c_distances_openmp import OPENMP_ENABLED as USED_OPENMP
 
 
-def _check_result_array(result: np.ndarray, shape: tuple) -> np.ndarray:
+def _check_result_array(result: npt.NDArray, shape: tuple) -> npt.NDArray:
     """Check if the result array is ok to use.
 
     The `result` array must meet the following requirements:
@@ -180,11 +181,11 @@ def _check_result_array(result: np.ndarray, shape: tuple) -> np.ndarray:
 
 @check_coords('reference', 'configuration', reduce_result_if_single=False,
               check_lengths_match=False, allow_atomgroup=True)
-def distance_array(reference: Union[np.ndarray, AtomGroup],
-                   configuration: Union[np.ndarray, AtomGroup],
-                   box: Optional[np.ndarray] = None,
-                   result: Optional[np.ndarray] = None,
-                   backend: str = "serial") -> np.ndarray:
+def distance_array(reference: Union[npt.NDArray, AtomGroup],
+                   configuration: Union[npt.NDArray, AtomGroup],
+                   box: Optional[npt.NDArray] = None,
+                   result: Optional[npt.NDArray] = None,
+                   backend: str = "serial") -> npt.NDArray:
     """Calculate all possible distances between a reference set and another
     configuration.
 
@@ -268,10 +269,10 @@ def distance_array(reference: Union[np.ndarray, AtomGroup],
 
 
 @check_coords('reference', reduce_result_if_single=False, allow_atomgroup=True)
-def self_distance_array(reference: Union[np.ndarray, AtomGroup],
-                        box: Optional[np.ndarray] = None,
-                        result: Optional[np.ndarray] = None,
-                        backend: str = "serial") -> np.ndarray:
+def self_distance_array(reference: Union[npt.NDArray, AtomGroup],
+                        box: Optional[npt.NDArray] = None,
+                        result: Optional[npt.NDArray] = None,
+                        backend: str = "serial") -> npt.NDArray:
     """Calculate all possible distances within a configuration `reference`.
 
     If the optional argument `box` is supplied, the minimum image convention is
@@ -1265,11 +1266,11 @@ def transform_StoR(coords, box, backend="serial"):
 
 
 @check_coords('coords1', 'coords2', allow_atomgroup=True)
-def calc_bonds(coords1: Union[np.ndarray, AtomGroup],
-               coords2: Union[np.ndarray, AtomGroup],
-               box: Optional[np.ndarray] = None,
-               result: Optional[np.ndarray] = None,
-               backend: str = "serial") -> np.ndarray:
+def calc_bonds(coords1: Union[npt.NDArray, AtomGroup],
+               coords2: Union[npt.NDArray, AtomGroup],
+               box: Optional[npt.NDArray] = None,
+               result: Optional[npt.NDArray] = None,
+               backend: str = "serial") -> npt.NDArray:
     """Calculates the bond lengths between pairs of atom positions from the two
     coordinate arrays `coords1` and `coords2`, which must contain the same
     number of coordinates. ``coords1[i]`` and ``coords2[i]`` represent the
@@ -1356,12 +1357,12 @@ def calc_bonds(coords1: Union[np.ndarray, AtomGroup],
 
 
 @check_coords('coords1', 'coords2', 'coords3', allow_atomgroup=True)
-def calc_angles(coords1: Union[np.ndarray, AtomGroup],
-                coords2: Union[np.ndarray, AtomGroup],
-                coords3: Union[np.ndarray, AtomGroup],
-                box: Optional[np.ndarray] = None,
-                result: Optional[np.ndarray] = None,
-                backend: str = "serial") -> np.ndarray:
+def calc_angles(coords1: Union[npt.NDArray, AtomGroup],
+                coords2: Union[npt.NDArray, AtomGroup],
+                coords3: Union[npt.NDArray, AtomGroup],
+                box: Optional[npt.NDArray] = None,
+                result: Optional[npt.NDArray] = None,
+                backend: str = "serial") -> npt.NDArray:
     """Calculates the angles formed between triplets of atom positions from the
     three coordinate arrays `coords1`, `coords2`, and `coords3`. All coordinate
     arrays must contain the same number of coordinates.
@@ -1458,13 +1459,13 @@ def calc_angles(coords1: Union[np.ndarray, AtomGroup],
 
 
 @check_coords('coords1', 'coords2', 'coords3', 'coords4', allow_atomgroup=True)
-def calc_dihedrals(coords1: Union[np.ndarray, AtomGroup],
-                   coords2: Union[np.ndarray, AtomGroup],
-                   coords3: Union[np.ndarray, AtomGroup],
-                   coords4: Union[np.ndarray, AtomGroup],
-                   box: Optional[np.ndarray] = None,
-                   result: Optional[np.ndarray] = None,
-                   backend: str = "serial") -> np.ndarray:
+def calc_dihedrals(coords1: Union[npt.NDArray, AtomGroup],
+                   coords2: Union[npt.NDArray, AtomGroup],
+                   coords3: Union[npt.NDArray, AtomGroup],
+                   coords4: Union[npt.NDArray, AtomGroup],
+                   box: Optional[npt.NDArray] = None,
+                   result: Optional[npt.NDArray] = None,
+                   backend: str = "serial") -> npt.NDArray:
     r"""Calculates the dihedral angles formed between quadruplets of positions
     from the four coordinate arrays `coords1`, `coords2`, `coords3`, and
     `coords4`, which must contain the same number of coordinates.
@@ -1575,9 +1576,9 @@ def calc_dihedrals(coords1: Union[np.ndarray, AtomGroup],
 
 
 @check_coords('coords', allow_atomgroup=True)
-def apply_PBC(coords: Union[np.ndarray, AtomGroup],
-              box: Optional[np.ndarray] = None,
-              backend: str = "serial") -> np.ndarray:
+def apply_PBC(coords: Union[npt.NDArray, AtomGroup],
+              box: Optional[npt.NDArray] = None,
+              backend: str = "serial") -> npt.NDArray:
     """Moves coordinates into the primary unit cell.
 
     Parameters
@@ -1623,7 +1624,7 @@ def apply_PBC(coords: Union[np.ndarray, AtomGroup],
 
 
 @check_coords('vectors', enforce_copy=False, enforce_dtype=False)
-def minimize_vectors(vectors: np.ndarray, box: np.ndarray) -> np.ndarray:
+def minimize_vectors(vectors: npt.NDArray, box: npt.NDArray) -> npt.NDArray:
     """Apply minimum image convention to an array of vectors
 
     This function is required for calculating the correct vectors between two

--- a/package/MDAnalysis/lib/distances.py
+++ b/package/MDAnalysis/lib/distances.py
@@ -198,10 +198,12 @@ def distance_array(reference: Union[np.ndarray, AtomGroup],
     ----------
     reference :numpy.ndarray or :class:`~MDAnalysis.core.groups.AtomGroup`
         Reference coordinate array of shape ``(3,)`` or ``(n, 3)`` (dtype is
-        arbitrary, will be converted to ``numpy.float32`` internally).
+        arbitrary, will be converted to ``numpy.float32`` internally). Also
+        accepts an :class:`~MDAnalysis.core.groups.AtomGroup`.
     configuration : numpy.ndarray or :class:`~MDAnalysis.core.groups.AtomGroup`
         Configuration coordinate array of shape ``(3,)`` or ``(m, 3)`` (dtype is
-        arbitrary, will be converted to ``numpy.float32`` internally).
+        arbitrary, will be converted to ``numpy.float32`` internally). Also
+        accepts an :class:`~MDAnalysis.core.groups.AtomGroup`.
     box : array_like, optional
         The unitcell dimensions of the system, which can be orthogonal or
         triclinic and must be provided in the same format as returned by
@@ -228,7 +230,8 @@ def distance_array(reference: Union[np.ndarray, AtomGroup],
        Internal dtype conversion of input coordinates to ``numpy.float32``.
        Now also accepts single coordinates as input.
     .. versionchanged:: 2.3.0
-       Now accepts AtomGroups as input and checks types using type hinting.
+       Can now accept an :class:`~MDAnalysis.core.groups.AtomGroup` as an
+       argument in any position and checks inputs using type hinting.
     """
     confnum = configuration.shape[0]
     refnum = reference.shape[0]
@@ -278,7 +281,8 @@ def self_distance_array(reference: Union[np.ndarray, AtomGroup],
     ----------
     reference : numpy.ndarray or :class:`~MDAnalysis.core.groups.AtomGroup`
         Reference coordinate array of shape ``(3,)`` or ``(n, 3)`` (dtype is
-        arbitrary, will be converted to ``numpy.float32`` internally).
+        arbitrary, will be converted to ``numpy.float32`` internally). Also
+        accepts an :class:`~MDAnalysis.core.groups.AtomGroup`.
     box : array_like, optional
         The unitcell dimensions of the system, which can be orthogonal or
         triclinic and must be provided in the same format as returned by
@@ -310,7 +314,8 @@ def self_distance_array(reference: Union[np.ndarray, AtomGroup],
     .. versionchanged:: 0.19.0
        Internal dtype conversion of input coordinates to ``numpy.float32``.
     .. versionchanged:: 2.3.0
-       Now accepts AtomGroups as input and checks types using type hinting.
+       Can now accept an :class:`~MDAnalysis.core.groups.AtomGroup` as an
+       argument in any position and checks inputs using type hinting.
     """
     refnum = reference.shape[0]
     distnum = refnum * (refnum - 1) // 2
@@ -1283,14 +1288,16 @@ def calc_bonds(coords1: Union[np.ndarray, AtomGroup],
 
     Parameters
     ----------
-    coords1 : numpy.ndarray
+    coords1 : numpy.ndarray or :class:`~MDAnalysis.core.groups.AtomGroup`
         Coordinate array of shape ``(3,)`` or ``(n, 3)`` for one half of a
         single or ``n`` bonds, respectively (dtype is arbitrary, will be
-        converted to ``numpy.float32`` internally).
+        converted to ``numpy.float32`` internally).  Also accepts an
+        :class:`~MDAnalysis.core.groups.AtomGroup`.
     coords2 : numpy.ndarray
         Coordinate array of shape ``(3,)`` or ``(n, 3)`` for the other half of
         a single or ``n`` bonds, respectively (dtype is arbitrary, will be
-        converted to ``numpy.float32`` internally).
+        converted to ``numpy.float32`` internally). Also accepts an
+        :class:`~MDAnalysis.core.groups.AtomGroup`.
     box : numpy.ndarray, optional
         The unitcell dimensions of the system, which can be orthogonal or
         triclinic and must be provided in the same format as returned by
@@ -1317,6 +1324,9 @@ def calc_bonds(coords1: Union[np.ndarray, AtomGroup],
     .. versionchanged:: 0.19.0
        Internal dtype conversion of input coordinates to ``numpy.float32``.
        Now also accepts single coordinates as input.
+    .. versionchanged:: 2.3.0
+       Can now accept an :class:`~MDAnalysis.core.groups.AtomGroup` as an
+       argument in any position and checks inputs using type hinting.
     """
     numatom = coords1.shape[0]
     bondlengths = _check_result_array(result, (numatom,))
@@ -1372,18 +1382,21 @@ def calc_angles(coords1: Union[np.ndarray, AtomGroup],
 
     Parameters
     ----------
-    coords1 : numpy.ndarray
+    coords1 : numpy.ndarray or :class:`~MDAnalysis.core.groups.AtomGroup`
         Array of shape ``(3,)`` or ``(n, 3)`` containing the coordinates of one
         side of a single or ``n`` angles, respectively (dtype is arbitrary, will
-        be converted to ``numpy.float32`` internally)
-    coords2 : numpy.ndarray
+        be converted to ``numpy.float32`` internally). Also accepts an
+        :class:`~MDAnalysis.core.groups.AtomGroup`.
+    coords2 :  numpy.ndarray or :class:`~MDAnalysis.core.groups.AtomGroup`
         Array of shape ``(3,)`` or ``(n, 3)`` containing the coordinates of the
         apices of a single or ``n`` angles, respectively (dtype is arbitrary,
-        will be converted to ``numpy.float32`` internally)
-    coords3 : numpy.ndarray
+        will be converted to ``numpy.float32`` internally). Also accepts an 
+        :class:`~MDAnalysis.core.groups.AtomGroup`.
+    coords3 :  numpy.ndarray or :class:`~MDAnalysis.core.groups.AtomGroup`
         Array of shape ``(3,)`` or ``(n, 3)`` containing the coordinates of the
         other side of a single or ``n`` angles, respectively (dtype is
-        arbitrary, will be converted to ``numpy.float32`` internally)
+        arbitrary, will be converted to ``numpy.float32`` internally).
+        Also accepts an :class:`~MDAnalysis.core.groups.AtomGroup`.
     box : numpy.ndarray, optional
         The unitcell dimensions of the system, which can be orthogonal or
         triclinic and must be provided in the same format as returned by
@@ -1413,6 +1426,9 @@ def calc_angles(coords1: Union[np.ndarray, AtomGroup],
     .. versionchanged:: 0.19.0
        Internal dtype conversion of input coordinates to ``numpy.float32``.
        Now also accepts single coordinates as input.
+    .. versionchanged:: 2.3.0
+       Can now accept an :class:`~MDAnalysis.core.groups.AtomGroup` as an
+       argument in any position and checks inputs using type hinting.
     """
     numatom = coords1.shape[0]
     angles = _check_result_array(result, (numatom,))

--- a/package/MDAnalysis/lib/distances.py
+++ b/package/MDAnalysis/lib/distances.py
@@ -98,7 +98,7 @@ except ImportError:
 del importlib
 
 def _run(funcname: Callable, args: Optional[tuple] = None,
-         kwargs: Optional[dict] = None, backend: str = "serial"):
+         kwargs: Optional[dict] = None, backend: str = "serial") -> Callable:
     """Helper function to select a backend function `funcname`."""
     args = args if args is not None else tuple()
     kwargs = kwargs if kwargs is not None else dict()
@@ -183,7 +183,7 @@ def distance_array(reference: Union[np.ndarray, AtomGroup],
                    configuration: Union[np.ndarray, AtomGroup],
                    box: Optional[np.ndarray] = None,
                    result: Optional[np.ndarray] = None,
-                   backend: str = "serial") -> None:
+                   backend: str = "serial") -> np.ndarray:
     """Calculate all possible distances between a reference set and another
     configuration.
 
@@ -270,7 +270,7 @@ def distance_array(reference: Union[np.ndarray, AtomGroup],
 def self_distance_array(reference: Union[np.ndarray, AtomGroup],
                         box: Optional[np.ndarray] = None,
                         result: Optional[np.ndarray] = None,
-                        backend: str = "serial") -> None:
+                        backend: str = "serial") -> np.ndarray:
     """Calculate all possible distances within a configuration `reference`.
 
     If the optional argument `box` is supplied, the minimum image convention is

--- a/package/MDAnalysis/lib/distances.py
+++ b/package/MDAnalysis/lib/distances.py
@@ -138,6 +138,7 @@ from .c_distances import (_UINT64_MAX,
 
 from .c_distances_openmp import OPENMP_ENABLED as USED_OPENMP
 
+
 # typing: numpy
 def _check_result_array(result: np.ndarray, shape: tuple) -> np.ndarray:
     """Check if the result array is ok to use.
@@ -178,6 +179,7 @@ def _check_result_array(result: np.ndarray, shape: tuple) -> np.ndarray:
 #    if not coords.flags['C_CONTIGUOUS']:
 #        raise ValueError("{0} is not C-contiguous.".format(desc))
     return result
+
 
 # typing: numpy
 @check_coords('reference', 'configuration', reduce_result_if_single=False,
@@ -267,6 +269,7 @@ def distance_array(reference: Union[np.ndarray, 'AtomGroup'],
              backend=backend)
 
     return distances
+
 
 # typing: numpy
 @check_coords('reference', reduce_result_if_single=False, allow_atomgroup=True)
@@ -1265,6 +1268,7 @@ def transform_StoR(coords, box, backend="serial"):
     _run("coord_transform", args=(coords, box), backend=backend)
     return coords
 
+
 # typing: numpy
 @check_coords('coords1', 'coords2', allow_atomgroup=True)
 def calc_bonds(coords1: Union[np.ndarray, 'AtomGroup'],
@@ -1355,6 +1359,7 @@ def calc_bonds(coords1: Union[np.ndarray, 'AtomGroup'],
                  backend=backend)
 
     return bondlengths
+
 
 # typing: numpy
 @check_coords('coords1', 'coords2', 'coords3', allow_atomgroup=True)
@@ -1457,6 +1462,7 @@ def calc_angles(coords1: Union[np.ndarray, 'AtomGroup'],
                    backend=backend)
 
     return angles
+
 
 # typing: numpy
 @check_coords('coords1', 'coords2', 'coords3', 'coords4', allow_atomgroup=True)
@@ -1575,6 +1581,7 @@ def calc_dihedrals(coords1: Union[np.ndarray, 'AtomGroup'],
 
     return dihedrals
 
+
 # typing: numpy
 @check_coords('coords', allow_atomgroup=True)
 def apply_PBC(coords: Union[np.ndarray, 'AtomGroup'],
@@ -1622,6 +1629,7 @@ def apply_PBC(coords: Union[np.ndarray, 'AtomGroup'],
         _run("triclinic_pbc", args=(coords, box), backend=backend)
 
     return coords
+
 
 # typing: numpy
 @check_coords('vectors', enforce_copy=False, enforce_dtype=False)

--- a/package/MDAnalysis/lib/distances.py
+++ b/package/MDAnalysis/lib/distances.py
@@ -29,8 +29,8 @@ Fast C-routines to calculate arrays of distances or angles from coordinate
 arrays. Distance functions can accept a NumPy :class:`np.ndarray` or an
 :class:`~MDAnalysis.core.groups.AtomGroup`. Many of the functions also exist
 in parallel versions, which typically provide higher performance than the
-serial code. The boolean attribute `MDAnalysis.lib.distances.USED_OPENMP` can be
-checked to see if OpenMP was used in the compilation of MDAnalysis.
+serial code. The boolean attribute `MDAnalysis.lib.distances.USED_OPENMP` can
+be checked to see if OpenMP was used in the compilation of MDAnalysis.
 
 Selection of acceleration ("backend")
 -------------------------------------
@@ -52,7 +52,7 @@ case-insensitive):
 
 .. versionadded:: 0.13.0
 .. versionchanged:: 2.3.0
-   Distance functions can now accept an 
+   Distance functions can now accept an
    :class:`~MDAnalysis.core.groups.AtomGroup` or an :class:`np.ndarray`
 
 Functions
@@ -96,6 +96,7 @@ try:
 except ImportError:
     pass
 del importlib
+
 
 def _run(funcname: Callable, args: Optional[tuple] = None,
          kwargs: Optional[dict] = None, backend: str = "serial") -> Callable:
@@ -1394,7 +1395,7 @@ def calc_angles(coords1: Union[np.ndarray, AtomGroup],
     coords2 :  numpy.ndarray or :class:`~MDAnalysis.core.groups.AtomGroup`
         Array of shape ``(3,)`` or ``(n, 3)`` containing the coordinates of the
         apices of a single or ``n`` angles, respectively (dtype is arbitrary,
-        will be converted to ``numpy.float32`` internally). Also accepts an 
+        will be converted to ``numpy.float32`` internally). Also accepts an
         :class:`~MDAnalysis.core.groups.AtomGroup`.
     coords3 :  numpy.ndarray or :class:`~MDAnalysis.core.groups.AtomGroup`
         Array of shape ``(3,)`` or ``(n, 3)`` containing the coordinates of the
@@ -1498,22 +1499,22 @@ def calc_dihedrals(coords1: Union[np.ndarray, AtomGroup],
     coords1 : numpy.ndarray or :class:`~MDAnalysis.core.groups.AtomGroup`
         Coordinate array of shape ``(3,)`` or ``(n, 3)`` containing the 1st
         positions in dihedrals (dtype is arbitrary, will be converted to
-        ``numpy.float32`` internally).  Also accepts an 
+        ``numpy.float32`` internally).  Also accepts an
         :class:`~MDAnalysis.core.groups.AtomGroup`.
     coords2 : numpy.ndarray or :class:`~MDAnalysis.core.groups.AtomGroup`
         Coordinate array of shape ``(3,)`` or ``(n, 3)`` containing the 2nd
         positions in dihedrals (dtype is arbitrary, will be converted to
-        ``numpy.float32`` internally).  Also accepts an 
+        ``numpy.float32`` internally).  Also accepts an
         :class:`~MDAnalysis.core.groups.AtomGroup`.
     coords3 : numpy.ndarray or :class:`~MDAnalysis.core.groups.AtomGroup`
         Coordinate array of shape ``(3,)`` or ``(n, 3)`` containing the 3rd
         positions in dihedrals (dtype is arbitrary, will be converted to
-        ``numpy.float32`` internally).  Also accepts an 
+        ``numpy.float32`` internally).  Also accepts an
         :class:`~MDAnalysis.core.groups.AtomGroup`.
     coords4 : numpy.ndarray or :class:`~MDAnalysis.core.groups.AtomGroup`
         Coordinate array of shape ``(3,)`` or ``(n, 3)`` containing the 4th
         positions in dihedrals (dtype is arbitrary, will be converted to
-        ``numpy.float32`` internally).  Also accepts an 
+        ``numpy.float32`` internally).  Also accepts an
         :class:`~MDAnalysis.core.groups.AtomGroup`.
     box : numpy.ndarray, optional
         The unitcell dimensions of the system, which can be orthogonal or
@@ -1583,7 +1584,7 @@ def apply_PBC(coords: Union[np.ndarray, AtomGroup],
     ----------
     coords : numpy.ndarray or :class:`~MDAnalysis.core.groups.AtomGroup`
         Coordinate array of shape ``(3,)`` or ``(n, 3)`` (dtype is arbitrary,
-        will be converted to ``numpy.float32`` internally). Also accepts an 
+        will be converted to ``numpy.float32`` internally). Also accepts an
         :class:`~MDAnalysis.core.groups.AtomGroup`.
     box : numpy.ndarray
         The unitcell dimensions of the system, which can be orthogonal or

--- a/package/MDAnalysis/lib/distances.py
+++ b/package/MDAnalysis/lib/distances.py
@@ -1268,7 +1268,7 @@ def calc_bonds(coords1: Union[np.ndarray, AtomGroup],
                coords2: Union[np.ndarray, AtomGroup],
                box: Optional[np.ndarray] = None,
                result: Optional[np.ndarray] = None,
-               backend: str = "serial") -> None:
+               backend: str = "serial") -> np.ndarray:
     """Calculates the bond lengths between pairs of atom positions from the two
     coordinate arrays `coords1` and `coords2`, which must contain the same
     number of coordinates. ``coords1[i]`` and ``coords2[i]`` represent the
@@ -1360,7 +1360,7 @@ def calc_angles(coords1: Union[np.ndarray, AtomGroup],
                 coords3: Union[np.ndarray, AtomGroup],
                 box: Optional[np.ndarray] = None,
                 result: Optional[np.ndarray] = None,
-                backend: str = "serial") -> None:
+                backend: str = "serial") -> np.ndarray:
     """Calculates the angles formed between triplets of atom positions from the
     three coordinate arrays `coords1`, `coords2`, and `coords3`. All coordinate
     arrays must contain the same number of coordinates.
@@ -1463,7 +1463,7 @@ def calc_dihedrals(coords1: Union[np.ndarray, AtomGroup],
                    coords4: Union[np.ndarray, AtomGroup],
                    box: Optional[np.ndarray] = None,
                    result: Optional[np.ndarray] = None,
-                   backend: str = "serial") -> None:
+                   backend: str = "serial") -> np.ndarray:
     r"""Calculates the dihedral angles formed between quadruplets of positions
     from the four coordinate arrays `coords1`, `coords2`, `coords3`, and
     `coords4`, which must contain the same number of coordinates.
@@ -1576,7 +1576,7 @@ def calc_dihedrals(coords1: Union[np.ndarray, AtomGroup],
 @check_coords('coords', allow_atomgroup=True)
 def apply_PBC(coords: Union[np.ndarray, AtomGroup],
               box: Optional[np.ndarray] = None,
-              backend: str = "serial") -> None:
+              backend: str = "serial") -> np.ndarray:
     """Moves coordinates into the primary unit cell.
 
     Parameters
@@ -1622,7 +1622,7 @@ def apply_PBC(coords: Union[np.ndarray, AtomGroup],
 
 
 @check_coords('vectors', enforce_copy=False, enforce_dtype=False)
-def minimize_vectors(vectors, box):
+def minimize_vectors(vectors: np.ndarray, box: np.ndarray) -> np.ndarray:
     """Apply minimum image convention to an array of vectors
 
     This function is required for calculating the correct vectors between two

--- a/package/MDAnalysis/lib/distances.py
+++ b/package/MDAnalysis/lib/distances.py
@@ -1581,9 +1581,10 @@ def apply_PBC(coords: Union[np.ndarray, AtomGroup],
 
     Parameters
     ----------
-    coords : numpy.ndarray
+    coords : numpy.ndarray or :class:`~MDAnalysis.core.groups.AtomGroup`
         Coordinate array of shape ``(3,)`` or ``(n, 3)`` (dtype is arbitrary,
-        will be converted to ``numpy.float32`` internally).
+        will be converted to ``numpy.float32`` internally). Also accepts an 
+        :class:`~MDAnalysis.core.groups.AtomGroup`.
     box : numpy.ndarray
         The unitcell dimensions of the system, which can be orthogonal or
         triclinic and must be provided in the same format as returned by

--- a/package/MDAnalysis/lib/distances.py
+++ b/package/MDAnalysis/lib/distances.py
@@ -132,7 +132,7 @@ from .c_distances import (_UINT64_MAX,
 from .c_distances_openmp import OPENMP_ENABLED as USED_OPENMP
 
 
-def _check_result_array(result: np.ndarray, shape: tuple):
+def _check_result_array(result: np.ndarray, shape: tuple) -> np.ndarray:
     """Check if the result array is ok to use.
 
     The `result` array must meet the following requirements:
@@ -1293,7 +1293,7 @@ def calc_bonds(coords1: Union[np.ndarray, AtomGroup],
         single or ``n`` bonds, respectively (dtype is arbitrary, will be
         converted to ``numpy.float32`` internally).  Also accepts an
         :class:`~MDAnalysis.core.groups.AtomGroup`.
-    coords2 : numpy.ndarray
+    coords2 : numpy.ndarray or :class:`~MDAnalysis.core.groups.AtomGroup`
         Coordinate array of shape ``(3,)`` or ``(n, 3)`` for the other half of
         a single or ``n`` bonds, respectively (dtype is arbitrary, will be
         converted to ``numpy.float32`` internally). Also accepts an

--- a/package/MDAnalysis/lib/distances.py
+++ b/package/MDAnalysis/lib/distances.py
@@ -26,10 +26,11 @@
 ===================================================================
 
 Fast C-routines to calculate arrays of distances or angles from coordinate
-arrays. Many of the functions also exist in parallel versions, which typically
-provide higher performance than the serial code.
-The boolean attribute `MDAnalysis.lib.distances.USED_OPENMP` can be checked to
-see if OpenMP was used in the compilation of MDAnalysis.
+arrays. Distance functions can accept a NumPy :class:`np.ndarray` or an
+:class:`~MDAnalysis.core.groups.AtomGroup`. Many of the functions also exist
+in parallel versions, which typically provide higher performance than the
+serial code. The boolean attribute `MDAnalysis.lib.distances.USED_OPENMP` can be
+checked to see if OpenMP was used in the compilation of MDAnalysis.
 
 Selection of acceleration ("backend")
 -------------------------------------
@@ -50,6 +51,9 @@ case-insensitive):
    ========== ========================= ======================================
 
 .. versionadded:: 0.13.0
+.. versionchanged:: 2.3.0
+   Distance functions can now accept an 
+   :class:`~MDAnalysis.core.groups.AtomGroup` or an :class:`np.ndarray`
 
 Functions
 ---------

--- a/package/MDAnalysis/lib/distances.py
+++ b/package/MDAnalysis/lib/distances.py
@@ -70,6 +70,8 @@ Functions
 import numpy as np
 from numpy.lib.utils import deprecate
 
+from typing import Union, Optional
+from ..core.groups import AtomGroup
 from .util import check_coords, check_box
 from .mdamath import triclinic_vectors
 from ._augment import augment_coordinates, undo_augment
@@ -172,8 +174,10 @@ def _check_result_array(result, shape):
 
 @check_coords('reference', 'configuration', reduce_result_if_single=False,
               check_lengths_match=False)
-def distance_array(reference, configuration, box=None, result=None,
-                   backend="serial"):
+def distance_array(reference: Union[np.ndarray, AtomGroup],
+                   configuration: Union[np.ndarray, AtomGroup],
+                   box: Optional[np.ndarray] = None, result=None,
+                   backend: str = "serial") -> None:
     """Calculate all possible distances between a reference set and another
     configuration.
 

--- a/package/MDAnalysis/lib/distances.py
+++ b/package/MDAnalysis/lib/distances.py
@@ -76,7 +76,9 @@ from numpy.lib.utils import deprecate
 import numpy.typing as npt
 
 from typing import Union, Optional, Callable
-from ..core.groups import AtomGroup
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from ..core.groups import AtomGroup
 from .util import check_coords, check_box
 from .mdamath import triclinic_vectors
 from ._augment import augment_coordinates, undo_augment
@@ -181,8 +183,8 @@ def _check_result_array(result: npt.NDArray, shape: tuple) -> npt.NDArray:
 
 @check_coords('reference', 'configuration', reduce_result_if_single=False,
               check_lengths_match=False, allow_atomgroup=True)
-def distance_array(reference: Union[npt.NDArray, AtomGroup],
-                   configuration: Union[npt.NDArray, AtomGroup],
+def distance_array(reference: Union[npt.NDArray, 'AtomGroup'],
+                   configuration: Union[npt.NDArray, 'AtomGroup'],
                    box: Optional[npt.NDArray] = None,
                    result: Optional[npt.NDArray] = None,
                    backend: str = "serial") -> npt.NDArray:
@@ -269,7 +271,7 @@ def distance_array(reference: Union[npt.NDArray, AtomGroup],
 
 
 @check_coords('reference', reduce_result_if_single=False, allow_atomgroup=True)
-def self_distance_array(reference: Union[npt.NDArray, AtomGroup],
+def self_distance_array(reference: Union[npt.NDArray, 'AtomGroup'],
                         box: Optional[npt.NDArray] = None,
                         result: Optional[npt.NDArray] = None,
                         backend: str = "serial") -> npt.NDArray:
@@ -1266,8 +1268,8 @@ def transform_StoR(coords, box, backend="serial"):
 
 
 @check_coords('coords1', 'coords2', allow_atomgroup=True)
-def calc_bonds(coords1: Union[npt.NDArray, AtomGroup],
-               coords2: Union[npt.NDArray, AtomGroup],
+def calc_bonds(coords1: Union[npt.NDArray, 'AtomGroup'],
+               coords2: Union[npt.NDArray, 'AtomGroup'],
                box: Optional[npt.NDArray] = None,
                result: Optional[npt.NDArray] = None,
                backend: str = "serial") -> npt.NDArray:
@@ -1357,9 +1359,9 @@ def calc_bonds(coords1: Union[npt.NDArray, AtomGroup],
 
 
 @check_coords('coords1', 'coords2', 'coords3', allow_atomgroup=True)
-def calc_angles(coords1: Union[npt.NDArray, AtomGroup],
-                coords2: Union[npt.NDArray, AtomGroup],
-                coords3: Union[npt.NDArray, AtomGroup],
+def calc_angles(coords1: Union[npt.NDArray, 'AtomGroup'],
+                coords2: Union[npt.NDArray, 'AtomGroup'],
+                coords3: Union[npt.NDArray, 'AtomGroup'],
                 box: Optional[npt.NDArray] = None,
                 result: Optional[npt.NDArray] = None,
                 backend: str = "serial") -> npt.NDArray:
@@ -1459,10 +1461,10 @@ def calc_angles(coords1: Union[npt.NDArray, AtomGroup],
 
 
 @check_coords('coords1', 'coords2', 'coords3', 'coords4', allow_atomgroup=True)
-def calc_dihedrals(coords1: Union[npt.NDArray, AtomGroup],
-                   coords2: Union[npt.NDArray, AtomGroup],
-                   coords3: Union[npt.NDArray, AtomGroup],
-                   coords4: Union[npt.NDArray, AtomGroup],
+def calc_dihedrals(coords1: Union[npt.NDArray, 'AtomGroup'],
+                   coords2: Union[npt.NDArray, 'AtomGroup'],
+                   coords3: Union[npt.NDArray, 'AtomGroup'],
+                   coords4: Union[npt.NDArray, 'AtomGroup'],
                    box: Optional[npt.NDArray] = None,
                    result: Optional[npt.NDArray] = None,
                    backend: str = "serial") -> npt.NDArray:
@@ -1576,7 +1578,7 @@ def calc_dihedrals(coords1: Union[npt.NDArray, AtomGroup],
 
 
 @check_coords('coords', allow_atomgroup=True)
-def apply_PBC(coords: Union[npt.NDArray, AtomGroup],
+def apply_PBC(coords: Union[npt.NDArray, 'AtomGroup'],
               box: Optional[npt.NDArray] = None,
               backend: str = "serial") -> npt.NDArray:
     """Moves coordinates into the primary unit cell.

--- a/package/MDAnalysis/lib/distances.py
+++ b/package/MDAnalysis/lib/distances.py
@@ -1547,6 +1547,9 @@ def calc_dihedrals(coords1: Union[np.ndarray, AtomGroup],
     .. versionchanged:: 0.19.0
        Internal dtype conversion of input coordinates to ``numpy.float32``.
        Now also accepts single coordinates as input.
+    .. versionchanged:: 2.3.0
+       Can now accept an :class:`~MDAnalysis.core.groups.AtomGroup` as an
+       argument in any position and checks inputs using type hinting.
     """
     numatom = coords1.shape[0]
     dihedrals = _check_result_array(result, (numatom,))
@@ -1570,8 +1573,10 @@ def calc_dihedrals(coords1: Union[np.ndarray, AtomGroup],
     return dihedrals
 
 
-@check_coords('coords')
-def apply_PBC(coords, box, backend="serial"):
+@check_coords('coords', allow_atomgroup=True)
+def apply_PBC(coords: Union[np.ndarray, AtomGroup],
+              box: Optional[np.ndarray] = None,
+              backend: str = "serial") -> None:
     """Moves coordinates into the primary unit cell.
 
     Parameters
@@ -1600,6 +1605,9 @@ def apply_PBC(coords, box, backend="serial"):
     .. versionchanged:: 0.19.0
        Internal dtype conversion of input coordinates to ``numpy.float32``.
        Now also accepts (and, likewise, returns) single coordinates.
+    .. versionchanged:: 2.3.0
+       Can now accept an :class:`~MDAnalysis.core.groups.AtomGroup` as an
+       argument in any position and checks inputs using type hinting.
     """
     if len(coords) == 0:
         return coords

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -1939,12 +1939,17 @@ def check_coords(*coord_names, **options):
     :mod:`MDAnalysis.lib.distances`.
     It takes an arbitrary number of positional arguments which must correspond
     to names of positional arguments of the decorated function.
-    It then checks if the corresponding values are valid coordinate arrays.
-    If all these arrays are single coordinates (i.e., their shape is ``(3,)``),
-    the decorated function can optionally return a single coordinate (or angle)
-    instead of an array of coordinates (or angles). This can be used to enable
-    computations of single observables using functions originally designed to
-    accept only 2-d coordinate arrays.
+    It then checks if the corresponding values are valid coordinate arrays or an
+    :class:`~MDAnalysis.core.groups.AtomGroup`.
+    If the input is an array and all these arrays are single coordinates
+    (i.e., their shape is ``(3,)``), the decorated function can optionally
+    return a single coordinate (or angle) instead of an array of coordinates
+    (or angles). This can be used to enable computations of single observables
+    using functions originally designed to accept only 2-d coordinate arrays.
+
+    If the input is an :class:`~MDAnalysis.core.groups.AtomGroup` it is
+    converted into its corresponding position array via a call to
+    `AtomGroup.positions`.
 
     The checks performed on each individual coordinate array are:
 
@@ -1994,7 +1999,8 @@ def check_coords(*coord_names, **options):
 
         If any of the coordinate arrays has a wrong shape.
     TypeError
-        If any of the coordinate arrays is not a :class:`numpy.ndarray`.
+        If any of the coordinate arrays is not a :class:`numpy.ndarray` or an
+        :class:`~MDAnalysis.core.groups.AtomGroup`. 
 
         If the dtype of any of the coordinate arrays is not convertible to
           ``numpy.float32``.
@@ -2016,6 +2022,11 @@ def check_coords(*coord_names, **options):
     >>> coordsum(np.zeros(3), np.ones(6)[::2])
     array([1., 1., 1.], dtype=float32)
     >>>
+    >>> # automatic handling of AtomGroups
+    >>> u = mda.Universe(PSF,DCD)
+    >>> coordsum(u.atoms, u.select_atoms("index 1 to 10"))
+    ...
+    >>> 
     >>> # automatic shape checking:
     >>> coordsum(np.zeros(3), np.ones(6))
     ValueError: coordsum(): coords2.shape must be (3,) or (n, 3), got (6,).

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -2107,8 +2107,6 @@ def check_coords(*coord_names, **options):
                                         "argument, but allow_atomgroup is"
                                         " False")
                         raise err
-                except TypeError:
-                    raise err
                 except AttributeError:
                     raise TypeError("{}(): Parameter '{}' must be a"
                                     " numpy.ndarray or an AtomGroup,"

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -2148,7 +2148,7 @@ def check_coords(*coord_names, **options):
                     all_single &= is_single
                     ncoords.append(ncoord)
                 else:
-                    kwargs[name], is_single, ncoord = _check_coords(kwargs[name], # nopep8
+                    kwargs[name], is_single, ncoord = _check_coords(kwargs[name],
                                                                     name)
                     all_single &= is_single
                     ncoords.append(ncoord)

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -2074,18 +2074,18 @@ def check_coords(*coord_names, **options):
             if isinstance(coords, np.ndarray):
                 if allow_single:
                     if (coords.ndim not in (1, 2)) or (coords.shape[-1] != 3):
-                        raise ValueError("{}(): {}.shape must be (3,) or"
-                                         " (n, 3), got {}.".format(fname,
-                                         argname, coords.shape))
+                        errmsg = (f"{fname}(): {argname}.shape must be (3,) or "
+                                  f"(n, 3), got {coords.shape})
+                        raise ValueError(errmsg)
                     if coords.ndim == 1:
                         is_single = True
                         if convert_single:
                             coords = coords[None, :]
                 else:
                     if (coords.ndim != 2) or (coords.shape[1] != 3):
-                        raise ValueError("{}(): {}.shape must be (n, 3),"
-                                         " got {}.".format(fname, argname,
-                                                          coords.shape))
+                        errmsg = (f"{fname}(): {argname}.shape must be (n, 3) "
+                                  f"got {coords.shape})
+                        raise ValueError(errmsg)
                 if enforce_dtype:
                     try:
                         coords = coords.astype(

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -2074,8 +2074,8 @@ def check_coords(*coord_names, **options):
             if isinstance(coords, np.ndarray):
                 if allow_single:
                     if (coords.ndim not in (1, 2)) or (coords.shape[-1] != 3):
-                        errmsg = (f"{fname}(): {argname}.shape must be (3,) or "
-                                  f"(n, 3), got {coords.shape}")
+                        errmsg = (f"{fname}(): {argname}.shape must be (3,) "
+                                  f"or (n, 3), got {coords.shape}")
                         raise ValueError(errmsg)
                     if coords.ndim == 1:
                         is_single = True

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -2111,7 +2111,7 @@ def check_coords(*coord_names, **options):
                     raise TypeError(f"{fname}(): Parameter '{argname}' must be"
                                     f" a numpy.ndarray or an AtomGroup,"
                                     f" got {type(coords)}.")
-            
+
             return coords, is_single, ncoord
 
         @wraps(func)

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -2108,10 +2108,9 @@ def check_coords(*coord_names, **options):
                                         " False")
                         raise err
                 except AttributeError:
-                    raise TypeError("{}(): Parameter '{}' must be a"
-                                    " numpy.ndarray or an AtomGroup,"
-                                    " got {}.".format(fname,
-                                    argname, type(coords)))
+                    raise TypeError(f"{fname}(): Parameter '{argname}' must be"
+                                    f" a numpy.ndarray or an AtomGroup,"
+                                    f" got {type(coords)}.")
             
             return coords, is_single, ncoord
 

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -2025,7 +2025,7 @@ def check_coords(*coord_names, **options):
     array([1., 1., 1.], dtype=float32)
     >>>
     >>> # automatic handling of AtomGroups
-    >>> u = mda.Universe(PSF,DCD)
+    >>> u = mda.Universe(PSF, DCD)
     >>> coordsum(u.atoms, u.select_atoms("index 1 to 10"))
     ...
     >>>

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -2101,9 +2101,7 @@ def check_coords(*coord_names, **options):
                 try:
                     coords = coords.positions  # homogenise to a numpy array
                     ncoord = coords.shape[0]
-                    if allow_atomgroup:
-                        pass
-                    else:
+                    if not allow_atomgroup:
                         err = TypeError("AtomGroup or other class with a"
                                         "`.positions` method supplied as an"
                                         "argument, but allow_atomgroup is"
@@ -2111,7 +2109,7 @@ def check_coords(*coord_names, **options):
                         raise err
                 except TypeError:
                     raise err
-                except:
+                except AttributeError:
                     raise TypeError("{}(): Parameter '{}' must be a"
                                     " numpy.ndarray or an AtomGroup,"
                                     " got {}.".format(fname,

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -2077,8 +2077,7 @@ def check_coords(*coord_names, **options):
                     if (coords.ndim not in (1, 2)) or (coords.shape[-1] != 3):
                         raise ValueError("{}(): {}.shape must be (3,) or"
                                          "(n, 3), got {}.".format(fname,
-                                                                  argname,
-                                                                  coords.shape))
+                                         argname, coords.shape))
                     if coords.ndim == 1:
                         is_single = True
                         if convert_single:
@@ -2094,7 +2093,8 @@ def check_coords(*coord_names, **options):
                             np.float32, order='C', copy=enforce_copy)
                     except ValueError:
                         errmsg = (f"{fname}(): {argname}.dtype must be"
-                                 f"convertible to float32, got {coords.dtype}.")
+                                  f"convertible to float32, got"
+                                  f" {coords.dtype}.")
                         raise TypeError(errmsg) from None
                 # coordinates should now be the right shape
                 ncoord = coords.shape[0]

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -2104,15 +2104,18 @@ def check_coords(*coord_names, **options):
                     if allow_atomgroup:
                         pass
                     else:
-                        err = TypeError("AtomGroup supplied as an argument, but"
-                                    "allow_atomgroup is False")
+                        err = TypeError("AtomGroup or other class with a"
+                                        "`.positions` method supplied as an"
+                                        "argument, but allow_atomgroup is"
+                                        " False")
                         raise err
                 except TypeError:
                     raise err
                 except:
-                    raise TypeError("{}(): Parameter '{}' must be a numpy.ndarray "
-                                " or an AtomGroup, got {}.".format(fname,
-                                argname, type(coords)))
+                    raise TypeError("{}(): Parameter '{}' must be a"
+                                    " numpy.ndarray or an AtomGroup,"
+                                    " got {}.".format(fname,
+                                    argname, type(coords)))
             
             return coords, is_single, ncoord
 

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -2076,7 +2076,7 @@ def check_coords(*coord_names, **options):
                 if allow_single:
                     if (coords.ndim not in (1, 2)) or (coords.shape[-1] != 3):
                         raise ValueError("{}(): {}.shape must be (3,) or"
-                                         "(n, 3), got {}.".format(fname,
+                                         " (n, 3), got {}.".format(fname,
                                          argname, coords.shape))
                     if coords.ndim == 1:
                         is_single = True
@@ -2085,7 +2085,7 @@ def check_coords(*coord_names, **options):
                 else:
                     if (coords.ndim != 2) or (coords.shape[1] != 3):
                         raise ValueError("{}(): {}.shape must be (n, 3),"
-                                        " got {}.".format(fname, argname,
+                                         " got {}.".format(fname, argname,
                                                           coords.shape))
                 if enforce_dtype:
                     try:

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -1939,8 +1939,8 @@ def check_coords(*coord_names, **options):
     :mod:`MDAnalysis.lib.distances`.
     It takes an arbitrary number of positional arguments which must correspond
     to names of positional arguments of the decorated function.
-    It then checks if the corresponding values are valid coordinate arrays or an
-    :class:`~MDAnalysis.core.groups.AtomGroup`.
+    It then checks if the corresponding values are valid coordinate arrays or
+    an :class:`~MDAnalysis.core.groups.AtomGroup`.
     If the input is an array and all these arrays are single coordinates
     (i.e., their shape is ``(3,)``), the decorated function can optionally
     return a single coordinate (or angle) instead of an array of coordinates
@@ -1987,7 +1987,7 @@ def check_coords(*coord_names, **options):
           :class:`ValueError` is raised if not all coordinate arrays contain the
           same number of coordinates. Default: ``True``
         * **allow_atomgroup** (:class:`bool`, optional) -- If ``False``, a
-          :class:`TypeError` is raised if an :class:`AtomGroup` is supplied 
+          :class:`TypeError` is raised if an :class:`AtomGroup` is supplied
           Default: ``False``
 
     Raises
@@ -2003,7 +2003,7 @@ def check_coords(*coord_names, **options):
         If any of the coordinate arrays has a wrong shape.
     TypeError
         If any of the coordinate arrays is not a :class:`numpy.ndarray` or an
-        :class:`~MDAnalysis.core.groups.AtomGroup`. 
+        :class:`~MDAnalysis.core.groups.AtomGroup`.
 
         If the dtype of any of the coordinate arrays is not convertible to
           ``numpy.float32``.
@@ -2029,7 +2029,7 @@ def check_coords(*coord_names, **options):
     >>> u = mda.Universe(PSF,DCD)
     >>> coordsum(u.atoms, u.select_atoms("index 1 to 10"))
     ...
-    >>> 
+    >>>
     >>> # automatic shape checking:
     >>> coordsum(np.zeros(3), np.ones(6))
     ValueError: coordsum(): coords2.shape must be (3,) or (n, 3), got (6,).
@@ -2075,30 +2075,32 @@ def check_coords(*coord_names, **options):
             if isinstance(coords, np.ndarray):
                 if allow_single:
                     if (coords.ndim not in (1, 2)) or (coords.shape[-1] != 3):
-                        raise ValueError("{}(): {}.shape must be (3,) or (n, 3), "
-                                         "got {}.".format(fname, argname,
-                                                          coords.shape))
+                        raise ValueError("{}(): {}.shape must be (3,) or"
+                                         "(n, 3), got {}.".format(fname,
+                                                                  argname,
+                                                                  coords.shape))
                     if coords.ndim == 1:
                         is_single = True
                         if convert_single:
                             coords = coords[None, :]
                 else:
                     if (coords.ndim != 2) or (coords.shape[1] != 3):
-                        raise ValueError("{}(): {}.shape must be (n, 3), got {}."
-                                         "".format(fname, argname, coords.shape))
+                        raise ValueError("{}(): {}.shape must be (n, 3),"
+                                        " got {}.".format(fname, argname,
+                                                          coords.shape))
                 if enforce_dtype:
                     try:
                         coords = coords.astype(
                             np.float32, order='C', copy=enforce_copy)
                     except ValueError:
-                        errmsg = (f"{fname}(): {argname}.dtype must be convertible to "
-                                  f"float32, got {coords.dtype}.")
+                        errmsg = (f"{fname}(): {argname}.dtype must be"
+                                 f"convertible to float32, got {coords.dtype}.")
                         raise TypeError(errmsg) from None
                 # coordinates should now be the right shape
                 ncoord = coords.shape[0]
             elif isinstance(coords, mda.core.groups.AtomGroup):
                 if allow_atomgroup:
-                    coords = coords.positions # homogenise to a numpy array
+                    coords = coords.positions  # homogenise to a numpy array
                     ncoord = coords.shape[0]
                 else:
                     raise TypeError("AtomGroup supplied as an argument, but "
@@ -2139,12 +2141,13 @@ def check_coords(*coord_names, **options):
             for name in coord_names:
                 idx = posargnames.index(name)
                 if idx < len(args):
-                    args[idx], is_single, ncoord = _check_coords(args[idx], name)
+                    args[idx], is_single, ncoord = _check_coords(args[idx],
+                                                                 name)
                     all_single &= is_single
                     ncoords.append(ncoord)
                 else:
                     kwargs[name], is_single, ncoord = _check_coords(kwargs[name],
-                                                            name)
+                                                                    name)
                     all_single &= is_single
                     ncoords.append(ncoord)
             if check_lengths_match and ncoords:

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -214,7 +214,6 @@ import inspect
 from .picklable_file_io import pickle_open, bz2_pickle_open, gzip_pickle_open
 
 from ..exceptions import StreamWarning, DuplicateWarning
-import MDAnalysis as mda
 
 try:
     from ._cutil import unique_int_1d
@@ -2098,18 +2097,23 @@ def check_coords(*coord_names, **options):
                         raise TypeError(errmsg) from None
                 # coordinates should now be the right shape
                 ncoord = coords.shape[0]
-            elif isinstance(coords, mda.core.groups.AtomGroup):
-                if allow_atomgroup:
+            else:
+                try:
                     coords = coords.positions  # homogenise to a numpy array
                     ncoord = coords.shape[0]
-                else:
-                    raise TypeError("AtomGroup supplied as an argument, but "
+                    if allow_atomgroup:
+                        pass
+                    else:
+                        err = TypeError("AtomGroup supplied as an argument, but"
                                     "allow_atomgroup is False")
-            else:
-                raise TypeError("{}(): Parameter '{}' must be a numpy.ndarray "
+                        raise err
+                except TypeError:
+                    raise err
+                except:
+                    raise TypeError("{}(): Parameter '{}' must be a numpy.ndarray "
                                 " or an AtomGroup, got {}.".format(fname,
                                 argname, type(coords)))
-
+            
             return coords, is_single, ncoord
 
         @wraps(func)

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -2075,7 +2075,7 @@ def check_coords(*coord_names, **options):
                 if allow_single:
                     if (coords.ndim not in (1, 2)) or (coords.shape[-1] != 3):
                         errmsg = (f"{fname}(): {argname}.shape must be (3,) or "
-                                  f"(n, 3), got {coords.shape})
+                                  f"(n, 3), got {coords.shape}")
                         raise ValueError(errmsg)
                     if coords.ndim == 1:
                         is_single = True
@@ -2084,7 +2084,7 @@ def check_coords(*coord_names, **options):
                 else:
                     if (coords.ndim != 2) or (coords.shape[1] != 3):
                         errmsg = (f"{fname}(): {argname}.shape must be (n, 3) "
-                                  f"got {coords.shape})
+                                  f"got {coords.shape}")
                         raise ValueError(errmsg)
                 if enforce_dtype:
                     try:

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -2148,7 +2148,7 @@ def check_coords(*coord_names, **options):
                     all_single &= is_single
                     ncoords.append(ncoord)
                 else:
-                    kwargs[name], is_single, ncoord = _check_coords(kwargs[name],
+                    kwargs[name], is_single, ncoord = _check_coords(kwargs[name], # nopep8
                                                                     name)
                     all_single &= is_single
                     ncoords.append(ncoord)

--- a/testsuite/MDAnalysisTests/lib/test_distances.py
+++ b/testsuite/MDAnalysisTests/lib/test_distances.py
@@ -410,7 +410,7 @@ class TestDistanceArrayDCD_TRIC(object):
         natoms = len(U.atoms)
         d = np.zeros((natoms, natoms), np.float64)
         distances.distance_array(x0, x1, result=d, backend=backend)
-        assert_equal(d.shape, (natoms, natoms), "wrong shape, should be" 
+        assert_equal(d.shape, (natoms, natoms), "wrong shape, should be"
                      " (Natoms,Natoms) entries")
         assert_almost_equal(d.min(), 0.11981228170520701, self.prec,
                             err_msg="wrong minimum distance value")
@@ -434,7 +434,7 @@ class TestDistanceArrayDCD_TRIC(object):
                             err_msg="wrong maximum distance value with PBC")
 
     def test_atomgroup_simple(self, DCD_Universe, backend):
-        # need two copies as moving timestep updates underlying array on atomgroup
+        # need two copies as moving ts updates underlying array on atomgroup
         U1, trajectory1 = DCD_Universe
         U2 = MDAnalysis.Universe(PSF, DCD)
         trajectory2 = U2.trajectory
@@ -452,9 +452,9 @@ class TestDistanceArrayDCD_TRIC(object):
 
     # check no box and ortho box types and some slices
     @pytest.mark.parametrize('box', [None, [50, 50, 50, 90, 90, 90]])
-    @pytest.mark.parametrize("sel, np_slice", [("all", np.s_[:,:]),
-                            ("index 0 to 8 ", np.s_[0:9,:]),
-                            ("index 9", np.s_[8,:])])
+    @pytest.mark.parametrize("sel, np_slice", [("all", np.s_[:, :]),
+                            ("index 0 to 8 ", np.s_[0:9, :]),
+                            ("index 9", np.s_[8, :])])
     def test_atomgroup_matches_numpy(self, DCD_Universe, backend, sel,
                                      np_slice, box):
         U, _ = DCD_Universe
@@ -463,16 +463,16 @@ class TestDistanceArrayDCD_TRIC(object):
         x1_ag = U.select_atoms(sel)
         x1_arr = U.atoms.positions[np_slice]
         d_ag = distances.distance_array(x0_ag, x1_ag, box=box,
-                                 backend=backend)
+                                        backend=backend)
         d_arr = distances.distance_array(x0_arr, x1_arr, box=box,
                                          backend=backend)
         assert_allclose(d_ag, d_arr,
                         err_msg="AtomGroup and NumPy distances do not match")
-    
+
     # check triclinic box and some slices
-    @pytest.mark.parametrize("sel, np_slice", [("all", np.s_[:,:]),
-                            ("index 0 to 8 ", np.s_[0:9,:]),
-                            ("index 9", np.s_[8,:])])
+    @pytest.mark.parametrize("sel, np_slice", [("all", np.s_[:, :]),
+                            ("index 0 to 8 ", np.s_[0:9, :]),
+                            ("index 9", np.s_[8, :])])
     def test_atomgroup_matches_numpy_tric(self, Triclinic_Universe, backend,
                                           sel, np_slice):
         U, _ = Triclinic_Universe
@@ -481,13 +481,13 @@ class TestDistanceArrayDCD_TRIC(object):
         x1_ag = U.select_atoms(sel)
         x1_arr = U.atoms.positions[np_slice]
         d_ag = distances.distance_array(x0_ag, x1_ag, box=U.coord.dimensions,
-                                 backend=backend)
+                                        backend=backend)
         d_arr = distances.distance_array(x0_arr, x1_arr,
                                          box=U.coord.dimensions,
                                          backend=backend)
         assert_allclose(d_ag, d_arr,
                         err_msg="AtomGroup and NumPy distances do not match")
-        
+
 
 @pytest.mark.parametrize('backend', ['serial', 'openmp'])
 class TestSelfDistanceArrayDCD_TRIC(object):
@@ -540,19 +540,20 @@ class TestSelfDistanceArrayDCD_TRIC(object):
         x0 = U.select_atoms("all")
         d = distances.self_distance_array(x0, backend=backend)
         N = 3341 * (3341 - 1) / 2
-        assert_equal(d.shape, (N,), "wrong shape (should be (Natoms*(Natoms-1)/2,))")
+        assert_equal(d.shape, (N,), "wrong shape (should be"
+                     " (Natoms*(Natoms-1)/2,))")
         assert_almost_equal(d.min(), 0.92905562402529318, self.prec,
                             err_msg="wrong minimum distance value")
         assert_almost_equal(d.max(), 52.4702570624190590, self.prec,
                             err_msg="wrong maximum distance value")
 
     # check no box and ortho box types and some slices
-    @pytest.mark.parametrize('box', [None, [50, 50, 50, 90, 90, 90]] )
-    @pytest.mark.parametrize("sel, np_slice", [("all", np.s_[:,:]),
-                            ("index 0 to 8 ", np.s_[0:9,:]),
-                            ("index 9", np.s_[8,:])])
-    def test_atomgroup_matches_numpy(self, DCD_Universe, backend, sel, np_slice,
-                                     box):
+    @pytest.mark.parametrize('box', [None, [50, 50, 50, 90, 90, 90]])
+    @pytest.mark.parametrize("sel, np_slice", [("all", np.s_[:, :]),
+                            ("index 0 to 8 ", np.s_[0:9, :]),
+                            ("index 9", np.s_[8, :])])
+    def test_atomgroup_matches_numpy(self, DCD_Universe, backend,
+                                     sel, np_slice,box):
         U, _ = DCD_Universe
 
         x0_ag = U.select_atoms(sel)
@@ -566,17 +567,17 @@ class TestSelfDistanceArrayDCD_TRIC(object):
 
     # check triclinic box and some slices
     @pytest.mark.parametrize("sel, np_slice", [
-                            ("index 0 to 8 ", np.s_[0:9,:]),
-                            ("index 9", np.s_[8,:])])
+                            ("index 0 to 8 ", np.s_[0:9, :]),
+                            ("index 9", np.s_[8, :])])
     def test_atomgroup_matches_numpy_tric(self, Triclinic_Universe, backend,
                                           sel, np_slice):
         U, _ = Triclinic_Universe
         x0_ag = U.select_atoms(sel)
         x0_arr = U.atoms.positions[np_slice]
         d_ag = distances.self_distance_array(x0_ag, box=U.coord.dimensions,
-                                 backend=backend)
+                                             backend=backend)
         d_arr = distances.self_distance_array(x0_arr, box=U.coord.dimensions,
-                                         backend=backend)
+                                              backend=backend)
         assert_allclose(d_ag, d_arr,
                         err_msg="AtomGroup and NumPy distances do not match")
 
@@ -751,17 +752,19 @@ def test_issue_3725(box):
 
     np.testing.assert_allclose(self_da_serial, self_da_openmp)
 
+
 def conv_dtype_if_ndarr(a, dtype):
     if isinstance(a, np.ndarray):
         return a.astype(dtype)
     else:
         return a
 
+
 def convert_position_dtype_if_ndarray(a, b, c, d, dtype):
-    return conv_dtype_if_ndarr(a ,dtype), \
-    conv_dtype_if_ndarr(b ,dtype), \
-    conv_dtype_if_ndarr(c ,dtype), \
-    conv_dtype_if_ndarr(d ,dtype)
+    return conv_dtype_if_ndarr(a, dtype), \
+    conv_dtype_if_ndarr(b, dtype), \
+    conv_dtype_if_ndarr(c, dtype), \
+    conv_dtype_if_ndarr(d, dtype)
 
 @pytest.mark.parametrize('backend', ['serial', 'openmp'])
 class TestCythonFunctions(object):
@@ -779,7 +782,7 @@ class TestCythonFunctions(object):
     @pytest.fixture()
     def triclinic_box():
         box_vecs = np.array([[10., 0., 0.], [1., 10., 0., ], [1., 0., 10.]],
-                               dtype=np.float32)
+                            dtype=np.float32)
         return mdamath.triclinic_box(box_vecs[0], box_vecs[1], box_vecs[2])
 
     @staticmethod

--- a/testsuite/MDAnalysisTests/lib/test_distances.py
+++ b/testsuite/MDAnalysisTests/lib/test_distances.py
@@ -589,7 +589,7 @@ class TestSelfDistanceArrayDCD(object):
                                          backend='serial')
         assert_allclose(d_ag, d_arr,
                         err_msg="AtomGroup and NumPy distances do not match")
-        # raise Exception
+
 @pytest.mark.parametrize('backend', ['serial', 'openmp'])
 class TestTriclinicDistances(object):
     """Unit tests for the Triclinic PBC functions.

--- a/testsuite/MDAnalysisTests/lib/test_distances.py
+++ b/testsuite/MDAnalysisTests/lib/test_distances.py
@@ -428,7 +428,7 @@ class TestDistanceArrayDCD(object):
                             err_msg="wrong maximum distance value with PBC")
 
 
-    def test_2x_atomgroup_simple(self, DCD_Universe, backend):
+    def test_atomgroup_simple(self, DCD_Universe, backend):
         # need two copies as moving timestep updates underlying array on atomgroup
         U1, trajectory1 = DCD_Universe
         U2 = MDAnalysis.Universe(PSF, DCD)
@@ -446,26 +446,20 @@ class TestDistanceArrayDCD(object):
                             err_msg="wrong maximum distance value")
 
     @pytest.mark.parametrize("sel_or_slice", [("all", np.s_[:,:]),
-                            ("index 0 to 8 ", np.s_[0:9,:])])
+                            ("index 0 to 8 ", np.s_[0:9,:]),
+                            ("index 9", np.s_[-1,:])])
     def test_atomgroup_matches_numpy(self, DCD_Universe, backend, sel_or_slice):
-        # need two copies as moving timestep updates underlying array on atomgroup
-        U1, trajectory1 = DCD_Universe
-        U2 = MDAnalysis.Universe(PSF, DCD)
-        trajectory2 = U2.trajectory
-        trajectory1.rewind()
-        trajectory2.rewind()
-        x0_arr = U1.atoms.positions[sel_or_slice[1]]
-        x0_ag = U1.select_atoms(sel_or_slice[0])
-        trajectory2[10]
-        x1_arr = U2.atoms.positions[sel_or_slice[1]]
-        x1_ag = U2.select_atoms(sel_or_slice[0])
+        U, trajectory = DCD_Universe
+        x0_ag = U.select_atoms(sel_or_slice[0])
+        x0_arr = U.atoms.positions[sel_or_slice[1]]
+        x1_ag = U.select_atoms(sel_or_slice[0])
+        x1_arr = U.atoms.positions[sel_or_slice[1]]
         d_ag = distances.distance_array(x0_ag, x1_ag, backend=backend)
         d_arr = distances.distance_array(x0_arr, x1_arr, backend=backend)
         assert_allclose(d_ag, d_arr,
                         err_msg="AtomGroup and NumPy distances do not match")
 
-
-    def test_iterator_mixed_array_ag_simple(self, DCD_Universe, backend):
+    def test_mixed_ag_arr(self, DCD_Universe, backend):
         U, trajectory = DCD_Universe
         trajectory.rewind()
         x0 = U.atoms.positions

--- a/testsuite/MDAnalysisTests/lib/test_distances.py
+++ b/testsuite/MDAnalysisTests/lib/test_distances.py
@@ -574,21 +574,22 @@ class TestSelfDistanceArrayDCD(object):
         assert_allclose(d_ag, d_arr,
                         err_msg="AtomGroup and NumPy distances do not match")
 
-    # # check triclinic box and some slices
-    # @pytest.mark.parametrize("sel, np_slice", [
-    #                         ("index 0 to 8 ", np.s_[0:9,:]),
-    #                         ("index 9", np.s_[8,:])])
-    # def test_atomgroup_matches_numpy_tric(self, Triclinic_Universe, backend, sel, np_slice):
-    #     U, _ = Triclinic_Universe
-    #     x0_ag = U.select_atoms(sel)
-    #     x0_arr = U.atoms.positions[np_slice]
-    #     d_ag = distances.self_distance_array(x0_ag, box=U.coord.dimensions,
-    #                              backend=backend)
-    #     d_arr = distances.self_distance_array(x0_arr, box=U.coord.dimensions,
-    #                                      backend=backend)
-    #     assert_allclose(d_ag, d_arr,
-    #                     err_msg="AtomGroup and NumPy distances do not match")
-    
+    # check triclinic box and some slices
+    @pytest.mark.parametrize("sel, np_slice", [
+                            ("index 0 to 8 ", np.s_[0:9,:]),
+                            ("index 9", np.s_[8,:])])
+    def test_atomgroup_matches_numpy_tric(self, Triclinic_Universe, backend, sel, np_slice):
+        U, trajectory = Triclinic_Universe
+
+        x0_ag = U.select_atoms(sel)
+        x0_arr = U.atoms.positions[np_slice]
+        d_ag = distances.self_distance_array(x0_ag, box=U.coord.dimensions,
+                                 backend='serial')
+        d_arr = distances.self_distance_array(x0_arr, box=U.coord.dimensions,
+                                         backend='serial')
+        assert_allclose(d_ag, d_arr,
+                        err_msg="AtomGroup and NumPy distances do not match")
+        # raise Exception
 @pytest.mark.parametrize('backend', ['serial', 'openmp'])
 class TestTriclinicDistances(object):
     """Unit tests for the Triclinic PBC functions.

--- a/testsuite/MDAnalysisTests/lib/test_distances.py
+++ b/testsuite/MDAnalysisTests/lib/test_distances.py
@@ -284,7 +284,7 @@ class TestDistanceArray(object):
         ]))
 
     def test_noPBC_atomgroup(self, backend, ref_system_universe, ref_system):
-        box, points, ref, conf = ref_system
+        _, points, ref, _ = ref_system
         ref_ag = ref_system_universe.select_atoms("index 0")
         d = distances.distance_array(ref_ag, ref_system_universe.atoms,
                                      backend=backend)
@@ -294,16 +294,44 @@ class TestDistanceArray(object):
             self._dist(points[2], ref[0]),
             self._dist(points[3], ref[0])]
         ]))
-
-
-
+    
+    def test_noPBC_mixed_ag_arr(self, backend, ref_system_universe, ref_system):
+        _, points, ref, _ = ref_system
+        ref_ag = ref_system_universe.select_atoms("index 0")
+        d = distances.distance_array(ref_ag, points,
+                                     backend=backend)
+        assert_almost_equal(d, np.array([[
+            self._dist(points[0], ref[0]),
+            self._dist(points[1], ref[0]),
+            self._dist(points[2], ref[0]),
+            self._dist(points[3], ref[0])]
+        ]))
 
     def test_PBC(self, backend, ref_system):
         box, points, ref, conf = ref_system
 
         d = distances.distance_array(ref, points, box=box, backend=backend)
 
-        assert_almost_equal(d, np.array([[0., 0., 0., self._dist(points[3], ref=[1, 1, 2])]]))
+        assert_almost_equal(d, np.array([[0., 0., 0., self._dist(points[3],
+                            ref=[1, 1, 2])]]))
+
+    def test_PBC_atomgroup(self, backend, ref_system, ref_system_universe):
+        _, points, ref, _ = ref_system
+        ref_ag = ref_system_universe.select_atoms("index 0")
+        d = distances.distance_array(ref_ag, ref_system_universe.atoms,
+                                     box=ref_system_universe.dimensions,
+                                     backend=backend)
+        assert_almost_equal(d, np.array([[0., 0., 0., self._dist(points[3],
+                            ref=[1, 1, 2])]]))
+
+    def test_PBC_mixed_ag_arr(self, backend, ref_system, ref_system_universe):
+        _, points, ref, _ = ref_system
+        ref_ag = ref_system_universe.select_atoms("index 0")
+        d = distances.distance_array(ref_ag, points,
+                                     box=ref_system_universe.dimensions,
+                                     backend=backend)
+        assert_almost_equal(d, np.array([[0., 0., 0., self._dist(points[3],
+                            ref=[1, 1, 2])]]))
 
     def test_PBC2(self, backend):
         a = np.array([7.90146923, -13.72858524, 3.75326586], dtype=np.float32)

--- a/testsuite/MDAnalysisTests/lib/test_distances.py
+++ b/testsuite/MDAnalysisTests/lib/test_distances.py
@@ -773,15 +773,11 @@ class TestCythonFunctions(object):
     @pytest.fixture()
     def positions_atomgroups(positions):
         a, b, c, d = positions
-        u_a = MDAnalysis.Universe.empty(a.shape[0], trajectory=True)
-        u_a.atoms.positions = a
-        u_b = MDAnalysis.Universe.empty(b.shape[0], trajectory=True)
-        u_b.atoms.positions = b
-        u_c = MDAnalysis.Universe.empty(c.shape[0], trajectory=True)
-        u_c.atoms.positions = c
-        u_d = MDAnalysis.Universe.empty(d.shape[0], trajectory=True)
-        u_d.atoms.positions = d
-        return u_a.atoms, u_b.atoms, u_c.atoms, u_d.atoms
+        arrs = [a,b,c,d]
+        universes = [MDAnalysis.Universe.empty(arr.shape[0], trajectory=True) for arr in arrs]
+        for u, a in zip(universes, arrs):
+            u.atoms.positions = a
+        return tuple([u.atoms for u in universes])
 
     @staticmethod
     def convert_position_dtype(a, b, c, d, dtype):

--- a/testsuite/MDAnalysisTests/lib/test_distances.py
+++ b/testsuite/MDAnalysisTests/lib/test_distances.py
@@ -1075,7 +1075,7 @@ class Test_apply_PBC(object):
         with pytest.raises(ValueError):
             cyth1 = distances.apply_PBC(positions, box[:3], backend=backend)
         cyth2 = distances.apply_PBC(positions, box, backend=backend)
-        reference = (DCD_universe_pos - 
+        reference = (DCD_universe_pos -
                      np.floor(DCD_universe_pos / box[:3]) * box[:3])
 
         assert_almost_equal(cyth2, reference, self.prec,

--- a/testsuite/MDAnalysisTests/lib/test_distances.py
+++ b/testsuite/MDAnalysisTests/lib/test_distances.py
@@ -256,14 +256,15 @@ def ref_system():
 
     return box, points, ref, conf
 
+
 @pytest.fixture()
 def ref_system_universe(ref_system):
     box, points, ref, conf = ref_system
-    u  = MDAnalysis.Universe.empty(points.shape[0], trajectory=True)
+    u = MDAnalysis.Universe.empty(points.shape[0], trajectory=True)
     u.atoms.positions = points
     u.trajectory.ts.dimensions = box
-    return box, u.atoms, u.select_atoms("index 0"), u.select_atoms("index 1 to" 
-                                                                  " 3")
+    return box, u.atoms, u.select_atoms("index 0"), u.select_atoms("index 1 to"
+                                                                   " 3")
 
 @pytest.mark.parametrize('backend', ['serial', 'openmp'])
 class TestDistanceArray(object):
@@ -276,7 +277,7 @@ class TestDistanceArray(object):
     # test both AtomGroup and numpy array
     @pytest.mark.parametrize('pos', ['ref_system', 'ref_system_universe'])
     def test_noPBC(self, backend, ref_system, pos, request):
-        _, points, reference, _ = ref_system # reference values
+        _, points, reference, _ = ref_system  # reference values
         _, all, ref, _ = request.getfixturevalue(pos)
 
         d = distances.distance_array(ref, all, backend=backend)
@@ -288,10 +289,11 @@ class TestDistanceArray(object):
         ]))
 
     # cycle through combinations of numpy array and AtomGroup
-    @pytest.mark.parametrize('pos0', ['ref_system', 'ref_system_universe'] )
+    @pytest.mark.parametrize('pos0', ['ref_system', 'ref_system_universe'])
     @pytest.mark.parametrize('pos1', ['ref_system', 'ref_system_universe'])
-    def test_noPBC_mixed_combinations(self, backend, ref_system, pos0, pos1, request):
-        _, points, reference, _ = ref_system # reference values
+    def test_noPBC_mixed_combinations(self, backend, ref_system, pos0, pos1,
+                                      request):
+        _, points, reference, _ = ref_system  # reference values
         _, _, ref_val, _ = request.getfixturevalue(pos0)
         _, points_val, _, _ = request.getfixturevalue(pos1)
         d = distances.distance_array(ref_val, points_val,
@@ -307,7 +309,7 @@ class TestDistanceArray(object):
     @pytest.mark.parametrize('pos', ['ref_system', 'ref_system_universe'])
     def test_PBC(self, backend, ref_system, pos, request):
         box, points, _, _ = ref_system
-        _, all, ref, _ = request.getfixturevalue(pos) 
+        _, all, ref, _ = request.getfixturevalue(pos)
 
         d = distances.distance_array(ref, all, box=box, backend=backend)
 
@@ -315,9 +317,10 @@ class TestDistanceArray(object):
                             ref=[1, 1, 2])]]))
 
     # cycle through combinations of numpy array and AtomGroup
-    @pytest.mark.parametrize('pos0', ['ref_system', 'ref_system_universe'] )
+    @pytest.mark.parametrize('pos0', ['ref_system', 'ref_system_universe'])
     @pytest.mark.parametrize('pos1', ['ref_system', 'ref_system_universe'])
-    def test_PBC_mixed_combinations(self, backend, ref_system, pos0, pos1, request):
+    def test_PBC_mixed_combinations(self, backend, ref_system, pos0, pos1,
+                                    request):
         box, points, _, _ = ref_system
         _, _, ref_val, _ = request.getfixturevalue(pos0)
         _, points_val, _, _ = request.getfixturevalue(pos1)
@@ -367,9 +370,10 @@ def DCD_Universe():
     trajectory = universe.trajectory
     return universe, trajectory
 
+
 @pytest.fixture()
 def Triclinic_Universe():
-    universe =  MDAnalysis.Universe(TRIC)
+    universe = MDAnalysis.Universe(TRIC)
     trajectory = universe.trajectory
     return universe, trajectory
 
@@ -390,7 +394,8 @@ class TestDistanceArrayDCD_TRIC(object):
         trajectory[10]
         x1 = U.atoms.positions
         d = distances.distance_array(x0, x1, backend=backend)
-        assert_equal(d.shape, (3341, 3341), "wrong shape (should be (Natoms,Natoms))")
+        assert_equal(d.shape, (3341, 3341), "wrong shape (should be"
+                     "(Natoms,Natoms))")
         assert_almost_equal(d.min(), 0.11981228170520701, self.prec,
                             err_msg="wrong minimum distance value")
         assert_almost_equal(d.max(), 53.572192429459619, self.prec,
@@ -405,7 +410,8 @@ class TestDistanceArrayDCD_TRIC(object):
         natoms = len(U.atoms)
         d = np.zeros((natoms, natoms), np.float64)
         distances.distance_array(x0, x1, result=d, backend=backend)
-        assert_equal(d.shape, (natoms, natoms), "wrong shape, shoud be  (Natoms,Natoms) entries")
+        assert_equal(d.shape, (natoms, natoms), "wrong shape, should be" 
+                     " (Natoms,Natoms) entries")
         assert_almost_equal(d.min(), 0.11981228170520701, self.prec,
                             err_msg="wrong minimum distance value")
         assert_almost_equal(d.max(), 53.572192429459619, self.prec,
@@ -420,12 +426,12 @@ class TestDistanceArrayDCD_TRIC(object):
         x1 = U.atoms.positions
         d = distances.distance_array(x0, x1, box=U.coord.dimensions,
                                      backend=backend)
-        assert_equal(d.shape, (3341, 3341), "should be square matrix with Natoms entries")
+        assert_equal(d.shape, (3341, 3341), "should be square matrix with"
+                     " Natoms entries")
         assert_almost_equal(d.min(), 0.11981228170520701, self.prec,
                             err_msg="wrong minimum distance value with PBC")
         assert_almost_equal(d.max(), 53.572192429459619, self.prec,
                             err_msg="wrong maximum distance value with PBC")
-
 
     def test_atomgroup_simple(self, DCD_Universe, backend):
         # need two copies as moving timestep updates underlying array on atomgroup
@@ -437,7 +443,8 @@ class TestDistanceArrayDCD_TRIC(object):
         trajectory2[10]
         x1 = U2.select_atoms("all")
         d = distances.distance_array(x0, x1, backend=backend)
-        assert_equal(d.shape, (3341, 3341), "wrong shape (should be (Natoms,Natoms))")
+        assert_equal(d.shape, (3341, 3341), "wrong shape (should be"
+                     " (Natoms,Natoms))")
         assert_almost_equal(d.min(), 0.11981228170520701, self.prec,
                             err_msg="wrong minimum distance value")
         assert_almost_equal(d.max(), 53.572192429459619, self.prec,
@@ -448,8 +455,8 @@ class TestDistanceArrayDCD_TRIC(object):
     @pytest.mark.parametrize("sel, np_slice", [("all", np.s_[:,:]),
                             ("index 0 to 8 ", np.s_[0:9,:]),
                             ("index 9", np.s_[8,:])])
-    def test_atomgroup_matches_numpy(self, DCD_Universe, backend, sel, np_slice,
-                                     box):
+    def test_atomgroup_matches_numpy(self, DCD_Universe, backend, sel,
+                                     np_slice, box):
         U, _ = DCD_Universe
         x0_ag = U.select_atoms(sel)
         x0_arr = U.atoms.positions[np_slice]
@@ -466,7 +473,8 @@ class TestDistanceArrayDCD_TRIC(object):
     @pytest.mark.parametrize("sel, np_slice", [("all", np.s_[:,:]),
                             ("index 0 to 8 ", np.s_[0:9,:]),
                             ("index 9", np.s_[8,:])])
-    def test_atomgroup_matches_numpy_tric(self, Triclinic_Universe, backend, sel, np_slice):
+    def test_atomgroup_matches_numpy_tric(self, Triclinic_Universe, backend,
+                                          sel, np_slice):
         U, _ = Triclinic_Universe
         x0_ag = U.select_atoms(sel)
         x0_arr = U.atoms.positions[np_slice]
@@ -474,7 +482,8 @@ class TestDistanceArrayDCD_TRIC(object):
         x1_arr = U.atoms.positions[np_slice]
         d_ag = distances.distance_array(x0_ag, x1_ag, box=U.coord.dimensions,
                                  backend=backend)
-        d_arr = distances.distance_array(x0_arr, x1_arr, box=U.coord.dimensions,
+        d_arr = distances.distance_array(x0_arr, x1_arr,
+                                         box=U.coord.dimensions,
                                          backend=backend)
         assert_allclose(d_ag, d_arr,
                         err_msg="AtomGroup and NumPy distances do not match")
@@ -559,7 +568,8 @@ class TestSelfDistanceArrayDCD_TRIC(object):
     @pytest.mark.parametrize("sel, np_slice", [
                             ("index 0 to 8 ", np.s_[0:9,:]),
                             ("index 9", np.s_[8,:])])
-    def test_atomgroup_matches_numpy_tric(self, Triclinic_Universe, backend, sel, np_slice):
+    def test_atomgroup_matches_numpy_tric(self, Triclinic_Universe, backend,
+                                          sel, np_slice):
         U, _ = Triclinic_Universe
         x0_ag = U.select_atoms(sel)
         x0_arr = U.atoms.positions[np_slice]

--- a/testsuite/MDAnalysisTests/lib/test_distances.py
+++ b/testsuite/MDAnalysisTests/lib/test_distances.py
@@ -326,8 +326,8 @@ class TestDistanceArray(object):
         d = distances.distance_array(ref_val, points_val,
                                      box=box,
                                      backend=backend)
-        assert_almost_equal(d, np.array([[0., 0., 0., self._dist(points[3],
-                            ref=[1, 1, 2])]]))
+        assert_almost_equal(
+            d, np.array([[0., 0., 0., self._dist(points[3], ref=[1, 1, 2])]]))
 
     def test_PBC2(self, backend):
         a = np.array([7.90146923, -13.72858524, 3.75326586], dtype=np.float32)

--- a/testsuite/MDAnalysisTests/lib/test_distances.py
+++ b/testsuite/MDAnalysisTests/lib/test_distances.py
@@ -580,7 +580,7 @@ class TestSelfDistanceArrayDCD(object):
                             ("index 9", np.s_[8,:])])
     def test_atomgroup_matches_numpy_tric(self, Triclinic_Universe, backend, sel, np_slice):
         U, trajectory = Triclinic_Universe
-
+        #BUG serial only for now as the OMP code path appears broken
         x0_ag = U.select_atoms(sel)
         x0_arr = U.atoms.positions[np_slice]
         d_ag = distances.self_distance_array(x0_ag, box=U.coord.dimensions,

--- a/testsuite/MDAnalysisTests/lib/test_distances.py
+++ b/testsuite/MDAnalysisTests/lib/test_distances.py
@@ -767,10 +767,10 @@ def conv_dtype_if_ndarr(a, dtype):
 
 
 def convert_position_dtype_if_ndarray(a, b, c, d, dtype):
-    return conv_dtype_if_ndarr(a, dtype), \
-    conv_dtype_if_ndarr(b, dtype), \
-    conv_dtype_if_ndarr(c, dtype), \
-    conv_dtype_if_ndarr(d, dtype)
+    return (conv_dtype_if_ndarr(a, dtype), 
+            conv_dtype_if_ndarr(b, dtype), 
+            conv_dtype_if_ndarr(c, dtype), 
+            conv_dtype_if_ndarr(d, dtype))
 
 @pytest.mark.parametrize('backend', ['serial', 'openmp'])
 class TestCythonFunctions(object):

--- a/testsuite/MDAnalysisTests/lib/test_distances.py
+++ b/testsuite/MDAnalysisTests/lib/test_distances.py
@@ -1392,7 +1392,6 @@ class TestInputUnchanged(object):
         ref = crd.positions.copy()
         res = distances.apply_PBC(crd, box, backend=backend)
         assert_equal(crd.positions, ref)
-        
 
 class TestEmptyInputCoordinates(object):
     """Tests ensuring that the following functions in MDAnalysis.lib.distances

--- a/testsuite/MDAnalysisTests/lib/test_distances.py
+++ b/testsuite/MDAnalysisTests/lib/test_distances.py
@@ -20,7 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from turtle import position
 import pytest
 import numpy as np
 from numpy.testing import assert_equal, assert_almost_equal, assert_allclose

--- a/testsuite/MDAnalysisTests/lib/test_distances.py
+++ b/testsuite/MDAnalysisTests/lib/test_distances.py
@@ -771,13 +771,17 @@ class TestCythonFunctions(object):
 
     @staticmethod
     @pytest.fixture()
-    def dummy_universes_a_b(positions):
-        a, b, _, _ = positions
+    def positions_atomgroups(positions):
+        a, b, c, d = positions
         u_a = MDAnalysis.Universe.empty(a.shape[0], trajectory=True)
         u_a.atoms.positions = a
         u_b = MDAnalysis.Universe.empty(b.shape[0], trajectory=True)
         u_b.atoms.positions = b
-        return u_a, u_b
+        u_c = MDAnalysis.Universe.empty(c.shape[0], trajectory=True)
+        u_c.atoms.positions = c
+        u_d = MDAnalysis.Universe.empty(d.shape[0], trajectory=True)
+        u_d.atoms.positions = d
+        return u_a.atoms, u_b.atoms, u_c.atoms, u_d.atoms
 
     @staticmethod
     def convert_position_dtype(a, b, c, d, dtype):
@@ -816,10 +820,8 @@ class TestCythonFunctions(object):
         assert_almost_equal(dists_pbc[3], 3.46410072, self.prec,
                             err_msg="PBC check #w with box")
 
-    def test_bonds_atomgroup(self, box, backend, dummy_universes_a_b):
-        u_a, u_b = dummy_universes_a_b
-        ag_a = u_a.atoms
-        ag_b = u_b.atoms
+    def test_bonds_atomgroup(self, box, backend, positions_atomgroups):
+        ag_a, ag_b, _, _ = positions_atomgroups
         dists = distances.calc_bonds(ag_a, ag_b, backend=backend)
         assert_equal(len(dists), 4, err_msg="calc_bonds results have wrong length")
         dists_pbc = distances.calc_bonds(ag_a, ag_b, box=box, backend=backend)
@@ -860,11 +862,9 @@ class TestCythonFunctions(object):
         reference = np.array([0.0, 1.7320508, 1.4142136, 2.82842712])
         assert_almost_equal(dists, reference, self.prec, err_msg="calc_bonds with triclinic box failed")
     
-    def test_bonds_triclinic_atomgroup(self, dummy_universes_a_b,
+    def test_bonds_triclinic_atomgroup(self, positions_atomgroups,
                                        triclinic_box, backend):
-        u_a, u_b = dummy_universes_a_b
-        ag_a = u_a.atoms
-        ag_b = u_b.atoms
+        ag_a, ag_b, _, _ = positions_atomgroups
         dists = distances.calc_bonds(ag_a, ag_b, box=triclinic_box, backend=backend)
         reference = np.array([0.0, 1.7320508, 1.4142136, 2.82842712])
         assert_almost_equal(dists, reference, self.prec, err_msg="calc_bonds with triclinic box failed")

--- a/testsuite/MDAnalysisTests/lib/test_distances.py
+++ b/testsuite/MDAnalysisTests/lib/test_distances.py
@@ -290,7 +290,7 @@ class TestDistanceArray(object):
     # cycle through combinations of numpy array and AtomGroup
     @pytest.mark.parametrize('pos0', ['ref_system', 'ref_system_universe'] )
     @pytest.mark.parametrize('pos1', ['ref_system', 'ref_system_universe'])
-    def test_noPBC_mixed_ag_arr(self, backend, ref_system, pos0, pos1, request):
+    def test_noPBC_mixed_combinations(self, backend, ref_system, pos0, pos1, request):
         _, points, reference, _ = ref_system # reference values
         _, _, ref_val, _ = request.getfixturevalue(pos0)
         _, points_val, _, _ = request.getfixturevalue(pos1)
@@ -317,7 +317,7 @@ class TestDistanceArray(object):
     # cycle through combinations of numpy array and AtomGroup
     @pytest.mark.parametrize('pos0', ['ref_system', 'ref_system_universe'] )
     @pytest.mark.parametrize('pos1', ['ref_system', 'ref_system_universe'])
-    def test_PBC_mixed_ag_arr(self, backend, ref_system, pos0, pos1, request):
+    def test_PBC_mixed_combinations(self, backend, ref_system, pos0, pos1, request):
         box, points, _, _ = ref_system
         _, _, ref_val, _ = request.getfixturevalue(pos0)
         _, points_val, _, _ = request.getfixturevalue(pos1)
@@ -479,18 +479,6 @@ class TestDistanceArrayDCD_TRIC(object):
         assert_allclose(d_ag, d_arr,
                         err_msg="AtomGroup and NumPy distances do not match")
         
-    def test_mixed_ag_arr_simple(self, DCD_Universe, backend):
-        U, trajectory = DCD_Universe
-        trajectory.rewind()
-        x0 = U.atoms.positions
-        trajectory[10]
-        x1 = U.select_atoms("all")
-        d = distances.distance_array(x0, x1, backend=backend)
-        assert_equal(d.shape, (3341, 3341), "wrong shape (should be (Natoms,Natoms))")
-        assert_almost_equal(d.min(), 0.11981228170520701, self.prec,
-                            err_msg="wrong minimum distance value")
-        assert_almost_equal(d.max(), 53.572192429459619, self.prec,
-                            err_msg="wrong maximum distance value")
 
 @pytest.mark.parametrize('backend', ['serial', 'openmp'])
 class TestSelfDistanceArrayDCD_TRIC(object):
@@ -573,13 +561,12 @@ class TestSelfDistanceArrayDCD_TRIC(object):
                             ("index 9", np.s_[8,:])])
     def test_atomgroup_matches_numpy_tric(self, Triclinic_Universe, backend, sel, np_slice):
         U, _ = Triclinic_Universe
-        #BUG serial only for now as the OMP code path appears broken
         x0_ag = U.select_atoms(sel)
         x0_arr = U.atoms.positions[np_slice]
         d_ag = distances.self_distance_array(x0_ag, box=U.coord.dimensions,
-                                 backend='serial')
+                                 backend=backend)
         d_arr = distances.self_distance_array(x0_arr, box=U.coord.dimensions,
-                                         backend='serial')
+                                         backend=backend)
         assert_allclose(d_ag, d_arr,
                         err_msg="AtomGroup and NumPy distances do not match")
 

--- a/testsuite/MDAnalysisTests/lib/test_distances.py
+++ b/testsuite/MDAnalysisTests/lib/test_distances.py
@@ -553,15 +553,15 @@ class TestSelfDistanceArrayDCD_TRIC(object):
                             ("index 0 to 8 ", np.s_[0:9, :]),
                             ("index 9", np.s_[8, :])])
     def test_atomgroup_matches_numpy(self, DCD_Universe, backend,
-                                     sel, np_slice,box):
+                                     sel, np_slice, box):
         U, _ = DCD_Universe
 
         x0_ag = U.select_atoms(sel)
         x0_arr = U.atoms.positions[np_slice]
         d_ag = distances.self_distance_array(x0_ag, box=box,
-                                 backend=backend)
+                                             backend=backend)
         d_arr = distances.self_distance_array(x0_arr, box=box,
-                                         backend=backend)
+                                              backend=backend)
         assert_allclose(d_ag, d_arr,
                         err_msg="AtomGroup and NumPy distances do not match")
 
@@ -799,8 +799,9 @@ class TestCythonFunctions(object):
     @pytest.fixture()
     def positions_atomgroups(positions):
         a, b, c, d = positions
-        arrs = [a,b,c,d]
-        universes = [MDAnalysis.Universe.empty(arr.shape[0], trajectory=True) for arr in arrs]
+        arrs = [a, b, c, d]
+        universes = [MDAnalysis.Universe.empty(arr.shape[0],
+                     trajectory=True) for arr in arrs]
         for u, a in zip(universes, arrs):
             u.atoms.positions = a
         return tuple([u.atoms for u in universes])
@@ -859,7 +860,8 @@ class TestCythonFunctions(object):
 
     @pytest.mark.parametrize('dtype', (np.float32, np.float64))
     @pytest.mark.parametrize('pos', ['positions', 'positions_atomgroups'])
-    def test_bonds_triclinic(self, triclinic_box, backend, dtype, pos, request):
+    def test_bonds_triclinic(self, triclinic_box, backend, dtype, pos,
+                             request):
         a, b, c, d = request.getfixturevalue(pos)
         a, b, c, d = convert_position_dtype_if_ndarray(a, b, c, d, dtype)
         dists = distances.calc_bonds(a, b, box=triclinic_box, backend=backend)
@@ -1036,7 +1038,7 @@ class Test_apply_PBC(object):
     def DCD_universe_ag(self, DCD_Universe):
         U, _ = DCD_Universe
         return U.atoms
-    
+
     @pytest.fixture()
     def Triclinic_universe_pos_box(self, Triclinic_Universe):
         U, _ = Triclinic_Universe
@@ -1057,7 +1059,7 @@ class Test_apply_PBC(object):
         atoms = U.atoms
         box = U.dimensions
         return atoms, box
-    
+
     @pytest.mark.parametrize('pos', ['DCD_universe_pos', 'DCD_universe_ag'])
     def test_ortho_PBC(self, backend, pos, request, DCD_universe_pos):
         positions = request.getfixturevalue(pos)
@@ -1071,7 +1073,7 @@ class Test_apply_PBC(object):
                             err_msg="Ortho apply_PBC #2 failed comparison with np")
 
     @pytest.mark.parametrize('pos', ['Triclinic_universe_pos_box',
-                        'Triclinic_universe_ag_box'])
+                             'Triclinic_universe_ag_box'])
     def test_tric_PBC(self, backend, pos, request):
         positions, box = request.getfixturevalue(pos)
         def numpy_PBC(coords, box):
@@ -1229,7 +1231,7 @@ class TestInputUnchanged(object):
                 np.array([[0.1, 0.1, 1.9], [-0.9, -0.9,  0.9]], dtype=np.float32),
                 np.array([[0.1, 1.9, 1.9], [-0.9,  0.9,  0.9]], dtype=np.float32),
                 np.array([[0.1, 1.9, 0.1], [-0.9,  0.9, -0.9]], dtype=np.float32)]
-    
+
     @staticmethod
     @pytest.fixture()
     def coords_atomgroups(coords):
@@ -1335,8 +1337,8 @@ class TestInputUnchanged(object):
 
     @pytest.mark.parametrize('box', boxes)
     @pytest.mark.parametrize('backend', ['serial', 'openmp'])
-    def test_input_unchanged_calc_angles_atomgroup(self, coords_atomgroups, box,
-                                                   backend):
+    def test_input_unchanged_calc_angles_atomgroup(self, coords_atomgroups,
+                                                   box, backend):
         crds = coords_atomgroups[:3]
         refs = [crd.positions.copy() for crd in crds]
         res = distances.calc_angles(crds[0], crds[1], crds[2], box=box,

--- a/testsuite/MDAnalysisTests/lib/test_distances.py
+++ b/testsuite/MDAnalysisTests/lib/test_distances.py
@@ -369,13 +369,15 @@ def DCD_Universe():
     trajectory = universe.trajectory
     return universe, trajectory
 
-# second independent universe required for 
+
+# second independent universe required for
 # TestDistanceArrayDCD_TRIC.test_atomgroup_simple
 @pytest.fixture()
 def DCD_Universe2():
     universe = MDAnalysis.Universe(PSF, DCD)
     trajectory = universe.trajectory
     return universe, trajectory
+
 
 @pytest.fixture()
 def Triclinic_Universe():
@@ -767,9 +769,9 @@ def conv_dtype_if_ndarr(a, dtype):
 
 
 def convert_position_dtype_if_ndarray(a, b, c, d, dtype):
-    return (conv_dtype_if_ndarr(a, dtype), 
-            conv_dtype_if_ndarr(b, dtype), 
-            conv_dtype_if_ndarr(c, dtype), 
+    return (conv_dtype_if_ndarr(a, dtype),
+            conv_dtype_if_ndarr(b, dtype),
+            conv_dtype_if_ndarr(c, dtype),
             conv_dtype_if_ndarr(d, dtype))
 
 @pytest.mark.parametrize('backend', ['serial', 'openmp'])
@@ -1073,7 +1075,8 @@ class Test_apply_PBC(object):
         with pytest.raises(ValueError):
             cyth1 = distances.apply_PBC(positions, box[:3], backend=backend)
         cyth2 = distances.apply_PBC(positions, box, backend=backend)
-        reference = DCD_universe_pos - np.floor(DCD_universe_pos / box[:3]) * box[:3]
+        reference = (DCD_universe_pos - 
+                     np.floor(DCD_universe_pos / box[:3]) * box[:3])
 
         assert_almost_equal(cyth2, reference, self.prec,
                             err_msg="Ortho apply_PBC #2 failed comparison with np")

--- a/testsuite/MDAnalysisTests/lib/test_distances.py
+++ b/testsuite/MDAnalysisTests/lib/test_distances.py
@@ -262,8 +262,8 @@ def ref_system_universe(ref_system):
     u = MDAnalysis.Universe.empty(points.shape[0], trajectory=True)
     u.atoms.positions = points
     u.trajectory.ts.dimensions = box
-    return box, u.atoms, u.select_atoms("index 0"), u.select_atoms("index 1 to"
-                                                                   " 3")
+    return (box, u.atoms, u.select_atoms("index 0"),
+            u.select_atoms("index 1 to 3"))
 
 @pytest.mark.parametrize('backend', ['serial', 'openmp'])
 class TestDistanceArray(object):

--- a/testsuite/MDAnalysisTests/lib/test_distances.py
+++ b/testsuite/MDAnalysisTests/lib/test_distances.py
@@ -820,7 +820,7 @@ class TestCythonFunctions(object):
         assert_almost_equal(dists_pbc[3], 3.46410072, self.prec,
                             err_msg="PBC check #w with box")
 
-    def test_bonds_atomgroup(self, box, backend, positions_atomgroups):
+    def test_bonds_atomgroup(self, positions_atomgroups, box, backend, ):
         ag_a, ag_b, _, _ = positions_atomgroups
         dists = distances.calc_bonds(ag_a, ag_b, backend=backend)
         assert_equal(len(dists), 4, err_msg="calc_bonds results have wrong length")
@@ -903,6 +903,20 @@ class TestCythonFunctions(object):
         assert_almost_equal(angles[3], 0.098174833, self.prec,
                             err_msg="Small angle failed in calc_angles")
 
+    def test_angles_atomgroup(self, positions_atomgroups, backend):
+        ag_a, ag_b, ag_c, _ = positions_atomgroups
+        angles = distances.calc_angles(ag_a, ag_b, ag_c, backend=backend)
+        # Check calculated values
+        assert_equal(len(angles), 4, err_msg="calc_angles results have wrong length")
+        #        assert_almost_equal(angles[0], 0.0, self.prec,
+        #                           err_msg="Zero length angle calculation failed") # What should this be?
+        assert_almost_equal(angles[1], np.pi, self.prec,
+                            err_msg="180 degree angle calculation failed")
+        assert_almost_equal(np.rad2deg(angles[2]), 90., self.prec,
+                            err_msg="Ninety degree angle in calc_angles failed")
+        assert_almost_equal(angles[3], 0.098174833, self.prec,
+                            err_msg="Small angle failed in calc_angles")
+
     def test_angles_bad_result(self, positions, backend):
         a, b, c, d = positions
         badresult = np.zeros(len(a) - 1)  # Bad result array
@@ -938,6 +952,17 @@ class TestCythonFunctions(object):
     def test_dihedrals(self, positions, backend, dtype):
         a, b, c, d = self.convert_position_dtype(*positions, dtype=dtype)
         dihedrals = distances.calc_dihedrals(a, b, c, d, backend=backend)
+        # Check calculated values
+        assert_equal(len(dihedrals), 4, err_msg="calc_dihedrals results have wrong length")
+        assert np.isnan(dihedrals[0]), "Zero length dihedral failed"
+        assert np.isnan(dihedrals[1]), "Straight line dihedral failed"
+        assert_almost_equal(dihedrals[2], np.pi, self.prec, err_msg="180 degree dihedral failed")
+        assert_almost_equal(dihedrals[3], -0.50714064, self.prec,
+                            err_msg="arbitrary dihedral angle failed")
+
+    def test_dihedrals_atomgroup(self, positions_atomgroups, backend):
+        ag_a, ag_b, ag_c, ag_d = positions_atomgroups
+        dihedrals = distances.calc_dihedrals(ag_a, ag_b, ag_c, ag_d, backend=backend)
         # Check calculated values
         assert_equal(len(dihedrals), 4, err_msg="calc_dihedrals results have wrong length")
         assert np.isnan(dihedrals[0]), "Zero length dihedral failed"

--- a/testsuite/MDAnalysisTests/lib/test_distances.py
+++ b/testsuite/MDAnalysisTests/lib/test_distances.py
@@ -369,6 +369,13 @@ def DCD_Universe():
     trajectory = universe.trajectory
     return universe, trajectory
 
+# second independent universe required for 
+# TestDistanceArrayDCD_TRIC.test_atomgroup_simple
+@pytest.fixture()
+def DCD_Universe2():
+    universe = MDAnalysis.Universe(PSF, DCD)
+    trajectory = universe.trajectory
+    return universe, trajectory
 
 @pytest.fixture()
 def Triclinic_Universe():
@@ -432,12 +439,12 @@ class TestDistanceArrayDCD_TRIC(object):
         assert_almost_equal(d.max(), 53.572192429459619, self.prec,
                             err_msg="wrong maximum distance value with PBC")
 
-    def test_atomgroup_simple(self, DCD_Universe, backend):
+    def test_atomgroup_simple(self, DCD_Universe, DCD_Universe2, backend):
         # need two copies as moving ts updates underlying array on atomgroup
         U1, trajectory1 = DCD_Universe
-        U2 = MDAnalysis.Universe(PSF, DCD)
-        trajectory2 = U2.trajectory
+        U2, trajectory2 = DCD_Universe2
         trajectory1.rewind()
+        trajectory2.rewind()
         x0 = U1.select_atoms("all")
         trajectory2[10]
         x1 = U2.select_atoms("all")

--- a/testsuite/MDAnalysisTests/lib/test_distances.py
+++ b/testsuite/MDAnalysisTests/lib/test_distances.py
@@ -378,6 +378,55 @@ class TestDistanceArrayDCD(object):
                             err_msg="wrong maximum distance value with PBC")
 
 
+    def test_2x_atomgroup_simple(self, DCD_Universe, backend):
+        # need two copies as moving timestep updates underlying array on atomgroup
+        U1, trajectory1 = DCD_Universe
+        U2 = MDAnalysis.Universe(PSF, DCD)
+        trajectory2 = U2.trajectory
+        trajectory1.rewind()
+        trajectory2.rewind()
+        x0 = U1.select_atoms("all")
+        trajectory2[10]
+        x1 = U2.select_atoms("all")
+        d = distances.distance_array(x0, x1, backend=backend)
+        assert_equal(d.shape, (3341, 3341), "wrong shape (should be (Natoms,Natoms))")
+        assert_almost_equal(d.min(), 0.11981228170520701, self.prec,
+                            err_msg="wrong minimum distance value")
+        assert_almost_equal(d.max(), 53.572192429459619, self.prec,
+                            err_msg="wrong maximum distance value")
+
+    @pytest.mark.parametrize("sel_or_slice", [("all", np.s_[:,:]),
+                            ("index 0 to 8 ", np.s_[0:9,:])])
+    def test_atomgroup_matches_numpy(self, DCD_Universe, backend, sel_or_slice):
+        # need two copies as moving timestep updates underlying array on atomgroup
+        U1, trajectory1 = DCD_Universe
+        U2 = MDAnalysis.Universe(PSF, DCD)
+        trajectory2 = U2.trajectory
+        trajectory1.rewind()
+        trajectory2.rewind()
+        x0_arr = U1.atoms.positions[sel_or_slice[1]]
+        x0_ag = U1.select_atoms(sel_or_slice[0])
+        trajectory2[10]
+        x1_arr = U2.atoms.positions[sel_or_slice[1]]
+        x1_ag = U2.select_atoms(sel_or_slice[0])
+        d_ag = distances.distance_array(x0_ag, x1_ag, backend=backend)
+        d_arr = distances.distance_array(x0_arr, x1_arr, backend=backend)
+        assert_allclose(d_ag, d_arr,
+                        err_msg="AtomGroup and NumPy distances do not match")
+
+
+    def test_iterator_mixed_array_ag_simple(self, DCD_Universe, backend):
+        U, trajectory = DCD_Universe
+        trajectory.rewind()
+        x0 = U.atoms.positions
+        trajectory[10]
+        x1 = U.select_atoms("all")
+        d = distances.distance_array(x0, x1, backend=backend)
+        assert_equal(d.shape, (3341, 3341), "wrong shape (should be (Natoms,Natoms))")
+        assert_almost_equal(d.min(), 0.11981228170520701, self.prec,
+                            err_msg="wrong minimum distance value")
+        assert_almost_equal(d.max(), 53.572192429459619, self.prec,
+                            err_msg="wrong maximum distance value")
 
 @pytest.mark.parametrize('backend', ['serial', 'openmp'])
 class TestSelfDistanceArrayDCD(object):

--- a/testsuite/MDAnalysisTests/lib/test_distances.py
+++ b/testsuite/MDAnalysisTests/lib/test_distances.py
@@ -1063,6 +1063,19 @@ class Test_apply_PBC(object):
         assert_almost_equal(cyth2, reference, self.prec,
                             err_msg="Ortho apply_PBC #2 failed comparison with np")
 
+    def test_ortho_PBC_atomgroup(self, backend):
+        U = MDAnalysis.Universe(PSF, DCD)
+        atoms = U.atoms.positions
+        ag = U.atoms
+        box = np.array([2.5, 2.5, 3.5, 90., 90., 90.], dtype=np.float32)
+        with pytest.raises(ValueError):
+            cyth1 = distances.apply_PBC(ag, box[:3], backend=backend)
+        cyth2 = distances.apply_PBC(ag, box, backend=backend)
+        reference = atoms - np.floor(atoms / box[:3]) * box[:3]
+
+        assert_almost_equal(cyth2, reference, self.prec,
+                            err_msg="Ortho apply_PBC #2 failed comparison with np")
+
     def test_tric_PBC(self, backend):
         U = MDAnalysis.Universe(TRIC)
         atoms = U.atoms.positions

--- a/testsuite/MDAnalysisTests/lib/test_distances.py
+++ b/testsuite/MDAnalysisTests/lib/test_distances.py
@@ -265,6 +265,7 @@ def ref_system_universe(ref_system):
     return (box, u.atoms, u.select_atoms("index 0"),
             u.select_atoms("index 1 to 3"))
 
+
 @pytest.mark.parametrize('backend', ['serial', 'openmp'])
 class TestDistanceArray(object):
     @staticmethod
@@ -461,8 +462,8 @@ class TestDistanceArrayDCD_TRIC(object):
     # check no box and ortho box types and some slices
     @pytest.mark.parametrize('box', [None, [50, 50, 50, 90, 90, 90]])
     @pytest.mark.parametrize("sel, np_slice", [("all", np.s_[:, :]),
-                            ("index 0 to 8 ", np.s_[0:9, :]),
-                            ("index 9", np.s_[8, :])])
+                             ("index 0 to 8 ", np.s_[0:9, :]),
+                             ("index 9", np.s_[8, :])])
     def test_atomgroup_matches_numpy(self, DCD_Universe, backend, sel,
                                      np_slice, box):
         U, _ = DCD_Universe
@@ -479,8 +480,8 @@ class TestDistanceArrayDCD_TRIC(object):
 
     # check triclinic box and some slices
     @pytest.mark.parametrize("sel, np_slice", [("all", np.s_[:, :]),
-                            ("index 0 to 8 ", np.s_[0:9, :]),
-                            ("index 9", np.s_[8, :])])
+                             ("index 0 to 8 ", np.s_[0:9, :]),
+                             ("index 9", np.s_[8, :])])
     def test_atomgroup_matches_numpy_tric(self, Triclinic_Universe, backend,
                                           sel, np_slice):
         U, _ = Triclinic_Universe
@@ -558,8 +559,8 @@ class TestSelfDistanceArrayDCD_TRIC(object):
     # check no box and ortho box types and some slices
     @pytest.mark.parametrize('box', [None, [50, 50, 50, 90, 90, 90]])
     @pytest.mark.parametrize("sel, np_slice", [("all", np.s_[:, :]),
-                            ("index 0 to 8 ", np.s_[0:9, :]),
-                            ("index 9", np.s_[8, :])])
+                             ("index 0 to 8 ", np.s_[0:9, :]),
+                             ("index 9", np.s_[8, :])])
     def test_atomgroup_matches_numpy(self, DCD_Universe, backend,
                                      sel, np_slice, box):
         U, _ = DCD_Universe
@@ -588,6 +589,7 @@ class TestSelfDistanceArrayDCD_TRIC(object):
                                               backend=backend)
         assert_allclose(d_ag, d_arr,
                         err_msg="AtomGroup and NumPy distances do not match")
+
 
 @pytest.mark.parametrize('backend', ['serial', 'openmp'])
 class TestTriclinicDistances(object):
@@ -773,6 +775,7 @@ def convert_position_dtype_if_ndarray(a, b, c, d, dtype):
             conv_dtype_if_ndarr(b, dtype),
             conv_dtype_if_ndarr(c, dtype),
             conv_dtype_if_ndarr(d, dtype))
+
 
 @pytest.mark.parametrize('backend', ['serial', 'openmp'])
 class TestCythonFunctions(object):
@@ -1389,6 +1392,7 @@ class TestInputUnchanged(object):
         ref = crd.positions.copy()
         res = distances.apply_PBC(crd, box, backend=backend)
         assert_equal(crd.positions, ref)
+        
 
 class TestEmptyInputCoordinates(object):
     """Tests ensuring that the following functions in MDAnalysis.lib.distances

--- a/testsuite/MDAnalysisTests/lib/test_distances.py
+++ b/testsuite/MDAnalysisTests/lib/test_distances.py
@@ -1062,25 +1062,18 @@ class Test_apply_PBC(object):
 
         assert_almost_equal(cyth2, reference, self.prec,
                             err_msg="Ortho apply_PBC #2 failed comparison with np")
-
-    def test_ortho_PBC_atomgroup(self, backend):
-        U = MDAnalysis.Universe(PSF, DCD)
-        atoms = U.atoms.positions
+        # also test atomgroup
         ag = U.atoms
-        box = np.array([2.5, 2.5, 3.5, 90., 90., 90.], dtype=np.float32)
-        with pytest.raises(ValueError):
-            cyth1 = distances.apply_PBC(ag, box[:3], backend=backend)
-        cyth2 = distances.apply_PBC(ag, box, backend=backend)
-        reference = atoms - np.floor(atoms / box[:3]) * box[:3]
-
-        assert_almost_equal(cyth2, reference, self.prec,
-                            err_msg="Ortho apply_PBC #2 failed comparison with np")
+        cyth3 = distances.apply_PBC(ag, box, backend=backend)
+        assert_almost_equal(cyth3, reference, self.prec,
+                            err_msg="Ortho AtomGroup apply_PBC #2 failed"
+                            " comparison with np")
 
     def test_tric_PBC(self, backend):
         U = MDAnalysis.Universe(TRIC)
         atoms = U.atoms.positions
         box = U.dimensions
-
+        ag = U.atoms
         def numpy_PBC(coords, box):
             # move to fractional coordinates
             fractional = distances.transform_RtoS(coords, box)
@@ -1090,10 +1083,16 @@ class Test_apply_PBC(object):
             return distances.transform_StoR(fractional, box)
 
         cyth1 = distances.apply_PBC(atoms, box, backend=backend)
+        # also test atomgroup
+        cyth_ag = distances.apply_PBC(ag, box, backend=backend)
+
         reference = numpy_PBC(atoms, box)
 
         assert_almost_equal(cyth1, reference, decimal=4,
                             err_msg="Triclinic apply_PBC failed comparison with np")
+        assert_almost_equal(cyth_ag, reference, decimal=4,
+                            err_msg="Triclinic AtomGroup apply_PBC failed" 
+                            "comparison with np")
 
         box = np.array([10, 7, 3, 45, 60, 90], dtype=np.float32)
         r = np.array([5.75, 0.36066014, 0.75], dtype=np.float32)

--- a/testsuite/MDAnalysisTests/lib/test_distances.py
+++ b/testsuite/MDAnalysisTests/lib/test_distances.py
@@ -374,6 +374,12 @@ def DCD_Universe():
 
     return universe, trajectory
 
+@pytest.fixture()
+def Triclinic_Universe():
+    universe =  MDAnalysis.Universe(TRIC)
+    trajectory = universe.trajectory
+    return universe, trajectory
+
 @pytest.mark.parametrize('backend', ['serial', 'openmp'])
 class TestDistanceArrayDCD(object):
     # reasonable precision so that tests succeed on 32 and 64 bit machines
@@ -444,12 +450,11 @@ class TestDistanceArrayDCD(object):
         assert_almost_equal(d.max(), 53.572192429459619, self.prec,
                             err_msg="wrong maximum distance value")
 
-    # check all three box types and some slices
-    @pytest.mark.parametrize('box', [None, [50, 50, 50, 90, 90, 90],
-                             [50, 50, 50, 60, 60, 60]])
+    # check no box and ortho box types and some slices
+    @pytest.mark.parametrize('box', [None, [50, 50, 50, 90, 90, 90]])
     @pytest.mark.parametrize("sel, np_slice", [("all", np.s_[:,:]),
                             ("index 0 to 8 ", np.s_[0:9,:]),
-                            ("index 9", np.s_[-1,:])])
+                            ("index 9", np.s_[8,:])])
     def test_atomgroup_matches_numpy(self, DCD_Universe, backend, sel, np_slice,
                                      box):
         U, _ = DCD_Universe
@@ -460,6 +465,23 @@ class TestDistanceArrayDCD(object):
         d_ag = distances.distance_array(x0_ag, x1_ag, box=box,
                                  backend=backend)
         d_arr = distances.distance_array(x0_arr, x1_arr, box=box,
+                                         backend=backend)
+        assert_allclose(d_ag, d_arr,
+                        err_msg="AtomGroup and NumPy distances do not match")
+    
+    # check triclinic box and some slices
+    @pytest.mark.parametrize("sel, np_slice", [("all", np.s_[:,:]),
+                            ("index 0 to 8 ", np.s_[0:9,:]),
+                            ("index 9", np.s_[8,:])])
+    def test_atomgroup_matches_numpy_tric(self, Triclinic_Universe, backend, sel, np_slice):
+        U, _ = Triclinic_Universe
+        x0_ag = U.select_atoms(sel)
+        x0_arr = U.atoms.positions[np_slice]
+        x1_ag = U.select_atoms(sel)
+        x1_arr = U.atoms.positions[np_slice]
+        d_ag = distances.distance_array(x0_ag, x1_ag, box=U.coord.dimensions,
+                                 backend=backend)
+        d_arr = distances.distance_array(x0_arr, x1_arr, box=U.coord.dimensions,
                                          backend=backend)
         assert_allclose(d_ag, d_arr,
                         err_msg="AtomGroup and NumPy distances do not match")
@@ -522,7 +544,51 @@ class TestSelfDistanceArrayDCD(object):
         assert_almost_equal(d.max(), 52.4702570624190590, self.prec,
                             err_msg="wrong maximum distance value with PBC")
 
+    def test_atomgroup_simple(self, DCD_Universe, backend):
+        U, trajectory = DCD_Universe
+        trajectory.rewind()
+        x0 = U.select_atoms("all")
+        d = distances.self_distance_array(x0, backend=backend)
+        N = 3341 * (3341 - 1) / 2
+        assert_equal(d.shape, (N,), "wrong shape (should be (Natoms*(Natoms-1)/2,))")
+        assert_almost_equal(d.min(), 0.92905562402529318, self.prec,
+                            err_msg="wrong minimum distance value")
+        assert_almost_equal(d.max(), 52.4702570624190590, self.prec,
+                            err_msg="wrong maximum distance value")
 
+    # check no box and ortho box types and some slices
+    @pytest.mark.parametrize('box', [None, [50, 50, 50, 90, 90, 90]] )
+    @pytest.mark.parametrize("sel, np_slice", [("all", np.s_[:,:]),
+                            ("index 0 to 8 ", np.s_[0:9,:]),
+                            ("index 9", np.s_[8,:])])
+    def test_atomgroup_matches_numpy(self, DCD_Universe, backend, sel, np_slice,
+                                     box):
+        U, _ = DCD_Universe
+
+        x0_ag = U.select_atoms(sel)
+        x0_arr = U.atoms.positions[np_slice]
+        d_ag = distances.self_distance_array(x0_ag, box=box,
+                                 backend=backend)
+        d_arr = distances.self_distance_array(x0_arr, box=box,
+                                         backend=backend)
+        assert_allclose(d_ag, d_arr,
+                        err_msg="AtomGroup and NumPy distances do not match")
+
+    # # check triclinic box and some slices
+    # @pytest.mark.parametrize("sel, np_slice", [
+    #                         ("index 0 to 8 ", np.s_[0:9,:]),
+    #                         ("index 9", np.s_[8,:])])
+    # def test_atomgroup_matches_numpy_tric(self, Triclinic_Universe, backend, sel, np_slice):
+    #     U, _ = Triclinic_Universe
+    #     x0_ag = U.select_atoms(sel)
+    #     x0_arr = U.atoms.positions[np_slice]
+    #     d_ag = distances.self_distance_array(x0_ag, box=U.coord.dimensions,
+    #                              backend=backend)
+    #     d_arr = distances.self_distance_array(x0_arr, box=U.coord.dimensions,
+    #                                      backend=backend)
+    #     assert_allclose(d_ag, d_arr,
+    #                     err_msg="AtomGroup and NumPy distances do not match")
+    
 @pytest.mark.parametrize('backend', ['serial', 'openmp'])
 class TestTriclinicDistances(object):
     """Unit tests for the Triclinic PBC functions.

--- a/testsuite/MDAnalysisTests/lib/test_distances.py
+++ b/testsuite/MDAnalysisTests/lib/test_distances.py
@@ -382,7 +382,7 @@ def Triclinic_Universe():
     return universe, trajectory
 
 @pytest.mark.parametrize('backend', ['serial', 'openmp'])
-class TestDistanceArrayDCD(object):
+class TestDistanceArrayDCD_TRIC(object):
     # reasonable precision so that tests succeed on 32 and 64 bit machines
     # (the reference values were obtained on 64 bit)
     # Example:
@@ -501,7 +501,7 @@ class TestDistanceArrayDCD(object):
                             err_msg="wrong maximum distance value")
 
 @pytest.mark.parametrize('backend', ['serial', 'openmp'])
-class TestSelfDistanceArrayDCD(object):
+class TestSelfDistanceArrayDCD_TRIC(object):
     prec = 5
 
     def test_simple(self, DCD_Universe, backend):
@@ -580,7 +580,7 @@ class TestSelfDistanceArrayDCD(object):
                             ("index 0 to 8 ", np.s_[0:9,:]),
                             ("index 9", np.s_[8,:])])
     def test_atomgroup_matches_numpy_tric(self, Triclinic_Universe, backend, sel, np_slice):
-        U, trajectory = Triclinic_Universe
+        U, _ = Triclinic_Universe
         #BUG serial only for now as the OMP code path appears broken
         x0_ag = U.select_atoms(sel)
         x0_arr = U.atoms.positions[np_slice]

--- a/testsuite/MDAnalysisTests/lib/test_util.py
+++ b/testsuite/MDAnalysisTests/lib/test_util.py
@@ -44,8 +44,7 @@ from MDAnalysis.lib.util import (cached, static_variables, warn_if_not_unique,
 from MDAnalysis.core.topologyattrs import Bonds
 from MDAnalysis.exceptions import NoDataError, DuplicateWarning
 from MDAnalysis.core.groups import AtomGroup
-
-from MDAnalysisTests.datafiles import (PSF, DCD, 
+from MDAnalysisTests.datafiles import (PSF, DCD,
     Make_Whole, TPR, GRO, fullerene, two_water_gro,
 )
 
@@ -1740,9 +1739,8 @@ class TestCheckCoords(object):
 
     @pytest.fixture()
     def atomgroup(self):
-        u = mda.Universe(PSF,DCD)
+        u = mda.Universe(PSF, DCD)
         return u.atoms
-
 
     # check atomgroup handling with every option except allow_atomgroup
     @pytest.mark.parametrize('enforce_copy', [True, False])
@@ -1751,12 +1749,12 @@ class TestCheckCoords(object):
     @pytest.mark.parametrize('convert_single', [True, False])
     @pytest.mark.parametrize('reduce_result_if_single', [True, False])
     @pytest.mark.parametrize('check_lengths_match', [True, False])
-    def test_atomgroup(self, atomgroup, enforce_copy, enforce_dtype, allow_single,
-                       convert_single, reduce_result_if_single,
+    def test_atomgroup(self, atomgroup, enforce_copy, enforce_dtype,
+                       allow_single, convert_single, reduce_result_if_single,
                        check_lengths_match):
         ag1 = atomgroup
         ag2 = atomgroup
-        
+
         @check_coords('ag1', 'ag2', enforce_copy=enforce_copy,
                       enforce_dtype=enforce_dtype, allow_single=allow_single,
                       convert_single=convert_single,
@@ -1772,17 +1770,17 @@ class TestCheckCoords(object):
 
         res = func(ag1, ag2)
 
-        assert_allclose(res, atomgroup.positions*2) 
-    
+        assert_allclose(res, atomgroup.positions*2)
+
     def test_atomgroup_not_allowed(self, atomgroup):
         
         @check_coords('ag1', allow_atomgroup=False)
         def func(ag1):
             return ag1
-        
+
         with pytest.raises(TypeError, match="allow_atomgroup is False"):
             _ = func(atomgroup)
-    
+
     def test_atomgroup_not_allowed_default(self, atomgroup):
 
         @check_coords('ag1')
@@ -1791,7 +1789,6 @@ class TestCheckCoords(object):
 
         with pytest.raises(TypeError, match="allow_atomgroup is False"):
             _ = func_default(atomgroup)
-        
 
     def test_enforce_copy(self):
 
@@ -1890,20 +1887,20 @@ class TestCheckCoords(object):
         # Assert arrays are just passed through:
         assert res_a is a_2d
         assert res_b is b_2d
-    
-    def test_atomgroup_mismatched_lengths(self ):
-        u = mda.Universe(PSF,DCD)
+
+    def test_atomgroup_mismatched_lengths(self):
+        u = mda.Universe(PSF, DCD)
         ag1 = u.select_atoms("index 0 to 10")
         ag2 = u.atoms
-        
+
         @check_coords('ag1', 'ag2', check_lengths_match=True,
                       allow_atomgroup=True)
         def func(ag1, ag2):
 
-            return ag1,  ag2
+            return ag1, ag2
 
         with pytest.raises(ValueError, match="must contain the same number of "
-                                     "coordinates"):
+                           "coordinates"):
             _, _ = func(ag1, ag2)
 
     def test_invalid_input(self):

--- a/testsuite/MDAnalysisTests/lib/test_util.py
+++ b/testsuite/MDAnalysisTests/lib/test_util.py
@@ -1865,6 +1865,20 @@ class TestCheckCoords(object):
         # Assert arrays are just passed through:
         assert res_a is a_2d
         assert res_b is b_2d
+    
+    def test_atomgroup_mismatched_lengths(self ):
+        u = mda.Universe(PSF,DCD)
+        ag1 = u.select_atoms("index 0 to 10")
+        ag2 = u.atoms
+        
+        @check_coords('ag1', 'ag2', check_lengths_match=True)
+        def func(ag1, ag2):
+
+            return ag1,  ag2
+
+        with pytest.raises(ValueError, match="must contain the same number of "
+                                     "coordinates"):
+            _, _ = func(ag1, ag2)
 
     def test_invalid_input(self):
 

--- a/testsuite/MDAnalysisTests/lib/test_util.py
+++ b/testsuite/MDAnalysisTests/lib/test_util.py
@@ -1773,7 +1773,7 @@ class TestCheckCoords(object):
         assert_allclose(res, atomgroup.positions*2)
 
     def test_atomgroup_not_allowed(self, atomgroup):
-        
+
         @check_coords('ag1', allow_atomgroup=False)
         def func(ag1):
             return ag1


### PR DESCRIPTION
Fixes #3708 
Successor to #3718 

Second attempt at addressing #3708 using a python only design. CZI_EOSS4 performance track. 

Changes made in this Pull Request:
- Change `@check_coords` to take also `AtomGroups` and return positions
-  Atomgroup parsing in `@check_coords` must be enabled with argument `allow_atomgroup` with default `False` maintaining current behaviour
- Added type hinting to lots of distances module
- Change `distance_array`, `self_distance_array`, `calc_bonds`, `calc_angles`, `calc_dihedrals`, and `apply_PBC` to take an atomgroup
- Added tests for AtomGroup input to distances.  Still some code duplication here can be possibly cleaned up .


 Do we want to also change `nsgrid` functions,   and the `transform_` functions? If so is that best done here or separate PR?


PR Checklist
------------
 - [X] Tests?
 - [X] Docs?
 - [X] CHANGELOG updated?
 - [X] Issue raised/referenced?
