### PR TITLE
Modernize more tests, ref #3743

### DIFF
--- a/testsuite/MDAnalysisTests/analysis/test_align.py
+++ b/testsuite/MDAnalysisTests/analysis/test_align.py
@@ -33,7 +33,7 @@ from MDAnalysis import SelectionError, SelectionWarning
 from MDAnalysisTests import executable_not_found
 from MDAnalysisTests.datafiles import (PSF, DCD, CRD, FASTA, ALIGN_BOUND,
                                        ALIGN_UNBOUND, PDB_helix)
-from numpy.testing import (assert_equal, assert_array_equal, assert_allclose)
+from numpy.testing import assert_equal, assert_array_equal, assert_allclose
 
 #Function for Parametrizing conditional raising
 @contextmanager

--- a/testsuite/MDAnalysisTests/core/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/core/test_atomgroup.py
@@ -25,7 +25,7 @@ import itertools
 from os import path
 
 import numpy as np
-from numpy.testing import (assert_allclose, assert_equal)
+from numpy.testing import assert_allclose, assert_equal
 
 import MDAnalysis as mda
 from MDAnalysis.exceptions import DuplicateWarning, NoDataError

--- a/testsuite/MDAnalysisTests/core/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/core/test_atomgroup.py
@@ -267,8 +267,8 @@ class _WriteAtoms(object):
         with mda.Writer(outfile) as W:
             W.write(U)
         u2 = self.universe_from_tmp(outfile)
-        err_msg = "written 4AKE universe does not match original universe "
-                  "in size"
+        err_msg = ("written 4AKE universe does not match original universe "
+                   "in size")
         assert len(u2.atoms) == len(U.atoms), err_msg
         assert_allclose(
             u2.atoms.positions, U.atoms.positions,

--- a/testsuite/MDAnalysisTests/core/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/core/test_atomgroup.py
@@ -242,8 +242,8 @@ class _WriteAtoms(object):
         u2 = self.universe_from_tmp(outfile)
         # check EVERYTHING, otherwise we might get false positives!
         sel2 = u2.atoms
-        assert len(u2.atoms) == len(sel.atoms), ("written selection does not "
-                                                 "match original selection")
+        sel_err_msg = "written selection does not match original selection"
+        assert len(u2.atoms) == len(sel.atoms), sel_err_msg
         assert_allclose(
             sel2.positions, sel.positions, rtol=0, atol=self.precision,
             err_msg="written coordinates do not agree with original")
@@ -255,21 +255,21 @@ class _WriteAtoms(object):
         u2 = self.universe_from_tmp(outfile)
         # check EVERYTHING, otherwise we might get false positives!
         G2 = u2.atoms
-        assert len(u2.atoms) == len(G.atoms), ("written R206 Residue does not "
-                                               "match original ResidueGroup")
+        err_msg = "written R206 Residue does not match original ResidueGroup"
+        assert len(u2.atoms) == len(G.atoms), err_msg
+        err_msg = "written Residue R206 coordinates do not agree with original"
         assert_allclose(
-            G2.positions, G.positions, rtol=0, atol=self.precision,
-            err_msg=("written Residue R206 coordinates do not "
-                     "agree with original"))
+            G2.positions, G.positions, rtol=0,
+            atol=self.precision, err_msg=err_msg)
 
     def test_write_Universe(self, universe, outfile):
         U = universe
         with mda.Writer(outfile) as W:
             W.write(U)
         u2 = self.universe_from_tmp(outfile)
