### PR TITLE
Allow kwargs to be passed through in `universe.transfer_to_memory()` and `in_memory=True``

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -19,6 +19,8 @@ The rules for this file:
  * 2.4.0
 
 Fixes
+  * Kwargs passed through to `MemoryReader` when using `transfer_to_memory()`
+    and `in_memory=True`.
   * NoDataError raised on empty atomgroup provided to `DCDReader.timeseries` 
     was changed to ValueError (see #3901). A matching ValueError was added to
     `MemoryReader.timeseries`(PR #3890). 

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -574,12 +574,12 @@ class Universe(object):
                                  trj_n_atoms=self.trajectory.n_atoms))
 
         if in_memory:
-            self.transfer_to_memory(step=in_memory_step)
+            self.transfer_to_memory(step=in_memory_step, **kwargs)
 
         return self
 
     def transfer_to_memory(self, start=None, stop=None, step=None,
-                           verbose=False **kwargs):
+                           verbose=False, **kwargs):
         """Transfer the trajectory to in memory representation.
 
         Replaces the current trajectory reader object with one of type
@@ -641,8 +641,7 @@ class Universe(object):
                 dt=self.trajectory.ts.dt * step,
                 filename=self.trajectory.filename,
                 velocities=velocities,
-                forces=forces, **kwargs
-            )
+                forces=forces, **kwargs)
 
     # python 2 doesn't allow an efficient splitting of kwargs in function
     # argument signatures.

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -541,6 +541,8 @@ class Universe(object):
         .. versionchanged:: 0.17.0
            Now returns a :class:`Universe` instead of the tuple of file/array
            and detected file type.
+        .. versionchanged:: 2.4.0
+           Passes through kwargs if `in_memory=True`.
 
         """
         # filename==None happens when only a topology is provided
@@ -600,6 +602,8 @@ class Universe(object):
 
 
         .. versionadded:: 0.16.0
+        .. versionchanged:: 2.4.0
+           Passes through kwargs to MemoryReader
         """
         from ..coordinates.memory import MemoryReader
 

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -579,7 +579,7 @@ class Universe(object):
         return self
 
     def transfer_to_memory(self, start=None, stop=None, step=None,
-                           verbose=False):
+                           verbose=False **kwargs):
         """Transfer the trajectory to in memory representation.
 
         Replaces the current trajectory reader object with one of type
@@ -641,7 +641,7 @@ class Universe(object):
                 dt=self.trajectory.ts.dt * step,
                 filename=self.trajectory.filename,
                 velocities=velocities,
-                forces=forces,
+                forces=forces, **kwargs
             )
 
     # python 2 doesn't allow an efficient splitting of kwargs in function

--- a/testsuite/MDAnalysisTests/core/test_universe.py
+++ b/testsuite/MDAnalysisTests/core/test_universe.py
@@ -602,6 +602,14 @@ class TestInMemoryUniverse(object):
                      (3341, 78, 3),
                      err_msg="Unexpected shape of trajectory timeseries")
 
+    def test_transfer_to_memory_kwargs(self):
+        u = mda.Universe(PSF, DCD)
+        u.transfer_to_memory(example_kwarg=True)
+        assert(u.trajectory._kwargs['example_kwarg'])
+
+    def test_in_memory_kwargs(self):
+        u = mda.Universe(PSF, DCD, in_memory=True, example_kwarg=True)
+        assert(u.trajectory._kwargs['example_kwarg'])
 
 class TestCustomReaders(object):
     """


### PR DESCRIPTION
Fixes #3684 

Changes made in this Pull Request:
 -  Passes through kwargs to `MemoryReader`  when using `u.transfer_to_memory()` and `in_memory=True`


PR Checklist
------------
 - [X] Tests?
 - [X] Docs?
 - [x] CHANGELOG updated?
 - [X]  Issue raised/referenced?
