### PR TITLE
Remove universal wheel creation from setup.cfg files

### DIFF
--- a/package/setup.cfg
+++ b/package/setup.cfg
@@ -8,8 +8,6 @@
 #keep_cythonized=True
 ## any additional compiler flags for core C routines, excluding ENCORE
 #extra_cflags = 
-[wheel]
-universal = 1
 
 [build_sphinx]
 all-files = 1

--- a/testsuite/setup.cfg
+++ b/testsuite/setup.cfg
@@ -1,6 +1,3 @@
-[wheel]
-universal = 1
-
 # "encountered in " Runtimewarnings come from numpy for unit cell conversions.
 # They should be activated again once we fixed the occurrence in the code.
 [tool:pytest]


### PR DESCRIPTION
Easy enough one whilst I'm making Saturday night dinner

We need to drop the creation of universal wheels because a) we have C extension, b) we don't support py2 anymore.

see: https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#wheels

**Note: as far as I'm aware there's no [wheel] entry anyways, it should be [bdist_wheel], but it does get interpreted by setuptools as the same. Removing the entry changes the generated wheel from `MDAnalysisTests-2.3.0.dev0-py2.py3-none-any.whl` to `MDAnalysisTests-2.3.0.dev0-py3-none-any.whl`  which is what we're looking for**

In practice we don't create them anyways, but we can see from conda-forge that there is an attempt at creating them as part of the package build.

Changes made in this Pull Request:
 - Remove 


PR Checklist
------------
 - Tests?
 - Docs?
 - CHANGELOG updated?
 - Issue raised/referenced?
