### PR TITLE
Reduce warnings from Universe.empty

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,7 +13,7 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-??/??/?? IAlibay, Luthaf, hmacdope, rafaelpap
+??/??/?? IAlibay, Luthaf, hmacdope, rafaelpap, jbarnoud
 
  * 2.4.0
 
@@ -28,6 +28,7 @@ Enhancements
 Changes
   * The "AMBER" entry in setup.py's extra_requires has now been removed. Please
     use `pip install ./package[extra_formats]` instead (PR #3810)
+  * `Universe.empty` emmits less warnings (PR #3814)
 
 Deprecations
 

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -445,13 +445,13 @@ class Universe(object):
             n_residues = 0
             n_segments = 0
 
-        if atom_resindex is None:
+        if atom_resindex is None and n_residues > 1:
             warnings.warn(
                 'Residues specified but no atom_resindex given.  '
                 'All atoms will be placed in first Residue.',
                 UserWarning)
 
-        if residue_segindex is None:
+        if residue_segindex is None and n_segments > 1:
             warnings.warn(
                 'Segments specified but no segment_resindex given.  '
                 'All residues will be placed in first Segment',

--- a/testsuite/MDAnalysisTests/core/test_universe.py
+++ b/testsuite/MDAnalysisTests/core/test_universe.py
@@ -27,6 +27,7 @@ import subprocess
 import errno
 from collections import defaultdict
 from io import StringIO
+import warnings
 
 import numpy as np
 from numpy.testing import (
@@ -1252,8 +1253,17 @@ class TestEmpty(object):
                         1, 1, 1, 1, 1])
 
         with pytest.warns(UserWarning):
-            u = mda.Universe.empty(n_atoms=10, n_residues=2, n_segments=1,
+            u = mda.Universe.empty(n_atoms=10, n_residues=2, n_segments=2,
                                    atom_resindex=res)
+
+    def test_no_trivial_warning(self):
+        """
+        Make sure that no warning is raised about atom_resindex and
+        residue_segindex when n_residues or n_segments is equal to 1.
+        """
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            u = mda.Universe.empty(n_atoms=10, n_residues=1, n_segments=1)
 
     def test_trajectory(self):
         u = mda.Universe.empty(10, trajectory=True)


### PR DESCRIPTION
Just fix a minor annoyance by silencing some useless warnings.

Universe.empty raises a warning when atom_resindex or residue_segindex
are not provided. The warnings tell the user that the atoms will all be
assigned to the first residue or that the residues will all be assigned
to the first segment. These warnings are expecilly important so that
users are aware some residues or segments aill be empty.

However, if n_residues is 1 or n_segments is 1, the behaviour from the
warning is the intended one. Therefore, there should not be a warning.
This commit removes the warnings in these specific cases.


PR Checklist
------------
 - [X] Tests?
 - [ ] ~Docs?~
 - [x] CHANGELOG updated?
 - [ ] ~Issue raised/referenced?~
