### PR TITLE
Modernize tests under converters and visualization

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -196,6 +196,7 @@ Chronological list of authors
   - Ricky Sexton
   - Rafael R. Pappalardo
   - Tengyu Xie
+  - Raymond Zhao
 
 
 External code

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,7 +13,7 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-??/??/?? IAlibay, PicoCentauri, orbeckst, hmacdope, rmeli, miss77jun
+??/??/?? IAlibay, PicoCentauri, orbeckst, hmacdope, rmeli, miss77jun, rzhao271
 
  * 2.3.0
 

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,7 +13,7 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-??/??/?? IAlibay, PicoCentauri, orbeckst, hmacdope, rmeli, miss77jun
+??/??/?? IAlibay, PicoCentauri, orbeckst, hmacdope, rmeli, miss77jun, rzhao271
 
  * 2.3.0
 
@@ -36,6 +36,8 @@ Changes
     as per NEP29 (PR #3737)
   * Narrowed variable scope to reduce use of OpenMP `private` clause (PR #3706, PR
     #3728)
+  * Refactored tests under `converters` and `visualization` directories
+    to avoid using `assert_almost_equal`
 
 Deprecations
   * The extras_requires target "AMBER" for `pip install ./package[AMBER]`

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,7 +13,7 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-??/??/?? IAlibay, PicoCentauri, orbeckst, hmacdope, rmeli, miss77jun, rzhao271
+??/??/?? IAlibay, PicoCentauri, orbeckst, hmacdope, rmeli, miss77jun
 
  * 2.3.0
 
@@ -36,8 +36,6 @@ Changes
     as per NEP29 (PR #3737)
   * Narrowed variable scope to reduce use of OpenMP `private` clause (PR #3706, PR
     #3728)
-  * Refactored tests under `converters` and `visualization` directories
-    to avoid using `assert_almost_equal`
 
 Deprecations
   * The extras_requires target "AMBER" for `pip install ./package[AMBER]`

--- a/testsuite/MDAnalysisTests/converters/test_openmm.py
+++ b/testsuite/MDAnalysisTests/converters/test_openmm.py
@@ -22,7 +22,7 @@
 #
 import pytest
 import numpy as np
-from numpy.testing import assert_almost_equal
+from numpy.testing import assert_allclose
 
 from MDAnalysisTests.datafiles import PDBX
 from MDAnalysisTests.coordinates.reference import RefAdKSmall
@@ -65,18 +65,19 @@ class TestOpenMMBasicSimulationReader():
         return mda.Universe(simulation)
 
     def test_dimensions(self, omm_sim_uni):
-        assert_almost_equal(
+        assert_allclose(
             omm_sim_uni.trajectory.ts.dimensions,
             np.array([20., 20., 20., 90., 90., 90.]),
-            3,
-            "OpenMMBasicSimulationReader failed to get unitcell dimensions " +
+            rtol=0,
+            atol=1e-3,
+            err_msg="OpenMMBasicSimulationReader failed to get unitcell dimensions " +
             "from OpenMM Simulation Object",
         )
 
     def test_coordinates(self, omm_sim_uni):
         up = omm_sim_uni.atoms.positions
         reference = np.ones((5, 3))
-        assert_almost_equal(up, reference, decimal=3)
+        assert_allclose(up, reference, rtol=0, atol=1e-3)
 
     def test_basic_topology(self, omm_sim_uni):
         assert omm_sim_uni.atoms.n_atoms == 5
@@ -93,21 +94,21 @@ class TestOpenMMPDBFileReader(_SingleFrameReader):
     def setUp(self):
         self.universe = mda.Universe(app.PDBFile(RefAdKSmall.filename))
         self.ref = mda.Universe(RefAdKSmall.filename)
-        self.prec = 3
 
     def test_dimensions(self):
-        assert_almost_equal(
+        assert_allclose(
             self.universe.trajectory.ts.dimensions,
             self.ref.trajectory.ts.dimensions,
-            self.prec,
-            "OpenMMPDBFileReader failed to get unitcell dimensions " +
+            rtol=0,
+            atol=1e-3,
+            err_msg="OpenMMPDBFileReader failed to get unitcell dimensions " +
             "from OpenMMPDBFile",
         )
 
     def test_coordinates(self):
         up = self.universe.atoms.positions
         rp = self.ref.atoms.positions
-        assert_almost_equal(up, rp, decimal=3)
+        assert_allclose(up, rp, rtol=0, atol=1e-3)
 
 
 class TestOpenMMModellerReader(_SingleFrameReader):
@@ -118,21 +119,21 @@ class TestOpenMMModellerReader(_SingleFrameReader):
         modeller = app.Modeller(pdb_obj.topology, pdb_obj.positions)
         self.universe = mda.Universe(modeller)
         self.ref = mda.Universe(RefAdKSmall.filename)
-        self.prec = 3
 
     def test_dimensions(self):
-        assert_almost_equal(
+        assert_allclose(
             self.universe.trajectory.ts.dimensions,
             self.ref.trajectory.ts.dimensions,
-            self.prec,
-            "OpenMMModellerReader failed to get unitcell dimensions " +
+            rtol=0,
+            atol=1e-3,
+            err_msg="OpenMMModellerReader failed to get unitcell dimensions " +
             "from OpenMMModeller",
         )
 
     def test_coordinates(self):
         up = self.universe.atoms.positions
         rp = self.ref.atoms.positions
-        assert_almost_equal(up, rp, decimal=3)
+        assert_allclose(up, rp, rtol=0, atol=1e-3)
 
 
 class TestOpenMMSimulationReader(_SingleFrameReader):
@@ -151,21 +152,21 @@ class TestOpenMMSimulationReader(_SingleFrameReader):
         sim.context.setPositions(pdb.positions)
         self.universe = mda.Universe(sim)
         self.ref = mda.Universe(RefAdKSmall.filename)
-        self.prec = 3
 
     def test_dimensions(self):
-        assert_almost_equal(
+        assert_allclose(
             self.universe.trajectory.ts.dimensions,
             self.ref.trajectory.ts.dimensions,
-            self.prec,
-            "OpenMMSimulationReader failed to get unitcell dimensions " +
+            rtol=0,
+            atol=1e-3,
+            err_msg="OpenMMSimulationReader failed to get unitcell dimensions " +
             "from OpenMMSimulation",
         )
 
     def test_coordinates(self):
         up = self.universe.atoms.positions
         rp = self.ref.atoms.positions
-        assert_almost_equal(up, rp, decimal=3)
+        assert_allclose(up, rp, rtol=0, atol=1e-3)
 
     @pytest.mark.xfail(reason='OpenMM pickling not supported yet')
     def test_pickle_singleframe_reader(self):
@@ -246,4 +247,4 @@ def test_pdbx_coordinates(PDBX_U):
         ]
     )
     rp = PDBX_U.atoms.positions
-    assert_almost_equal(ref_pos, rp, decimal=3)
+    assert_allclose(ref_pos, rp, rtol=0, atol=1e-3)

--- a/testsuite/MDAnalysisTests/converters/test_openmm.py
+++ b/testsuite/MDAnalysisTests/converters/test_openmm.py
@@ -71,7 +71,7 @@ class TestOpenMMBasicSimulationReader():
             rtol=0,
             atol=1e-3,
             err_msg="OpenMMBasicSimulationReader failed to get unitcell " +
-            "dimensions from OpenMM Simulation Object",
+                    "dimensions from OpenMM Simulation Object",
         )
 
     def test_coordinates(self, omm_sim_uni):
@@ -102,7 +102,7 @@ class TestOpenMMPDBFileReader(_SingleFrameReader):
             rtol=0,
             atol=1e-3,
             err_msg="OpenMMPDBFileReader failed to get unitcell dimensions " +
-            "from OpenMMPDBFile",
+                    "from OpenMMPDBFile",
         )
 
     def test_coordinates(self):
@@ -127,7 +127,7 @@ class TestOpenMMModellerReader(_SingleFrameReader):
             rtol=0,
             atol=1e-3,
             err_msg="OpenMMModellerReader failed to get unitcell dimensions " +
-            "from OpenMMModeller",
+                    "from OpenMMModeller",
         )
 
     def test_coordinates(self):
@@ -159,8 +159,8 @@ class TestOpenMMSimulationReader(_SingleFrameReader):
             self.ref.trajectory.ts.dimensions,
             rtol=0,
             atol=1e-3,
-            err_msg="OpenMMSimulationReader failed to get unitcell dimensions " +
-            "from OpenMMSimulation",
+            err_msg="OpenMMSimulationReader failed to get unitcell " +
+                    "dimensions from OpenMMSimulation",
         )
 
     def test_coordinates(self):

--- a/testsuite/MDAnalysisTests/converters/test_openmm.py
+++ b/testsuite/MDAnalysisTests/converters/test_openmm.py
@@ -70,8 +70,8 @@ class TestOpenMMBasicSimulationReader():
             np.array([20., 20., 20., 90., 90., 90.]),
             rtol=0,
             atol=1e-3,
-            err_msg="OpenMMBasicSimulationReader failed to get unitcell " +
-                    "dimensions from OpenMM Simulation Object",
+            err_msg=("OpenMMBasicSimulationReader failed to get unitcell "
+                     "dimensions from OpenMM Simulation Object"),
         )
 
     def test_coordinates(self, omm_sim_uni):
@@ -102,8 +102,8 @@ class TestOpenMMPDBFileReader(_SingleFrameReader):
             self.ref.trajectory.ts.dimensions,
             rtol=0,
             atol=1e-3,
-            err_msg="OpenMMPDBFileReader failed to get unitcell dimensions " +
-                    "from OpenMMPDBFile",
+            err_msg=("OpenMMPDBFileReader failed to get unitcell dimensions "
+                     "from OpenMMPDBFile"),
         )
 
     def test_coordinates(self):
