### PR TITLE
Access hbonds results through new results member in count_by_ids() and count_by_type()

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -19,6 +19,7 @@ The rules for this file:
  * 2.4.0
 
 Fixes
+  * hbond analysis: access hbonds results through new results member in count_by_ids() and count_by_type()
   * Added isolayer selection method (Issue #3845)
   * Auxiliary; determination of representative frames: Removed undefined
     behaviour for cutoff values < -1 (PR # 3749)

--- a/package/MDAnalysis/analysis/hydrogenbonds/hbond_analysis.py
+++ b/package/MDAnalysis/analysis/hydrogenbonds/hbond_analysis.py
@@ -797,8 +797,8 @@ class HydrogenBondAnalysis(AnalysisBase):
         acceptor atoms in a hydrogen bond.
         """
 
-        d = self.u.atoms[self.hbonds[:, 1].astype(np.intp)]
-        a = self.u.atoms[self.hbonds[:, 3].astype(np.intp)]
+        d = self.u.atoms[self.results.hbonds[:, 1].astype(np.intp)]
+        a = self.u.atoms[self.results.hbonds[:, 3].astype(np.intp)]
 
         tmp_hbonds = np.array([d.resnames, d.types, a.resnames, a.types],
                               dtype=str).T
@@ -826,9 +826,9 @@ class HydrogenBondAnalysis(AnalysisBase):
         in a hydrogen bond.
         """
 
-        d = self.u.atoms[self.hbonds[:, 1].astype(np.intp)]
-        h = self.u.atoms[self.hbonds[:, 2].astype(np.intp)]
-        a = self.u.atoms[self.hbonds[:, 3].astype(np.intp)]
+        d = self.u.atoms[self.results.hbonds[:, 1].astype(np.intp)]
+        h = self.u.atoms[self.results.hbonds[:, 2].astype(np.intp)]
+        a = self.u.atoms[self.results.hbonds[:, 3].astype(np.intp)]
 
         tmp_hbonds = np.array([d.ids, h.ids, a.ids]).T
         hbond_ids, ids_counts = np.unique(tmp_hbonds, axis=0,


### PR DESCRIPTION
Hi! 
Quick PR since this makes User Guide tests with nbval fail due to the `UserWarning` being thrown.

Fixes:
`count_by_ids()` and `count_by_type()` throw a deprecation warning for accessing the `hbonds` attribute directly.


PR Checklist
------------
 - [NO] Tests?
 - [NO] Docs?
 - [YES] CHANGELOG updated?
 - [NO] Issue raised/referenced?
