### PR TITLE
ENH: support pathlib in ReaderBase

### DIFF
--- a/package/MDAnalysis/coordinates/XDR.py
+++ b/package/MDAnalysis/coordinates/XDR.py
@@ -145,7 +145,7 @@ class XDRBaseReader(base.ReaderBase):
         super(XDRBaseReader, self).__init__(filename,
                                             convert_units=convert_units,
                                             **kwargs)
-        self._xdr = self._file(str(self.filename))
+        self._xdr = self._file(self.filename)
 
         self._sub = sub
         if self._sub is not None:

--- a/package/MDAnalysis/coordinates/XDR.py
+++ b/package/MDAnalysis/coordinates/XDR.py
@@ -145,7 +145,7 @@ class XDRBaseReader(base.ReaderBase):
         super(XDRBaseReader, self).__init__(filename,
                                             convert_units=convert_units,
                                             **kwargs)
-        self._xdr = self._file(self.filename)
+        self._xdr = self._file(str(self.filename))
 
         self._sub = sub
         if self._sub is not None:

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -1458,7 +1458,7 @@ class ReaderBase(ProtoReader):
     def __init__(self, filename, convert_units=True, **kwargs):
         super(ReaderBase, self).__init__()
 
-        self.filename = filename
+        self.filename = str(filename)
         self.convert_units = convert_units
 
         ts_kwargs = {}

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -143,6 +143,7 @@ from ..auxiliary.core import auxreader
 from ..auxiliary.core import get_auxreader_for
 from ..auxiliary import _AUXREADERS
 from ..lib.util import asiterable, Namespace, store_init_arguments
+from ..lib.util import NamedStream
 
 
 class FrameIteratorBase(object):
@@ -1458,7 +1459,10 @@ class ReaderBase(ProtoReader):
     def __init__(self, filename, convert_units=True, **kwargs):
         super(ReaderBase, self).__init__()
 
-        self.filename = str(filename)
+        if isinstance(filename, NamedStream):
+            self.filename = filename
+        else:
+            self.filename = str(filename)
         self.convert_units = convert_units
 
         ts_kwargs = {}

--- a/testsuite/MDAnalysisTests/coordinates/test_dcd.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_dcd.py
@@ -20,6 +20,7 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
+from pathlib import Path
 import numpy as np
 
 import MDAnalysis as mda
@@ -424,3 +425,14 @@ def test_ts_time(universe):
                  for ts in u.trajectory]
     times = [ts.time for ts in u.trajectory]
     assert_almost_equal(times, ref_times, decimal=5)
+
+
+def test_pathlib():
+    # regression test for DCD path of
+    # gh-2497
+    top = Path(PSF)
+    traj = Path(DCD)
+    u = mda.Universe(top, traj)
+    # we really only care that pathlib
+    # object handling worked
+    assert u.atoms.n_atoms == 3341

--- a/testsuite/MDAnalysisTests/coordinates/test_xdr.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_xdr.py
@@ -29,6 +29,7 @@ import os
 from os.path import split
 import shutil
 import subprocess
+from pathlib import Path
 
 from numpy.testing import (assert_equal,
                            assert_almost_equal,
@@ -904,3 +905,14 @@ class TestTRRReader_offsets(_GromacsReader_offsets):
         9155712, 10300176
     ])
     _reader = mda.coordinates.TRR.TRRReader
+
+
+def test_pathlib():
+    # regression test for XDR path of
+    # gh-2497
+    top = Path(GRO)
+    traj = Path(XTC)
+    u = mda.Universe(top, traj)
+    # we really only care that pathlib
+    # object handling worked
+    assert u.atoms.n_atoms == 47681


### PR DESCRIPTION
* the creation of a `Universe` object involving GROMACS formats should now accept `pathlib`
objects as requested in gh-2497; resolving that issue entirely is a separate matter, this branch focuses only on the GROMACS format and only if you proceed via the public `Universe` creation API

* probably could make it work in Cython directly, though I'm not convinced we need to do that for this part of the fix at least, and we probably should still support strings as well of course