### PR TITLE
Rename wheel_cache_size to build_cache_size in asv.conf.json

### DIFF
--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -44,7 +44,7 @@
     // environments in.  If not provided, defaults to "env"
     "env_dir": "env",
     "environment_type": "conda",
-    "wheel_cache_size": 10,
+    "build_cache_size": 10,
     // The directory (relative to the current directory) that raw benchmark
     // results are stored in.  If not provided, defaults to "results".
     "results_dir": "results",


### PR DESCRIPTION
Simple enough one

See: https://github.com/airspeed-velocity/asv/blob/b54d3024f5b77ddf81f82e5929e9b97ed85f7067/asv/config.py#L66-L70

Happened ~ 4 years ago from the looks of things, so we should be good? 

PR Checklist
------------
 - Tests?
 - Docs?
 - CHANGELOG updated?
 - Issue raised/referenced?
