### PR TITLE
Add deprecation warning for memoryreader inclusive indexing in timeseries. 

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -62,6 +62,7 @@ Changes
   * adding element attribute to TXYZParser if all atom names are valid element symbols (PR #3826)
 
 Deprecations
+  * Add deprecation warning for inclusive start, stop, step indexing in MemoryReader.timeseries 
 
 
 08/29/22 IAlibay, PicoCentauri, orbeckst, hmacdope, rmeli, miss77jun, rzhao271,

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -62,7 +62,8 @@ Changes
   * adding element attribute to TXYZParser if all atom names are valid element symbols (PR #3826)
 
 Deprecations
-  * Add deprecation warning for inclusive start, stop, step indexing in MemoryReader.timeseries 
+  * Add deprecation warning for inclusive start, stop, step indexing
+    in MemoryReader.timeseries (#PR 3894)  
 
 
 08/29/22 IAlibay, PicoCentauri, orbeckst, hmacdope, rmeli, miss77jun, rzhao271,

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -62,8 +62,8 @@ Changes
   * adding element attribute to TXYZParser if all atom names are valid element symbols (PR #3826)
 
 Deprecations
-  * Add deprecation warning for inclusive start, stop, step indexing
-    in MemoryReader.timeseries (#PR 3894)  
+  * Add deprecation warning for inclusive stop indexing in
+    MemoryReader.timeseries (#PR 3894)
 
 
 08/29/22 IAlibay, PicoCentauri, orbeckst, hmacdope, rmeli, miss77jun, rzhao271,

--- a/package/MDAnalysis/coordinates/memory.py
+++ b/package/MDAnalysis/coordinates/memory.py
@@ -515,6 +515,12 @@ class MemoryReader(base.ProtoReader):
         .. versionchanged:: 1.0.0
            Deprecated `format` keyword has been removed. Use `order` instead.
         """
+        warnings.warn(
+            "Inclusive `start` and `stop` indexing will be removed in 3.0 in" 
+            " favour of exclusive indexing"
+            category=DeprecationWarning
+        )
+
         array = self.get_array()
         if order == self.stored_order:
             pass

--- a/package/MDAnalysis/coordinates/memory.py
+++ b/package/MDAnalysis/coordinates/memory.py
@@ -501,11 +501,14 @@ class MemoryReader(base.ProtoReader):
             of the underlying numpy array is returned, while a copy of the
             data is returned whenever `asel` is different from ``None``.
         start : int (optional)
+            the start trajectory frame
         stop : int (optional)
+            the end trajectory frame
             .. deprecated:: 2.4.0
                 Note that `stop` is currently *inclusive* but will be
                 changed in favour of being *exclusive* in version 3.0.  
         step : int (optional)
+            the number of trajectory frames to skip
         order : {"afc", "acf", "caf", "fac", "fca", "cfa"} (optional)
             the order/shape of the return data array, corresponding
             to (a)tom, (f)rame, (c)oordinates all six combinations

--- a/package/MDAnalysis/coordinates/memory.py
+++ b/package/MDAnalysis/coordinates/memory.py
@@ -504,9 +504,11 @@ class MemoryReader(base.ProtoReader):
             the start trajectory frame
         stop : int (optional)
             the end trajectory frame
+
             .. deprecated:: 2.4.0
-            Note that `stop` is currently *inclusive* but will be
-            changed in favour of being *exclusive* in version 3.0.  
+               Note that `stop` is currently *inclusive* but will be
+               changed in favour of being *exclusive* in version 3.0.  
+
         step : int (optional)
             the number of trajectory frames to skip
         order : {"afc", "acf", "caf", "fac", "fca", "cfa"} (optional)
@@ -523,7 +525,7 @@ class MemoryReader(base.ProtoReader):
         if stop != -1:
             warnings.warn("MemoryReader.timeseries inclusive `stop` "
                       "indexing will be removed in 3.0 in favour of exclusive "
-                      "indexing",category=DeprecationWarning)
+                      "indexing", category=DeprecationWarning)
 
         array = self.get_array()
         if order == self.stored_order:

--- a/package/MDAnalysis/coordinates/memory.py
+++ b/package/MDAnalysis/coordinates/memory.py
@@ -505,8 +505,8 @@ class MemoryReader(base.ProtoReader):
         stop : int (optional)
             the end trajectory frame
             .. deprecated:: 2.4.0
-                Note that `stop` is currently *inclusive* but will be
-                changed in favour of being *exclusive* in version 3.0.  
+            Note that `stop` is currently *inclusive* but will be
+            changed in favour of being *exclusive* in version 3.0.  
         step : int (optional)
             the number of trajectory frames to skip
         order : {"afc", "acf", "caf", "fac", "fca", "cfa"} (optional)

--- a/package/MDAnalysis/coordinates/memory.py
+++ b/package/MDAnalysis/coordinates/memory.py
@@ -502,8 +502,12 @@ class MemoryReader(base.ProtoReader):
             data is returned whenever `asel` is different from ``None``.
         start : int (optional)
         stop : int (optional)
+            Note that `stop` is currently *inclusive* but will be deprecated in
+            favour of being *exclusive* in 3.0.  
         step : int (optional)
-            range of trajectory to access, `start` and `stop` are *inclusive*
+            range of trajectory to access, `start` and `stop` are
+            currently *inclusive* but will be changed to be *exclusive* in
+            3.0.
         order : {"afc", "acf", "caf", "fac", "fca", "cfa"} (optional)
             the order/shape of the return data array, corresponding
             to (a)tom, (f)rame, (c)oordinates all six combinations
@@ -514,8 +518,11 @@ class MemoryReader(base.ProtoReader):
 
         .. versionchanged:: 1.0.0
            Deprecated `format` keyword has been removed. Use `order` instead.
+        .. versionchanged:: 2.4.0
+           Deprecation warning 
         """
-        warnings.warn("MemoryReader.timeseries inclusive `start` and `stop`"
+        if stop != -1:
+            warnings.warn("MemoryReader.timeseries inclusive `start` and `stop`"
                       "indexing will be removed in 3.0 in favour of exclusive"
                       "indexing",category=DeprecationWarning)
 

--- a/package/MDAnalysis/coordinates/memory.py
+++ b/package/MDAnalysis/coordinates/memory.py
@@ -523,7 +523,7 @@ class MemoryReader(base.ProtoReader):
         """
         if stop != -1:
             warnings.warn("MemoryReader.timeseries inclusive `start` and `stop`"
-                      "indexing will be removed in 3.0 in favour of exclusive"
+                      " indexing will be removed in 3.0 in favour of exclusive "
                       "indexing",category=DeprecationWarning)
 
         array = self.get_array()

--- a/package/MDAnalysis/coordinates/memory.py
+++ b/package/MDAnalysis/coordinates/memory.py
@@ -515,11 +515,9 @@ class MemoryReader(base.ProtoReader):
         .. versionchanged:: 1.0.0
            Deprecated `format` keyword has been removed. Use `order` instead.
         """
-        warnings.warn(
-            "Inclusive `start` and `stop` indexing will be removed in 3.0 in" 
-            " favour of exclusive indexing"
-            category=DeprecationWarning
-        )
+        warnings.warn("MemoryReader.timeseries inclusive `start` and `stop`"
+                      "indexing will be removed in 3.0 in favour of exclusive"
+                      "indexing",category=DeprecationWarning)
 
         array = self.get_array()
         if order == self.stored_order:

--- a/package/MDAnalysis/coordinates/memory.py
+++ b/package/MDAnalysis/coordinates/memory.py
@@ -502,9 +502,9 @@ class MemoryReader(base.ProtoReader):
             data is returned whenever `asel` is different from ``None``.
         start : int (optional)
         stop : int (optional)
-            .. deprecated:: 3.0
+            .. deprecated:: 2.4.0
                 Note that `stop` is currently *inclusive* but will be
-                deprecated in favour of being *exclusive* in 3.0.  
+                changed in favour of being *exclusive* in version 3.0.  
         step : int (optional)
         order : {"afc", "acf", "caf", "fac", "fca", "cfa"} (optional)
             the order/shape of the return data array, corresponding

--- a/package/MDAnalysis/coordinates/memory.py
+++ b/package/MDAnalysis/coordinates/memory.py
@@ -502,12 +502,10 @@ class MemoryReader(base.ProtoReader):
             data is returned whenever `asel` is different from ``None``.
         start : int (optional)
         stop : int (optional)
-            Note that `stop` is currently *inclusive* but will be deprecated in
-            favour of being *exclusive* in 3.0.  
+            .. deprecated:: 3.0
+                Note that `stop` is currently *inclusive* but will be
+                deprecated in favour of being *exclusive* in 3.0.  
         step : int (optional)
-            range of trajectory to access, `start` and `stop` are
-            currently *inclusive* but will be changed to be *exclusive* in
-            3.0.
         order : {"afc", "acf", "caf", "fac", "fca", "cfa"} (optional)
             the order/shape of the return data array, corresponding
             to (a)tom, (f)rame, (c)oordinates all six combinations
@@ -518,12 +516,10 @@ class MemoryReader(base.ProtoReader):
 
         .. versionchanged:: 1.0.0
            Deprecated `format` keyword has been removed. Use `order` instead.
-        .. versionchanged:: 2.4.0
-           Deprecation warning 
         """
         if stop != -1:
-            warnings.warn("MemoryReader.timeseries inclusive `start` and `stop`"
-                      " indexing will be removed in 3.0 in favour of exclusive "
+            warnings.warn("MemoryReader.timeseries inclusive `stop` "
+                      "indexing will be removed in 3.0 in favour of exclusive "
                       "indexing",category=DeprecationWarning)
 
         array = self.get_array()

--- a/testsuite/MDAnalysisTests/coordinates/test_memory.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_memory.py
@@ -197,6 +197,10 @@ class TestMemoryReader(MultiframeReaderTest):
         reader[0]
         assert_almost_equal(reader.ts.positions, new_positions)
 
+    def test_timeseries_warns_deprecation(self, reader):
+        with pytest.raises(DeprecationWarning):
+            reader.timeseries(start=0, stop=3, step=1)
+
 
 class TestMemoryReaderVelsForces(object):
     @staticmethod

--- a/testsuite/MDAnalysisTests/coordinates/test_memory.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_memory.py
@@ -198,7 +198,8 @@ class TestMemoryReader(MultiframeReaderTest):
         assert_almost_equal(reader.ts.positions, new_positions)
 
     def test_timeseries_warns_deprecation(self, reader):
-        with pytest.raises(DeprecationWarning):
+        with pytest.warns(DeprecationWarning, match="MemoryReader.timeseries "
+                          "inclusive"):
             reader.timeseries(start=0, stop=3, step=1)
 
 


### PR DESCRIPTION
Related to #3893 
Changes made in this Pull Request:
 - Adds deprecation warning for memoryreader. 


PR Checklist
------------
 - [X] Tests?
 - [X] Docs?
 - [X] CHANGELOG updated?
 - [X] Issue raised/referenced?
