### PR TITLE
Adding Appending Functionality method to WriterBase

### DIFF
--- a/package/MDAnalysis/coordinates/CRD.py
+++ b/package/MDAnalysis/coordinates/CRD.py
@@ -110,7 +110,7 @@ class CRDReader(base.SingleFrameReaderBase):
         return CRDWriter(filename, **kwargs)
 
 
-class CRDWriter(base.WriterBase):
+class CRDWriter(base.SingleFrameWriterBase):
     """CRD writer that implements the CHARMM CRD coordinate format.
 
     It automatically writes the CHARMM EXT extended format if there
@@ -148,13 +148,16 @@ class CRDWriter(base.WriterBase):
         "NUMATOMS": "{0:5d}\n",
     }
 
-    def __init__(self, filename, **kwargs):
+    def __init__(self, filename, n_atoms=None, append=False, **kwargs):
         """
         Parameters
         ----------
         filename : str or :class:`~MDAnalysis.lib.util.NamedStream`
              name of the output file or a stream
-
+        n_atoms : int (optional)
+                number of atoms in the coordinate file;
+        append : bool (optional)
+                append to an existing CRD file; default is to overwrite
         extended : bool (optional)
              By default, noextended CRD format is used [``False``].
              However, extended CRD format can be forced by
@@ -165,13 +168,14 @@ class CRDWriter(base.WriterBase):
              .. versionadded:: 2.2.0
         """
 
-        self.filename = util.filename(filename, ext='crd')
+        filename = util.filename(filename, ext='crd')
+        super().__init__(filename, n_atoms, append)
         self.crd = None
 
         # account for explicit crd format, if requested
         self.extended = kwargs.pop("extended", False)
 
-    def write(self, selection, frame=None):
+    def _write_next_frame(self, selection, frame=None):
         """Write selection at current trajectory frame to file.
 
         Parameters

--- a/package/MDAnalysis/coordinates/DCD.py
+++ b/package/MDAnalysis/coordinates/DCD.py
@@ -338,6 +338,7 @@ class DCDWriter(base.WriterBase):
     def __init__(self,
                  filename,
                  n_atoms,
+                 append=False,
                  convert_units=True,
                  step=1,
                  dt=1,
@@ -351,6 +352,9 @@ class DCDWriter(base.WriterBase):
             filename of trajectory
         n_atoms : int
             number of atoms to be written
+        append : bool (optional)
+            append to an existing trajectory if True, default is to
+            overwrite an existing file: ``False``
         convert_units : bool (optional)
             convert from MDAnalysis units to format specific units
         step : int (optional)
@@ -376,11 +380,10 @@ class DCDWriter(base.WriterBase):
             General writer arguments
 
         """
-        self.filename = filename
         self._convert_units = convert_units
         if n_atoms is None:
             raise ValueError("n_atoms argument is required")
-        self.n_atoms = n_atoms
+        super().__init__(filename, n_atoms, append)
         self._file = DCDFile(self.filename, 'w')
         self.step = step
         self.dt = dt

--- a/package/MDAnalysis/coordinates/FHIAIMS.py
+++ b/package/MDAnalysis/coordinates/FHIAIMS.py
@@ -205,7 +205,7 @@ class FHIAIMSReader(base.SingleFrameReaderBase):
         return FHIAIMSWriter(filename, n_atoms=n_atoms, **kwargs)
 
 
-class FHIAIMSWriter(base.WriterBase):
+class FHIAIMSWriter(base.SingleFrameWriterBase):
     """FHI-AIMS Writer.
 
        Single frame writer for the `FHI-AIMS`_ format.  Writes geometry (3D and
@@ -228,7 +228,8 @@ class FHIAIMSWriter(base.WriterBase):
         'box_triclinic': "lattice_vector {box[0]:12.8f} {box[1]:12.8f} {box[2]:12.8f}\nlattice_vector {box[3]:12.8f} {box[4]:12.8f} {box[5]:12.8f}\nlattice_vector {box[6]:12.8f} {box[7]:12.8f} {box[8]:12.8f}\n"
     }
 
-    def __init__(self, filename, convert_units=True, n_atoms=None, **kwargs):
+    def __init__(self, filename, convert_units=True, n_atoms=None,
+                 append=False, **kwargs):
         """Set up the FHI-AIMS Writer
 
         Parameters
@@ -239,8 +240,8 @@ class FHIAIMSWriter(base.WriterBase):
             number of atoms
 
         """
-        self.filename = util.filename(filename, ext='.in', keep=True)
-        self.n_atoms = n_atoms
+        filename = util.filename(filename, ext='.in', keep=True)
+        super().__init__(filename, n_atoms, append)
 
     def _write_next_frame(self, obj):
         """Write selection at current trajectory frame to file.

--- a/package/MDAnalysis/coordinates/GRO.py
+++ b/package/MDAnalysis/coordinates/GRO.py
@@ -261,7 +261,7 @@ class GROReader(base.SingleFrameReaderBase):
         return GROWriter(filename, n_atoms=n_atoms, **kwargs)
 
 
-class GROWriter(base.WriterBase):
+class GROWriter(base.SingleFrameWriterBase):
     """GRO Writer that conforms to the Trajectory API.
 
     Will attempt to write the following information from the topology:
@@ -311,7 +311,8 @@ class GROWriter(base.WriterBase):
     }
     fmt['xyz_v'] = fmt['xyz'][:-1] + "{vel[0]:8.4f}{vel[1]:8.4f}{vel[2]:8.4f}\n"
 