@@ -128,8 +128,8 @@ class TestOpenMMModellerReader(_SingleFrameReader):
             self.ref.trajectory.ts.dimensions,
             rtol=0,
             atol=1e-3,
-            err_msg="OpenMMModellerReader failed to get unitcell dimensions " +
-                    "from OpenMMModeller",
+            err_msg=("OpenMMModellerReader failed to get unitcell dimensions "
+                     "from OpenMMModeller"),
         )
 
     def test_coordinates(self):
@@ -162,8 +162,8 @@ class TestOpenMMSimulationReader(_SingleFrameReader):
             self.ref.trajectory.ts.dimensions,
             rtol=0,
             atol=1e-3,
-            err_msg="OpenMMSimulationReader failed to get unitcell " +
-                    "dimensions from OpenMMSimulation",
+            err_msg=("OpenMMSimulationReader failed to get unitcell "
+                     "dimensions from OpenMMSimulation"),
         )
 
     def test_coordinates(self):

--- a/testsuite/MDAnalysisTests/converters/test_openmm.py
+++ b/testsuite/MDAnalysisTests/converters/test_openmm.py
@@ -70,8 +70,8 @@ class TestOpenMMBasicSimulationReader():
             np.array([20., 20., 20., 90., 90., 90.]),
             rtol=0,
             atol=1e-3,