-        assert len(u2.atoms) == len(U.atoms), ("written 4AKE universe does "
-                                               "not match original universe "
-                                               "in size")
+        err_msg = "written 4AKE universe does not match original universe "
+                  "in size"
+        assert len(u2.atoms) == len(U.atoms), err_msg
         assert_allclose(
             u2.atoms.positions, U.atoms.positions,
             rtol=0, atol=self.precision,
@@ -1669,9 +1669,8 @@ class TestAtomGroup(object):
         pos = ag.positions + 3.14
         ag.positions = pos
         # should work
-        assert_allclose(ag.positions, pos,
-                        err_msg=("failed to update atoms 12:42 position "
-                                 "to new position"))
+        err_msg = "failed to update atoms 12:42 position to new position"
+        assert_allclose(ag.positions, pos, err_msg=err_msg)
 
         rg = np.random.RandomState(121989)
         # create wrong size array

--- a/testsuite/MDAnalysisTests/formats/test_libdcd.py
+++ b/testsuite/MDAnalysisTests/formats/test_libdcd.py
@@ -27,8 +27,7 @@ from hypothesis import example, given
 import hypothesis
 import numpy as np
 
-from numpy.testing import (assert_array_almost_equal, assert_equal,
-                           assert_array_equal, assert_almost_equal)
+from numpy.testing import (assert_allclose, assert_equal, assert_array_equal)
 
 from MDAnalysis.lib.formats.libdcd import DCDFile, DCD_IS_CHARMM, DCD_HAS_EXTRA_BLOCK
 
@@ -70,7 +69,7 @@ def test_read_unit_cell(dcdfile, unit_cell):
     # MDAnalysis implementation of DCD file handling
     with DCDFile(dcdfile) as dcd:
         dcd_frame = dcd.read()
-    assert_array_almost_equal(dcd_frame.unitcell, unit_cell)
+    assert_allclose(dcd_frame.unitcell, unit_cell, rtol=0, atol=1.5e-6)
 
 
 def test_seek_over_max():
@@ -93,8 +92,8 @@ def _assert_compare_readers(old_reader, new_reader):
 
     assert old_reader.fname == new_reader.fname
     assert old_reader.tell() == new_reader.tell()
-    assert_almost_equal(frame.xyz, new_frame.xyz)
-    assert_almost_equal(frame.unitcell, new_frame.unitcell)
+    assert_allclose(frame.xyz, new_frame.xyz)
+    assert_allclose(frame.unitcell, new_frame.unitcell)
 
 
 def test_pickle(dcd):
@@ -255,7 +254,7 @@ def test_readframes(dcdfile, legacy_data, frame_idx):
         xyz = frames.xyz
         assert_equal(len(xyz), len(dcd))
         for index, frame_num in enumerate(frame_idx):
-            assert_array_almost_equal(xyz[frame_num], legacy[index])
+            assert_allclose(xyz[frame_num], legacy[index])
 
 
 def test_write_header(tmpdir):
@@ -421,14 +420,14 @@ def test_written_coord_match(written_dcd):
     with DCDFile(written_dcd.testfile) as test, DCDFile(
             written_dcd.orgfile) as ref:
         for frame, o_frame in zip(test, ref):
-            assert_array_almost_equal(frame.xyz, o_frame.xyz)
+            assert_allclose(frame.xyz, o_frame.xyz)
 
 
 def test_written_unit_cell(written_dcd):
     with DCDFile(written_dcd.testfile) as test, DCDFile(
             written_dcd.orgfile) as ref:
         for frame, o_frame in zip(test, ref):
-            assert_array_almost_equal(frame.unitcell, o_frame.unitcell)
+            assert_allclose(frame.unitcell, o_frame.unitcell)
 
 
 @pytest.mark.parametrize("dtype", (np.int32, np.int64, np.float32, np.float64,
@@ -550,7 +549,7 @@ def test_readframes_slices(slice, length, dcd):
     frames = dcd.readframes(start=start, stop=stop, step=step)
     xyz = frames.xyz
     assert len(xyz) == length
-    assert_array_almost_equal(xyz, allframes[start:stop:step])
+    assert_allclose(xyz, allframes[start:stop:step])
 
 
 @pytest.mark.parametrize("order, shape", (
@@ -572,7 +571,7 @@ def test_readframes_atomindices(indices, dcd):
     frames = dcd.readframes(indices=indices, order='afc')
     xyz = frames.xyz
     assert len(xyz) == len(indices)
-    assert_array_almost_equal(xyz, allframes[indices])
+    assert_allclose(xyz, allframes[indices])
 
 
 def test_write_random_unitcell(tmpdir):
@@ -589,4 +588,4 @@ def test_write_random_unitcell(tmpdir):
 
     with DCDFile(testname) as test:
         for index, frame in enumerate(test):
-            assert_array_almost_equal(frame.unitcell, random_unitcells[index])
+            assert_allclose(frame.unitcell, random_unitcells[index])

--- a/testsuite/MDAnalysisTests/formats/test_libdcd.py
+++ b/testsuite/MDAnalysisTests/formats/test_libdcd.py
@@ -27,7 +27,7 @@ from hypothesis import example, given
 import hypothesis
 import numpy as np
 
-from numpy.testing import (assert_allclose, assert_equal, assert_array_equal)
+from numpy.testing import assert_allclose, assert_equal, assert_array_equal
 
 from MDAnalysis.lib.formats.libdcd import DCDFile, DCD_IS_CHARMM, DCD_HAS_EXTRA_BLOCK
 

--- a/testsuite/MDAnalysisTests/formats/test_libmdaxdr.py
+++ b/testsuite/MDAnalysisTests/formats/test_libmdaxdr.py
@@ -24,8 +24,7 @@ import pickle
 
 import numpy as np
 
-from numpy.testing import (assert_almost_equal, assert_array_almost_equal,
-                           assert_array_equal, assert_equal)
+from numpy.testing import (assert_allclose, assert_array_equal, assert_equal)
 
 from MDAnalysis.lib.formats.libmdaxdr import TRRFile, XTCFile
 
@@ -136,10 +135,10 @@ class TestCommonAPI(object):
         assert old_reader.tell() == new_reader.tell()
 
         assert_equal(old_reader.offsets, new_reader.offsets)
-        assert_almost_equal(frame.x, new_frame.x)
-        assert_almost_equal(frame.box, new_frame.box)
+        assert frame.x == pytest.approx(new_frame.x)
+        assert_allclose(frame.box, new_frame.box)
         assert frame.step == new_frame.step
-        assert_almost_equal(frame.time, new_frame.time)
+        assert frame.time == pytest.approx(new_frame.time)
 
     def test_pickle(self, reader):
         mid = len(reader) // 2
@@ -258,42 +257,42 @@ def test_time(xdrfile, fname):
 def test_box_xtc(xtc):
     box = np.eye(3) * 20
     for frame in xtc:
-        assert_array_almost_equal(frame.box, box, decimal=3)
+        assert_allclose(frame.box, box, rtol=0, atol=1e-3)
 
 
 def test_xyz_xtc(xtc):
     ones = np.ones(30).reshape(10, 3)
     for i, frame in enumerate(xtc):
-        assert_array_almost_equal(frame.x, ones * i, decimal=3)
+        assert_allclose(frame.x, ones * i, rtol=0, atol=1e-3)
 
 
 def test_box_trr(trr):
     box = np.eye(3) * 20
     for frame in trr:
-        assert_array_almost_equal(frame.box, box)
+        assert_allclose(frame.box, box)
 
 
 def test_xyz_trr(trr):
     ones = np.ones(30).reshape(10, 3)
     for i, frame in enumerate(trr):
-        assert_array_almost_equal(frame.x, ones * i)
+        assert_allclose(frame.x, ones * i)
 
 
 def test_velocities_trr(trr):
     ones = np.ones(30).reshape(10, 3)
     for i, frame in enumerate(trr):
-        assert_array_almost_equal(frame.v, ones * i + 10)
+        assert_allclose(frame.v, ones * i + 10)
 
 
 def test_forces_trr(trr):
     ones = np.ones(30).reshape(10, 3)
     for i, frame in enumerate(trr):
-        assert_array_almost_equal(frame.f, ones * i + 20)
+        assert_allclose(frame.f, ones * i + 20)
 
 
 def test_lmbda_trr(trr):
     for i, frame in enumerate(trr):
-        assert_almost_equal(frame.lmbda, .01 * i)
+        assert_allclose(frame.lmbda, .01 * i)
 
 
 @pytest.fixture
@@ -324,13 +323,13 @@ def test_written_prec_xtc(written_xtc):
 def test_written_box_xtc(written_xtc):
     box = np.eye(3) * 20
     for frame in written_xtc:
-        assert_array_almost_equal(frame.box, box, decimal=3)
+        assert_allclose(frame.box, box, rtol=0, atol=1e-3)
 
 
 def test_written_xyx_xtc(written_xtc):
     ones = np.ones(30).reshape(10, 3)
     for i, frame in enumerate(written_xtc):
-        assert_array_almost_equal(frame.x, ones * i, decimal=3)
+        assert_allclose(frame.x, ones * i, rtol=0, atol=1e-3)
 
 
 @pytest.mark.parametrize(
@@ -393,8 +392,8 @@ def test_different_box_xtc(tmpdir, xtc):
         assert len(xtc) == 2
         frame_1 = xtc.read()
         frame_2 = xtc.read()
-        assert_array_almost_equal(frame_1.box, orig_box)
-        assert_array_almost_equal(frame_1.box + 1, frame_2.box)
+        assert_allclose(frame_1.box, orig_box)
+        assert_allclose(frame_1.box + 1, frame_2.box)
 
 
 def test_write_different_x_xtc(tmpdir, xtc):
@@ -443,25 +442,25 @@ def test_written_time_trr(written_trr):
 def test_written_box_trr(written_trr):
     box = np.eye(3) * 20
     for frame in written_trr:
-        assert_array_almost_equal(frame.box, box)
+        assert_allclose(frame.box, box)
 
 
 def test_written_xyx_trr(written_trr):
     ones = np.ones(30).reshape(10, 3)
     for i, frame in enumerate(written_trr):
-        assert_array_almost_equal(frame.x, ones * i)
+        assert_allclose(frame.x, ones * i)
 
 
 def test_written_velocities_trr(written_trr):
     ones = np.ones(30).reshape(10, 3)
     for i, frame in enumerate(written_trr):
-        assert_array_almost_equal(frame.v, ones * i + 10)
+        assert_allclose(frame.v, ones * i + 10)
 
 
 def test_written_forces_trr(written_trr):
     ones = np.ones(30).reshape(10, 3)
     for i, frame in enumerate(written_trr):
-        assert_array_almost_equal(frame.f, ones * i + 20)
+        assert_allclose(frame.f, ones * i + 20)
 
 
 @pytest.mark.parametrize(
@@ -513,8 +512,8 @@ def test_write_different_box_trr(tmpdir, trr):
         assert len(trr) == 2
         frame_1 = trr.read()
         frame_2 = trr.read()
-        assert_array_almost_equal(frame_1.box, orig_box)
-        assert_array_almost_equal(frame_1.box + 1, frame_2.box)
+        assert_allclose(frame_1.box, orig_box)
+        assert_allclose(frame_1.box + 1, frame_2.box)
 
 
 @pytest.fixture

--- a/testsuite/MDAnalysisTests/formats/test_libmdaxdr.py
+++ b/testsuite/MDAnalysisTests/formats/test_libmdaxdr.py
@@ -24,7 +24,7 @@ import pickle
 
 import numpy as np
 
-from numpy.testing import (assert_allclose, assert_array_equal, assert_equal)
+from numpy.testing import assert_allclose, assert_array_equal, assert_equal
 
 from MDAnalysis.lib.formats.libmdaxdr import TRRFile, XTCFile
 

--- a/testsuite/MDAnalysisTests/lib/test_util.py
+++ b/testsuite/MDAnalysisTests/lib/test_util.py
@@ -32,7 +32,7 @@ import sys
 import copy
 
 import numpy as np
-from numpy.testing import (assert_equal, assert_array_equal, assert_allclose)
+from numpy.testing import assert_equal, assert_array_equal, assert_allclose
 from itertools import combinations_with_replacement as comb_wr
 
 import MDAnalysis as mda

--- a/testsuite/MDAnalysisTests/lib/test_util.py
+++ b/testsuite/MDAnalysisTests/lib/test_util.py
@@ -210,7 +210,7 @@ class TestGeometryFunctions(object):
     def test_angle_range(self, x):
         r = 1000.
         v = r * np.array([np.cos(x), np.sin(x), 0])
-        assert_allclose(mdamath.angle(self.e1, v), x, rtol=0, atol=1e-6)
+        assert mdamath.angle(self.e1, v) == approx(x, abs=1e-6)
 
     @pytest.mark.parametrize('vector, value', [
         (e3, 1),
@@ -436,8 +436,9 @@ class TestMatrixOperations(object):
                              comb_wr([-10, 0, 20, 70, 90, 120, 180], 3))
     def test_box_volume(self, lengths, angles):
         box = np.array(lengths + angles, dtype=np.float32)
-        approx_det = approx(np.linalg.det(self.ref_trivecs(box)), abs=1e-5)
-        assert mdamath.box_volume(box) == approx_det
+        assert_allclose(mdamath.box_volume(box),
+                        np.linalg.det(self.ref_trivecs(box)),
+                        rtol=0, atol=1e-5)
 
     def test_sarrus_det(self):
         comb = comb_wr(np.linspace(-133.7, 133.7, num=5), 9)

--- a/testsuite/MDAnalysisTests/utils/test_qcprot.py
+++ b/testsuite/MDAnalysisTests/utils/test_qcprot.py
@@ -142,7 +142,8 @@ def test_CalcRMSDRotationalMatrix():
         [0.72216358, -0.52038257, -0.45572112],
         [0.69118937, 0.51700833, 0.50493528],
         [-0.0271479, -0.67963547, 0.73304748]])
-    errmsg="Rotation matrix for aliging B to A does not have expected values."
+    errmsg = ("Rotation matrix for aliging B to A "
+              "does not have expected values.")
     assert_allclose(rot.reshape((3, 3)), expected_rot, rtol=0, atol=1e-6,
                     err_msg=errmsg)
 

--- a/testsuite/MDAnalysisTests/utils/test_qcprot.py
+++ b/testsuite/MDAnalysisTests/utils/test_qcprot.py
@@ -142,8 +142,9 @@ def test_CalcRMSDRotationalMatrix():
         [0.72216358, -0.52038257, -0.45572112],
         [0.69118937, 0.51700833, 0.50493528],
         [-0.0271479, -0.67963547, 0.73304748]])
+    errmsg="Rotation matrix for aliging B to A does not have expected values."
     assert_allclose(rot.reshape((3, 3)), expected_rot, rtol=0, atol=1e-6,
-                    err_msg="Rotation matrix for aliging B to A does not have expected values.")
+                    err_msg=errmsg)
 
 
 def test_innerproduct(atoms_a, atoms_b):

--- a/testsuite/MDAnalysisTests/utils/test_qcprot.py
+++ b/testsuite/MDAnalysisTests/utils/test_qcprot.py
@@ -40,9 +40,10 @@ import numpy as np
 
 import MDAnalysis.lib.qcprot as qcp
 
-from numpy.testing import assert_almost_equal, assert_array_almost_equal
+from numpy.testing import assert_allclose
 import MDAnalysis.analysis.rms as rms
 import pytest
+from pytest import approx
 
 
 @pytest.fixture()
@@ -134,14 +135,15 @@ def test_CalcRMSDRotationalMatrix():
     aligned_rmsd = rmsd(frag_br.T, frag_a)
     #print 'rmsd after applying rotation: ',rmsd
 
-    assert_almost_equal(aligned_rmsd, 0.719106, 6, "RMSD between fragments A and B does not match excpected value.")
+    assert aligned_rmsd == approx(0.719106, abs=1e-6), ("RMSD between "
+           "fragments A and B does not match excpected value.")
 
     expected_rot = np.array([
         [0.72216358, -0.52038257, -0.45572112],
         [0.69118937, 0.51700833, 0.50493528],
         [-0.0271479, -0.67963547, 0.73304748]])
-    assert_almost_equal(rot.reshape((3, 3)), expected_rot, 6,
-                        "Rotation matrix for aliging B to A does not have expected values.")
+    assert_allclose(rot.reshape((3, 3)), expected_rot, rtol=0, atol=1e-6,
+                    err_msg="Rotation matrix for aliging B to A does not have expected values.")
 
 
 def test_innerproduct(atoms_a, atoms_b):
@@ -151,8 +153,8 @@ def test_innerproduct(atoms_a, atoms_b):
 
     e = np.zeros(9, dtype=np.float64)
     g = qcp.InnerProduct(e, atoms_a, atoms_b, number_of_atoms, None)
-    assert_almost_equal(a, g)
-    assert_array_almost_equal(b, e)
+    assert a == approx(g)
+    assert_allclose(b, e)
 
 
 def test_RMSDmatrix(atoms_a, atoms_b):
@@ -161,10 +163,10 @@ def test_RMSDmatrix(atoms_a, atoms_b):
     rmsd = qcp.CalcRMSDRotationalMatrix(atoms_a, atoms_b, number_of_atoms, rotation, None) # no weights
 
     rmsd_ref = 20.73219522556076
-    assert_almost_equal(rmsd_ref, rmsd)
+    assert rmsd_ref == approx(rmsd)
 
     rotation_ref = np.array([0.9977195, 0.02926979, 0.06082009, -.0310942, 0.9990878, 0.02926979, -0.05990789, -.0310942, 0.9977195])
-    assert_array_almost_equal(rotation, rotation_ref, 6)
+    assert_allclose(rotation, rotation_ref, rtol=0, atol=1e-6)
 
 
 def test_RMSDmatrix_simple(atoms_a, atoms_b):
@@ -173,10 +175,10 @@ def test_RMSDmatrix_simple(atoms_a, atoms_b):
     rmsd = qcp.CalcRMSDRotationalMatrix(atoms_a, atoms_b, number_of_atoms, rotation, None) # no weights
 
     rmsd_ref = 20.73219522556076
-    assert_almost_equal(rmsd_ref, rmsd)
+    assert rmsd_ref == approx(rmsd)
 
     rotation_ref = np.array([0.9977195, 0.02926979, 0.06082009, -.0310942, 0.9990878, 0.02926979, -0.05990789, -.0310942, 0.9977195])
-    assert_array_almost_equal(rotation, rotation_ref, 6)
+    assert_allclose(rotation, rotation_ref, rtol=0, atol=1e-6)
 
     
 def test_rmsd(atoms_a, atoms_b):
@@ -184,7 +186,7 @@ def test_rmsd(atoms_a, atoms_b):
     atoms_b_aligned = np.dot(atoms_b, rotation_m)
     rmsd = rms.rmsd(atoms_b_aligned, atoms_a)
     rmsd_ref = 20.73219522556076
-    assert_almost_equal(rmsd, rmsd_ref, 6)
+    assert rmsd == approx(rmsd_ref, abs=1e-6)
 
 
 def test_weights(atoms_a, atoms_b):
@@ -194,6 +196,6 @@ def test_weights(atoms_a, atoms_b):
     rotation = np.zeros(9, dtype=np.float64)
     rmsd = qcp.CalcRMSDRotationalMatrix(atoms_a, atoms_b, no_of_atoms, rotation, weights)
 
-    assert_almost_equal(rmsd, 32.798779202159416)
+    assert rmsd == approx(32.798779202159416)
     rotation_ref = np.array([0.99861395, .022982, .04735006, -.02409085, .99944556, .022982, -.04679564, -.02409085, .99861395])
-    np.testing.assert_almost_equal(rotation_ref, rotation)
+    assert_allclose(rotation_ref, rotation)

--- a/testsuite/MDAnalysisTests/utils/test_streamio.py
+++ b/testsuite/MDAnalysisTests/utils/test_streamio.py
@@ -381,7 +381,8 @@ class TestStreamIO(RefAdKSmall):
                         rtol=0, atol=1e-3,
                         err_msg="wrong coordinates for water 2 OW")
         assert_allclose(u.atoms[3].velocity,
-                        10. * np.array([0.2519, 0.3140, -0.1734]), # manually convert nm/ps -> A/ps
+                        # manually convert nm/ps -> A/ps
+                        10. * np.array([0.2519, 0.3140, -0.1734]),
                         rtol=0, atol=1e-3,
                         err_msg="wrong velocity for water 2 OW")
 

--- a/testsuite/MDAnalysisTests/utils/test_streamio.py
+++ b/testsuite/MDAnalysisTests/utils/test_streamio.py
@@ -400,6 +400,7 @@ class TestStreamIO(RefAdKSmall):
         assert_equal(u.trajectory.frame, 1)  # !!!! ???
         u.trajectory.next()  # frame 2
         assert_equal(u.trajectory.frame, 2)
-        assert_allclose(u.atoms[2].position, np.array([0.45600, 18.48700, 16.26500]),
+        assert_allclose(u.atoms[2].position,
+                        np.array([0.45600, 18.48700, 16.26500]),
                         rtol=0, atol=1e-3,
                         err_msg="wrong coordinates for atom CA at frame 2")

--- a/testsuite/MDAnalysisTests/utils/test_streamio.py
+++ b/testsuite/MDAnalysisTests/utils/test_streamio.py
@@ -358,7 +358,8 @@ class TestStreamIO(RefAdKSmall):
         approx_total_charge = approx(self.ref_charmm_totalcharge, abs=1e-3)
         errmsg = "Total charge in (CHARMM) does not match expected value."
         assert u.atoms.total_charge() == approx_total_charge, errmsg
-        assert_allclose(u.atoms.select_atoms('name H').charges, self.ref_charmm_Hcharges,
+        assert_allclose(u.atoms.select_atoms('name H').charges,
+                        self.ref_charmm_Hcharges,
                         rtol=0, atol=1e-3,
                         err_msg="Charges for H atoms do not match.")
 

--- a/testsuite/MDAnalysisTests/utils/test_streamio.py
+++ b/testsuite/MDAnalysisTests/utils/test_streamio.py
@@ -376,7 +376,8 @@ class TestStreamIO(RefAdKSmall):
         u = MDAnalysis.Universe(streamData.as_NamedStream('GRO'))
         assert_equal(u.atoms.n_atoms, 6)
         assert_allclose(u.atoms[3].position,
-                        10. * np.array([1.275, 0.053, 0.622]), # manually convert nm -> A
+                        # manually convert nm -> A
+                        10. * np.array([1.275, 0.053, 0.622]),
                         rtol=0, atol=1e-3,
                         err_msg="wrong coordinates for water 2 OW")
         assert_allclose(u.atoms[3].velocity,

--- a/testsuite/MDAnalysisTests/utils/test_streamio.py
+++ b/testsuite/MDAnalysisTests/utils/test_streamio.py
@@ -356,8 +356,8 @@ class TestStreamIO(RefAdKSmall):
         u = MDAnalysis.Universe(streamData.as_NamedStream('PQR'))
         assert_equal(u.atoms.n_atoms, self.ref_n_atoms)
         approx_total_charge = approx(self.ref_charmm_totalcharge, abs=1e-3)
-        assert u.atoms.total_charge() == approx_total_charge, ("Total "
-               "charge in (CHARMM) does not match expected value.")
+        errmsg = "Total charge in (CHARMM) does not match expected value."
+        assert u.atoms.total_charge() == approx_total_charge, errmsg
         assert_allclose(u.atoms.select_atoms('name H').charges, self.ref_charmm_Hcharges,
                         rtol=0, atol=1e-3,
                         err_msg="Charges for H atoms do not match.")


### PR DESCRIPTION
Ref #3743

Changes made in this Pull Request:
 - Changed more tests to use `approx` and `assert_allclose` rather than `assert_almost_equals` and `assert_array_almost_equals`.


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
