### PR TITLE
bump up azure and gh CI to py3.11

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -47,7 +47,7 @@ jobs:
           fetch-depth: 0
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2
+        uses: pypa/cibuildwheel@v2.11
         with:
           package-dir: package
         env:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - "package-*"
-      - "develop"
   push:
     branches:
       - "package-*"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -189,9 +189,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         type: ["FULL", "MIN"]
         exclude:
+          # Py311 doesn't support all optional deps yet
+          - python-version: "3.11"
+            type: "FULL"
           # Multiple deps don't like windows
           - os: windows-latest
             python-version: "3.8"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - "package-*"
+      - "develop"
   push:
     branches:
       - "package-*"
@@ -33,10 +34,10 @@ jobs:
       fail-fast: false
       matrix:
         buildplat:
-          - [ubuntu-18.04, manylinux_x86_64]
-          - [macos-10.15, macosx_*]
+          - [ubuntu-20.04, manylinux_x86_64]
+          - [macos-11, macosx_*]
           - [windows-2019, win_amd64]
-        python: ["cp38", "cp39", "cp310"]
+        python: ["cp38", "cp39", "cp310", "cp311"]
     defaults:
       run:
         working-directory: ./package
@@ -46,7 +47,7 @@ jobs:
           fetch-depth: 0
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.6.0
+        uses: pypa/cibuildwheel@v2
         with:
           package-dir: package
         env:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -47,7 +47,7 @@ jobs:
           fetch-depth: 0
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.11
+        uses: pypa/cibuildwheel@v2.11.2
         with:
           package-dir: package
         env:

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -28,11 +28,17 @@ jobs:
         fail-fast: false
         matrix:
           os: [ubuntu-latest, ]
-          python-version: [3.8, 3.9, "3.10"]
+          python-version: ["3.8", "3.9", "3.10"]
           full-deps: [true, ]
           install_hole: [true, ]
           codecov: [true, ]
           include:
+            - name: py311-ubuntu-min
+              os: ubuntu-latest
+              python-version: "3.11"
+              full-deps: false
+              install_hole: true
+              codecov: false
             - name: macOS_monterey_py39
               os: macOS-12
               python-version: 3.9

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -120,7 +120,6 @@ jobs:
       networkx
       parmed
       tidynamics>=1.0.0
-      # rdkit>=2020.03.1
     displayName: 'Install additional dependencies for 64-bit tests'
     condition: and(succeeded(), eq(variables['PYTHON_ARCH'], 'x64'))
   - powershell: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,6 +74,7 @@ jobs:
   # "manually"
   - powershell: |
       cd package
+      python -m pip install numpy==1.21.6
       python -m pip -vvv install .
       cd ..
     displayName: 'Build MDAnalysis (wheel)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -128,6 +128,9 @@ jobs:
       cd ..
     displayName: 'Build MDAnalysis'
     condition: and(succeeded(), eq(variables['BUILD_TYPE'], 'normal'))
+  - script: >-
+      pip list
+    displayName: 'list of installed python packages'
   - powershell: |
       cd testsuite
       pytest MDAnalysisTests --disable-pytest-warnings -n 2 -rsx --cov=MDAnalysis

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,16 +31,16 @@ jobs:
           PYTHON_ARCH: 'x64'
           BUILD_TYPE: 'normal'
           imageName: 'windows-2019'
-        Win-Python311-64bit-full:
-          PYTHON_VERSION: '3.11'
+        Win-Python310-64bit-full:
+          PYTHON_VERSION: '3.10'
           PYTHON_ARCH: 'x64'
           BUILD_TYPE: 'normal'
           imageName: 'windows-2019'
-        Win-Python311-64bit-full-wheel:
-          PYTHON_VERSION: '3.11'
+        Win-Python310-64bit-full-wheel:
+          PYTHON_VERSION: '3.10'
           PYTHON_ARCH: 'x64'
           BUILD_TYPE: 'wheel'
-          NUMPY_MIN: '1.20.0'
+          NUMPY_MIN: '1.21.6'
           imageName: 'windows-2019'
         Win-Python38-64bit-full-wheel:
           PYTHON_VERSION: '3.8'
@@ -48,11 +48,11 @@ jobs:
           BUILD_TYPE: 'wheel'
           NUMPY_MIN: '1.20.0'
           imageName: 'windows-2019'
-        Linux-Python311-64bit-full-wheel:
-          PYTHON_VERSION: '3.11'
+        Linux-Python310-64bit-full-wheel:
+          PYTHON_VERSION: '3.10'
           PYTHON_ARCH: 'x64'
           BUILD_TYPE: 'wheel'
-          NUMPY_MIN: '1.20.0'
+          NUMPY_MIN: '1.21.6'
           imageName: 'ubuntu-latest'
         Linux-Python38-64bit-full-wheel:
           PYTHON_VERSION: '3.8'
@@ -81,7 +81,7 @@ jobs:
   - script: python -m pip install --upgrade pip setuptools wheel
     displayName: 'Install tools'
   - script: >-
-      python -m pip install --only-binary=scipy
+      python -m pip install --only-binary=h5py,scipy
       cython
       hypothesis
       matplotlib
