### PR TITLE
Rename libmda to libmdanalysis and clean up __init__.pxd

### DIFF
--- a/package/MDAnalysis/libmda/__init__.pxd
+++ b/package/MDAnalysis/libmda/__init__.pxd
@@ -1,2 +1,0 @@
-from .coordinates cimport timestep
-from .lib cimport _cutil

--- a/package/MDAnalysis/libmdanalysis/__init__.pxd
+++ b/package/MDAnalysis/libmdanalysis/__init__.pxd
@@ -1,0 +1,4 @@
+# Public Cython API for MDAnalysis. Centralises Cython core datastructures in a
+# single place. 
+
+from .coordinates cimport timestep


### PR DESCRIPTION
Fixes #3738 

Triggered by discussion on #3734 

Changes made in this Pull Request:
 - Changes the name of libmda to `libmdanalysis`
 - Clean up accidental cimport of `cutil.pxd` 

PR Checklist
------------
 - [X] Issue raised/referenced?
