### PR TITLE
Pre-release 2.4.1 + fix pyproject.toml version pins

### DIFF
--- a/maintainer/conda/MDAnalysis/meta.yaml
+++ b/maintainer/conda/MDAnalysis/meta.yaml
@@ -1,7 +1,7 @@
 package:
   name: mdanalysis
   # This has to be changed after a release
-  version: "2.5.0-dev0"
+  version: "2.4.1"
 
 source:
    git_url: https://github.com/MDAnalysis/mdanalysis

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,17 +13,12 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-??/??/?? IAlibay
+12/17/22 IAlibay
 
- * 2.5.0
+ * 2.4.1
 
 Fixes
-
-Enhancements
-
-Changes
-
-Deprecations
+* Fixes pyproject.toml minimum pin for biopython
 
 
 12/16/22 IAlibay, Luthaf, hmacdope, rafaelpap, jbarnoud, BFedder, aya9aladdin,

--- a/package/MDAnalysis/version.py
+++ b/package/MDAnalysis/version.py
@@ -67,4 +67,4 @@ Data
 # e.g. with lib.log
 
 #: Release of MDAnalysis as a string, using `semantic versioning`_.
-__version__ = "2.5.0-dev0"  # NOTE: keep in sync with RELEASE in setup.py
+__version__ = "2.4.1"  # NOTE: keep in sync with RELEASE in setup.py

--- a/package/pyproject.toml
+++ b/package/pyproject.toml
@@ -40,7 +40,7 @@ maintainers = [
 requires-python = ">=3.8"
 dependencies = [
     'numpy>=1.20.0',
-    'biopython>=1.71',
+    'biopython>=1.80',
     'networkx>=2.0',
     'GridDataFormats>=0.4.0',
     'mmtf-python>=1.0.0',
@@ -84,6 +84,7 @@ extra_formats = [
     "h5py>=2.10",
     "chemfiles>=0.10",
     "pyedr>=0.7.0",
+    "pytng>=0.2.3",
 ]
 analysis = [
     "seaborn",

--- a/package/setup.py
+++ b/package/setup.py
@@ -67,7 +67,7 @@ import configparser
 from subprocess import getoutput
 
 # NOTE: keep in sync with MDAnalysis.__version__ in version.py
-RELEASE = "2.5.0-dev0"
+RELEASE = "2.4.1"
 
 is_release = 'dev' not in RELEASE
 

--- a/testsuite/MDAnalysisTests/__init__.py
+++ b/testsuite/MDAnalysisTests/__init__.py
@@ -97,7 +97,7 @@ import pytest
 logger = logging.getLogger("MDAnalysisTests.__init__")
 
 # keep in sync with RELEASE in setup.py
-__version__ = "2.5.0-dev0"
+__version__ = "2.4.1"
 
 
 # Do NOT import MDAnalysis at this level. Tests should do it themselves.

--- a/testsuite/setup.py
+++ b/testsuite/setup.py
@@ -87,7 +87,7 @@ if sys.version_info[:2] < (3, 8):
 
 if __name__ == '__main__':
     # this must be in-sync with MDAnalysis
-    RELEASE = "2.5.0-dev0"
+    RELEASE = "2.4.1"
     with open("README") as summary:
         LONG_DESCRIPTION = summary.read()
 


### PR DESCRIPTION
We goofed with the 2.4.0 release, pyproject.toml had an incorrect minimum pin. Also pytng was missing from the extras (much less of an issue).

@mdanalysis/coredevs Do we want to target this for a 2.4.1? The incorrect minimum pin probably isn't going to mess things up too much, but it'll break things if someone tries to just purely update MDA.

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