-    def __init__(self, filename, convert_units=True, n_atoms=None, **kwargs):
+    def __init__(self, filename, convert_units=True, n_atoms=None,
+                 append=False, **kwargs):
         """Set up a GROWriter with a precision of 3 decimal places.
 
         Parameters
@@ -326,7 +327,9 @@ class GROWriter(base.WriterBase):
             By default, all the atoms were reindexed to have a atom id starting
             from 1. [``True``] However, this behaviour can be turned off by
             specifying `reindex` ``=False``.
-
+        append : bool (optional)
+            If ``True``, open file in append mode. [``False``]
+            
         Note
         ----
         To use the reindex keyword, user can follow the two examples given
@@ -344,13 +347,13 @@ class GROWriter(base.WriterBase):
                w.write(u.atoms)
 
         """
-        self.filename = util.filename(filename, ext='gro', keep=True)
-        self.n_atoms = n_atoms
+        filename = util.filename(filename, ext='gro', keep=True)
+        super().__init__(filename, n_atoms, append)
         self.reindex = kwargs.pop('reindex', True)
 
         self.convert_units = convert_units  # convert length and time to base units
 
-    def write(self, obj):
+    def _write_next_frame(self, obj):
         """Write selection at current trajectory frame to file.
 
         Parameters

--- a/package/MDAnalysis/coordinates/H5MD.py
+++ b/package/MDAnalysis/coordinates/H5MD.py
@@ -1050,7 +1050,8 @@ class H5MDWriter(base.WriterBase):
     @due.dcite(Doi("10.1016/j.cpc.2014.01.018"),
                description="Specifications of the H5MD standard",
                path=__name__, version='1.1')
-    def __init__(self, filename, n_atoms, n_frames=None, driver=None,
+    def __init__(self, filename, n_atoms, 
+                 append=False, n_frames=None, driver=None,
                  convert_units=True, chunks=None, compression=None,
                  compression_opts=None, positions=True, velocities=True,
                  forces=True, timeunit=None, lengthunit=None,
@@ -1060,14 +1061,13 @@ class H5MDWriter(base.WriterBase):
 
         if not HAS_H5PY:
             raise RuntimeError("H5MDWriter: Please install h5py")
-        self.filename = filename
         if n_atoms == 0:
             raise ValueError("H5MDWriter: no atoms in output trajectory")
+        super().__init__(filename, n_atoms, append)
         self._driver = driver
         if self._driver == 'mpio':
             raise ValueError("H5MDWriter: parallel writing with MPI I/O "
                              "is not currently supported.")
-        self.n_atoms = n_atoms
         self.n_frames = n_frames
         self.chunks = (1, n_atoms, 3) if chunks is None else chunks
         if self.chunks is False and self.n_frames is None:

--- a/package/MDAnalysis/coordinates/MOL2.py
+++ b/package/MDAnalysis/coordinates/MOL2.py
@@ -287,17 +287,21 @@ class MOL2Writer(base.WriterBase):
     multiframe = True
     units = {'time': None, 'length': 'Angstrom'}
 
-    def __init__(self, filename, n_atoms=None, convert_units=True):
+    def __init__(self, filename, n_atoms=None, append=False, 
+                 convert_units=True):
         """Create a new MOL2Writer
 
         Parameters
         ----------
         filename: str
             name of output file
