### PR TITLE
remove deprecated attributes from nucleicacids results classes

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -22,6 +22,10 @@ Fixes
 Enhancements
 
 Changes
+  * The deprecated direct indexing and `times` from the `results` attribute of
+    analysis.nucleicacids' NucPairDist and WatsonCrickDist classes has been
+    removed. Please use the `results.pair_distances` and `times` attributes
+    instead (Issue #3744)
 
 Deprecations
 

--- a/package/MDAnalysis/analysis/nucleicacids.py
+++ b/package/MDAnalysis/analysis/nucleicacids.py
@@ -70,30 +70,6 @@ from .base import AnalysisBase, Results
 from MDAnalysis.core.groups import Residue
 
 
-# Remove in 2.5.0
-class DeprecatedResults(Results):
-    def __getitem__(self, key):
-        if key in self.data:
-            if key == "times":
-                wmsg = ("The `times` results attribute is deprecated and will "
-                        "be removed in MDAnalysis 2.5.0.")
-                warnings.warn(wmsg, DeprecationWarning)
-            return self.data[key]
-        if hasattr(self.__class__, "__missing__"):
-            return self.__class__.__missing__(self, key)
-        if isinstance(key, int) and key >= 0:
-            try:
-                item = self['pair_distances'][:, key]
-            except IndexError:
-                raise KeyError(key)
-            else:
-                wmsg = ("Accessing results via selection indices is "
-                        "deprecated and will be removed in MDAnalysis 2.5.0")
-                warnings.warn(wmsg, DeprecationWarning)
-                return item
-        raise KeyError(key)
-
-
 class NucPairDist(AnalysisBase):
     r"""Atom Pair distance calculation base class.
 
@@ -118,20 +94,6 @@ class NucPairDist(AnalysisBase):
     ----------
     times: numpy.ndarray
         Simulation times for analysis.
-    results: numpy.ndarray
-        Array of pair distances. First index is selection, second index is time.
-
-        .. deprecated:: 2.4.0
-           Will be removed in MDAnalysis 2.5.0. Please use
-           :attr:`results.pair_distances` instead.
-
-    results.times: numpy.ndarray
-        Simulation times used in analysis
-
-        .. deprecated:: 2.4.0
-           Will be removed in MDAnalysis 2.5.0. Please use
-           :attr:`times` instead.
-
     results.pair_distances: numpy.ndarray
         2D array of pair distances. First dimension is simulation time, second
         dimension contains the pair distances for each each entry pair in
@@ -147,12 +109,12 @@ class NucPairDist(AnalysisBase):
         If the selections given are not the same length
 
 
-    .. deprecated:: 2.4.0
-       Accessing results by passing selection indices to :attr:`results` is
-       now deprecated and will be removed in MDAnalysis version 2.5.0. Please
-       use :attr:`results.pair_distances` instead.
-       The :attr:`results.times` is deprecated and will be removed in version
-       2.5.0. Please use the class attribute :attr:`times` instead.
+    .. versionchanged:: 2.5.0
+       The ability to access by passing selection indices to :attr:`results` is
+       is now removed as of MDAnalysis version 2.5.0. Please use
+       :attr:`results.pair_distances` instead.
+       The :attr:`results.times` was deprecated and is now removed as of
+       MDAnalysis 2.5.0. Please use the class attribute :attr:`times` instead.
     """
 
     _s1: mda.AtomGroup
@@ -178,8 +140,6 @@ class NucPairDist(AnalysisBase):
             self._s1 += selection1[i]
             self._s2 += selection2[i]
 
-        self.results = DeprecatedResults()
-
     def _prepare(self) -> None:
         self._res_array: np.ndarray = np.zeros([self.n_frames, self._n_sel])
 
@@ -188,8 +148,6 @@ class NucPairDist(AnalysisBase):
         self._res_array[self._frame_index, :] = dist
 
     def _conclude(self) -> None:
-        # Remove 2.5.0
-        self.results['times'] = np.array(self.times)
         self.results['pair_distances'] = self._res_array
 
 
@@ -227,21 +185,6 @@ class WatsonCrickDist(NucPairDist):
     ----------
     times: numpy.ndarray
         Simulation times for analysis.
-    results: numpy.ndarray
-        Array of Watson-Crick basepair distances. First index is selection,
-        second index is time.
-
-        .. deprecated:: 2.4.0
-           Will be removed in MDAnalysis 2.5.0. Please use
-           :attr:`results.pair_distances` instead.
-
-    results.times: numpy.ndarray
-        Simulation times used in analysis
-
-        .. deprecated:: 2.4.0
-           Will be removed in MDAnalysis 2.5.0. Please use
-           :attr:`times` instead.
-
     results.pair_distances: numpy.ndarray
         2D array of Watson-Crick basepair distances. First dimension is
         simulation time, second dimension contains the pair distances for
@@ -258,12 +201,12 @@ class WatsonCrickDist(NucPairDist):
         If the selections given are not the same length
 
 
-    .. deprecated:: 2.4.0
+    .. versionchanged:: 2.5.0
        Accessing results by passing strand indices to :attr:`results` is
-       now deprecated and will be removed in MDAnalysis version 2.5.0. Please
+       was deprecated and is now removed as of MDAnalysis version 2.5.0. Please
        use :attr:`results.pair_distances` instead.
-       The :attr:`results.times` is deprecated and will be removed in version
-       2.5.0. Please use the class attribute :attr:`times` instead.
+       The :attr:`results.times` was deprecated and is now removed as of
+       MDAnalysis 2.5.0. Please use the class attribute :attr:`times` instead.
     """
 
     def __init__(self, strand1: List[Residue], strand2: List[Residue],

--- a/testsuite/MDAnalysisTests/analysis/test_nucleicacids.py
+++ b/testsuite/MDAnalysisTests/analysis/test_nucleicacids.py
@@ -49,7 +49,7 @@ def test_wc_dist(wc_rna):
     assert_allclose(wc_rna.results.pair_distances[0, 1], 4.1716404, atol=1e-3)
 
 
-@pytest.mark.parametrize('key', [0, 1, 2, 'parsnips', 'time', -1])
+@pytest.mark.parametrize("key", [0, 1, 2, "parsnips", "time", -1])
 def test_wc_dis_results_keyerrs(wc_rna, key):
     with pytest.raises(KeyError, match=f"{key}"):
         wc_rna.results[key]

--- a/testsuite/MDAnalysisTests/analysis/test_nucleicacids.py
+++ b/testsuite/MDAnalysisTests/analysis/test_nucleicacids.py
@@ -49,28 +49,7 @@ def test_wc_dist(wc_rna):
     assert_allclose(wc_rna.results.pair_distances[0, 1], 4.1716404, atol=1e-3)
 
 
-def test_wc_dist_sel_indices_deprecated(wc_rna):
-    wmsg = ("Accessing results via selection indices is "
-            "deprecated and will be removed in MDAnalysis 2.5.0")
-
-    with pytest.deprecated_call(match=wmsg):
-        for i in range(wc_rna._n_sel):
-            assert_allclose(
-                    wc_rna.results.pair_distances[:, i],
-                    wc_rna.results[i][0]
-            )
-
-
-def test_wc_dist_times_deprecated(wc_rna):
-    wmsg = ("The `times` results attribute is deprecated and will "
-            "be removed in MDAnalysis 2.5.0.")
-
-    with pytest.deprecated_call(match=wmsg):
-        assert_allclose(wc_rna.times, wc_rna.results.times)
-
-
-@pytest.mark.parametrize('key', [2, 'parsnips', 'time', -1])
+@pytest.mark.parametrize('key', [0, 1, 2, 'parsnips', 'time', -1])
 def test_wc_dis_results_keyerrs(wc_rna, key):
-
     with pytest.raises(KeyError, match=f"{key}"):
         wc_rna.results[key]


### PR DESCRIPTION
Fixes #3961 

Changes made in this Pull Request:
 - Remove deprecated `times` and direct indexing from the results dictionaries of the nucleicacids classes


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