@@ -91,15 +91,11 @@ jobs:
       pytest-cov
       pytest-xdist
       scikit-learn
+      h5py>=2.10
       tqdm
       threadpoolctl
       fasteners
     displayName: 'Install dependencies'
-  # h5py wheels are not available for 3.11 yet, so we skip them if necessary
-  - script: >-
-      python -m pip install h5py>=2.10 --only-binary=h5py
-    displayName: 'h5py install'
-    condition: not(eq(variables['PYTHON_VERSION'], '3.11'))
   # for wheel install testing, we pin to an
   # older NumPy, the oldest version we support and that
   # supports the Python version in use
@@ -120,6 +116,7 @@ jobs:
       networkx
       parmed
       tidynamics>=1.0.0
+      rdkit>=2020.03.1
     displayName: 'Install additional dependencies for 64-bit tests'
     condition: and(succeeded(), eq(variables['PYTHON_ARCH'], 'x64'))
   - powershell: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -104,7 +104,6 @@ jobs:
       python -m pip install numpy==$(NUMPY_MIN)
     displayName: 'pin to older NumPy (wheel test)'
     condition: and(succeeded(), eq(variables['BUILD_TYPE'], 'wheel'))
-  # TODO: recent rdkit is not on PyPI
   - script: >-
       python -m pip install
       biopython
@@ -117,6 +116,7 @@ jobs:
       networkx
       parmed
       tidynamics>=1.0.0
+      rdkit>=2020.03.1
     displayName: 'Install additional dependencies for 64-bit tests'
     condition: and(succeeded(), eq(variables['PYTHON_ARCH'], 'x64'))
   - powershell: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,7 +40,7 @@ jobs:
           PYTHON_VERSION: '3.10'
           PYTHON_ARCH: 'x64'
           BUILD_TYPE: 'wheel'
-          NUMPY_MIN: '1.22.0'
+          NUMPY_MIN: '1.21.6'
           imageName: 'windows-2019'
         Win-Python38-64bit-full-wheel:
           PYTHON_VERSION: '3.8'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,7 +74,7 @@ jobs:
   # "manually"
   - powershell: |
       cd package
-      python -m pip install .
+      python -m pip -vvv install .
       cd ..
     displayName: 'Build MDAnalysis (wheel)'
     condition: and(succeeded(), eq(variables['BUILD_TYPE'], 'wheel'))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,13 +31,13 @@ jobs:
           PYTHON_ARCH: 'x64'
           BUILD_TYPE: 'normal'
           imageName: 'windows-2019'
-        Win-Python310-64bit-full:
-          PYTHON_VERSION: '3.10'
+        Win-Python311-64bit-full:
+          PYTHON_VERSION: '3.11'
           PYTHON_ARCH: 'x64'
           BUILD_TYPE: 'normal'
           imageName: 'windows-2019'
-        Win-Python39-64bit-full-wheel:
-          PYTHON_VERSION: '3.9'
+        Win-Python311-64bit-full-wheel:
+          PYTHON_VERSION: '3.11'
           PYTHON_ARCH: 'x64'
           BUILD_TYPE: 'wheel'
           NUMPY_MIN: '1.20.0'
@@ -48,8 +48,8 @@ jobs:
           BUILD_TYPE: 'wheel'
           NUMPY_MIN: '1.20.0'
           imageName: 'windows-2019'
-        Linux-Python39-64bit-full-wheel:
-          PYTHON_VERSION: '3.9'
+        Linux-Python311-64bit-full-wheel:
+          PYTHON_VERSION: '3.11'
           PYTHON_ARCH: 'x64'
           BUILD_TYPE: 'wheel'
           NUMPY_MIN: '1.20.0'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,7 +37,7 @@ jobs:
           BUILD_TYPE: 'normal'
           imageName: 'windows-2019'
         Win-Python310-64bit-full-wheel:
-          PYTHON_VERSION: '3.10'
+          PYTHON_VERSION: '3.9'
           PYTHON_ARCH: 'x64'
           BUILD_TYPE: 'wheel'
           NUMPY_MIN: '1.21.6'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -120,7 +120,7 @@ jobs:
       networkx
       parmed
       tidynamics>=1.0.0
-      rdkit>=2020.03.1
+      # rdkit>=2020.03.1
     displayName: 'Install additional dependencies for 64-bit tests'
     condition: and(succeeded(), eq(variables['PYTHON_ARCH'], 'x64'))
   - powershell: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,10 +37,10 @@ jobs:
           BUILD_TYPE: 'normal'
           imageName: 'windows-2019'
         Win-Python310-64bit-full-wheel:
-          PYTHON_VERSION: '3.9'
+          PYTHON_VERSION: '3.10'
           PYTHON_ARCH: 'x64'
           BUILD_TYPE: 'wheel'
-          NUMPY_MIN: '1.21.6'
+          NUMPY_MIN: '1.22.0'
           imageName: 'windows-2019'
         Win-Python38-64bit-full-wheel:
           PYTHON_VERSION: '3.8'
@@ -74,8 +74,7 @@ jobs:
   # "manually"
   - powershell: |
       cd package