+        append: bool (optional)
+            If ``True``, append to an existing file. If ``False``, overwrite
+            the file. Default is ``False``.
         convert_units: bool (optional)
             units are converted to the MDAnalysis base format; [``True``]
         """
-        self.filename = filename
+        super().__init__(filename, n_atoms, append)
         self.convert_units = convert_units  # convert length and time to base units
 
         self.frames_written = 0

--- a/package/MDAnalysis/coordinates/NAMDBIN.py
+++ b/package/MDAnalysis/coordinates/NAMDBIN.py
@@ -91,7 +91,7 @@ class NAMDBINReader(base.SingleFrameReaderBase):
         return NAMDBINWriter(filename, **kwargs)
 
 
-class NAMDBINWriter(base.WriterBase):
+class NAMDBINWriter(base.SingleFrameWriterBase):
     """Writer for NAMD binary coordinate files.
     
     
@@ -100,7 +100,7 @@ class NAMDBINWriter(base.WriterBase):
     format = ['COOR', 'NAMDBIN']
     units = {'time': None, 'length': 'Angstrom'}
 
-    def __init__(self, filename, n_atoms=None, **kwargs):
+    def __init__(self, filename, n_atoms=None, append=False, **kwargs):
         """
         Parameters
         ----------
@@ -109,7 +109,8 @@ class NAMDBINWriter(base.WriterBase):
         n_atoms  : int
             number of atoms for the output coordinate
         """
-        self.filename = util.filename(filename)
+        filename = util.filename(filename)
+        super().__init__(filename, n_atoms, append)
 
     def _write_next_frame(self, obj):
         """Write information associated with ``obj`` at current frame into

--- a/package/MDAnalysis/coordinates/PDB.py
+++ b/package/MDAnalysis/coordinates/PDB.py
@@ -461,7 +461,7 @@ class PDBReader(base.ReaderBase):
         self._pdbfile.close()
 
 
-class PDBWriter(base.WriterBase):
+class PDBWriter(base.SingleFrameWriterBase):
     """PDB writer that implements a subset of the `PDB 3.3 standard`_ .
 
     PDB format as used by NAMD/CHARMM: 4-letter resnames and segID are allowed,
@@ -612,7 +612,8 @@ class PDBWriter(base.WriterBase):
 
     def __init__(self, filename, bonds="conect", n_atoms=None, start=0, step=1,
                  remarks="Created by PDBWriter",
-                 convert_units=True, multiframe=None, reindex=True):
+                 convert_units=True, multiframe=None, reindex=True,
+                 append=False):
         """Create a new PDBWriter
 
         Parameters
@@ -643,7 +644,9 @@ class PDBWriter(base.WriterBase):
         reindex: bool (optional)
             If ``True`` (default), the atom serial is set to be consecutive
             numbers starting at 1. Else, use the atom id.
-
+        append: bool (optional)
+            If ``True``, append to an existing file. If ``False``, overwrite
+            the file. [``False``]
         """
         # n_atoms = None : dummy keyword argument
         # (not used, but Writer() always provides n_atoms as the second argument)
@@ -651,7 +654,7 @@ class PDBWriter(base.WriterBase):
         # TODO: - remarks should be a list of lines and written to REMARK
         #       - additional title keyword could contain line for TITLE
 
-        self.filename = filename
+        super().__init__(filename, n_atoms, append)
         # convert length and time to base units
         self.convert_units = convert_units
         self._multiframe = self.multiframe if multiframe is None else multiframe
@@ -895,32 +898,7 @@ class PDBWriter(base.WriterBase):
         # hack...
         self.obj = obj
         self.ts = obj.universe.trajectory.ts
