### PR TITLE
Add tests for exception raise in PSA (closes #4036)

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -208,6 +208,7 @@ Chronological list of authors
   - Meet Brijwani
   - Vishal Parmar
   - Moritz Schaeffler
+  - Xu Hong Chen
 
 External code
 -------------

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -15,10 +15,11 @@ The rules for this file:
 ------------------------------------------------------------------------------
   
 ??/??/?? IAlibay, pgbarletta, mglagolev, hmacdope, manuel.nuno.melo, chrispfae, 
-         ooprathamm, MeetB7, BFedder, v-parmar, MoSchaeffler, jbarnoud, jandom
+         ooprathamm, MeetB7, BFedder, v-parmar, MoSchaeffler, jbarnoud, jandom, xhgchen
  * 2.5.0
 
 Fixes
+  * Add tests for "No path data" exception raise in test_psa.py (Issue #4036)
   * Fix uninitialized `format` variable issue when calling `selections.get_writer` directly (PR #4043)
   * Fix tests should use results.rmsf to avoid DeprecationWarning (Issue #3695)
   * Fix EDRReader failing when parsing single-frame EDR files (Issue #3999)

--- a/testsuite/MDAnalysisTests/analysis/test_psa.py
+++ b/testsuite/MDAnalysisTests/analysis/test_psa.py
@@ -313,17 +313,23 @@ class TestPSAExceptions(object):
                              path_select='name CA',
                              targetdir=str(tmpdir))
 
-        # Case where user did not run Path.to_path()
+        # Case in class Path where user did not run Path.to_path()
+        # before running get_num_atoms()
         with pytest.raises(ValueError, match=match_exp):
             path.get_num_atoms()
 
-        # Cases where user did not run PSAnalysis.generate_paths()
+        # Case 1 in class PSA where user did not run
+        # PSAnalysis.generate_paths() before running get_num_atoms()
         with pytest.raises(ValueError, match=match_exp):
             psa.get_num_atoms()
 
+        # Case 2 in class PSA where user did not run
+        # PSAnalysis.generate_paths() before running get_num_paths()
         with pytest.raises(ValueError, match=match_exp):
             psa.get_num_paths()
 
+        # Case 3 in class PSA where user did not run
+        # PSAnalysis.generate_paths() before running get_paths()
         with pytest.raises(ValueError, match=match_exp):
             psa.get_paths()
 

--- a/testsuite/MDAnalysisTests/analysis/test_psa.py
+++ b/testsuite/MDAnalysisTests/analysis/test_psa.py
@@ -307,7 +307,7 @@ class TestPSAExceptions(object):
         did not run PSAnalysis.generate_paths()"""
         match_exp = "No path data"
         with pytest.raises(ValueError, match=match_exp):
-            psa = PSA.PSAnalysis([universe_no_path, universe_no_path, 
+            psa = PSA.PSAnalysis([universe_no_path, universe_no_path,
                                   universe_no_path],
                                  path_select='name CA',
                                  targetdir=str(tmpdir))
@@ -326,7 +326,7 @@ class TestPSAExceptions(object):
         did not run PSAnalysis.generate_paths()"""
         match_exp = "No path data"
         with pytest.raises(ValueError, match=match_exp):
-            psa = PSA.PSAnalysis([universe_no_path, universe_no_path, 
+            psa = PSA.PSAnalysis([universe_no_path, universe_no_path,
                                   universe_no_path],
                                  path_select='name CA',
                                  targetdir=str(tmpdir))

--- a/testsuite/MDAnalysisTests/analysis/test_psa.py
+++ b/testsuite/MDAnalysisTests/analysis/test_psa.py
@@ -291,7 +291,7 @@ class TestPSAnalysis(object):
         assert_almost_equal(hausd_pairs_dists2,
                             dists[self.iu1],
                             decimal=6, err_msg=err_msg)
-    
+
     def test_get_num_atoms_no_path_data(self, tmpdir):
         """Test that ValueError is raised when no path data i.e. user did not
         run generate_paths() in class PSAnalysis"""

--- a/testsuite/MDAnalysisTests/analysis/test_psa.py
+++ b/testsuite/MDAnalysisTests/analysis/test_psa.py
@@ -302,45 +302,29 @@ class TestPSAExceptions(object):
         universe1 = mda.Universe(PSF, DCD)
         return universe1
 
-    def test_get_num_atoms_psa_no_path_data(self, universe_no_path, tmpdir):
-        """Test that ValueError is raised when no path data i.e. user
-        did not run PSAnalysis.generate_paths()"""
+    def test_no_path_data(self, universe_no_path, tmpdir):
+        """Test that ValueError is raised when no path data. Covers
+        get_num_atoms() in class Path and get_num_atoms(),
+        get_num_paths(), and get_paths() in class PSAnalysis"""
         match_exp = "No path data"
-        with pytest.raises(ValueError, match=match_exp):
-            psa = PSA.PSAnalysis([universe_no_path, universe_no_path,
-                                  universe_no_path],
-                                 path_select='name CA',
-                                 targetdir=str(tmpdir))
-            psa.get_num_atoms()
+        path = PSA.Path(universe_no_path, universe_no_path)
+        psa = PSA.PSAnalysis([universe_no_path, universe_no_path,
+                              universe_no_path],
+                             path_select='name CA',
+                             targetdir=str(tmpdir))
 
-    def test_get_num_atoms_path_no_path_data(self, universe_no_path):
-        """Test that ValueError is raised when no path data i.e. user
-        did not run Path.to_path()"""
-        match_exp = "No path data"
+        # Case where user did not run Path.to_path()
         with pytest.raises(ValueError, match=match_exp):
-            path = PSA.Path(universe_no_path, universe_no_path)
             path.get_num_atoms()
 
-    def test_get_num_paths_psa_no_path_data(self, universe_no_path, tmpdir):
-        """Test that ValueError is raised when no path data i.e. user
-        did not run PSAnalysis.generate_paths()"""
-        match_exp = "No path data"
+        # Cases where user did not run PSAnalysis.generate_paths()
         with pytest.raises(ValueError, match=match_exp):
-            psa = PSA.PSAnalysis([universe_no_path, universe_no_path,
-                                  universe_no_path],
-                                 path_select='name CA',
-                                 targetdir=str(tmpdir))
+            psa.get_num_atoms()
+
+        with pytest.raises(ValueError, match=match_exp):
             psa.get_num_paths()
 
-    def test_get_paths_psa_no_path_data(self, universe_no_path, tmpdir):
-        """Test that ValueError is raised when no path data i.e. user
-        did not run PSAnalysis.generate_paths()"""
-        match_exp = "No path data"
         with pytest.raises(ValueError, match=match_exp):
-            psa = PSA.PSAnalysis([universe_no_path, universe_no_path,
-                                  universe_no_path],
-                                 path_select='name CA',
-                                 targetdir=str(tmpdir))
             psa.get_paths()
 
     def test_get_path_metric_func_bad_key(self):

--- a/testsuite/MDAnalysisTests/analysis/test_psa.py
+++ b/testsuite/MDAnalysisTests/analysis/test_psa.py
@@ -294,7 +294,7 @@ class TestPSAnalysis(object):
 
     def test_get_num_atoms_no_path_data(self, tmpdir):
         """Test that ValueError is raised when no path data i.e. user did not
-        run generate_paths() in class PSAnalysis"""
+        run PSAnalysis.generate_paths()"""
         match_exp = "No path data"
         with pytest.raises(ValueError, match=match_exp):
             universe1 = mda.Universe(PSF, DCD)
@@ -519,7 +519,7 @@ class DiscreteFrechetDistance(object):
 
 def test_get_num_atoms_path_no_path_data():
     """Test that ValueError is raised when no path data i.e. user did not
-    run generate_paths() in class Path"""
+    run Path.to_path()"""
     match_exp = "No path data"
     with pytest.raises(ValueError, match=match_exp):
         universe1 = mda.Universe(PSF, DCD)

--- a/testsuite/MDAnalysisTests/analysis/test_psa.py
+++ b/testsuite/MDAnalysisTests/analysis/test_psa.py
@@ -292,24 +292,56 @@ class TestPSAnalysis(object):
                             dists[self.iu1],
                             decimal=6, err_msg=err_msg)
 
-    def test_get_num_atoms_no_path_data(self, tmpdir):
-        """Test that ValueError is raised when no path data i.e. user did not
-        run PSAnalysis.generate_paths()"""
-        match_exp = "No path data"
-        with pytest.raises(ValueError, match=match_exp):
-            universe1 = mda.Universe(PSF, DCD)
-            universe2 = mda.Universe(PSF, DCD2)
-            universe_rev = mda.Universe(PSF, DCD)
-
-            psa = PSA.PSAnalysis([universe1, universe2, universe_rev],
-                                 path_select='name CA',
-                                 targetdir=str(tmpdir))
-            psa.get_num_atoms()
-
 
 class TestPSAExceptions(object):
     '''Tests for exceptions that should be raised
     or caught by code in the psa module.'''
+
+    @pytest.fixture()
+    def universe_no_path(self):
+        universe1 = mda.Universe(PSF, DCD)
+        return universe1
+
+    def test_get_num_atoms_psa_no_path_data(self, universe_no_path, tmpdir):
+        """Test that ValueError is raised when no path data i.e. user
+        did not run PSAnalysis.generate_paths()"""
+        match_exp = "No path data"
+        with pytest.raises(ValueError, match=match_exp):
+            psa = PSA.PSAnalysis([universe_no_path, universe_no_path, 
+                                  universe_no_path],
+                                 path_select='name CA',
+                                 targetdir=str(tmpdir))
+            psa.get_num_atoms()
+
+    def test_get_num_atoms_path_no_path_data(self, universe_no_path):
+        """Test that ValueError is raised when no path data i.e. user
+        did not run Path.to_path()"""
+        match_exp = "No path data"
+        with pytest.raises(ValueError, match=match_exp):
+            path = PSA.Path(universe_no_path, universe_no_path)
+            path.get_num_atoms()
+
+    def test_get_num_paths_psa_no_path_data(self, universe_no_path, tmpdir):
+        """Test that ValueError is raised when no path data i.e. user
+        did not run PSAnalysis.generate_paths()"""
+        match_exp = "No path data"
+        with pytest.raises(ValueError, match=match_exp):
+            psa = PSA.PSAnalysis([universe_no_path, universe_no_path, 
+                                  universe_no_path],
+                                 path_select='name CA',
+                                 targetdir=str(tmpdir))
+            psa.get_num_paths()
+
+    def test_get_paths_psa_no_path_data(self, universe_no_path, tmpdir):
+        """Test that ValueError is raised when no path data i.e. user
+        did not run PSAnalysis.generate_paths()"""
+        match_exp = "No path data"
+        with pytest.raises(ValueError, match=match_exp):
+            psa = PSA.PSAnalysis([universe_no_path, universe_no_path,
+                                  universe_no_path],
+                                 path_select='name CA',
+                                 targetdir=str(tmpdir))
+            psa.get_paths()
 
     def test_get_path_metric_func_bad_key(self):
         '''Test that KeyError is caught by
@@ -515,15 +547,3 @@ class DiscreteFrechetDistance(object):
         expected = 4.5
         actual = PSA.discrete_frechet(path_1, path_2)
         assert_almost_equal(actual, expected)
-
-
-def test_get_num_atoms_path_no_path_data():
-    """Test that ValueError is raised when no path data i.e. user did not
-    run Path.to_path()"""
-    match_exp = "No path data"
-    with pytest.raises(ValueError, match=match_exp):
-        universe1 = mda.Universe(PSF, DCD)
-        universe_rev = mda.Universe(PSF, DCD)
-
-        path = PSA.Path(universe1, universe_rev)
-        path.get_num_atoms()

--- a/testsuite/MDAnalysisTests/analysis/test_psa.py
+++ b/testsuite/MDAnalysisTests/analysis/test_psa.py
@@ -291,6 +291,21 @@ class TestPSAnalysis(object):
         assert_almost_equal(hausd_pairs_dists2,
                             dists[self.iu1],
                             decimal=6, err_msg=err_msg)
+    
+    def test_get_num_atoms_no_path_data(self, tmpdir):
+        """Test that ValueError is raised when no path data i.e. user did not
+        run generate_paths() in class PSAnalysis"""
+        match_exp = "No path data"
+        with pytest.raises(ValueError, match=match_exp):
+            universe1 = mda.Universe(PSF, DCD)
+            universe2 = mda.Universe(PSF, DCD2)
+            universe_rev = mda.Universe(PSF, DCD)
+
+            psa = PSA.PSAnalysis([universe1, universe2, universe_rev],
+                                 path_select='name CA',
+                                 targetdir=str(tmpdir))
+            psa.get_num_atoms()
+
 
 class TestPSAExceptions(object):
     '''Tests for exceptions that should be raised
@@ -500,3 +515,15 @@ class DiscreteFrechetDistance(object):
         expected = 4.5
         actual = PSA.discrete_frechet(path_1, path_2)
         assert_almost_equal(actual, expected)
+
+
+def test_get_num_atoms_path_no_path_data():
+    """Test that ValueError is raised when no path data i.e. user did not
+    run generate_paths() in class Path"""
+    match_exp = "No path data"
+    with pytest.raises(ValueError, match=match_exp):
+        universe1 = mda.Universe(PSF, DCD)
+        universe_rev = mda.Universe(PSF, DCD)
+
+        path = PSA.Path(universe1, universe_rev)
+        path.get_num_atoms()


### PR DESCRIPTION
* Closes #4036 
* Towards #597
* Checks that get_num_atoms in PSAnalysis and Path raises a ValueError and displays "No path data"