### PR TITLE
[to be discussed] Don't limit pyproject.toml NumPy support to known versions

### DIFF
--- a/package/pyproject.toml
+++ b/package/pyproject.toml
@@ -4,6 +4,7 @@ requires = [
     "Cython>=0.28",
     "packaging",
     # lowest NumPy we can use for a given Python,
+    # In part adapted from: https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg
     # except for more exotic platform (Mac Arm flavors)
     # aarch64, AIX, s390x all support < 1.20 so we can safely pin to this
     "numpy==1.20.0; python_version=='3.8' and (platform_machine!='arm64' or platform_system!='Darwin')",
@@ -19,7 +20,9 @@ requires = [
     # NumPy version. In that case we just let it be a bare NumPy install
     # Same thing goes for PyPy and Python >=3.8
     "numpy; python_version>='3.12'",
-    "numpy; python_version>='3.8' and platform_python_implementation=='PyPy'",
+    # PyPy requirements
+    "numpy==1.22.2; python_version=='3.8' and platform_machine!='loongarch64' and platform_python_implementation=='PyPy'",
+    "numpy; python_version>='3.9' and platform_python_implementation=='PyPy'",
     "setuptools",
     "wheel",
 ]

--- a/package/pyproject.toml
+++ b/package/pyproject.toml
@@ -19,7 +19,7 @@ requires = [
     "numpy==1.23.2; python_version=='3.11' and platform_python_implementation != 'PyPy'",
     # For unreleased versions of Python there is currently no known supported
     # NumPy version. In that case we just let it be a bare NumPy install
-    "numpy; python_version>='3.12'",
+    "numpy<2.0; python_version>='3.12'",
     "setuptools",
     "wheel",
 ]

--- a/package/pyproject.toml
+++ b/package/pyproject.toml
@@ -7,22 +7,19 @@ requires = [
     # In part adapted from: https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg
     # except for more exotic platform (Mac Arm flavors)
     # aarch64, AIX, s390x all support < 1.20 so we can safely pin to this
-    "numpy==1.20.0; python_version=='3.8' and (platform_machine!='arm64' or platform_system!='Darwin')",
-    "numpy==1.20.0; python_version=='3.9' and (platform_machine!='arm64' or platform_system!='Darwin')",
+    # Note: MDA does not build with PyPy so we do not support it in the build system
+    "numpy==1.20.0; python_version=='3.8' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_python_implementation != 'PyPy'",
+    "numpy==1.20.0; python_version=='3.9' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_python_implementation != 'PyPy'",
     # arm64 on darwin for py3.8+ requires numpy >=1.21.0
-    "numpy==1.21.0; python_version=='3.8' and platform_machine=='arm64' and platform_system=='Darwin'",
-    "numpy==1.21.0; python_version=='3.9' and platform_machine=='arm64' and platform_system=='Darwin'",
+    "numpy==1.21.0; python_version=='3.8' and platform_machine=='arm64' and platform_system=='Darwin' and platform_python_implementation != 'PyPy'",
+    "numpy==1.21.0; python_version=='3.9' and platform_machine=='arm64' and platform_system=='Darwin' and platform_python_implementation != 'PyPy'",
     # As per https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg
     # safest to build at 1.21.6 for all platforms
     "numpy==1.21.6; python_version=='3.10' and platform_python_implementation != 'PyPy'",
     "numpy==1.23.2; python_version=='3.11' and platform_python_implementation != 'PyPy'",
     # For unreleased versions of Python there is currently no known supported
     # NumPy version. In that case we just let it be a bare NumPy install
-    # Same thing goes for PyPy and Python >=3.8
     "numpy; python_version>='3.12'",
-    # PyPy requirements
-    "numpy==1.22.2; python_version=='3.8' and platform_machine!='loongarch64' and platform_python_implementation=='PyPy'",
-    "numpy; python_version>='3.9' and platform_python_implementation=='PyPy'",
     "setuptools",
     "wheel",
 ]

--- a/package/pyproject.toml
+++ b/package/pyproject.toml
@@ -15,6 +15,11 @@ requires = [
     # safest to build at 1.21.6 for all platforms
     "numpy==1.21.6; python_version=='3.10' and platform_python_implementation != 'PyPy'",
     "numpy==1.23.2; python_version=='3.11' and platform_python_implementation != 'PyPy'",
+    # For unreleased versions of Python there is currently no known supported
+    # NumPy version. In that case we just let it be a bare NumPy install
+    # Same thing goes for PyPy and Python >=3.8
+    "numpy; python_version>='3.12'",
+    "numpy; python_version>='3.8' and platform_python_implementation=='PyPy'",
     "setuptools",
     "wheel",
 ]


### PR DESCRIPTION
This is something that I realised recently after looking at a few packaging things over the last few days.

The way we define the NumPy bounds in `pyproject.toml` make it such that if a new version of Python is released, then a released version of the MDA package can no longer be installed with that new Python version because there are no adequate NumPy version defined for it in `pyproject.toml`.

The proposed way around this is to just set `pyproject.toml` to have a bare `numpy` install requirement when dealing with unknowns, such as for unreleased Python versions (note: scipy does this too).

On the positive side of things, this will allow folks to use packages beyond the known dependency ranges at the time of release.

On the negative side of things, this may lead folks to use older versions of MDA with newer dependencies in a way that _could_ be broken.

**My personal view:**

I would prefer allowing installs with unknown versions of Python, in part because we happen to be upstream of a lot of packages that might want to test their code with new versions of Python.

We don't apply upper dependency pins on anything else, so it seems weird that we apply it to NumPy.

One middle ground option here is to use an upper bound on the `numpy` entry, such that it is no greater than the next semver major version (i.e. `numpy<2.0`). It doesn't really do much but at least it'll protect against really bad API changes?

PR Checklist
------------
 - Tests?
 - Docs?
 - CHANGELOG updated?
 - Issue raised/referenced?
