### PR TITLE
Fix 32bit azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,6 @@ jobs:
           PYTHON_ARCH: 'x86'
           BUILD_TYPE: 'normal'
           imageName: 'windows-2019'
-          PIP_PRE_EXTRAS: 'scipy==1.9.1'
         Win-Python38-64bit-full:
           PYTHON_VERSION: '3.8'
           PYTHON_ARCH: 'x64'
@@ -81,11 +80,8 @@ jobs:
     condition: and(succeeded(), eq(variables['BUILD_TYPE'], 'wheel'))
   - script: python -m pip install --upgrade pip setuptools wheel
     displayName: 'Install tools'
-  - script: python -m pip install $(PIP_PRE_EXTRAS)
-    displayName: 'Pre-deps extras'
-    condition: ne(variables['PIP_PRE_EXTRAS'], '')
   - script: >-
-      python -m pip install --only-binary=h5py
+      python -m pip install --only-binary=h5py,scipy
       cython
       hypothesis
       matplotlib
@@ -95,7 +91,6 @@ jobs:
       pytest-cov
       pytest-xdist
       scikit-learn
-      scipy
       h5py>=2.10
       tqdm
       threadpoolctl


### PR DESCRIPTION
Azure 32 bit is failing again, looks like somehow pip is just ignoring the pre-installed scipy and is trying to go ahead with an install of scipy again.

I've switched things to what @tylerjereddy proposed last time (just rely on `only-binary`). Let's see what happens.

PR Checklist
------------
 - Tests?
 - Docs?
 - CHANGELOG updated?
 - Issue raised/referenced?
