### PR TITLE
Typo fix

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -206,6 +206,7 @@ Chronological list of authors
   - Christian Pfaendner
   - Pratham Chauhan
   - Meet Brijwani
+  - Moritz Schaeffler
 
 
 External code

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -15,7 +15,7 @@ The rules for this file:
 ------------------------------------------------------------------------------
 
 ??/??/?? IAlibay, pgbarletta, mglagolev, hmacdope, manuel.nuno.melo, chrispfae, 
-         ooprathamm, MeetB7, BFedder
+         ooprathamm, MeetB7, BFedder, MoSchaeffler
  * 2.5.0
 
 Fixes
@@ -24,6 +24,8 @@ Fixes
   * Fix MSD docs to use the correct error metric in example (Issue #3991)
   * Add 'PairIJ Coeffs' to the list of sections in LAMMPSParser.py
     (Issue #3336)
+  * Fix typo in the Documentation of Hydrogen Bond Analysis, missing ")"
+    (Issue #4026)
 
 Enhancements
   * Add distopia distance calculation library bindings as a selectable backend

--- a/package/MDAnalysis/analysis/hydrogenbonds/hbond_analysis.py
+++ b/package/MDAnalysis/analysis/hydrogenbonds/hbond_analysis.py
@@ -163,8 +163,8 @@ or water-water hydrogen bonds::
   water_hydrogens_sel = "resname TIP3 and name H1 H2"
   water_acceptors_sel = "resname TIP3 and name OH2"
 
-  hbonds.hydrogens_sel = f"({protein_hydrogens_sel}) or ({water_hydrogens_sel}"
-  hbonds.acceptors_sel = f"({protein_acceptors_sel}) or ({water_acceptors_sel}"
+  hbonds.hydrogens_sel = f"({protein_hydrogens_sel}) or ({water_hydrogens_sel})"
+  hbonds.acceptors_sel = f"({protein_acceptors_sel}) or ({water_acceptors_sel})"
 
   hbonds.run()
 


### PR DESCRIPTION
Fixes https://github.com/MDAnalysis/mdanalysis/issues/4026

Fixed a typo in the documentation of the selection in the example for hydrogen bonds between different group.

Changes made in this Pull Request:
 -  added two ")"
