### PR TITLE
Move libmdanalysis to lib

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -49,6 +49,7 @@ Enhancements
   * Added benchmarks for bonds topology attribute (Issue #3785, PR #3806)
 
 Changes
+ * Moved `libmdanalysis` cython header to `lib`(Issue #3912, PR #3913)
  * Auxiliary; determination of representative frames: The default value for
    cutoff is now None, not -1. Negative values are now turned
    to None. (PR #3749)

--- a/package/MDAnalysis/lib/libmdanalysis/__init__.pxd
+++ b/package/MDAnalysis/lib/libmdanalysis/__init__.pxd
@@ -1,4 +1,4 @@
 # Public Cython API for MDAnalysis. Centralises Cython core datastructures in a
 # single place. 
 
-from .coordinates cimport timestep
+from ..coordinates cimport timestep


### PR DESCRIPTION
Fixes #3912 

Changes made in this Pull Request:
 - Moves the `libmdanalysis` __init__.pxd file to lib.


PR Checklist
------------
 - [x] CHANGELOG updated?
 - [X] Issue raised/referenced?
