### PR TITLE
Remove duplicate author

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -82,7 +82,6 @@ Chronological list of authors
   - Pedro Reis
  2017
   - Ruggero Cortini
-  - Xiki Tempula
   - Kashish Punjani
   - Utkarsh Bansal
   - Shobhit Agarwal


### PR DESCRIPTION
Tiny one but this always comes up every time I have to work out our current author count.

This is just something that fell out of the testsuite authors merge in https://github.com/MDAnalysis/mdanalysis/pull/2100, turns out one of the authors was using their github handle for one and their real name for the other.


PR Checklist
------------
 - Tests?
 - Docs?
 - CHANGELOG updated?
 - Issue raised/referenced?