-
-    def write(self, obj):
-        """Write object *obj* at current trajectory frame to file.
-
-        *obj* can be a selection (i.e. a
-        :class:`~MDAnalysis.core.groups.AtomGroup`) or a whole
-        :class:`~MDAnalysis.core.universe.Universe`.
-
-        The last letter of the :attr:`~MDAnalysis.core.groups.Atom.segid` is
-        used as the PDB chainID (but see :meth:`~PDBWriter.ATOM` for
-        details).
-
-        Parameters
-        ----------
-        obj
-            The :class:`~MDAnalysis.core.groups.AtomGroup` or
-            :class:`~MDAnalysis.core.universe.Universe` to write.
-        """
-
-        self._update_frame(obj)
-        self._write_pdb_header()
-        # Issue 105: with write() ONLY write a single frame; use
-        # write_all_timesteps() to dump everything in one go, or do the
-        # traditional loop over frames
-        self._write_next_frame(self.ts, multiframe=self._multiframe)
-        # END and CONECT records are written when file is being close()d
+        
 
     def write_all_timesteps(self, obj):
         """Write all timesteps associated with *obj* to the PDB file.
@@ -965,7 +943,7 @@ class PDBWriter(base.WriterBase):
 
         for framenumber in range(start, len(traj), step):
             traj[framenumber]
-            self._write_next_frame(self.ts, multiframe=True)
+            self._write_next_frame(obj, multiframe=True)
 
         # CONECT record is written when the file is being close()d
         self.close()
@@ -973,7 +951,7 @@ class PDBWriter(base.WriterBase):
         # Set the trajectory to the starting position
         traj[start]
 
-    def _write_next_frame(self, ts=None, **kwargs):
+    def _write_next_frame(self, obj, **kwargs):
         '''write a new timestep to the PDB file
 
         :Keywords:
@@ -994,13 +972,17 @@ class PDBWriter(base.WriterBase):
         .. versionchanged:: 1.0.0
            Renamed from `write_next_timestep` to `_write_next_frame`.
         '''
-        if ts is None:
-            try:
-                ts = self.ts
-            except AttributeError:
-                errmsg = ("PBDWriter: no coordinate data to write to "
-                          "trajectory file")
-                raise NoDataError(errmsg) from None
+
+        self._update_frame(obj)
+        self._write_pdb_header()
+
+        try:
+            ts = self.ts
+        except AttributeError:
+            errmsg = ("PBDWriter: no coordinate data to write to "
+                        "trajectory file")
+            raise NoDataError(errmsg) from None
+
         self._check_pdb_coordinates()
         self._write_timestep(ts, **kwargs)
 
@@ -1360,3 +1342,21 @@ class MultiPDBWriter(PDBWriter):
     format = ['PDB', 'ENT']
     multiframe = True  # For Writer registration
     singleframe = False
+
+    def write(self, obj, **kwargs):
+        """Write current timestep, using the supplied `obj`.
+
+        Parameters
+        ----------
+        obj : :class:`~MDAnalysis.core.groups.AtomGroup` or :class:`~MDAnalysis.core.universe.Universe`
+            write coordinate information associate with `obj`
+
+        Note
+        ----
+        The size of the `obj` must be the same as the number of atoms provided
+        when setting up the trajectory.
+        """
+
+        # overwrite the default behavior of PDBWriter
+        self._n_frames_written += 1
+        return self._write_next_frame(obj, multiframe=True, **kwargs)

--- a/package/MDAnalysis/coordinates/PDBQT.py
+++ b/package/MDAnalysis/coordinates/PDBQT.py
@@ -190,7 +190,7 @@ class PDBQTReader(base.SingleFrameReaderBase):
         return PDBQTWriter(filename, **kwargs)
 
 
-class PDBQTWriter(base.WriterBase):
+class PDBQTWriter(base.SingleFrameWriterBase):
     """PDBQT writer that implements a subset of the PDB_ 3.2 standard and the PDBQT_ spec.
 
     .. _PDB: http://www.wwpdb.org/documentation/file-format-content/format32/v3.2.html
@@ -212,14 +212,15 @@ class PDBQTWriter(base.WriterBase):
     units = {'time': None, 'length': 'Angstrom'}
     pdb_coor_limits = {"min": -999.9995, "max": 9999.9995}
 
-    def __init__(self, filename, **kwargs):
-        self.filename = util.filename(filename, ext='pdbqt')
+    def __init__(self, filename, n_atoms=None, append=False, **kwargs):
+        filename = util.filename(filename, ext='pdbqt')
+        super().__init__(filename, n_atoms, append)
         self.pdb = util.anyopen(self.filename, 'w')
 
     def close(self):
         self.pdb.close()
 
-    def write(self, selection, frame=None):
+    def _write_next_frame(self, selection, frame=None):
         """Write selection at current trajectory frame to file.
 
         Parameters

--- a/package/MDAnalysis/coordinates/PQR.py
+++ b/package/MDAnalysis/coordinates/PQR.py
@@ -171,7 +171,7 @@ class PQRReader(base.SingleFrameReaderBase):
         return PQRWriter(filename, **kwargs)
 
 
-class PQRWriter(base.WriterBase):
+class PQRWriter(base.SingleFrameWriterBase):
     """Write a single coordinate frame in whitespace-separated PQR format.
 
     Charges ("Q") are taken from the
