### PR TITLE
Fix deprecated numpy dec import issue

### DIFF
--- a/.github/workflows/gh-ci-cron.yaml
+++ b/.github/workflows/gh-ci-cron.yaml
@@ -1,5 +1,11 @@
 name: GH Actions Cron CI
 on:
+  push:
+    branches:
+      - develop
+  pull_request:
+    branches:
+      - develop
   schedule:
     # 3 am Tuesdays and Fridays
     - cron: "0 3 * * 2,5"

--- a/.github/workflows/gh-ci-cron.yaml
+++ b/.github/workflows/gh-ci-cron.yaml
@@ -1,11 +1,5 @@
 name: GH Actions Cron CI
 on:
-  push:
-    branches:
-      - develop
-  pull_request:
-    branches:
-      - develop
   schedule:
     # 3 am Tuesdays and Fridays
     - cron: "0 3 * * 2,5"
@@ -58,9 +52,7 @@ jobs:
       # overwrite installs by picking up nightly wheels
     - name: nightly_wheels
       run: |
-        #pip install --pre -U -i https://pypi.anaconda.org/scipy-wheels-nightly/simple scipy numpy h5py matplotlib
-        pip install --pre -U -i https://pypi.anaconda.org/scipy-wheels-nightly/simple matplotlib
-
+        pip install --pre -U -i https://pypi.anaconda.org/scipy-wheels-nightly/simple scipy numpy h5py matplotlib
 
     - name: list_deps
       run: |

--- a/.github/workflows/gh-ci-cron.yaml
+++ b/.github/workflows/gh-ci-cron.yaml
@@ -58,7 +58,8 @@ jobs:
       # overwrite installs by picking up nightly wheels
     - name: nightly_wheels
       run: |
-        pip install --pre -U -i https://pypi.anaconda.org/scipy-wheels-nightly/simple scipy numpy h5py matplotlib
+        pip install --pre -U -i https://pypi.anaconda.org/scipy-wheels-nightly/simple scipy numpy h5py
+        pip install matplotlib
 
 
     - name: list_deps

--- a/.github/workflows/gh-ci-cron.yaml
+++ b/.github/workflows/gh-ci-cron.yaml
@@ -58,8 +58,8 @@ jobs:
       # overwrite installs by picking up nightly wheels
     - name: nightly_wheels
       run: |
-        pip install --pre -U -i https://pypi.anaconda.org/scipy-wheels-nightly/simple scipy numpy h5py
-        pip install matplotlib
+        #pip install --pre -U -i https://pypi.anaconda.org/scipy-wheels-nightly/simple scipy numpy h5py matplotlib
+        pip install --pre -U -i https://pypi.anaconda.org/scipy-wheels-nightly/simple matplotlib
 
 
     - name: list_deps

--- a/testsuite/MDAnalysisTests/utils/test_selections.py
+++ b/testsuite/MDAnalysisTests/utils/test_selections.py
@@ -29,7 +29,7 @@ from io import StringIO
 import re
 
 import numpy as np
-from numpy.testing import TestCase, assert_equal, assert_array_equal
+from numpy.testing import assert_equal, assert_array_equal
 
 from MDAnalysis.tests.datafiles import PSF, DCD
 

--- a/testsuite/MDAnalysisTests/utils/test_selections.py
+++ b/testsuite/MDAnalysisTests/utils/test_selections.py
@@ -29,7 +29,7 @@ from io import StringIO
 import re
 
 import numpy as np
-from numpy.testing import TestCase, assert_equal, assert_array_equal, dec
+from numpy.testing import TestCase, assert_equal, assert_array_equal
 
 from MDAnalysis.tests.datafiles import PSF, DCD
 


### PR DESCRIPTION
CI cron has been failing for a couple of weeks, unfortunately I don't receive the emails so I only found out today :(

There are two failures:
  - dec is no longer part of numpy.testing (it's an unused import on our end anyways)
  - there's an issue with seaborn heatmap plotting due to some recent changes in matplotlib.

The dec import is something we can fix on our end, the seaborn one is an upstream issue.

PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
