### PR TITLE
[2.4.0 release fix] move readme to dynamic

### DIFF
--- a/package/pyproject.toml
+++ b/package/pyproject.toml
@@ -28,9 +28,8 @@ requires = [
 
 [project]
 name = "MDAnalysis"
-dynamic = ['version',]
+dynamic = ['version', 'readme']
 license = {file = "LICENSE"}
-readme = "README.rst"
 description = "An object-oriented toolkit to analyze molecular dynamics trajectories."
 authors = [
     {name = 'MDAnalysis Development Team', email = 'mdanalysis@numfocus.org'}


### PR DESCRIPTION
pip doesn't like objects outside of the root direction so we have to set it as dynamic and get the setup.py to extract the long_description properly.

I'm not sure how long this will remain a valid path, but setuptools doesn't seem to be in a hurry to remove things.

Changes made in this Pull Request:
 - move pyproject.toml `readme` to `dynamic`


PR Checklist
------------
 - Tests? - tested in a 2.4.0b0 release on testpypi https://test.pypi.org/project/MDAnalysis/2.4.0b0/
 - Docs?
 - CHANGELOG updated?
 - Issue raised/referenced?