-            err_msg="OpenMMBasicSimulationReader failed to get unitcell dimensions " +
-            "from OpenMM Simulation Object",
+            err_msg="OpenMMBasicSimulationReader failed to get unitcell " +
+            "dimensions from OpenMM Simulation Object",
         )
 
     def test_coordinates(self, omm_sim_uni):

--- a/testsuite/MDAnalysisTests/converters/test_openmm.py
+++ b/testsuite/MDAnalysisTests/converters/test_openmm.py
@@ -94,6 +94,7 @@ class TestOpenMMPDBFileReader(_SingleFrameReader):
     def setUp(self):
         self.universe = mda.Universe(app.PDBFile(RefAdKSmall.filename))
         self.ref = mda.Universe(RefAdKSmall.filename)
+        self.prec = 3
 
     def test_dimensions(self):
         assert_allclose(
@@ -119,6 +120,7 @@ class TestOpenMMModellerReader(_SingleFrameReader):
         modeller = app.Modeller(pdb_obj.topology, pdb_obj.positions)
         self.universe = mda.Universe(modeller)
         self.ref = mda.Universe(RefAdKSmall.filename)
+        self.prec = 3
 
     def test_dimensions(self):
         assert_allclose(
@@ -152,6 +154,7 @@ class TestOpenMMSimulationReader(_SingleFrameReader):
         sim.context.setPositions(pdb.positions)
         self.universe = mda.Universe(sim)
         self.ref = mda.Universe(RefAdKSmall.filename)
+        self.prec = 3
 
     def test_dimensions(self):
         assert_allclose(

--- a/testsuite/MDAnalysisTests/converters/test_parmed.py
+++ b/testsuite/MDAnalysisTests/converters/test_parmed.py
@@ -24,8 +24,7 @@ import pytest
 import MDAnalysis as mda
 
 from numpy.testing import (assert_equal,
-                           assert_almost_equal,
-                           assert_almost_equal)
+                           assert_allclose)
 
 from MDAnalysisTests.coordinates.base import _SingleFrameReader
 from MDAnalysisTests.coordinates.reference import RefAdKSmall
@@ -51,38 +50,38 @@ class TestParmEdReaderGRO:
 
     universe = mda.Universe(pmd.load_file(GRO))
     ref = mda.Universe(GRO)
-    prec = 3
 
     def test_dimensions(self):
-        assert_almost_equal(
+        assert_allclose(
             self.universe.trajectory.ts.dimensions, 
             self.ref.trajectory.ts.dimensions,
-            self.prec,
-            "ParmEdReader failed to get unitcell dimensions from ParmEd")
+            rtol=0,
+            atol=1e-3,
+            err_msg="ParmEdReader failed to get unitcell dimensions from ParmEd")
     
     def test_coordinates(self):
         up = self.universe.atoms.positions
         rp = self.ref.atoms.positions
-        assert_almost_equal(up, rp, decimal=3)
+        assert_allclose(up, rp, rtol=0, atol=1e-3)
     
 
 class BaseTestParmEdReader(_SingleFrameReader):
     def setUp(self):
         self.universe = mda.Universe(pmd.load_file(self.ref_filename))
         self.ref = mda.Universe(self.ref_filename)
-        self.prec = 3
 
     def test_dimensions(self):
-        assert_almost_equal(
+        assert_allclose(
             self.universe.trajectory.ts.dimensions, 
             self.ref.trajectory.ts.dimensions,
-            self.prec,
-            "ParmEdReader failed to get unitcell dimensions from ParmEd")
+            rtol=0,
+            atol=1e-3,
+            err_msg="ParmEdReader failed to get unitcell dimensions from ParmEd")
     
     def test_coordinates(self):
         up = self.universe.atoms.positions
         rp = self.ref.atoms.positions
-        assert_almost_equal(up, rp, decimal=3)
+        assert_allclose(up, rp, rtol=0, atol=1e-3)
     
 
 class TestParmEdReaderPDB(BaseTestParmEdReader):
@@ -187,7 +186,7 @@ class BaseTestParmEdConverter:
             for attr in self.almost_equal_atom_attrs:
                 ra = getattr(r, attr)
                 oa = getattr(o, attr)
-                assert_almost_equal(ra, oa, decimal=2, err_msg='atom {} not almost equal for atoms {} and {}'.format(attr, r, o))
+                assert_allclose(ra, oa, rtol=0, atol=1e-2, err_msg='atom {} not almost equal for atoms {} and {}'.format(attr, r, o))
 
     @pytest.mark.parametrize('attr', ('bonds', 'angles', 'impropers',
                      'cmaps'))
@@ -292,7 +291,7 @@ class TestParmEdConverterPDB(BaseTestParmEdConverter):
     almost_equal_atom_attrs = ('charge', 'occupancy')
 
     def test_equivalent_coordinates(self, ref, output):
-        assert_almost_equal(ref.coordinates, output.coordinates, decimal=3)
+        assert_allclose(ref.coordinates, output.coordinates, rtol=0, atol=1e-3)
 
 
 def test_incorrect_object_passed_typeerror():

--- a/testsuite/MDAnalysisTests/converters/test_parmed.py
+++ b/testsuite/MDAnalysisTests/converters/test_parmed.py
@@ -56,7 +56,8 @@ class TestParmEdReaderGRO:
             self.ref.trajectory.ts.dimensions,
             rtol=0,
             atol=1e-3,
-            err_msg="ParmEdReader failed to get unitcell dimensions from ParmEd")
+            err_msg="ParmEdReader failed to get unitcell dimensions " +
+                    "from ParmEd")
     
     def test_coordinates(self):
         up = self.universe.atoms.positions
