### PR TITLE
 Pin back pytest-cov

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,6 +7,7 @@ omit =
     */legacy/*
     */due.py
 concurrency = thread, multiprocessing
+parallel = True
 
 [report]
 exclude_lines =

--- a/.github/actions/setup-deps/action.yaml
+++ b/.github/actions/setup-deps/action.yaml
@@ -71,9 +71,9 @@ inputs:
     default: 'tidynamics>=1.0.0'
   # pip-installed min dependencies
   coverage:
-    default: 'coverage'
+    default: 'coverage<5.0'
   pytest-cov:
-    default: 'pytest-cov'
+    default: 'pytest-cov<=2.8.1'
   pytest-xdist:
     default: 'pytest-xdist'
   # pip-install optional dependencies

--- a/.github/actions/setup-deps/action.yaml
+++ b/.github/actions/setup-deps/action.yaml
@@ -73,7 +73,7 @@ inputs:
   coverage:
     default: 'coverage'
   pytest-cov:
-    default: 'pytest-cov'
+    default: 'pytest-cov<=2.8.1'
   pytest-xdist:
     default: 'pytest-xdist'
   # pip-install optional dependencies

--- a/.github/actions/setup-deps/action.yaml
+++ b/.github/actions/setup-deps/action.yaml
@@ -73,7 +73,7 @@ inputs:
   coverage:
     default: 'coverage<5.0'
   pytest-cov:
-    default: 'pytest-cov<=2.8.1'
+    default: 'pytest-cov<=2.10.1'
   pytest-xdist:
     default: 'pytest-xdist'
   # pip-install optional dependencies

--- a/.github/actions/setup-deps/action.yaml
+++ b/.github/actions/setup-deps/action.yaml
@@ -73,7 +73,7 @@ inputs:
   coverage:
     default: 'coverage'
   pytest-cov:
-    default: 'pytest-cov<=2.8.1'
+    default: 'pytest-cov'
   pytest-xdist:
     default: 'pytest-xdist'
   # pip-install optional dependencies

--- a/package/.coveragerc
+++ b/package/.coveragerc
@@ -1,2 +1,0 @@
-[run]
-plugins = Cython.Coverage


### PR DESCRIPTION
This is going to take a bit of time, essentially just seeing what pin will stops these conflicting tracer file errors.

Changes made in this Pull Request:
 - re-pin pytest-cov but at 2.8.1 max


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
