### PR TITLE
WIP, CI: 3.11rc2 check

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -28,7 +28,7 @@ jobs:
         fail-fast: false
         matrix:
           os: [ubuntu-latest, ]
-          python-version: [3.8, 3.9, "3.10"]
+          python-version: [3.8, 3.9, "3.10", "3.11.0-rc.2"]
           full-deps: [true, ]
           install_hole: [true, ]
           codecov: [true, ]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,6 +48,12 @@ jobs:
           BUILD_TYPE: 'wheel'
           NUMPY_MIN: '1.20.0'
           imageName: 'windows-2019'
+        Linux-Python311rc-64bit-full-wheel:
+          PYTHON_VERSION: '3.11.0-rc.2'
+          PYTHON_ARCH: 'x64'
+          BUILD_TYPE: 'wheel'
+          NUMPY_MIN: '1.23.3'
+          imageName: 'ubuntu-latest'
         Linux-Python39-64bit-full-wheel:
           PYTHON_VERSION: '3.9'
           PYTHON_ARCH: 'x64'
@@ -68,6 +74,7 @@ jobs:
       versionSpec: $(PYTHON_VERSION)
       addToPath: true
       architecture: $(PYTHON_ARCH)
+      allowUnstable: true
   # a PEP518 compliant wheel build shoud be
   # able to build MDAnalysis in an isolated
   # environment *before* any deps are installed

--- a/package/pyproject.toml
+++ b/package/pyproject.toml
@@ -14,6 +14,7 @@ requires = [
     # As per https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg
     # safest to build at 1.21.6 for all platforms
     "numpy==1.21.6; python_version=='3.10' and platform_python_implementation != 'PyPy'",
+    "numpy==1.23.2; python_version=='3.11' and platform_python_implementation != 'PyPy'",
     "setuptools",
     "wheel",
 ]


### PR DESCRIPTION
* Python 3.11rc2 is guaranteed ABI stable with the final release per: https://www.python.org/downloads/release/python-3110rc2/

* the final release is about two weeks away, so let's see what goes wrong with `3.11` a bit before it hits; most of the major dependencies have releasd PyPI wheels because of the above ABI stability guarantee

* I believe the CI workflow I adjusted may use a mix of conda and pip, so I'm less confident of what will go wrong vs. pure PyPI workflow