@@ -75,7 +76,8 @@ class BaseTestParmEdReader(_SingleFrameReader):
             self.ref.trajectory.ts.dimensions,
             rtol=0,
             atol=1e-3,
-            err_msg="ParmEdReader failed to get unitcell dimensions from ParmEd")
+            err_msg="ParmEdReader failed to get unitcell dimensions " +
+                    "from ParmEd")
     
     def test_coordinates(self):
         up = self.universe.atoms.positions
@@ -190,7 +192,8 @@ class BaseTestParmEdConverter:
                     oa,
                     rtol=0,
                     atol=1e-2,
-                    err_msg='atom {} not almost equal for atoms {} and {}'.format(attr, r, o))
+                    err_msg=('atom {} not almost equal for atoms' +
+                             '{} and {}').format(attr, r, o))
 
     @pytest.mark.parametrize('attr', ('bonds', 'angles', 'impropers',
                      'cmaps'))

--- a/testsuite/MDAnalysisTests/converters/test_parmed.py
+++ b/testsuite/MDAnalysisTests/converters/test_parmed.py
@@ -56,8 +56,8 @@ class TestParmEdReaderGRO:
             self.ref.trajectory.ts.dimensions,
             rtol=0,
             atol=1e-3,
-            err_msg="ParmEdReader failed to get unitcell dimensions " +
-                    "from ParmEd")
+            err_msg=("ParmEdReader failed to get unitcell dimensions "
+                     "from ParmEd"))
     
     def test_coordinates(self):
         up = self.universe.atoms.positions
