### PR TITLE
Add timeseries for all readers

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -19,8 +19,9 @@ The rules for this file:
  * 2.4.0
 
 Fixes
-  * NoDataErrors raised on empty atomgroup provided to timeseries in DCDReader and MemoryReader
-    were changed to ValueError as NoDataError is intended for TopologyAttrs (cf #3901)
+  * NoDataError raised on empty atomgroup provided to `DCDReader.timeseries` 
+    was changed to ValueError (see #3901). A matching ValueError was added to
+    `MemoryReader.timeseries`(PR #3890). 
   * LAMMPSDump Reader translates the box to the origin (#3741)
   * hbond analysis: access hbonds results through new results member in count_by_ids() and count_by_type()
   * Added isolayer selection method (Issue #3845)
@@ -33,8 +34,8 @@ Fixes
     (e.g. bonds, angles) (PR #3779).
 
 Enhancements
-  * The timeseries method for dumping coordinates to a NumPy array was added
-    to ProtoReader (PR #3890)
+  * The timeseries method for exporting coordinates from multiple frames to a
+    NumPy array was added to ProtoReader (PR #3890)
   * LAMMPSDump Reader optionally unwraps trajectories with image flags upon 
     loading (#3843
   * LAMMPSDump Reader now imports velocities and forces (#3843)

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -33,7 +33,8 @@ Fixes
     (e.g. bonds, angles) (PR #3779).
 
 Enhancements
-  * The timeseries method for dumping coordinates to a NumPy array was added to ProtoReader
+  * The timeseries method for dumping coordinates to a NumPy array was added
+    to ProtoReader (PR #3890)
   * LAMMPSDump Reader optionally unwraps trajectories with image flags upon 
     loading (#3843
   * LAMMPSDump Reader now imports velocities and forces (#3843)

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -19,6 +19,8 @@ The rules for this file:
  * 2.4.0
 
 Fixes
+  * NoDataErrors raised on empty atomgroup provided to timeseries in DCDReader and MemoryReader
+    were changed to ValueError as NoDataError is intended for TopologyAttrs (cf #3901)
   * LAMMPSDump Reader translates the box to the origin (#3741)
   * hbond analysis: access hbonds results through new results member in count_by_ids() and count_by_type()
   * Added isolayer selection method (Issue #3845)
@@ -31,6 +33,7 @@ Fixes
     (e.g. bonds, angles) (PR #3779).
 
 Enhancements
+  * The timeseries method for dumping coordinates to a NumPy array was added to ProtoReader
   * LAMMPSDump Reader optionally unwraps trajectories with image flags upon 
     loading (#3843
   * LAMMPSDump Reader now imports velocities and forces (#3843)

--- a/package/MDAnalysis/coordinates/DCD.py
+++ b/package/MDAnalysis/coordinates/DCD.py
@@ -64,7 +64,6 @@ import types
 import warnings
 
 from .. import units as mdaunits  # use mdaunits instead of units to avoid a clash
-from ..exceptions import NoDataError
 from . import base, core
 from ..lib.formats.libdcd import DCDFile
 from ..lib.mdamath import triclinic_box
@@ -304,7 +303,7 @@ class DCDReader(base.ReaderBase):
 
         if asel is not None:
             if len(asel) == 0:
-                raise NoDataError(
+                raise ValueError(
                     "Timeseries requires at least one atom to analyze")
             atom_numbers = list(asel.indices)
         else:

--- a/package/MDAnalysis/coordinates/DCD.py
+++ b/package/MDAnalysis/coordinates/DCD.py
@@ -297,6 +297,9 @@ class DCDReader(base.ReaderBase):
 
         .. versionchanged:: 1.0.0
            `skip` and `format` keywords have been removed.
+        .. versionchanged:: 2.4.0
+            ValueError now raised instead of NoDataError for empty input
+            AtomGroup
         """
 
         start, stop, step = self.check_slice_indices(start, stop, step)

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -1039,12 +1039,13 @@ class ProtoReader(IOBase, metaclass=_Readermeta):
         if order != default_order:
             try:
                 newidx = [default_order.index(i) for i in order]
+                print(newidx)
             except ValueError:
                 raise ValueError(f"Unrecognized order key in {order}, "
                                  "must be permutation of 'fac'")
 
             try:
-                coordinates = np.moveaxis(coordinates, [0, 1, 2], newidx)
+                coordinates = np.moveaxis(coordinates, newidx, [0, 1, 2])
             except ValueError:
                 errmsg = ("Repeated or missing keys passed to argument "
                           f"`order`: {order}, each key must be used once")

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -986,6 +986,7 @@ class ProtoReader(IOBase, metaclass=_Readermeta):
                    step: Optional[int]=None,
                    order: Optional[str]='fac') -> np.ndarray:
         """Return a subset of coordinate data for an AtomGroup
+        
         Parameters
         ----------
         asel : AtomGroup (optional)
@@ -993,15 +994,15 @@ class ProtoReader(IOBase, metaclass=_Readermeta):
             coordinates from. Defaults to ``None``, in which case the full set of
             coordinate data is returned.
         start :  int (optional)
-             Begin reading the trajectory at frame index `start` (where 0 is the index
-             of the first frame in the trajectory); the default ``None`` starts
-             at the beginning.
+            Begin reading the trajectory at frame index `start` (where 0 is the index
+            of the first frame in the trajectory); the default ``None`` starts
+            at the beginning.
         stop : int (optional)
-             End reading the trajectory at frame index `stop`-1, i.e, `stop` is excluded.
-             The trajectory is read to the end with the default ``None``.
+            End reading the trajectory at frame index `stop`-1, i.e, `stop` is excluded.
+            The trajectory is read to the end with the default ``None``.
         step : int (optional)
-             Step size for reading; the default ``None`` is equivalent to 1 and means to
-             read every frame.
+            Step size for reading; the default ``None`` is equivalent to 1 and means to
+            read every frame.
         order : str (optional)
             the order/shape of the return data array, corresponding
             to (a)tom, (f)rame, (c)oordinates all six combinations

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -131,7 +131,6 @@ from typing import Union, Optional, List, Dict
 
 from .timestep import Timestep
 from . import core
-from .. import NoDataError
 from .. import (
     _READERS, _READER_HINTS,
     _SINGLEFRAME_WRITERS,
@@ -1023,7 +1022,7 @@ class ProtoReader(IOBase, metaclass=_Readermeta):
 
         if asel is not None:
             if len(asel) == 0:
-                raise NoDataError(
+                raise ValueError(
                     "Timeseries requires at least one atom to analyze")
             atom_numbers = asel.indices
             natoms = len(atom_numbers)

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -1029,7 +1029,7 @@ class ProtoReader(IOBase, metaclass=_Readermeta):
             natoms = self.n_atoms
             atom_numbers = np.arange(natoms)
 
-        # allocate output array in 'fac' (_default_timeseries_order) order
+        # allocate output array in 'fac' order
         coordinates = np.empty((nframes, natoms, 3), dtype=np.float32)
         for i, ts in enumerate(self[start:stop:step]):
             coordinates[i, :] = ts.positions[atom_numbers]
@@ -1050,7 +1050,6 @@ class ProtoReader(IOBase, metaclass=_Readermeta):
                           f"`order`: {order}, each key must be used once")
                 raise ValueError(errmsg)
         return coordinates
-
 
 # TODO: Change order of aux_spec and auxdata for 3.0 release, cf. Issue #3811
     def add_auxiliary(self,

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -986,23 +986,24 @@ class ProtoReader(IOBase, metaclass=_Readermeta):
                    step: Optional[int]=None,
                    order: Optional[str]='fac') -> np.ndarray:
         """Return a subset of coordinate data for an AtomGroup
-        
+
         Parameters
         ----------
         asel : AtomGroup (optional)
             The :class:`~MDAnalysis.core.groups.AtomGroup` to read the
-            coordinates from. Defaults to ``None``, in which case the full set of
-            coordinate data is returned.
+            coordinates from. Defaults to ``None``, in which case the full set
+            of coordinate data is returned.
         start :  int (optional)
-            Begin reading the trajectory at frame index `start` (where 0 is the index
-            of the first frame in the trajectory); the default ``None`` starts
-            at the beginning.
+            Begin reading the trajectory at frame index `start` (where 0 is the
+            index of the first frame in the trajectory); the default
+            ``None`` starts at the beginning.
         stop : int (optional)
-            End reading the trajectory at frame index `stop`-1, i.e, `stop` is excluded.
-            The trajectory is read to the end with the default ``None``.
+            End reading the trajectory at frame index `stop`-1, i.e, `stop` is
+            excluded. The trajectory is read to the end with the default
+            ``None``.
         step : int (optional)
-            Step size for reading; the default ``None`` is equivalent to 1 and means to
-            read every frame.
+            Step size for reading; the default ``None`` is equivalent to 1 and
+            means to read every frame.
         order : str (optional)
             the order/shape of the return data array, corresponding
             to (a)tom, (f)rame, (c)oordinates all six combinations

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -1039,7 +1039,6 @@ class ProtoReader(IOBase, metaclass=_Readermeta):
         if order != default_order:
             try:
                 newidx = [default_order.index(i) for i in order]
-                print(newidx)
             except ValueError:
                 raise ValueError(f"Unrecognized order key in {order}, "
                                  "must be permutation of 'fac'")

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -1018,6 +1018,9 @@ class ProtoReader(IOBase, metaclass=_Readermeta):
         start, stop, step = self.check_slice_indices(start, stop, step)
         nframes = len(range(start, stop, step))
 
+        if sorted(order) != sorted(self._default_timeseries_order):
+            raise ValueError("The order of the returned coordinate array must"
+                            " be a permutation of `fac`.")
         if asel is not None:
             if len(asel) == 0:
                 raise NoDataError(
@@ -1049,8 +1052,7 @@ class ProtoReader(IOBase, metaclass=_Readermeta):
             coordinates = np.swapaxes(coordinates, 2, 0)
             coordinates = np.swapaxes(coordinates, 1, 2)
         else:
-            raise ValueError("The order of the returned coordinate array must"
-                            " be a permutation of `fac`.")
+            pass
         return coordinates
 
 

--- a/package/MDAnalysis/coordinates/memory.py
+++ b/package/MDAnalysis/coordinates/memory.py
@@ -188,7 +188,6 @@ import warnings
 import copy
 
 from . import base
-from .. import NoDataError
 from .timestep import Timestep
 
 
@@ -522,6 +521,9 @@ class MemoryReader(base.ProtoReader):
 
         .. versionchanged:: 1.0.0
            Deprecated `format` keyword has been removed. Use `order` instead.
+        .. versionchanged:: 2.4.0
+            ValueError now raised instead of NoDataError for empty input
+            AtomGroup
         """
         if stop != -1:
             warnings.warn("MemoryReader.timeseries inclusive `stop` "
@@ -561,7 +563,7 @@ class MemoryReader(base.ProtoReader):
             return array
         else:
             if len(asel) == 0:
-                raise NoDataError("Timeseries requires at least one atom "
+                raise ValueError("Timeseries requires at least one atom "
                                   "to analyze")
             # If selection is specified, return a copy
             return array.take(asel.indices, a_index)

--- a/package/MDAnalysis/coordinates/memory.py
+++ b/package/MDAnalysis/coordinates/memory.py
@@ -188,6 +188,7 @@ import warnings
 import copy
 
 from . import base
+from .. import NoDataError
 from .timestep import Timestep
 
 
@@ -547,6 +548,9 @@ class MemoryReader(base.ProtoReader):
         if (asel is None or asel is asel.universe.atoms):
             return array
         else:
+            if len(asel) == 0:
+                raise NoDataError("Timeseries requires at least one atom "
+                                  "to analyze")
             # If selection is specified, return a copy
             return array.take(asel.indices, a_index)
 

--- a/testsuite/MDAnalysisTests/coordinates/base.py
+++ b/testsuite/MDAnalysisTests/coordinates/base.py
@@ -470,6 +470,11 @@ class BaseReaderTest(object):
         timeseries = reader.timeseries(start=slice[0], stop=slice[1],
                                        step=slice[2], order='fac')
         assert_allclose(timeseries, positions)
+    
+    def test_timeseries_empty_asel(self, reader):
+        atoms = mda.Universe(reader.filename).select_atoms(None)
+        with pytest.raises(NoDataError, match="Timeseries requires at least"):
+            reader.timeseries(atoms)
 
 class MultiframeReaderTest(BaseReaderTest):
     def test_last_frame(self, ref, reader):

--- a/testsuite/MDAnalysisTests/coordinates/base.py
+++ b/testsuite/MDAnalysisTests/coordinates/base.py
@@ -461,7 +461,7 @@ class BaseReaderTest(object):
     def test_timeseries_values(self, reader, slice):
         ts_positions = []
         if slice[1] > len(reader):
-            pytest.xfail()
+            pytest.skip()
         for i in range(slice[0], slice[1], slice[2]):
             ts = reader[i]
             ts_positions.append(ts.positions.copy())

--- a/testsuite/MDAnalysisTests/coordinates/base.py
+++ b/testsuite/MDAnalysisTests/coordinates/base.py
@@ -32,7 +32,6 @@ from numpy.testing import (assert_equal, assert_almost_equal,
 import MDAnalysis as mda
 from MDAnalysis.coordinates.timestep import Timestep
 from MDAnalysis.transformations import translate
-from MDAnalysis import NoDataError
 
 
 from MDAnalysisTests.coordinates.reference import RefAdKSmall
@@ -481,7 +480,7 @@ class BaseReaderTest(object):
     
     def test_timeseries_empty_asel(self, reader):
         atoms = mda.Universe(reader.filename).select_atoms(None)
-        with pytest.raises(NoDataError, match="Timeseries requires at least"):
+        with pytest.raises(ValueError, match="Timeseries requires at least"):
             reader.timeseries(atoms)
 
 class MultiframeReaderTest(BaseReaderTest):

--- a/testsuite/MDAnalysisTests/coordinates/base.py
+++ b/testsuite/MDAnalysisTests/coordinates/base.py
@@ -21,7 +21,6 @@
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
 import itertools
-from os import terminal_size
 import pickle
 
 import numpy as np
@@ -450,9 +449,9 @@ class BaseReaderTest(object):
     @pytest.mark.parametrize('order', ('fac', 'fca', 'afc', 'acf', 'caf', 'cfa'))
     def test_timeseries_shape(self, reader, order):
         timeseries = reader.timeseries(order=order)
-        a_index = order.find('a')
-        f_index = order.find('f')
-        c_index = order.find('c')
+        a_index = order.index('a')
+        f_index = order.index('f')
+        c_index = order.index('c')
         assert(timeseries.shape[a_index] == reader.n_atoms)
         assert(timeseries.shape[f_index] == len(reader))
         assert(timeseries.shape[c_index] == 3)
@@ -461,13 +460,14 @@ class BaseReaderTest(object):
     def test_timeseries_values(self, reader, slice):
         ts_positions = []
         if slice[1] > len(reader):
-            pytest.skip()
+            pytest.skip("too few frames in reader")
         for i in range(slice[0], slice[1], slice[2]):
             ts = reader[i]
             ts_positions.append(ts.positions.copy())
         positions = np.asarray(ts_positions)
-        timeseries = reader.timeseries(start=slice[0], stop=slice[1], step=slice[2], order='fac')
-        np.testing.assert_allclose(timeseries, positions)
+        timeseries = reader.timeseries(start=slice[0], stop=slice[1],
+                                       step=slice[2], order='fac')
+        assert_allclose(timeseries, positions)
 
 
 class MultiframeReaderTest(BaseReaderTest):

--- a/testsuite/MDAnalysisTests/coordinates/base.py
+++ b/testsuite/MDAnalysisTests/coordinates/base.py
@@ -460,7 +460,8 @@ class BaseReaderTest(object):
     def test_timeseries_values(self, reader, slice):
         ts_positions = []
         if isinstance(reader, mda.coordinates.memory.MemoryReader):
-            pytest.xfail("MemoryReader uses deprecated indexing")
+            pytest.xfail("MemoryReader uses deprecated stop inclusive"
+                         " indexing, see Issue #3893")
         if slice[1] > len(reader):
             pytest.skip("too few frames in reader")
         for i in range(slice[0], slice[1], slice[2]):

--- a/testsuite/MDAnalysisTests/coordinates/base.py
+++ b/testsuite/MDAnalysisTests/coordinates/base.py
@@ -459,6 +459,8 @@ class BaseReaderTest(object):
     @pytest.mark.parametrize('slice', ([0,2,1], [0,10,2], [0,10,3]))
     def test_timeseries_values(self, reader, slice):
         ts_positions = []
+        if isinstance(reader, mda.coordinates.memory.MemoryReader):
+            pytest.xfail("MemoryReader uses deprecated indexing")
         if slice[1] > len(reader):
             pytest.skip("too few frames in reader")
         for i in range(slice[0], slice[1], slice[2]):

--- a/testsuite/MDAnalysisTests/coordinates/base.py
+++ b/testsuite/MDAnalysisTests/coordinates/base.py
@@ -445,7 +445,6 @@ class BaseReaderTest(object):
         assert_equal(reader.ts, reader_p.ts,
                      "Timestep is changed after pickling")
 
-    
     @pytest.mark.parametrize('order', ('fac', 'fca', 'afc', 'acf', 'caf', 'cfa'))
     def test_timeseries_shape(self, reader, order):
         timeseries = reader.timeseries(order=order)
@@ -471,7 +470,6 @@ class BaseReaderTest(object):
         timeseries = reader.timeseries(start=slice[0], stop=slice[1],
                                        step=slice[2], order='fac')
         assert_allclose(timeseries, positions)
-
 
 class MultiframeReaderTest(BaseReaderTest):
     def test_last_frame(self, ref, reader):

--- a/testsuite/MDAnalysisTests/coordinates/base.py
+++ b/testsuite/MDAnalysisTests/coordinates/base.py
@@ -470,6 +470,14 @@ class BaseReaderTest(object):
         timeseries = reader.timeseries(start=slice[0], stop=slice[1],
                                        step=slice[2], order='fac')
         assert_allclose(timeseries, positions)
+
+    @pytest.mark.parametrize('asel', ("index 1", "index 2", "index 1 to 3"))
+    def test_timeseries_asel_shape(self, reader, asel):
+        atoms = mda.Universe(reader.filename).select_atoms(asel)
+        timeseries = reader.timeseries(atoms, order='fac')
+        assert(timeseries.shape[0] == len(reader))
+        assert(timeseries.shape[1] == len(atoms))
+        assert(timeseries.shape[2] == 3)
     
     def test_timeseries_empty_asel(self, reader):
         atoms = mda.Universe(reader.filename).select_atoms(None)

--- a/testsuite/MDAnalysisTests/coordinates/test_dcd.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_dcd.py
@@ -24,7 +24,6 @@ import numpy as np
 
 import MDAnalysis as mda
 from MDAnalysis.coordinates.DCD import DCDReader
-from MDAnalysis.exceptions import NoDataError
 
 from numpy.testing import (assert_equal, assert_array_equal,
                            assert_almost_equal, assert_array_almost_equal)
@@ -231,7 +230,7 @@ def test_timeseries_atomindices(indices, universe_dcd):
 
 
 def test_timeseries_empty_selection(universe_dcd):
-    with pytest.raises(NoDataError):
+    with pytest.raises(ValueError):
         asel = universe_dcd.select_atoms('name FOO')
         universe_dcd.trajectory.timeseries(asel=asel)
 

--- a/testsuite/MDAnalysisTests/coordinates/test_reader_api.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_reader_api.py
@@ -133,6 +133,10 @@ class _TestReader(object):
         with pytest.raises(StopIteration):
             next(reader)
 
+    @pytest.mark.parametrize('order', ['turnip', 'abc', ''])
+    def test_timeseries_raises_incorrect_order(self, reader, order):
+        with pytest.raises(ValueError, match="must be a permutation of `fac`"):
+            reader.timeseries(order=order)
 
 class _Multi(_TestReader):
     n_frames = 10

--- a/testsuite/MDAnalysisTests/coordinates/test_reader_api.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_reader_api.py
@@ -133,9 +133,14 @@ class _TestReader(object):
         with pytest.raises(StopIteration):
             next(reader)
 
-    @pytest.mark.parametrize('order', ['turnip', 'abc', ''])
-    def test_timeseries_raises_incorrect_order(self, reader, order):
-        with pytest.raises(ValueError, match="must be a permutation of `fac`"):
+    @pytest.mark.parametrize('order', ['turnip', 'abc'])
+    def test_timeseries_raises_unknown_order_key(self, reader, order):
+        with pytest.raises(ValueError, match="Unrecognized order key"):
+            reader.timeseries(order=order)
+
+    @pytest.mark.parametrize('order', ['faac', 'affc', 'afcc', ''])
+    def test_timeseries_raises_incorrect_order_key(self, reader, order):
+        with pytest.raises(ValueError, match="Repeated or missing keys"):
             reader.timeseries(order=order)
 
 class _Multi(_TestReader):


### PR DESCRIPTION
Fixes MDAnalysis/mdanalysis#3881 MDAnalysis/mdanalysis#2271 MDAnalysis/mdanalysis#3898 MDAnalysis/mdanalysis#2948 MDAnalysis/mdaencore#30

Changes made in this Pull Request:
 - Add timeseries attribute to all readers as a method of `ReaderBase`
 - Make MemoryReader raise a NoDataError on empty atomgroup. 

@MDAnalysis/coredevs one issue to be discussed. The MemoryReader has **inclusive** start, stop, step which is not in line with python `range` while this has PR been set up to have non-inclusive start-stop-step. Which would we prefer? One of the two implementations will need to change for consistency. 

PR Checklist
------------
 - [X] Tests?
 - [X] Docs?
 - [X] CHANGELOG updated?
 - [X] Issue raised/referenced?
