### PR TITLE
Switch to miniforge to avoid current failures

### DIFF
--- a/.github/workflows/gh-ci-cron.yaml
+++ b/.github/workflows/gh-ci-cron.yaml
@@ -93,7 +93,8 @@ jobs:
         auto-update-conda: true
         channel-priority: flexible
         channels: conda-forge, bioconda
-        mamba-version: "*"
+        uses-mamba: true
+        miniforge-variant: Mambaforge
         add-pip-as-python-dependency: true
         architecture: x64
 

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -3,11 +3,9 @@ on:
   push:
     branches:
       - develop
-      - master
   pull_request:
     branches:
       - develop
-      - master
 
 concurrency:
   # Probably overly cautious group naming.
@@ -91,7 +89,8 @@ jobs:
         channel-priority: flexible
         channels: conda-forge, bioconda
         add-pip-as-python-dependency: true
-        mamba-version: "*"
+        uses-mamba: true
+        miniforge-variant: Mambaforge
         architecture: x64
 
     - name: install_deps
@@ -155,7 +154,8 @@ jobs:
         channels: conda-forge, bioconda
         add-pip-as-python-dependency: true
         architecture: x64
-        mamba-version: "*"
+        uses-mamba: true
+        miniforge-variant: Mambaforge
 
     - name: install_deps
       uses: ./.github/actions/setup-deps

--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -32,7 +32,8 @@ jobs:
           channel-priority: flexible
           channels: conda-forge, bioconda
           add-pip-as-python-dependency: true
-          mamba-version: "*"
+          uses-mamba: true
+          miniforge-variant: Mambaforge
           architecture: x64
 
       - name: install_deps


### PR DESCRIPTION
Changes made in this Pull Request:
 - switching things to use miniforge where possible

Context: there's some problems with `use-mamba: *` which were causing all our CI runners to fail. Relevant upstream issue: https://github.com/conda-incubator/setup-miniconda/issues/274


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
