### PR TITLE
Add py311rc2 cron job

### DIFF
--- a/.github/workflows/gh-ci-cron.yaml
+++ b/.github/workflows/gh-ci-cron.yaml
@@ -3,6 +3,9 @@ on:
   schedule:
     # once a week at midnight on Sunday
     - cron: "0 3 * * 0"
+  push:
+    branches:
+      - develop
   pull_request:
     branches:
       - develop
@@ -130,7 +133,7 @@ jobs:
       with:
         os-type: "ubuntu"
 
-    - name: actions/setup-python@v4
+    - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/gh-ci-cron.yaml
+++ b/.github/workflows/gh-ci-cron.yaml
@@ -1,14 +1,8 @@
 name: GH Actions Cron CI
 on:
   schedule:
-    # once a week at midnight on Sunday
-    - cron: "0 3 * * 0"
-  push:
-    branches:
-      - develop
-  pull_request:
-    branches:
-      - develop
+    # 3 am Tuesdays and Fridays
+    - cron: "0 3 * * 2,5"
 
 concurrency:
   # Probably overly cautious group naming.

--- a/.github/workflows/gh-ci-cron.yaml
+++ b/.github/workflows/gh-ci-cron.yaml
@@ -137,12 +137,10 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: build_srcs
-      uses: ./.github/actions/build-src
-      with:
-        build-hole: false
-        build-tests: true
-        build-docs: false
+    - name: pip install mdanalysis
+      run: |
+        cd package && pip install .
+        cd testsuite && pip install .
 
     - name: install_pip_extras
       run: |

--- a/.github/workflows/gh-ci-cron.yaml
+++ b/.github/workflows/gh-ci-cron.yaml
@@ -3,6 +3,9 @@ on:
   schedule:
     # once a week at midnight on Sunday
     - cron: "0 3 * * 0"
+  pull_request:
+    branches:
+      - develop
 
 concurrency:
   # Probably overly cautious group naming.

--- a/.github/workflows/gh-ci-cron.yaml
+++ b/.github/workflows/gh-ci-cron.yaml
@@ -140,6 +140,9 @@ jobs:
     - name: pip install mdanalysis
       run: |
         cd package && pip install .
+
+    - name: pip install mdanalysistests
+      run: |
         cd testsuite && pip install .
 
     - name: install_pip_extras

--- a/.github/workflows/gh-ci-cron.yaml
+++ b/.github/workflows/gh-ci-cron.yaml
@@ -115,7 +115,10 @@ jobs:
   pip-only:
     if: "github.repository == 'MDAnalysis/mdanalysis'"
     runs-on: ubuntu-latest
-
+    strategy:
+        fail-fast: false
+        matrix:
+          python-version: ["3.10", "3.11.0-rc.2"]
     steps:
     - uses: actions/checkout@v3
 
@@ -124,17 +127,9 @@ jobs:
       with:
         os-type: "ubuntu"
 
-    - name: setup_miniconda
-      uses: conda-incubator/setup-miniconda@v2
+    - name: actions/setup-python@v4
       with:
-        python-version: 3.9
-        auto-update-conda: true
-        add-pip-as-python-dependency: true
-        architecture: x64
-
-    - name: install_minimum_pip
-      run: |
-        pip install numpy Cython pytest-xdist
+        python-version: ${{ matrix.python-version }}
 
     - name: build_srcs
       uses: ./.github/actions/build-src
@@ -142,6 +137,10 @@ jobs:
         build-hole: false
         build-tests: true
         build-docs: false
+
+    - name: install_pip_extras
+      run: |
+        pip install pytest-xdist
 
     - name: run_tests
       run: |

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -28,9 +28,8 @@ Fixes
     those methods were giving unexpected results for some topology attributes
     (e.g. bonds, angles) (PR #3779).
 
-
-
 Enhancements
+  * Minimum NumPy version for py3.11 is now set to 1.23.2.
   * Added decorator to check for an empty atom group, applied in topological 
     attributes(Issue #3837)
   * AuxReaders now have a memory_limit parameter to control when memory usage
@@ -41,7 +40,6 @@ Enhancements
   * A new AuxReader for the GROMACS EDR file format was implemented.
     (Issue # 3629, PR # 3749)
   * Added benchmarks for bonds topology attribute (Issue #3785, PR #3806)
-
 
 Changes
  * Auxiliary; determination of representative frames: The default value for

--- a/package/pyproject.toml
+++ b/package/pyproject.toml
@@ -14,6 +14,7 @@ requires = [
     # As per https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg
     # safest to build at 1.21.6 for all platforms
     "numpy==1.21.6; python_version=='3.10' and platform_python_implementation != 'PyPy'",
+    "numpy==1.23.2; python_version=='3.11' and platform_python_implementation != 'PyPy'",
     "setuptools",
     "wheel",
 ]


### PR DESCRIPTION
Supersedes #3857 

Changes made in this Pull Request:
 - Changes pip only action to not use conda
 - Adds py311rc2 to matrix for above action
 - Adds numpy 1.23.2 as minimum supported version for py311


PR Checklist
------------
 - Tests?
 - Docs?
 - [x] CHANGELOG updated?
 - Issue raised/referenced?