@@ -197,7 +197,7 @@ class PQRWriter(base.WriterBase):
                 " {pos[2]:-8.3f} {charge:-7.4f} {radius:6.4f}\n")
     fmt_remark = "REMARK   {0} {1}\n"
 
-    def __init__(self, filename, convert_units=True, **kwargs):
+    def __init__(self, filename, n_atoms=None, append=False, convert_units=True, **kwargs):
         """Set up a PQRWriter with full whitespace separation.
 
         Parameters
@@ -210,11 +210,12 @@ class PQRWriter(base.WriterBase):
              remark lines (list of strings) or single string to be added to the
              top of the PQR file
         """
-        self.filename = util.filename(filename, ext='pqr')
+        filename = util.filename(filename, ext='pqr')
+        super().__init__(filename, n_atoms, append)
         self.convert_units = convert_units  # convert length and time to base units
         self.remarks = kwargs.pop('remarks', "PQR file written by MDAnalysis")
 
-    def write(self, selection, frame=None):
+    def _write_next_frame(self, selection, frame=None):
         """Write selection at current trajectory frame to file.
 
         Parameters

--- a/package/MDAnalysis/coordinates/TRJ.py
+++ b/package/MDAnalysis/coordinates/TRJ.py
@@ -885,15 +885,15 @@ class NCDFWriter(base.WriterBase):
              'velocity': 'Angstrom/ps',
              'force': 'kcal/(mol*Angstrom)'}
 
-    def __init__(self, filename, n_atoms, remarks=None, convert_units=True,
+    def __init__(self, filename, n_atoms, append=False,
+                 remarks=None, convert_units=True,
                  velocities=False, forces=False, scale_time=None,
                  scale_cell_lengths=None, scale_cell_angles=None,
                  scale_coordinates=None, scale_velocities=None,
                  scale_forces=None, **kwargs):
-        self.filename = filename
         if n_atoms == 0:
             raise ValueError("NCDFWriter: no atoms in output trajectory")
-        self.n_atoms = n_atoms
+        super().__init__(filename, n_atoms, append)
         # convert length and time to base units on the fly?
         self.convert_units = convert_units
 

--- a/package/MDAnalysis/coordinates/TRZ.py
+++ b/package/MDAnalysis/coordinates/TRZ.py
@@ -397,7 +397,8 @@ class TRZWriter(base.WriterBase):
 
     units = {'time': 'ps', 'length': 'nm', 'velocity': 'nm/ps'}
 
-    def __init__(self, filename, n_atoms, title='TRZ', convert_units=True):
+    def __init__(self, filename, n_atoms, append=False,
+                 title='TRZ', convert_units=True):
         """Create a TRZWriter
 
         Parameters
@@ -406,18 +407,21 @@ class TRZWriter(base.WriterBase):
             name of output file
         n_atoms : int
             number of atoms in trajectory
+        append : bool (optional)
+            If ``True``, append to an existing file. If ``False``, overwrite
+            the file. Default is ``False``.
         title : str (optional)
             title of the trajectory; the title must be 80 characters or
             shorter, a longer title raises a ValueError exception.
         convert_units : bool (optional)
             units are converted to the MDAnalysis base format; [``True``]
         """
-        self.filename = filename
         if n_atoms is None:
             raise ValueError("TRZWriter requires the n_atoms keyword")
         if n_atoms == 0:
             raise ValueError("TRZWriter: no atoms in output trajectory")
-        self.n_atoms = n_atoms
+
+        super().__init__(filename, n_atoms, append)
 
         if len(title) > 80:
             raise ValueError("TRZWriter: 'title' must be 80 characters of shorter")

--- a/package/MDAnalysis/coordinates/XDR.py
+++ b/package/MDAnalysis/coordinates/XDR.py
@@ -306,7 +306,8 @@ class XDRBaseReader(base.ReaderBase):
 class XDRBaseWriter(base.WriterBase):
     """Base class for libmdaxdr file formats xtc and trr"""
 
-    def __init__(self, filename, n_atoms, convert_units=True, **kwargs):
+    def __init__(self, filename, n_atoms, append=False,
+                 convert_units=True, **kwargs):
         """
         Parameters
         ----------
