### PR TITLE
Allow XYZ writer to use atom types, compatible with LAMMPS

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,7 +13,8 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-??/??/?? IAlibay, Luthaf, hmacdope, rafaelpap, jbarnoud, BFedder, aya9aladdin
+??/??/?? IAlibay, Luthaf, hmacdope, rafaelpap, jbarnoud, BFedder, aya9aladdin,
+         jaclark5
 
  * 2.4.0
 
@@ -25,6 +26,7 @@ Fixes
   * fixes guessed_attributes and read_attributes methods of the Topology class, as 
     those methods were giving unexpected results for some topology attributes
     (e.g. bonds, angles) (PR #3779).
+  * Allow XYZWriter to use atom.types
    
 
 

--- a/package/MDAnalysis/coordinates/XYZ.py
+++ b/package/MDAnalysis/coordinates/XYZ.py
@@ -170,6 +170,8 @@ class XYZWriter(base.WriterBase):
            parameter is no longer relevant and has been removed. If passing
            an empty universe, please use ``add_TopologyAttr`` to add in the
            required elements or names.
+        .. versionchanged:: 2.4.0
+           Allow XYZWriter to use atom.types
         """
         self.filename = filename
         self.remark = remark
@@ -187,11 +189,14 @@ class XYZWriter(base.WriterBase):
             try:
                 return atoms.atoms.names
             except (AttributeError, NoDataError):
-                wmsg = ("Input AtomGroup or Universe does not have atom "
-                        "elements or names attributes, writer will default "
-                        "atom names to 'X'")
-                warnings.warn(wmsg)
-                return itertools.cycle(('X',))
+                try:
+                    return atoms.atoms.types
+                except:
+                    wmsg = ("Input AtomGroup or Universe does not have atom "
+                            "elements, names, or types attributes, writer will"
+                            " default atom names to 'X'")
+                    warnings.warn(wmsg)
+                    return itertools.cycle(('X',))
 
     def close(self):
         """Close the trajectory file and finalize the writing"""

--- a/testsuite/MDAnalysisTests/coordinates/test_xyz.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_xyz.py
@@ -153,7 +153,7 @@ class TestXYZWriterNames(object):
         """Atoms should all be named 'X'"""
         u = make_Universe(trajectory=True)
         
-        wmsg = "does not have atom elements or names"
+        wmsg = "does not have atom elements, names, or types"
 
         with pytest.warns(UserWarning, match=wmsg):
             w = XYZWriter(outfile)


### PR DESCRIPTION
Fixes #3851 

Changes made in this Pull Request:
 - Added additional try/except statement in XYZ writer that allows atom types to be used instead of Xs.


PR Checklist
------------
 - [X] Tests?
 - [X] Docs?
 - [X] CHANGELOG updated?
 - [X] Issue raised/referenced?