@@ -76,8 +76,8 @@ class BaseTestParmEdReader(_SingleFrameReader):
             self.ref.trajectory.ts.dimensions,
             rtol=0,
             atol=1e-3,
-            err_msg="ParmEdReader failed to get unitcell dimensions " +
-                    "from ParmEd")
+            err_msg=("ParmEdReader failed to get unitcell dimensions "
+                     "from ParmEd"))
     
     def test_coordinates(self):
         up = self.universe.atoms.positions
@@ -188,8 +188,8 @@ class BaseTestParmEdConverter:
                 ra = getattr(r, attr)
                 oa = getattr(o, attr)
                 assert_allclose(ra, oa, rtol=0, atol=1e-2,
-                    err_msg=f'atom {attr} not almost equal for atoms '
-                            f'{r} and {o}')
+                    err_msg=(f'atom {attr} not almost equal for atoms '
+                             f'{r} and {o}'))
 
     @pytest.mark.parametrize('attr', ('bonds', 'angles', 'impropers',
                      'cmaps'))

--- a/testsuite/MDAnalysisTests/converters/test_parmed.py
+++ b/testsuite/MDAnalysisTests/converters/test_parmed.py
@@ -187,13 +187,9 @@ class BaseTestParmEdConverter:
             for attr in self.almost_equal_atom_attrs:
                 ra = getattr(r, attr)
                 oa = getattr(o, attr)
