### PR TITLE
bump up numpy min version to 1.20

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -57,7 +57,7 @@ jobs:
               full-deps: false
               install_hole: false
               codecov: false
-              numpy: numpy=1.19.0
+              numpy: numpy=1.20.0
             - name: asv_check
               os: ubuntu-latest
               python-version: 3.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
       group: edge
       if: type = cron
       before_install:
-        - python -m pip install cython "numpy>=1.19.2" scipy
+        - python -m pip install cython "numpy>=1.20.0" scipy
         - python -m pip install --no-build-isolation hypothesis matplotlib packaging pytest pytest-cov pytest-xdist tqdm threadpoolctl fasteners
       install:
         - cd package

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,25 +40,25 @@ jobs:
           PYTHON_VERSION: '3.9'
           PYTHON_ARCH: 'x64'
           BUILD_TYPE: 'wheel'
-          NUMPY_MIN: '1.19.3'
+          NUMPY_MIN: '1.20.0'
           imageName: 'windows-2019'
         Win-Python38-64bit-full-wheel:
           PYTHON_VERSION: '3.8'
           PYTHON_ARCH: 'x64'
           BUILD_TYPE: 'wheel'
-          NUMPY_MIN: '1.19.0'
+          NUMPY_MIN: '1.20.0'
           imageName: 'windows-2019'
         Linux-Python39-64bit-full-wheel:
           PYTHON_VERSION: '3.9'
           PYTHON_ARCH: 'x64'
           BUILD_TYPE: 'wheel'
-          NUMPY_MIN: '1.19.3'
+          NUMPY_MIN: '1.20.0'
           imageName: 'ubuntu-latest'
         Linux-Python38-64bit-full-wheel:
           PYTHON_VERSION: '3.8'
           PYTHON_ARCH: 'x64'
           BUILD_TYPE: 'wheel'
-          NUMPY_MIN: '1.19.3'
+          NUMPY_MIN: '1.20.0'
           imageName: 'ubuntu-latest'
   pool:
     vmImage: $(imageName)

--- a/maintainer/conda/environment.yml
+++ b/maintainer/conda/environment.yml
@@ -16,7 +16,7 @@ dependencies:
   - mmtf-python
   - mock
   - networkx
-  - numpy>=1.19
+  - numpy>=1.20
   - pytest
   - python==3.8
   - scikit-learn

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -29,6 +29,7 @@ Enhancements
     (CZI Performance track, PR #3683)
 
 Changes
+  * Minimum supported NumPy version is now 1.20 as per NEP29 (PR #3737)
   * Narrowed variable scope to reduce use of OpenMP `private` clause (PR #3706, PR
     #3728)
 

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -29,7 +29,8 @@ Enhancements
     (CZI Performance track, PR #3683)
 
 Changes
-  * Minimum supported NumPy version is now 1.20 as per NEP29 (PR #3737)
+  * Minimum supported NumPy version is now 1.20 (1.21 for macosx-arm64)
+    as per NEP29 (PR #3737)
   * Narrowed variable scope to reduce use of OpenMP `private` clause (PR #3706, PR
     #3728)
 

--- a/package/pyproject.toml
+++ b/package/pyproject.toml
@@ -4,13 +4,10 @@ requires = [
     "Cython>=0.28",
     "packaging",
     # lowest NumPy we can use for a given Python,
-    # except for more exotic platforms (linux/Mac ARM flavors)
-    "numpy==1.19; python_version=='3.8' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='aarch64'",
-    "numpy==1.19.3; python_version=='3.9' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='aarch64'",
+    # arm65 on Darwin supports py3.8 and above and requires numpy>=1.20.0
+    "numpy==1.20.0; python_version=='3.8'",
+    "numpy==1.20.0; python_version=='3.9'",
     "numpy==1.21.4; python_version=='3.10' and platform_python_implementation != 'PyPy'",
     "setuptools",
     "wheel",
-    # arm64 on Darwin supports Python 3.8 and above and requires numpy>=1.20.0
-    "numpy==1.20.0; python_version=='3.8' and platform_machine=='arm64' and platform_system=='Darwin'",
-    "numpy==1.20.0; python_version=='3.9' and platform_machine=='arm64' and platform_system=='Darwin'",
 ]

--- a/package/pyproject.toml
+++ b/package/pyproject.toml
@@ -4,10 +4,16 @@ requires = [
     "Cython>=0.28",
     "packaging",
     # lowest NumPy we can use for a given Python,
-    # arm65 on Darwin supports py3.8 and above and requires numpy>=1.20.0
-    "numpy==1.20.0; python_version=='3.8'",
-    "numpy==1.20.0; python_version=='3.9'",
-    "numpy==1.21.4; python_version=='3.10' and platform_python_implementation != 'PyPy'",
+    # except for more exotic platform (Mac Arm flavors)
+    # aarch64, AIX, s390x all support < 1.20 so we can safely pin to this
+    "numpy==1.20.0; python_version=='3.8' and (platform_machine!='arm64' or platform_system!='Darwin')",
+    "numpy==1.20.0; python_version=='3.9' and (platform_machine!='arm64' or platform_system!='Darwin')",
+    # arm64 on darwin for py3.8+ requires numpy >=1.21.0
+    "numpy==1.21.0; python_version=='3.8' and platform_machine=='arm64' and platform_system=='Darwin'",
+    "numpy==1.21.0; python_version=='3.9' and platform_machine=='arm64' and platform_system=='Darwin'",
+    # As per https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg
+    # safest to build at 1.21.6 for all platforms
+    "numpy==1.21.6; python_version=='3.10' and platform_python_implementation != 'PyPy'",
     "setuptools",
     "wheel",
 ]

--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -11,7 +11,7 @@ mmtf-python
 msmb_theme==1.2.0
 netcdf4
 networkx
-numpy>=1.19.0
+numpy>=1.20.0
 packaging
 parmed
 pytest

--- a/package/setup.py
+++ b/package/setup.py
@@ -190,7 +190,7 @@ def get_numpy_include():
         import numpy as np
     except ImportError:
         print('*** package "numpy" not found ***')
-        print('MDAnalysis requires a version of NumPy (>=1.19.0), even for setup.')
+        print('MDAnalysis requires a version of NumPy (>=1.20.0), even for setup.')
         print('Please get it from http://numpy.scipy.org/ or install it through '
               'your package manager.')
         sys.exit(-1)
@@ -597,7 +597,7 @@ if __name__ == '__main__':
     exts, cythonfiles = extensions(config)
 
     install_requires = [
-          'numpy>=1.19.0',
+          'numpy>=1.20.0',
           'biopython>=1.71',
           'networkx>=2.0',
           'GridDataFormats>=0.4.0',
@@ -646,7 +646,7 @@ if __name__ == '__main__':
           # all standard requirements are available through PyPi and
           # typically can be installed without difficulties through setuptools
           setup_requires=[
-              'numpy>=1.19.0',
+              'numpy>=1.20.0',
               'packaging',
           ],
           install_requires=install_requires,


### PR DESCRIPTION
For 2.3.0 we'll likely have a minimum of 1.20 support as per NEP29

Changes made in this Pull Request:
 - 


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
