### PR TITLE
Replace deprecated pytest.warns(None)

### DIFF
--- a/testsuite/MDAnalysisTests/converters/test_rdkit.py
+++ b/testsuite/MDAnalysisTests/converters/test_rdkit.py
@@ -398,7 +398,8 @@ class TestRDKitConverter(object):
         with pytest.warns(UserWarning, match="Could not sanitize molecule"):
             u.atoms.convert_to.rdkit(NoImplicit=False)
         with warnings.catch_warnings():
-            warnings.simplefilter("error")
+            warnings.filterwarnings("error", "Could not sanitize molecule")
+            warnings.warn("Could not sanitize molecule: failed during step")
             u.atoms.convert_to.rdkit()
 
 

--- a/testsuite/MDAnalysisTests/converters/test_rdkit.py
+++ b/testsuite/MDAnalysisTests/converters/test_rdkit.py
@@ -399,7 +399,6 @@ class TestRDKitConverter(object):
             u.atoms.convert_to.rdkit(NoImplicit=False)
         with warnings.catch_warnings():
             warnings.filterwarnings("error", "Could not sanitize molecule")
-            warnings.warn("Could not sanitize molecule: failed during step")
             u.atoms.convert_to.rdkit()
 
 

--- a/testsuite/MDAnalysisTests/converters/test_rdkit.py
+++ b/testsuite/MDAnalysisTests/converters/test_rdkit.py
@@ -23,6 +23,7 @@
 
 import copy
 from io import StringIO
+import warnings
 import pytest
 import MDAnalysis as mda
 from MDAnalysis.topology.guessers import guess_atom_element

--- a/testsuite/MDAnalysisTests/converters/test_rdkit.py
+++ b/testsuite/MDAnalysisTests/converters/test_rdkit.py
@@ -400,9 +400,6 @@ class TestRDKitConverter(object):
         with warnings.catch_warnings():
             warnings.simplefilter("error")
             u.atoms.convert_to.rdkit()
-        if record:
-            assert all("Could not sanitize molecule" not in str(w.message)
-                       for w in record.list)
 
 
 @requires_rdkit

--- a/testsuite/MDAnalysisTests/converters/test_rdkit.py
+++ b/testsuite/MDAnalysisTests/converters/test_rdkit.py
@@ -255,9 +255,9 @@ class TestRDKitConverter(object):
             uo2.atoms.convert_to("RDKIT")
 
     def test_error_no_hydrogen_implicit(self, uo2):
-        with pytest.warns(None) as record:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
             uo2.atoms.convert_to.rdkit(NoImplicit=False)
-        assert len(record) == 0
 
     def test_warning_no_hydrogen_force(self, uo2):
         with pytest.warns(UserWarning,
@@ -396,7 +396,8 @@ class TestRDKitConverter(object):
         u = mda.Universe(mol)
         with pytest.warns(UserWarning, match="Could not sanitize molecule"):
             u.atoms.convert_to.rdkit(NoImplicit=False)
-        with pytest.warns(None) as record:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
             u.atoms.convert_to.rdkit()
         if record:
             assert all("Could not sanitize molecule" not in str(w.message)

--- a/testsuite/MDAnalysisTests/lib/test_util.py
+++ b/testsuite/MDAnalysisTests/lib/test_util.py
@@ -1535,7 +1535,7 @@ class TestStaticVariables(object):
 
 
 class TestWarnIfNotUnique(object):
-    """Tests concerning the decorator @warn_if_not_uniue
+    """Tests concerning the decorator @warn_if_not_unique
     """
 
     def warn_msg(self, func, group, group_name):
@@ -1569,10 +1569,11 @@ class TestWarnIfNotUnique(object):
 
         # Check that no warning is raised for a unique group:
         assert atoms.isunique
-        with pytest.warns(None) as w:
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
             x = outer(atoms)
             assert x == 0
-            assert not w.list
 
         # Check that a warning is raised for a group with duplicates:
         ag = atoms + atoms[0]
@@ -1700,9 +1701,9 @@ class TestWarnIfNotUnique(object):
         with warnings.catch_warnings(record=True) as record:
             warnings.resetwarnings()
             warnings.filterwarnings("ignore", category=UserWarning)
-            with pytest.warns(None) as w:
+            with warnings.catch_warnings():
+                warnings.simplefilter("error")
                 func(atoms)
-                assert not w.list
             assert len(record) == 0
 
 


### PR DESCRIPTION
That was the only other deprecation warning being thrown (at least from my local checks)

Changes made in this Pull Request:
 - replace pytest.warns(None) calls with the recommended approach from https://docs.pytest.org/en/latest/how-to/capture-warnings.html#additional-use-cases-of-warnings-in-tests


PR Checklist
------------
 - [x] Tests?
 - Docs?
 - CHANGELOG updated?
 - Issue raised/referenced?
