### PR TITLE
[CI] Update main ci components to use py311 at upper limit

### DIFF
--- a/.github/workflows/gh-ci-cron.yaml
+++ b/.github/workflows/gh-ci-cron.yaml
@@ -35,7 +35,7 @@ jobs:
     - name: setup_miniconda
       uses: conda-incubator/setup-miniconda@v2
       with:
-        python-version: "3.10"
+        python-version: "3.11"
         miniforge-variant: Mambaforge
         miniforge-version: latest
         channel-priority: strict
@@ -88,7 +88,7 @@ jobs:
     - name: setup_miniconda
       uses: conda-incubator/setup-miniconda@v2
       with:
-        python-version: 3.9
+        python-version: 3.11
         auto-update-conda: true
         channel-priority: flexible
         channels: conda-forge, bioconda

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -26,17 +26,11 @@ jobs:
         fail-fast: false
         matrix:
           os: [ubuntu-latest, ]
-          python-version: ["3.8", "3.9", "3.10"]
+          python-version: ["3.8", "3.9", "3.10", "3.11"]
           full-deps: [true, ]
           install_hole: [true, ]
           codecov: [true, ]
           include:
-            - name: py311-ubuntu-min
-              os: ubuntu-latest
-              python-version: "3.11"
-              full-deps: false
-              install_hole: true
-              codecov: false
             - name: macOS_monterey_py39
               os: macOS-12
               python-version: 3.9

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,7 +41,7 @@ jobs:
           PYTHON_VERSION: '3.11'
           PYTHON_ARCH: 'x64'
           BUILD_TYPE: 'wheel'
-          NUMPY_MIN: '1.22.3'
+          NUMPY_MIN: '1.23.2'
           imageName: 'windows-2019'
         Win-Python38-64bit-full-wheel:
           PYTHON_VERSION: '3.8'
@@ -53,7 +53,7 @@ jobs:
           PYTHON_VERSION: '3.11'
           PYTHON_ARCH: 'x64'
           BUILD_TYPE: 'wheel'
-          NUMPY_MIN: '1.21.6'
+          NUMPY_MIN: '1.23.2'
           imageName: 'ubuntu-latest'
         Linux-Python38-64bit-full-wheel:
           PYTHON_VERSION: '3.8'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,13 +32,13 @@ jobs:
           PYTHON_ARCH: 'x64'
           BUILD_TYPE: 'normal'
           imageName: 'windows-2019'
-        Win-Python310-64bit-full:
-          PYTHON_VERSION: '3.10'
+        Win-Python311-64bit-full:
+          PYTHON_VERSION: '3.11'
           PYTHON_ARCH: 'x64'
           BUILD_TYPE: 'normal'
           imageName: 'windows-2019'
-        Win-Python310-64bit-full-wheel:
-          PYTHON_VERSION: '3.10'
+        Win-Python311-64bit-full-wheel:
+          PYTHON_VERSION: '3.11'
           PYTHON_ARCH: 'x64'
           BUILD_TYPE: 'wheel'
           NUMPY_MIN: '1.22.3'
@@ -49,8 +49,8 @@ jobs:
           BUILD_TYPE: 'wheel'
           NUMPY_MIN: '1.21.0'
           imageName: 'windows-2019'
-        Linux-Python310-64bit-full-wheel:
-          PYTHON_VERSION: '3.10'
+        Linux-Python311-64bit-full-wheel:
+          PYTHON_VERSION: '3.11'
           PYTHON_ARCH: 'x64'
           BUILD_TYPE: 'wheel'
           NUMPY_MIN: '1.21.6'


### PR DESCRIPTION
Most if not all of upstream is not py311 compliant, let's see if this works.

Changes made in this Pull Request:
 - 


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
