### PR TITLE
Fix doctest for MDAnalysis.core.topology

### DIFF
--- a/package/MDAnalysis/core/topology.py
+++ b/package/MDAnalysis/core/topology.py
@@ -88,7 +88,10 @@ def make_downshift_arrays(upshift, nparents):
     --------
 
     To find the residue to atom mappings for a given atom to residue mapping:
-
+    
+    >>> import numpy as np
+    >>> import MDAnalysis as mda
+    >>> from MDAnalysis.core.topology import make_downshift_arrays
     >>> atom2res = np.array([0, 1, 0, 2, 2, 0, 2])
     >>> make_downshift_arrays(atom2res, 3)
     array([array([0, 2, 5]), array([1]), array([3, 4, 6]), None], dtype=object)

--- a/package/MDAnalysis/core/topology.py
+++ b/package/MDAnalysis/core/topology.py
@@ -88,7 +88,7 @@ def make_downshift_arrays(upshift, nparents):
     --------
 
     To find the residue to atom mappings for a given atom to residue mapping:
-    
+
     >>> import numpy as np
     >>> import MDAnalysis as mda
     >>> from MDAnalysis.core.topology import make_downshift_arrays


### PR DESCRIPTION
Part of #3925 for MDAnalysis.core.topology

Changes made in this Pull Request:
 -  Adds missing imports in docstrings in MDAnalysis.core.topology, so that the doctests pass for this particular file

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?
