### PR TITLE
Fix the citation and year info in `calc_distances.h`

### DIFF
--- a/package/MDAnalysis/lib/include/calc_distances.h
+++ b/package/MDAnalysis/lib/include/calc_distances.h
@@ -1,19 +1,24 @@
 /* -*- Mode: C; tab-width: 4; indent-tabs-mode:nil; -*- */
 /* vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 */
 /*
-  MDAnalysis --- http://mdanalysis.googlecode.com
+ MDAnalysis --- https://www.mdanalysis.org
+ Copyright (c) 2006-2017 The MDAnalysis Development Team and contributors
+ (see the file AUTHORS for the full list of names)
 
-  Copyright (c) 2006-2014 Naveen Michaud-Agrawal,
-                Elizabeth J. Denning, Oliver Beckstein,
-                and contributors (see AUTHORS for the full list)
-  Released under the GNU Public Licence, v2 or any higher version
+ Released under the GNU Public Licence, v2 or any higher version
 
-  Please cite your use of MDAnalysis in published work:
+ Please cite your use of MDAnalysis in published work:
 
-      N. Michaud-Agrawal, E. J. Denning, T. B. Woolf, and
-      O. Beckstein. MDAnalysis: A Toolkit for the Analysis of
-      Molecular Dynamics Simulations. J. Comput. Chem. 32 (2011), 2319--2327,
-      in press.
+ R. J. Gowers, M. Linke, J. Barnoud, T. J. E. Reddy, M. N. Melo, S. L. Seyler,
+ D. L. Dotson, J. Domanski, S. Buchoux, I. M. Kenney, and O. Beckstein.
+ MDAnalysis: A Python package for the rapid analysis of molecular dynamics
+ simulations. In S. Benthall and S. Rostrup editors, Proceedings of the 15th
+ Python in Science Conference, pages 102-109, Austin, TX, 2016. SciPy.
+ doi: 10.25080/majora-629e541a-00e
+
+ N. Michaud-Agrawal, E. J. Denning, T. B. Woolf, and O. Beckstein.
+ MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
+ J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 */
 
 #ifndef __DISTANCES_H


### PR DESCRIPTION
Fixes #3717 

Changes made in this Pull Request:
 - Fixes the copyright year and citation in `calc_distance.h`

 - [X] Issue raised/referenced?
