### PR TITLE
Temporarily xfail velocity read/write test for chemfiles

### DIFF
--- a/testsuite/MDAnalysisTests/coordinates/test_chemfiles.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_chemfiles.py
@@ -236,6 +236,7 @@ class TestChemfiles(object):
             check = mda.Universe(outfile)
             assert check.trajectory.ts.n_atoms == group.n_atoms
 
+    @pytest.mark.xfail  # Issue #3798 - float writing not consisten
     def test_write_velocities(self, tmpdir):
         u = mda.Universe.empty(4, trajectory=True)
         u.add_TopologyAttr("type", values=["H", "H", "H", "H"])


### PR DESCRIPTION
Temp patch for #3798

Changes made in this Pull Request:
 - xfail the one test that is failing due to trailing zeroes now being written with chemfiles 0.10.3 


PR Checklist
------------
 - [x] Tests?
 - Docs?
 - CHANGELOG updated?
 - [x] Issue raised/referenced?
