### PR TITLE
Fix test clobbering in lib/test_util.py

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,18 +13,18 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-??/??/?? IAlibay, pgbarletta, mglagolev, hmacdope
+??/??/?? IAlibay, pgbarletta, mglagolev, hmacdope, manuel.nuno.melo
 
  * 2.5.0
 
 Fixes
+  * Fix test clobbering in lib/test_util.py (PR #4000)
   * Fix MSD docs to use the correct error metric in example (Issue #3991)
   * Add 'PairIJ Coeffs' to the list of sections in LAMMPSParser.py
     (Issue #3336)
 
 Enhancements
-
-* Add pickling support for Atom, Residue, Segment, ResidueGroup 
+  * Add pickling support for Atom, Residue, Segment, ResidueGroup 
     and SegmentGroup. (PR #3953)
 
 Changes

--- a/testsuite/MDAnalysisTests/lib/test_util.py
+++ b/testsuite/MDAnalysisTests/lib/test_util.py
@@ -938,19 +938,11 @@ def test_check_weights_ok(atoms, weights, result):
                          [42,
                           "geometry",
                           np.array(1.0),
+                          np.array([12.0, 1.0, 12.0, 1.0]),
+                          [12.0, 1.0],
+                          np.array([[12.0, 1.0, 12.0]]),
+                          np.array([[12.0, 1.0, 12.0], [12.0, 1.0, 12.0]]),
                           ])
-def test_check_weights_raises_ValueError(atoms, weights):
-    with pytest.raises(ValueError):
-        util.get_weights(atoms, weights)
-
-
-@pytest.mark.parametrize('weights',
-                         [
-                             np.array([12.0, 1.0, 12.0, 1.0]),
-                             [12.0, 1.0],
-                             np.array([[12.0, 1.0, 12.0]]),
-                             np.array([[12.0, 1.0, 12.0], [12.0, 1.0, 12.0]]),
-                         ])
 def test_check_weights_raises_ValueError(atoms, weights):
     with pytest.raises(ValueError):
         util.get_weights(atoms, weights)


### PR DESCRIPTION
In the course of trying to get #3169 merged I came across linter warnings for clobbered function names in `test_util.py`. Indeed, a test is being shadowed by a later one with the same name. Just fixed that.

PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [ ] Issue raised/referenced?
