### PR TITLE
Updated XYZwriter to allow file mode

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,7 +13,8 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-??/??/?? IAlibay, Luthaf, hmacdope, rafaelpap, jbarnoud, BFedder, aya9aladdin
+??/??/?? IAlibay, Luthaf, hmacdope, rafaelpap, jbarnoud, BFedder, aya9aladdin,
+         jaclark5
 
  * 2.4.0
 
@@ -25,7 +26,6 @@ Fixes
   * fixes guessed_attributes and read_attributes methods of the Topology class, as 
     those methods were giving unexpected results for some topology attributes
     (e.g. bonds, angles) (PR #3779).
-   
 
 
 Enhancements
@@ -37,6 +37,7 @@ Enhancements
   * A new AuxReader for the GROMACS EDR file format was implemented.
     (Issue # 3629, PR # 3749)
   * Added benchmarks for bonds topology attribute (Issue #3785, PR #3806)
+  * Allow XYZWriter to use multiple modes to open
 
 
 Changes

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,6 +13,7 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
+
 ??/??/?? IAlibay, Luthaf, hmacdope, rafaelpap, jbarnoud, BFedder, aya9aladdin,
          jaclark5
 

--- a/package/MDAnalysis/coordinates/XYZ.py
+++ b/package/MDAnalysis/coordinates/XYZ.py
@@ -141,7 +141,7 @@ class XYZWriter(base.WriterBase):
     units = {'time': 'ps', 'length': 'Angstrom'}
 
     def __init__(self, filename, n_atoms=None, convert_units=True,
-                 remark=None, **kwargs):
+                 remark=None, mode='wt', **kwargs):
         """Initialize the XYZ trajectory writer
 
         Parameters
@@ -161,6 +161,8 @@ class XYZWriter(base.WriterBase):
         remark: str (optional)
             single line of text ("molecule name"). By default writes MDAnalysis
             version and frame
+        mode : str (optional)
+            Mode to open file with, by default "wt" is used.
 
 
         .. versionchanged:: 1.0.0
@@ -170,6 +172,8 @@ class XYZWriter(base.WriterBase):
            parameter is no longer relevant and has been removed. If passing
            an empty universe, please use ``add_TopologyAttr`` to add in the
            required elements or names.
+        .. versionchanged:: 2.4.0
+           Chage open mode to be a keyword argument.
         """
         self.filename = filename
         self.remark = remark
@@ -177,7 +181,7 @@ class XYZWriter(base.WriterBase):
         self.convert_units = convert_units
 
         # can also be gz, bz2
-        self._xyz = util.anyopen(self.filename, 'wt')
+        self._xyz = util.anyopen(self.filename, mode)
 
     def _get_atoms_elements_or_names(self, atoms):
         """Return a list of atom elements (if present) or fallback to atom names"""

--- a/testsuite/MDAnalysisTests/coordinates/test_xyz.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_xyz.py
@@ -152,7 +152,6 @@ class TestXYZWriterNames(object):
     def test_no_names(self, outfile):
         """Atoms should all be named 'X'"""
         u = make_Universe(trajectory=True)
-        
         wmsg = "does not have atom elements or names"
 
         with pytest.warns(UserWarning, match=wmsg):


### PR DESCRIPTION
Fixes #3836 

Changes made in this Pull Request:
 - Add key word argument to XYZWriter to allow users to specify the mode with which to open an XYZ file (default is 'wt'). 


PR Checklist
------------
 - [X] Tests?
 - [NA] Docs?
 - [X] CHANGELOG updated?
 - [X] Issue raised/referenced?