-                assert_allclose(
-                    ra,
-                    oa,
-                    rtol=0,
-                    atol=1e-2,
-                    err_msg=('atom {} not almost equal for atoms' +
-                             '{} and {}').format(attr, r, o))
+                assert_allclose(ra, oa, rtol=0, atol=1e-2,
+                    err_msg=f'atom {attr} not almost equal for atoms '
+                            f'{r} and {o}')
 
     @pytest.mark.parametrize('attr', ('bonds', 'angles', 'impropers',
                      'cmaps'))

--- a/testsuite/MDAnalysisTests/converters/test_parmed.py
+++ b/testsuite/MDAnalysisTests/converters/test_parmed.py
@@ -23,8 +23,7 @@
 import pytest
 import MDAnalysis as mda
 
-from numpy.testing import (assert_equal,
-                           assert_allclose)
+from numpy.testing import (assert_allclose, assert_equal)
 
 from MDAnalysisTests.coordinates.base import _SingleFrameReader
 from MDAnalysisTests.coordinates.reference import RefAdKSmall
@@ -186,7 +185,12 @@ class BaseTestParmEdConverter:
             for attr in self.almost_equal_atom_attrs:
                 ra = getattr(r, attr)
                 oa = getattr(o, attr)
-                assert_allclose(ra, oa, rtol=0, atol=1e-2, err_msg='atom {} not almost equal for atoms {} and {}'.format(attr, r, o))
+                assert_allclose(
+                    ra,
+                    oa,
+                    rtol=0,
+                    atol=1e-2,
+                    err_msg='atom {} not almost equal for atoms {} and {}'.format(attr, r, o))
 
     @pytest.mark.parametrize('attr', ('bonds', 'angles', 'impropers',
                      'cmaps'))

--- a/testsuite/MDAnalysisTests/converters/test_rdkit.py
+++ b/testsuite/MDAnalysisTests/converters/test_rdkit.py
@@ -215,10 +215,11 @@ class TestRDKitConverter(object):
         assert_equal(u.atoms.bonds, u2.atoms.bonds)
         assert_equal(u.atoms.elements, u2.atoms.elements)
         assert_equal(u.atoms.names, u2.atoms.names)
-        assert_allclose(u.atoms.positions,
-                        u2.atoms.positions,
-                        rtol=0,
-                        atol=1e-7)
+        assert_allclose(
+            u.atoms.positions,
+            u2.atoms.positions,
+            rtol=0,
+            atol=1e-7)
 
     def test_raise_requires_elements(self):
         u = mda.Universe(mol2_molecule)

--- a/testsuite/MDAnalysisTests/converters/test_rdkit.py
+++ b/testsuite/MDAnalysisTests/converters/test_rdkit.py
@@ -28,7 +28,7 @@ import MDAnalysis as mda
 from MDAnalysis.topology.guessers import guess_atom_element
 import numpy as np
 from numpy.testing import (assert_equal,
-                           assert_almost_equal)
+                           assert_allclose)
 
 from MDAnalysisTests.datafiles import mol2_molecule, PDB_full, GRO, PDB_helix
 from MDAnalysisTests.util import import_not_available
@@ -216,7 +216,7 @@ class TestRDKitConverter(object):
         assert_equal(u.atoms.bonds, u2.atoms.bonds)
         assert_equal(u.atoms.elements, u2.atoms.elements)
         assert_equal(u.atoms.names, u2.atoms.names)