-      python -m pip install numpy==1.21.6
-      python -m pip -vvv install .
+      python -m pip -vv install .
       cd ..
     displayName: 'Build MDAnalysis (wheel)'
     condition: and(succeeded(), eq(variables['BUILD_TYPE'], 'wheel'))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -117,7 +117,6 @@ jobs:
       networkx
       parmed
       tidynamics>=1.0.0
-      rdkit>=2020.03.1
     displayName: 'Install additional dependencies for 64-bit tests'
     condition: and(succeeded(), eq(variables['PYTHON_ARCH'], 'x64'))
   - powershell: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -81,7 +81,7 @@ jobs:
   - script: python -m pip install --upgrade pip setuptools wheel
     displayName: 'Install tools'
   - script: >-
-      python -m pip install --only-binary=h5py,scipy
+      python -m pip install --only-binary=scipy
       cython
       hypothesis
       matplotlib
@@ -91,11 +91,15 @@ jobs:
       pytest-cov
       pytest-xdist
       scikit-learn
-      h5py>=2.10
       tqdm
       threadpoolctl
       fasteners
     displayName: 'Install dependencies'
+  # h5py wheels are not available for 3.11 yet, so we skip them if necessary
+  - script: >-
+      python -m pip install h5py>=2.10 --only-binary=h5py
+    displayName: 'h5py install'
+    condition: not(eq(variables['PYTHON_VERSION'], '3.11'))
   # for wheel install testing, we pin to an
   # older NumPy, the oldest version we support and that
   # supports the Python version in use

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,7 +40,7 @@ jobs:
           PYTHON_VERSION: '3.10'
           PYTHON_ARCH: 'x64'
           BUILD_TYPE: 'wheel'
-          NUMPY_MIN: '1.21.6'
+          NUMPY_MIN: '1.22.3'
           imageName: 'windows-2019'
         Win-Python38-64bit-full-wheel:
           PYTHON_VERSION: '3.8'
@@ -74,7 +74,7 @@ jobs:
   # "manually"
   - powershell: |
       cd package
-      python -m pip -vv install .
+      python -m pip -v install .
       cd ..
     displayName: 'Build MDAnalysis (wheel)'
     condition: and(succeeded(), eq(variables['BUILD_TYPE'], 'wheel'))
@@ -116,6 +116,7 @@ jobs:
       networkx
       parmed
       tidynamics>=1.0.0
+      rdkit>=2020.03.1
     displayName: 'Install additional dependencies for 64-bit tests'
     condition: and(succeeded(), eq(variables['PYTHON_ARCH'], 'x64'))
   - powershell: |
@@ -127,9 +128,6 @@ jobs:
       cd ..
     displayName: 'Build MDAnalysis'
     condition: and(succeeded(), eq(variables['BUILD_TYPE'], 'normal'))
-  - script: >-
-      pip list
-    displayName: 'list of installed python packages'
   - powershell: |
       cd testsuite
       pytest MDAnalysisTests --disable-pytest-warnings -n 2 -rsx --cov=MDAnalysis

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -47,6 +47,8 @@ Enhancements
   * Added benchmarks for bonds topology attribute (Issue #3785, PR #3806)
 
 Changes
+ * Minimum numpy version for python 3.10 and Windows has been raised to 1.22.3
+   (PR #3903)
  * Auxiliary; determination of representative frames: The default value for
    cutoff is now None, not -1. Negative values are now turned
    to None. (PR #3749)

--- a/package/pyproject.toml
+++ b/package/pyproject.toml
@@ -13,9 +13,11 @@ requires = [
     # arm64 on darwin for py3.8+ requires numpy >=1.21.0
     "numpy==1.21.0; python_version=='3.8' and platform_machine=='arm64' and platform_system=='Darwin' and platform_python_implementation != 'PyPy'",
     "numpy==1.21.0; python_version=='3.9' and platform_machine=='arm64' and platform_system=='Darwin' and platform_python_implementation != 'PyPy'",
+    # Scipy: On windows avoid 1.21.6, 1.22.0, and 1.22.1 because they were built on vc142
+    "numpy==1.22.3; python_version=='3.10' and platform_system=='Windows' and platform_python_implementation != 'PyPy'",
     # As per https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg
-    # safest to build at 1.21.6 for all platforms
-    "numpy==1.21.6; python_version=='3.10' and platform_python_implementation != 'PyPy'",
+    # safest to build at 1.21.6 for all other platforms
+    "numpy==1.21.6; python_version=='3.10' and platform_system !='Windows'and platform_python_implementation != 'PyPy'",
     "numpy==1.23.2; python_version=='3.11' and platform_python_implementation != 'PyPy'",
     # For unreleased versions of Python there is currently no known supported
     # NumPy version. In that case we just let it be a bare NumPy install


### PR DESCRIPTION
Towards #3878

Changes made in this Pull Request:
 - bump up azure to py3.11
 - bump up gh actions CI to py3.11 for a "minimal deps" build (I know that openmm and rdkit don't have 3.11 builds yet, so we're blocked on a full deps build for now).
 - Add py3.11 to CD workflow

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
