### PR TITLE
Add pickling of Atom, Residue, Segment and groups.

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -200,6 +200,7 @@ Chronological list of authors
   - Jennifer A Clark
   - Jake Fennick
   - Utsav Khatu
+  - Patricio Barletta
 
 
 External code

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,13 +13,16 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-??/??/?? IAlibay
+??/??/?? IAlibay, pgbarletta
 
  * 2.5.0
 
 Fixes
 
 Enhancements
+
+* Add pickling support for Atom, Residue, Segment, ResidueGroup 
+    and SegmentGroup. (PR #3953)
 
 Changes
 

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -119,6 +119,11 @@ def _unpickle(u, ix):
     return u.atoms[ix]
 
 
+# TODO 3.0: deprecate _unpickle in favor of _unpickle2.
+def _unpickle2(u, ix, cls):
+    return cls(ix, u)
+
+
 def _unpickle_uag(basepickle, selections, selstrs):
     bfunc, bargs = basepickle[0], basepickle[1:][0]
     basegroup = bfunc(*bargs)
@@ -2525,9 +2530,6 @@ class AtomGroup(GroupBase):
        Indexing an AtomGroup with ``None`` raises a ``TypeError``.
     """
 
-    def __reduce__(self):
-        return (_unpickle, (self.universe, self.ix))
-
     def __getattr__(self, attr):
         # special-case timestep info
         if attr in ('velocities', 'forces'):
@@ -2535,6 +2537,9 @@ class AtomGroup(GroupBase):
         elif attr == 'positions':
             raise NoDataError('This Universe has no coordinates')
         return super(AtomGroup, self).__getattr__(attr)
+
+    def __reduce__(self):
+        return (_unpickle, (self.universe, self.ix))
 
     @property
     def atoms(self):
@@ -3655,6 +3660,9 @@ class ResidueGroup(GroupBase):
        Indexing an ResidueGroup with ``None`` raises a ``TypeError``.
     """
 
+    def __reduce__(self):
+        return (_unpickle2, (self.universe, self.ix, ResidueGroup))
+
     @property
     def atoms(self):
         """An :class:`AtomGroup` of :class:`Atoms<Atom>` present in this
@@ -3847,6 +3855,9 @@ class SegmentGroup(GroupBase):
     .. versionchanged:: 2.1.0
        Indexing an SegmentGroup with ``None`` raises a ``TypeError``.
     """
+
+    def __reduce__(self):
+        return (_unpickle2, (self.universe, self.ix, SegmentGroup))
 
     @property
     def atoms(self):
@@ -4140,6 +4151,9 @@ class Atom(ComponentBase):
             me += ' and altLoc {}'.format(self.altLoc)
         return me + '>'
 
+    def __reduce__(self):
+        return (_unpickle2, (self.universe, self.ix, Atom))
+
     def __getattr__(self, attr):
         # special-case timestep info
         ts = {'velocity': 'velocities', 'force': 'forces'}
@@ -4262,6 +4276,9 @@ class Residue(ComponentBase):
 
         return me + '>'
 
+    def __reduce__(self):
+        return (_unpickle2, (self.universe, self.ix, Residue))
+
     @property
     def atoms(self):
         """An :class:`AtomGroup` of :class:`Atoms<Atom>` present in this
@@ -4311,6 +4328,9 @@ class Segment(ComponentBase):
         if hasattr(self, 'segid'):
             me += ' {}'.format(self.segid)
         return me + '>'
+
+    def __reduce__(self):
+        return (_unpickle2, (self.universe, self.ix, Segment))
 
     @property
     def atoms(self):

--- a/testsuite/MDAnalysisTests/core/test_atom.py
+++ b/testsuite/MDAnalysisTests/core/test_atom.py
@@ -20,9 +20,11 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-import MDAnalysis as mda
-import numpy as np
+import pickle
 import pytest
+import numpy as np
+
+import MDAnalysis as mda
 from MDAnalysis import NoDataError
 from MDAnalysisTests.datafiles import (
     PSF, DCD,
@@ -112,6 +114,12 @@ class TestAtom(object):
     def test_undefined_occupancy(self, universe):
         with pytest.raises(AttributeError):
             universe.atoms[0].occupancy
+
+    @pytest.mark.parametrize("ix", (1, -1))
+    def test_atom_pickle(self, universe, ix):
+        atm_out = universe.atoms[ix]
+        atm_in = pickle.loads(pickle.dumps(atm_out))
+        assert atm_in == atm_out
 
 
 class TestAtomNoForceNoVel(object):

--- a/testsuite/MDAnalysisTests/core/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/core/test_atomgroup.py
@@ -23,6 +23,7 @@
 from glob import glob
 import itertools
 from os import path
+import pickle
 
 import numpy as np
 
@@ -1789,3 +1790,17 @@ class TestAtomGroupSort(object):
         ref = [6, 5, 4, 3, 2, 1, 0]
         agsort = ag.sort("positions", keyfunc=lambda x: x[:, 1])
         assert np.array_equal(ref, agsort.ix)
+
+
+class TestAtomGroupPickle(object):
+    """Test AtomGroup pickling support."""
+
+    @pytest.fixture()
+    def universe(self):
+        return mda.Universe(PSF, DCD)
+
+    @pytest.mark.parametrize("selection", ("name CA", "segid 4AKE"))
+    def test_atomgroup_pickle(self, universe, selection):
+        sel = universe.select_atoms(selection)
+        atm = pickle.loads(pickle.dumps(sel))
+        assert_almost_equal(sel.positions, atm.positions)

--- a/testsuite/MDAnalysisTests/core/test_residue.py
+++ b/testsuite/MDAnalysisTests/core/test_residue.py
@@ -24,7 +24,7 @@ from numpy.testing import (
     assert_equal,
 )
 import pytest
-
+import pickle
 import MDAnalysis as mda
 
 from MDAnalysisTests.datafiles import PSF, DCD
@@ -54,3 +54,8 @@ def test_index(res):
 def test_atom_order(res):
     assert_equal(res.atoms.indices,
                  sorted(res.atoms.indices))
+
+
+def test_residue_pickle(res):
+    res_in = pickle.loads(pickle.dumps(res))
+    assert res_in == res

--- a/testsuite/MDAnalysisTests/core/test_residuegroup.py
+++ b/testsuite/MDAnalysisTests/core/test_residuegroup.py
@@ -21,7 +21,8 @@
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
 import numpy as np
-from numpy.testing import assert_equal
+import pickle
+from numpy.testing import assert_equal, assert_almost_equal
 import pytest
 
 import MDAnalysis as mda
@@ -281,3 +282,9 @@ class TestResidueGroup(object):
         prev_resids = [r.resid if r is not None else None for r in prev_res]
         assert_equal(len(prev_res), len(unsorted_rep_res))
         assert_equal(prev_resids, resids)
+
+    @pytest.mark.parametrize("selection", ("name CA", "segid 4AKE"))
+    def test_residuegroup_pickle(self, universe, selection):
+        seg_res = universe.select_atoms(selection).residues
+        seg = pickle.loads(pickle.dumps(seg_res))
+        assert_almost_equal(seg_res.atoms.positions, seg.atoms.positions)

--- a/testsuite/MDAnalysisTests/core/test_segment.py
+++ b/testsuite/MDAnalysisTests/core/test_segment.py
@@ -24,6 +24,7 @@ from numpy.testing import (
     assert_equal,
 )
 import pytest
+import pickle
 
 import MDAnalysis as mda
 
@@ -62,3 +63,9 @@ class TestSegment(object):
     def test_atom_order(self, universe):
         assert_equal(universe.segments[0].atoms.indices,
                      sorted(universe.segments[0].atoms.indices))
+
+    @pytest.mark.parametrize("ix", (1, -1))
+    def test_residue_pickle(self, universe, ix):
+        seg_out = universe.segments[ix]
+        seg_in = pickle.loads(pickle.dumps(seg_out))
+        assert seg_in == seg_out

--- a/testsuite/MDAnalysisTests/core/test_segmentgroup.py
+++ b/testsuite/MDAnalysisTests/core/test_segmentgroup.py
@@ -20,10 +20,9 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from numpy.testing import (
-    assert_equal,
-)
+from numpy.testing import assert_equal
 import pytest
+import pickle
 
 import MDAnalysis as mda
 
@@ -109,3 +108,15 @@ def test_set_segids_many():
 def test_atom_order(universe):
     assert_equal(universe.segments.atoms.indices,
                  sorted(universe.segments.atoms.indices))
+
+
+def test_segmentgroup_pickle():
+    u = mda.Universe.empty(10)
+    u.add_Segment(segid="X")
+    u.add_Segment(segid="Y")
+    u.add_Segment(segid="Z")
+    segids = ["A", "X", "Y", "Z"]
+    u.add_TopologyAttr("segids", values=["A", "X", "Y", "Z"])
+    seg_group = mda.SegmentGroup((1, 3), u)
+    seg = pickle.loads(pickle.dumps(seg_group))
+    assert_equal(seg.universe.segments.segids, segids)


### PR DESCRIPTION
From #3947

Changes made in this Pull Request:

- Add reduce() method to both ResidueGroup and SegmentGroup 
- Change _unpickle() so it can create any kind of group from its indices. 
- Add one test for each group in the parallelism section.


PR Checklist
------------
 - [X] Tests?
 - [x] Docs?
 - [X] CHANGELOG updated?
 - [X] Issue raised/referenced?

PD: sorry for the new PR. I synced up my fork from develop and that somehow closed the previous PR.