-        assert_almost_equal(u.atoms.positions, u2.atoms.positions, decimal=7)
+        assert_allclose(u.atoms.positions, u2.atoms.positions, rtol=0, atol=1e-7)
 
     def test_raise_requires_elements(self):
         u = mda.Universe(mol2_molecule)
@@ -304,7 +304,7 @@ class TestRDKitConverter(object):
     def test_assign_coordinates(self, pdb):
         mol = pdb.atoms.convert_to.rdkit(NoImplicit=False)
         positions = mol.GetConformer().GetPositions()
-        assert_almost_equal(positions, pdb.atoms.positions)
+        assert_allclose(positions, pdb.atoms.positions)
 
     def test_assign_stereochemistry(self, mol2):
         umol = mol2.atoms.convert_to("RDKIT")
@@ -317,7 +317,7 @@ class TestRDKitConverter(object):
         for ts in u.trajectory:
             mol = u.atoms.convert_to("RDKIT")
             positions = mol.GetConformer().GetPositions()
-            assert_almost_equal(positions, ts.positions)
+            assert_allclose(positions, ts.positions)
 
     def test_nan_coords(self):
         u = mda.Universe.from_smiles("CCO")

--- a/testsuite/MDAnalysisTests/converters/test_rdkit.py
+++ b/testsuite/MDAnalysisTests/converters/test_rdkit.py
@@ -27,8 +27,7 @@ import pytest
 import MDAnalysis as mda
 from MDAnalysis.topology.guessers import guess_atom_element
 import numpy as np
-from numpy.testing import (assert_equal,
-                           assert_allclose)
+from numpy.testing import (assert_allclose, assert_equal)
 
 from MDAnalysisTests.datafiles import mol2_molecule, PDB_full, GRO, PDB_helix
 from MDAnalysisTests.util import import_not_available
@@ -216,7 +215,10 @@ class TestRDKitConverter(object):
         assert_equal(u.atoms.bonds, u2.atoms.bonds)
         assert_equal(u.atoms.elements, u2.atoms.elements)
         assert_equal(u.atoms.names, u2.atoms.names)
-        assert_allclose(u.atoms.positions, u2.atoms.positions, rtol=0, atol=1e-7)
+        assert_allclose(u.atoms.positions,
+                        u2.atoms.positions,
+                        rtol=0,
+                        atol=1e-7)
 
     def test_raise_requires_elements(self):
         u = mda.Universe(mol2_molecule)

--- a/testsuite/MDAnalysisTests/visualization/test_streamlines.py
+++ b/testsuite/MDAnalysisTests/visualization/test_streamlines.py
@@ -21,13 +21,13 @@
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
 import numpy as np
-from numpy.testing import assert_almost_equal
 import MDAnalysis
 from MDAnalysis.visualization import (streamlines,
                                       streamlines_3D)
 from MDAnalysis.coordinates.XTC import XTCWriter
 from MDAnalysisTests.datafiles import Martini_membrane_gro
 import pytest
+from pytest import approx
 import matplotlib.pyplot as plt
 import os
 
@@ -105,6 +105,6 @@ def test_streamplot_3D(membrane_xtc, univ, tmpdir):
     assert dx.shape == (5, 5, 2)
     assert dy.shape == (5, 5, 2)
     assert dz.shape == (5, 5, 2)
-    assert_almost_equal(dx[4, 4, 0], 0.700004, decimal=5)
-    assert_almost_equal(dy[0, 0, 0], 0.460000, decimal=5)
-    assert_almost_equal(dz[2, 2, 0], 0.240005, decimal=5)
+    assert dx[4, 4, 0] == approx(0.700004, abs=1e-5)
+    assert dy[0, 0, 0] == approx(0.460000, abs=1e-5)
+    assert dz[2, 2, 0] == approx(0.240005, abs=1e-5)


### PR DESCRIPTION
Affects #3743

Changes made in this Pull Request:
 - Changed `assert_almost_equal` to `assert_allclose` or `approx`

This PR only affects tests under the `converters` and `visualization` directories for now.


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