@@ -314,11 +315,15 @@ class XDRBaseWriter(base.WriterBase):
             filename of trajectory
         n_atoms : int
             number of atoms to be written
+        append: bool (optional)
+            If ``True``, append to an existing file. If ``False``, overwrite
+            the file. Default is ``False``.
         convert_units : bool (optional)
             convert from MDAnalysis units to format specific units
         **kwargs : dict
             General writer arguments
         """
+        super().__init__(filename, n_atoms, append)
         self.filename = filename
         self._convert_units = convert_units
         self.n_atoms = n_atoms

--- a/package/MDAnalysis/coordinates/XTC.py
+++ b/package/MDAnalysis/coordinates/XTC.py
@@ -51,8 +51,8 @@ class XTCWriter(XDRBaseWriter):
     units = {'time': 'ps', 'length': 'nm'}
     _file = XTCFile
 
-    def __init__(self, filename, n_atoms, convert_units=True,
-                 precision=3, **kwargs):
+    def __init__(self, filename, n_atoms, append=False,
+                 convert_units=True, precision=3, **kwargs):
         """
         Parameters
         ----------
@@ -60,13 +60,15 @@ class XTCWriter(XDRBaseWriter):
             filename of the trajectory
         n_atoms : int
             number of atoms to write
+        append : bool (optional)
+            append to an existing trajectory if True
         convert_units : bool (optional)
             convert into MDAnalysis units
         precision : float (optional)
             set precision of saved trjactory to this number of decimal places.
         """
-        super(XTCWriter, self).__init__(filename, n_atoms, convert_units,
-                                        **kwargs)
+        super().__init__(filename, n_atoms, append=append,
+                         convert_units=convert_units, **kwargs)
         self.precision = precision
 
     def _write_next_frame(self, ag):

--- a/package/MDAnalysis/coordinates/chemfiles.py
+++ b/package/MDAnalysis/coordinates/chemfiles.py
@@ -275,6 +275,7 @@ class ChemfilesWriter(base.WriterBase):
         self,
         filename,
         n_atoms=0,
+        append=False,
         mode="w",
         chemfiles_format="",
         topology=None,
@@ -308,8 +309,7 @@ class ChemfilesWriter(base.WriterBase):
             raise RuntimeError(
                 "Please install Chemfiles > {}" "".format(MIN_CHEMFILES_VERSION)
             )
-        self.filename = filename
-        self.n_atoms = n_atoms
+        super().__init__(filename, n_atoms, append)
         if mode != "a" and mode != "w":
             raise IOError("Expected 'a' or 'w' as mode in ChemfilesWriter")
         self._file = chemfiles.Trajectory(self.filename, mode, chemfiles_format)

--- a/package/MDAnalysis/coordinates/core.py
+++ b/package/MDAnalysis/coordinates/core.py
@@ -85,7 +85,7 @@ def reader(filename, format=None, **kwargs):
         raise TypeError(errmsg) from None
 
 
-def writer(filename, n_atoms=None, **kwargs):
+def writer(filename, n_atoms=None, append=False, **kwargs):
     """Initialize a trajectory writer instance for *filename*.
 
     Parameters
@@ -96,6 +96,9 @@ def writer(filename, n_atoms=None, **kwargs):
     n_atoms : int (optional)
         The number of atoms in the output trajectory; can be ommitted
         for single-frame writers.
+    append: bool (optional)
+        If ``True``, append to an existing file. If ``False``, overwrite
+        he file. Default is ``False``.
     multiframe : bool (optional)
         ``True``: write a trajectory with multiple frames; ``False``
         only write a single frame snapshot; ``None`` first try to get
