### PR TITLE
Bump up codecov action, add token secret

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -122,8 +122,9 @@ jobs:
 
     - name: codecov
       if: matrix.codecov
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         file: coverage.xml
         fail_ci_if_error: True
         verbose: True


### PR DESCRIPTION
The codecov reports here are a little bit over the place, and I'm not really sure that this is the best way forward, but at the same time if it doesn't prevent PRs coming from forks then there's no major cost.

We should keep an eye out to see if the relevant issues, e.g. https://github.com/codecov/feedback/issues/126 are fixed & things can be reverted back.

PR Checklist
------------
 - Tests?
 - Docs?
 - CHANGELOG updated?
 - Issue raised/referenced?