@@ -123,4 +126,4 @@ def writer(filename, n_atoms=None, **kwargs):
     """
     Writer = get_writer_for(filename, format=kwargs.pop('format', None),
                             multiframe=kwargs.pop('multiframe', None))
-    return Writer(filename, n_atoms=n_atoms, **kwargs)
+    return Writer(filename, n_atoms=n_atoms, append=append, **kwargs)

--- a/package/MDAnalysis/coordinates/null.py
+++ b/package/MDAnalysis/coordinates/null.py
@@ -51,8 +51,8 @@ class NullWriter(base.WriterBase):
     multiframe = True
     units = {'time': 'ps', 'length': 'Angstrom'}
 
-    def __init__(self, filename, **kwargs):
-        pass
+    def __init__(self, filename, n_atoms=None, append=False, **kwargs):
+        super().__init__(filename, n_atoms, append)
 
     def _write_next_frame(self, obj):
         try:

--- a/testsuite/MDAnalysisTests/coordinates/test_crd.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_crd.py
@@ -96,7 +96,17 @@ class TestCRDWriter(object):
             len(u2.atoms.segments)), 'Equal number of segments expected in'\
                         'both CRD formats'
         assert_allclose(cog1, cog2, rtol=1e-6, atol=0), 'Same centroid expected for both CRD formats'
+    
+    def test_append_to_trajectory(self, u, outfile):
+        with pytest.raises(ValueError, match="Single frame"):
+            u.atoms.write(outfile, append=True)
 
+    def test_write_multiple_frame(self, u, outfile):
+        with pytest.raises(ValueError, match="SingleFrameBaseWriter can"):
+            print(outfile)
+            with u.trajectory.Writer(outfile) as W:
+                W.write(u)
+                W.write(u)
 
 class TestCRDWriterMissingAttrs(object):
     # All required attributes with the default value

--- a/testsuite/MDAnalysisTests/coordinates/test_crd.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_crd.py
@@ -103,7 +103,6 @@ class TestCRDWriter(object):
 
     def test_write_multiple_frame(self, u, outfile):
         with pytest.raises(ValueError, match="SingleFrameBaseWriter can"):
-            print(outfile)
             with u.trajectory.Writer(outfile) as W:
                 W.write(u)
                 W.write(u)

--- a/testsuite/MDAnalysisTests/coordinates/test_fhiaims.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_fhiaims.py
@@ -28,7 +28,7 @@ import MDAnalysis as mda
 import numpy as np
 from MDAnalysisTests import make_Universe
 from MDAnalysisTests.coordinates.base import (
-    _SingleFrameReader, BaseWriterTest)
+    _SingleFrameReader, SingleFrameBaseWriterTest)
 from MDAnalysisTests.datafiles import FHIAIMS
 from numpy.testing import (assert_equal,
                            assert_array_almost_equal,
@@ -189,7 +189,7 @@ class TestFHIAIMSReader(object):
                             "FHIAIMSReader failed to read positions in lattice units properly")
 
 
-class TestFHIAIMSWriter(BaseWriterTest):
+class TestFHIAIMSWriter(SingleFrameBaseWriterTest):
     prec = 6
     ext = ".in"
 

--- a/testsuite/MDAnalysisTests/coordinates/test_gro.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_gro.py
@@ -28,7 +28,7 @@ from MDAnalysis.coordinates.GRO import GROReader, GROWriter
 from MDAnalysis.transformations import translate
 from MDAnalysisTests import make_Universe
 from MDAnalysisTests.coordinates.base import (
-    BaseReference, BaseReaderTest, BaseWriterTest,
+    BaseReference, BaseReaderTest, SingleFrameBaseWriterTest,
 )
 from MDAnalysisTests.coordinates.reference import RefAdK
 from MDAnalysisTests.datafiles import (
@@ -188,7 +188,7 @@ class TestGROReader(BaseReaderTest):
         assert_equal(frames, np.arange(u.trajectory.n_frames))
 
 
-class TestGROWriter(BaseWriterTest):
+class TestGROWriter(SingleFrameBaseWriterTest):
     @staticmethod
     @pytest.fixture(scope='class')
     def ref():
@@ -301,7 +301,7 @@ class TestGROReaderNoConversion(BaseReaderTest):
         return transformed
 
 
-class TestGROWriterNoConversion(BaseWriterTest):
+class TestGROWriterNoConversion(SingleFrameBaseWriterTest):
     @staticmethod
     @pytest.fixture(scope='class')
     def ref():
@@ -334,7 +334,7 @@ class TestGROReaderIncompleteVelocities(BaseReaderTest):
         return GROReaderIncompleteVelocitiesReference()
 
 
-class TestGROWriterIncompleteVelocities(BaseWriterTest):
+class TestGROWriterIncompleteVelocities(SingleFrameBaseWriterTest):
     @staticmethod
     @pytest.fixture(scope='class')
     def ref():
@@ -355,7 +355,7 @@ class TestGROBZ2Reader(BaseReaderTest):
         return GROBZReference()
 
 
-class TestGROBZ2Writer(BaseWriterTest):
+class TestGROBZ2Writer(SingleFrameBaseWriterTest):
     @staticmethod
     @pytest.fixture(scope='class')
     def ref():
@@ -369,7 +369,7 @@ class GROLargeReference(GROReference):
         self.topology = GRO_large
 
 
-class TestGROLargeWriter(BaseWriterTest):
+class TestGROLargeWriter(SingleFrameBaseWriterTest):
     @staticmethod
     @pytest.fixture(scope='class')
     def ref():

--- a/testsuite/MDAnalysisTests/coordinates/test_namdbin.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_namdbin.py
@@ -32,7 +32,7 @@ import MDAnalysis as mda
 from MDAnalysisTests.datafiles import NAMDBIN, PDB_small
 from MDAnalysisTests.coordinates.base import (_SingleFrameReader,
                                               BaseReference,
-                                              BaseWriterTest)
+                                              SingleFrameBaseWriterTest)
 
 
 class TestNAMDBINReader(_SingleFrameReader):
@@ -70,7 +70,7 @@ class NAMDBINReference(BaseReference):
         self.container_format = True
 
 
-class NAMDBINWriter(BaseWriterTest):
+class NAMDBINWriter(SingleFrameBaseWriterTest):
     __test__ = True
     @staticmethod
     @pytest.fixture()

--- a/testsuite/MDAnalysisTests/coordinates/test_pdb.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_pdb.py
@@ -435,10 +435,8 @@ class TestPDBWriter(object):
                     if line.startswith("MODEL"):
                         yield line
 
-        print(outfile)
         MODEL_lines = list(get_MODEL_lines(outfile))
 
-        print(MODEL_lines)
         assert len(MODEL_lines) == maxframes
         for model, line in enumerate(MODEL_lines, start=startframe+1):
             # test that only the right-most 4 digits are stored (rest must be space)
@@ -1194,7 +1192,6 @@ def test_atom_not_match(tmpdir):
     protein = u.select_atoms("protein and name CA")
     atoms = u.select_atoms(
         'resid 1 or resid 10 or resid 100 or resid 1000 or resid 10000')
-    print(outfile)
     with mda.Writer(outfile, multiframe=True, n_atoms=10) as pdb:
         # write these two groups of atoms to pdb
         # Then the n_atoms will not match

--- a/testsuite/MDAnalysisTests/coordinates/test_pdb.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_pdb.py
@@ -435,8 +435,10 @@ class TestPDBWriter(object):
                     if line.startswith("MODEL"):
                         yield line
 
+        print(outfile)
         MODEL_lines = list(get_MODEL_lines(outfile))
 
+        print(MODEL_lines)
         assert len(MODEL_lines) == maxframes
         for model, line in enumerate(MODEL_lines, start=startframe+1):
             # test that only the right-most 4 digits are stored (rest must be space)
@@ -1192,6 +1194,7 @@ def test_atom_not_match(tmpdir):
     protein = u.select_atoms("protein and name CA")
     atoms = u.select_atoms(
         'resid 1 or resid 10 or resid 100 or resid 1000 or resid 10000')
+    print(outfile)
     with mda.Writer(outfile, multiframe=True, n_atoms=10) as pdb:
         # write these two groups of atoms to pdb
         # Then the n_atoms will not match

--- a/testsuite/MDAnalysisTests/coordinates/test_writer_registration.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_writer_registration.py
@@ -31,10 +31,6 @@ class TestWriterCreation(object):
         # this writer does the 'magic' format
         format = 'MAGIC'
 
-        def __init__(self, filename, n_atoms=None):
-            self.filename = filename
-            self.n_atoms = n_atoms
-
     class MultiMagicWriter(MagicWriter):
         # this writer does the 'magic' and 'magic2' formats
         # but *only* supports multiframe writing.


### PR DESCRIPTION
Fixes #3861 

Changes made in this Pull Request:
 - add new SingleFrameWriterBase
 - add new flag `append` for appending trajectory to WriterBase
 - add a check for the number of frames written by WriterBase.
 - make sure `write` is not overwritten by Writers (they only modified `_write_next_frame`)

TODO:
- add tests for writers that are not covered by BaseWriterTest

PR Checklist
------------
 - [x] Tests?
 - [] Docs?
 - [] CHANGELOG updated?
 - [x] Issue raised/referenced?
