### PR TITLE
modernize testing code #3743

### DIFF
--- a/package/MDAnalysis/analysis/dielectric.py
+++ b/package/MDAnalysis/analysis/dielectric.py
@@ -129,7 +129,7 @@ class DielectricConstant(AnalysisBase):
             raise NoDataError("No charges defined given atomgroup.")
 
         if not np.allclose(self.atomgroup.total_charge(compound='fragments'),
-                           0.0, atol=1E-5):
+                           0.0, atol=1e-5):
             raise NotImplementedError("Analysis for non-neutral systems or"
                                       " systems with free charges are not"
                                       " available.")

--- a/package/MDAnalysis/visualization/streamlines_3D.py
+++ b/package/MDAnalysis/visualization/streamlines_3D.py
@@ -251,8 +251,8 @@ def per_core_work(start_frame_coord_array, end_frame_coord_array, dictionary_cub
         cube_half_side_length = scipy.spatial.distance.pdist(array_cube_vertices, 'euclidean').min() / 2.0
         array_cube_vertex_distances_from_centroid = scipy.spatial.distance.cdist(array_cube_vertices,
                                                                                  cube_centroid[np.newaxis, :])
-        np.testing.assert_almost_equal(array_cube_vertex_distances_from_centroid.min(),
-                                          array_cube_vertex_distances_from_centroid.max(), decimal=4,
+        np.testing.assert_allclose(array_cube_vertex_distances_from_centroid.min(),
+                                          array_cube_vertex_distances_from_centroid.max(), atol=1e-04,
                                           err_msg="not all cube vertex to centroid distances are the same, "
                                                   "so not a true cube")
         absolute_delta_coords = np.absolute(np.subtract(array_point_coordinates, cube_centroid))

--- a/testsuite/MDAnalysisTests/analysis/test_align.py
+++ b/testsuite/MDAnalysisTests/analysis/test_align.py
@@ -33,10 +33,8 @@ from MDAnalysisTests import executable_not_found
 from MDAnalysisTests.datafiles import (PSF, DCD, CRD, FASTA, ALIGN_BOUND,
                                        ALIGN_UNBOUND, PDB_helix)
 from numpy.testing import (
-    assert_almost_equal,
     assert_equal,
     assert_array_equal,
-    assert_array_almost_equal,
     assert_allclose,
 )
 
@@ -166,7 +164,7 @@ class TestGetMatchingAtoms(object):
 
         with expectation:
             rmsd = align.alignto(universe, reference, subselection=subselection)
-            assert_almost_equal(rmsd[1], 0.0, decimal=9)
+            assert_allclose(rmsd[1], 0.0, atol=1e-09)
 
     def test_no_atom_masses(self, universe):
         #if no masses are present
@@ -198,16 +196,16 @@ class TestAlign(object):
         first_frame = bb.positions
         universe.trajectory[-1]
         last_frame = bb.positions
-        assert_almost_equal(rms.rmsd(first_frame, first_frame), 0.0, 5,
+        assert_allclose(rms.rmsd(first_frame, first_frame), 0.0, 1e-05,
                             err_msg="error: rmsd(X,X) should be 0")
         # rmsd(A,B) = rmsd(B,A) should be exact but spurious failures in the
         # 9th decimal have been observed (see Issue 57 comment #1) so we relax
         # the test to 6 decimals.
         rmsd = rms.rmsd(first_frame, last_frame, superposition=True)
-        assert_almost_equal(
+        assert_allclose(
             rms.rmsd(last_frame, first_frame, superposition=True), rmsd, 6,
             err_msg="error: rmsd() is not symmetric")
-        assert_almost_equal(rmsd, 6.820321761927005, 5,
+        assert_allclose(rmsd, 6.820321761927005, 1e-05,
                             err_msg="RMSD calculation between 1st and last AdK frame gave wrong answer")
         # test masses as weights
         last_atoms_weight = universe.atoms.masses
@@ -216,7 +214,7 @@ class TestAlign(object):
         rmsd = align.alignto(universe, reference, weights='mass')
         rmsd_sup_weight = rms.rmsd(A, B, weights=last_atoms_weight, center=True,
                                    superposition=True)
-        assert_almost_equal(rmsd[1], rmsd_sup_weight, 6)
+        assert_allclose(rmsd[1], rmsd_sup_weight, 1e-06)
 
     def test_rmsd_custom_mass_weights(self, universe, reference):
         last_atoms_weight = universe.atoms.masses
@@ -226,7 +224,7 @@ class TestAlign(object):
                              weights=reference.atoms.masses)
         rmsd_sup_weight = rms.rmsd(A, B, weights=last_atoms_weight, center=True,
                                    superposition=True)
-        assert_almost_equal(rmsd[1], rmsd_sup_weight, 6)
+        assert_allclose(rmsd[1], rmsd_sup_weight, 1e-06)
 
     def test_rmsd_custom_weights(self, universe, reference):
         weights = np.zeros(universe.atoms.n_atoms)
@@ -234,7 +232,7 @@ class TestAlign(object):
         weights[ca.indices] = 1
         rmsd = align.alignto(universe, reference, select='name CA')
         rmsd_weights = align.alignto(universe, reference, weights=weights)
-        assert_almost_equal(rmsd[1], rmsd_weights[1], 6)
+        assert_allclose(rmsd[1], rmsd_weights[1], 1e-06)
 
     def test_AlignTraj_outfile_default(self, universe, reference, tmpdir):
         with tmpdir.as_cwd():
@@ -284,8 +282,8 @@ class TestAlign(object):
         x = align.AlignTraj(universe, reference, filename=outfile).run()
         fitted = mda.Universe(PSF, outfile)
 
-        assert_almost_equal(x.results.rmsd[0], 6.9290, decimal=3)
-        assert_almost_equal(x.results.rmsd[-1], 5.2797e-07, decimal=3)
+        assert_allclose(x.results.rmsd[0], 6.9290, atol=1e-03)
+        assert_allclose(x.results.rmsd[-1], 5.2797e-07, atol=1e-03)
 
         # RMSD against the reference frame
         # calculated on Mac OS X x86 with MDA 0.7.2 r689
@@ -298,8 +296,8 @@ class TestAlign(object):
         x = align.AlignTraj(universe, reference,
                             filename=outfile, weights='mass').run()
         fitted = mda.Universe(PSF, outfile)
-        assert_almost_equal(x.results.rmsd[0], 0, decimal=3)
-        assert_almost_equal(x.results.rmsd[-1], 6.9033, decimal=3)
+        assert_allclose(x.results.rmsd[0], 0, atol=1e-03)
+        assert_allclose(x.results.rmsd[-1], 6.9033, atol=1e-03)
 
         self._assert_rmsd(reference, fitted, 0, 0.0,
                           weights=universe.atoms.masses)
@@ -326,8 +324,8 @@ class TestAlign(object):
                             filename=outfile,
                             weights=reference.atoms.masses).run()
         fitted = mda.Universe(PSF, outfile)
-        assert_almost_equal(x.results.rmsd[0], 0, decimal=3)
-        assert_almost_equal(x.results.rmsd[-1], 6.9033, decimal=3)
+        assert_allclose(x.results.rmsd[0], 0, atol=1e-03)
+        assert_allclose(x.results.rmsd[-1], 6.9033, atol=1e-03)
 
         self._assert_rmsd(reference, fitted, 0, 0.0,
                           weights=universe.atoms.masses)
@@ -347,8 +345,8 @@ class TestAlign(object):
         x = align.AlignTraj(universe, reference, filename=outfile,
                             in_memory=True).run()
         assert x.filename is None
-        assert_almost_equal(x.results.rmsd[0], 6.9290, decimal=3)
-        assert_almost_equal(x.results.rmsd[-1], 5.2797e-07, decimal=3)
+        assert_allclose(x.results.rmsd[0], 6.9290, atol=1e-03)
+        assert_allclose(x.results.rmsd[-1], 5.2797e-07, atol=1e-03)
 
         # check in memory trajectory
         self._assert_rmsd(reference, universe, 0, 6.929083044751061)
@@ -358,7 +356,7 @@ class TestAlign(object):
         fitted.trajectory[frame]
         rmsd = rms.rmsd(reference.atoms.positions, fitted.atoms.positions,
                         superposition=True)
-        assert_almost_equal(rmsd, desired, decimal=5,
+        assert_allclose(rmsd, desired, atol=1e-05,
                             err_msg="frame {0:d} of fit does not have "
                                     "expected RMSD".format(frame))
 
@@ -394,7 +392,7 @@ class TestAlign(object):
 
         align.alignto(u_free, u_bound, select=selection)
         assert_array_almost_equal(segB_bound.positions, segB_free.positions,
-                                  decimal=3)
+                                  atol=1e-03)
 
 
 def _get_aligned_average_positions(ref_files, ref, select="all", **kwargs):
@@ -437,31 +435,31 @@ class TestAverageStructure(object):
     def test_average_structure(self, universe, reference):
         ref, rmsd = _get_aligned_average_positions(self.ref_files, reference)
         avg = align.AverageStructure(universe, reference).run()
-        assert_almost_equal(avg.results.universe.atoms.positions, ref,
-                            decimal=4)
-        assert_almost_equal(avg.results.rmsd, rmsd)
+        assert_allclose(avg.results.universe.atoms.positions, ref,
+                            atol=1e-04)
+        assert_allclose(avg.results.rmsd, rmsd)
 
     def test_average_structure_mass_weighted(self, universe, reference):
         ref, rmsd = _get_aligned_average_positions(self.ref_files, reference, weights='mass')
         avg = align.AverageStructure(universe, reference, weights='mass').run()
-        assert_almost_equal(avg.results.universe.atoms.positions, ref,
-                            decimal=4)
-        assert_almost_equal(avg.results.rmsd, rmsd)
+        assert_allclose(avg.results.universe.atoms.positions, ref,
+                            atol=1e-04)
+        assert_allclose(avg.results.rmsd, rmsd)
 
     def test_average_structure_select(self, universe, reference):
         select = 'protein and name CA and resid 3-5'
         ref, rmsd = _get_aligned_average_positions(self.ref_files, reference, select=select)
         avg = align.AverageStructure(universe, reference, select=select).run()
-        assert_almost_equal(avg.results.universe.atoms.positions, ref,
-                            decimal=4)
-        assert_almost_equal(avg.results.rmsd, rmsd)
+        assert_allclose(avg.results.universe.atoms.positions, ref,
+                            atol=1e-04)
+        assert_allclose(avg.results.rmsd, rmsd)
 
     def test_average_structure_no_ref(self, universe):
         ref, rmsd = _get_aligned_average_positions(self.ref_files, universe)
         avg = align.AverageStructure(universe).run()
-        assert_almost_equal(avg.results.universe.atoms.positions, ref,
-                            decimal=4)
-        assert_almost_equal(avg.results.rmsd, rmsd)
+        assert_allclose(avg.results.universe.atoms.positions, ref,
+                            atol=1e-04)
+        assert_allclose(avg.results.rmsd, rmsd)
 
     def test_average_structure_no_msf(self, universe):
         avg = align.AverageStructure(universe).run()
@@ -484,15 +482,15 @@ class TestAverageStructure(object):
         universe.trajectory[0]
         ref, rmsd = _get_aligned_average_positions(self.ref_files, u)
         avg = align.AverageStructure(universe, ref_frame=ref_frame).run()
-        assert_almost_equal(avg.results.universe.atoms.positions, ref,
-                            decimal=4)
-        assert_almost_equal(avg.results.rmsd, rmsd)
+        assert_allclose(avg.results.universe.atoms.positions, ref,
+                            atol=1e-04)
+        assert_allclose(avg.results.rmsd, rmsd)
 
     def test_average_structure_in_memory(self, universe):
         avg = align.AverageStructure(universe, in_memory=True).run()
         reference_coordinates = universe.trajectory.timeseries().mean(axis=1)
-        assert_almost_equal(avg.results.universe.atoms.positions,
-                            reference_coordinates, decimal=4)
+        assert_allclose(avg.results.universe.atoms.positions,
+                            reference_coordinates, atol=1e-04)
         assert avg.filename is None
 
 

--- a/testsuite/MDAnalysisTests/analysis/test_base.py
+++ b/testsuite/MDAnalysisTests/analysis/test_base.py
@@ -27,7 +27,7 @@ import pytest
 
 import numpy as np
 
-from numpy.testing import assert_equal, assert_almost_equal
+from numpy.testing import assert_equal, assert_allclose
 
 import MDAnalysis as mda
 from MDAnalysis.analysis import base
@@ -194,7 +194,7 @@ def test_start_stop_step(u, run_kwargs, frames):
     assert an.n_frames == len(frames)
     assert_equal(an.found_frames, frames)
     assert_equal(an.frames, frames, err_msg=FRAMES_ERR)
-    assert_almost_equal(an.times, frames+1, decimal=4, err_msg=TIMES_ERR)
+    assert_allclose(an.times, frames+1, atol=1e-04, err_msg=TIMES_ERR)
 
 
 @pytest.mark.parametrize('run_kwargs, frames', [
@@ -251,7 +251,7 @@ def test_frames_times():
     assert an.n_frames == len(frames)
     assert_equal(an.found_frames, frames)
     assert_equal(an.frames, frames, err_msg=FRAMES_ERR)
-    assert_almost_equal(an.times, frames*100, decimal=4, err_msg=TIMES_ERR)
+    assert_allclose(an.times, frames*100, atol=1e-04, err_msg=TIMES_ERR)
 
 
 def test_verbose(u):
@@ -366,7 +366,7 @@ def test_AnalysisFromFunction_args_content(u):
     ans = base.AnalysisFromFunction(mass_xyz, protein, another, masses)
     assert len(ans.args) == 3
     result = np.sum(ans.run().results.timeseries)
-    assert_almost_equal(result, -317054.67757345125, decimal=6)
+    assert_allclose(result, -317054.67757345125, atol=1e-06)
     assert (ans.args[0] is protein) and (ans.args[1] is another)
     assert ans._trajectory is protein.universe.trajectory
 

--- a/testsuite/MDAnalysisTests/analysis/test_bat.py
+++ b/testsuite/MDAnalysisTests/analysis/test_bat.py
@@ -23,7 +23,7 @@
 from __future__ import absolute_import
 
 import numpy as np
-from numpy.testing import assert_equal, assert_almost_equal
+from numpy.testing import assert_equal, assert_allclose
 import pytest
 import copy
 
@@ -66,35 +66,35 @@ class TestBAT(object):
 
     def test_bat_coordinates(self, bat):
         test_bat = np.load(BATArray)
-        assert_almost_equal(
+        assert_allclose(
             bat,
             test_bat,
-            5,
+            1e-05,
             err_msg="error: BAT coordinates should match test values")
 
     def test_bat_coordinates_single_frame(self, selected_residues):
         bat = BAT(selected_residues).run(start=1, stop=2).results.bat
         test_bat = [np.load(BATArray)[1]]
-        assert_almost_equal(
+        assert_allclose(
             bat,
             test_bat,
-            5,
+            1e-05,
             err_msg="error: BAT coordinates should match test values")
 
     def test_bat_reconstruction(self, selected_residues, bat):
         R = BAT(selected_residues)
         XYZ = R.Cartesian(bat[0])
-        assert_almost_equal(XYZ, selected_residues.positions, 5,
+        assert_allclose(XYZ, selected_residues.positions, 1e-05,
             err_msg="error: Reconstructed Cartesian coordinates " + \
                     "don't match original")
 
     def test_bat_IO(self, bat_npz, selected_residues, bat):
         R2 = BAT(selected_residues, filename=bat_npz)
         test_bat = R2.results.bat
-        assert_almost_equal(
+        assert_allclose(
             bat,
             test_bat,
-            5,
+            1e-05,
             err_msg="error: Loaded BAT coordinates should match test values")
 
     def test_bat_nobonds(self):
@@ -133,7 +133,7 @@ class TestBAT(object):
         R = BAT(selected_residues)
         pre_transformation = copy.deepcopy(bat[0])
         R.Cartesian(bat[0])
-        assert_almost_equal(
+        assert_allclose(
             pre_transformation, bat[0],
             err_msg="BAT.Cartesian modified input data"
         )

--- a/testsuite/MDAnalysisTests/analysis/test_contacts.py
+++ b/testsuite/MDAnalysisTests/analysis/test_contacts.py
@@ -27,10 +27,9 @@ from MDAnalysis.analysis import contacts
 from MDAnalysis.analysis.distances import distance_array
 
 from numpy.testing import (
-    assert_almost_equal,
+    assert_allclose,
     assert_equal,
     assert_array_equal,
-    assert_array_almost_equal
 )
 import numpy as np
 
@@ -48,8 +47,8 @@ from MDAnalysisTests.datafiles import (
 def test_soft_cut_q():
     # just check some of the extremal points
     assert contacts.soft_cut_q([0], [0]) == .5
-    assert_almost_equal(contacts.soft_cut_q([100], [0]), 0)
-    assert_almost_equal(contacts.soft_cut_q([-100], [0]), 1)
+    assert_allclose(contacts.soft_cut_q([100], [0]), 0)
+    assert_allclose(contacts.soft_cut_q([-100], [0]), 1e-01)
 
 
 def test_soft_cut_q_folded():
@@ -67,7 +66,7 @@ def test_soft_cut_q_folded():
     lambda_constant = 1.8
     Q = 1 / (1 + np.exp(beta * (r - lambda_constant * r0)))
 
-    assert_almost_equal(Q.mean(), 1.0, decimal=3)
+    assert_allclose(Q.mean(), 1.0, atol=1e-03)
 
 
 def test_soft_cut_q_unfolded():
@@ -85,7 +84,7 @@ def test_soft_cut_q_unfolded():
     lambda_constant = 1.8
     Q = 1 / (1 + np.exp(beta * (r - lambda_constant * r0)))
 
-    assert_almost_equal(Q.mean(), 0.0, decimal=1)
+    assert_allclose(Q.mean(), 0.0, atol=1e-01)
 
 
 @pytest.mark.parametrize('r, cutoff, expected_value', [
@@ -263,7 +262,7 @@ class TestContacts(object):
         q.run()
 
         results = soft_cut(f, u, sel, sel)
-        assert_almost_equal(q.results.timeseries[:, 1], results[:, 1])
+        assert_allclose(q.results.timeseries[:, 1], results[:, 1])
 
     def test_villin_unfolded(self):
         # both folded
@@ -280,7 +279,7 @@ class TestContacts(object):
         q.run()
 
         results = soft_cut(f, u, sel, sel)
-        assert_almost_equal(q.results.timeseries[:, 1], results[:, 1])
+        assert_allclose(q.results.timeseries[:, 1], results[:, 1])
 
     def test_hard_cut_method(self, universe):
         ca = self._run_Contacts(universe)

--- a/testsuite/MDAnalysisTests/analysis/test_diffusionmap.py
+++ b/testsuite/MDAnalysisTests/analysis/test_diffusionmap.py
@@ -25,7 +25,7 @@ import MDAnalysis.analysis.diffusionmap as diffusionmap
 import numpy as np
 import pytest
 from MDAnalysisTests.datafiles import PDB, XTC
-from numpy.testing import assert_array_almost_equal, assert_allclose
+from numpy.testing import assert_allclose
 
 
 @pytest.fixture(scope='module')

--- a/testsuite/MDAnalysisTests/analysis/test_dihedrals.py
+++ b/testsuite/MDAnalysisTests/analysis/test_dihedrals.py
@@ -21,7 +21,7 @@
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
 import numpy as np
-from numpy.testing import assert_almost_equal, assert_equal
+from numpy.testing import assert_equal, assert_allclose
 import matplotlib
 import pytest
 
@@ -46,7 +46,7 @@ class TestDihedral(object):
         dihedral = Dihedral([atomgroup]).run()
         test_dihedral = np.load(DihedralArray)
 
-        assert_almost_equal(dihedral.results.angles, test_dihedral, 5,
+        assert_allclose(dihedral.results.angles, test_dihedral, 1e-05,
                             err_msg="error: dihedral angles should "
                             "match test values")
 
@@ -54,7 +54,7 @@ class TestDihedral(object):
         dihedral = Dihedral([atomgroup]).run(start=5, stop=6)
         test_dihedral = [np.load(DihedralArray)[5]]
 
-        assert_almost_equal(dihedral.results.angles, test_dihedral, 5,
+        assert_allclose(dihedral.results.angles, test_dihedral, 1e-05,
                             err_msg="error: dihedral angles should "
                             "match test vales")
 
@@ -62,7 +62,7 @@ class TestDihedral(object):
         dihedral = Dihedral([atomgroup, atomgroup]).run()
         test_dihedral = np.load(DihedralsArray)
 
-        assert_almost_equal(dihedral.results.angles, test_dihedral, 5,
+        assert_allclose(dihedral.results.angles, test_dihedral, 1e-05,
                             err_msg="error: dihedral angles should "
                             "match test values")
 
@@ -91,7 +91,7 @@ class TestRamachandran(object):
     def test_ramachandran(self, universe, rama_ref_array):
         rama = Ramachandran(universe.select_atoms("protein")).run()
 
-        assert_almost_equal(rama.results.angles, rama_ref_array, 5,
+        assert_allclose(rama.results.angles, rama_ref_array, 1e-05,
                             err_msg="error: dihedral angles should "
                             "match test values")
 
@@ -99,7 +99,7 @@ class TestRamachandran(object):
         rama = Ramachandran(universe.select_atoms("protein")).run(
             start=5, stop=6)
 
-        assert_almost_equal(rama.results.angles[0], rama_ref_array[5], 5,
+        assert_allclose(rama.results.angles[0], rama_ref_array[5], 1e-05,
                             err_msg="error: dihedral angles should "
                             "match test values")
 
@@ -107,7 +107,7 @@ class TestRamachandran(object):
         rama = Ramachandran(universe.select_atoms("resname GLY")).run()
         test_rama = np.load(GLYRamaArray)
 
-        assert_almost_equal(rama.results.angles, test_rama, 5,
+        assert_allclose(rama.results.angles, test_rama, 1e-05,
                             err_msg="error: dihedral angles should "
                             "match test values")
 
@@ -169,14 +169,14 @@ class TestJanin(object):
         janin = Janin(u.select_atoms("protein")).run()
 
         # Test precision lowered to account for platform differences with osx
-        assert_almost_equal(janin.results.angles, ref_array, 3,
+        assert_allclose(janin.results.angles, ref_array, 1e-03,
                             err_msg="error: dihedral angles should "
                             "match test values")
 
     def test_janin_single_frame(self, universe, janin_ref_array):
         janin = Janin(universe.select_atoms("protein")).run(start=5, stop=6)
 
-        assert_almost_equal(janin.results.angles[0], janin_ref_array[5], 3,
+        assert_allclose(janin.results.angles[0], janin_ref_array[5], 1e-03,
                             err_msg="error: dihedral angles should "
                             "match test values")
 
@@ -184,7 +184,7 @@ class TestJanin(object):
         janin = Janin(universe.select_atoms("resname LYS")).run()
         test_janin = np.load(LYSJaninArray)
 
-        assert_almost_equal(janin.results.angles, test_janin, 3,
+        assert_allclose(janin.results.angles, test_janin, 3,
                             err_msg="error: dihedral angles should "
                             "match test values")
 

--- a/testsuite/MDAnalysisTests/analysis/test_distances.py
+++ b/testsuite/MDAnalysisTests/analysis/test_distances.py
@@ -29,8 +29,8 @@ from MDAnalysisTests.datafiles import GRO
 
 import MDAnalysis.analysis.distances
 
-from numpy.testing import (assert_equal, assert_array_equal, assert_almost_equal, 
-                           assert_array_almost_equal,assert_allclose)
+from numpy.testing import (assert_equal,assert_array_equal, 
+                           assert_allclose)
 import numpy as np
 
 

--- a/testsuite/MDAnalysisTests/analysis/test_encore.py
+++ b/testsuite/MDAnalysisTests/analysis/test_encore.py
@@ -32,7 +32,7 @@ import warnings
 import platform
 
 import pytest
-from numpy.testing import assert_equal, assert_almost_equal
+from numpy.testing import assert_equal, assert_allclose, assert_almost_equal
 
 from MDAnalysisTests.datafiles import DCD, DCD2, PSF, TPR, XTC
 from MDAnalysisTests import block_import
@@ -153,7 +153,7 @@ inconsistent results")
             "Calculated RMSD values differ from "
             "the reference implementation")
         for i, rmsd in enumerate(reference.results.rmsd):
-            assert_almost_equal(conf_dist_matrix[0, i], rmsd[2], 3, err_msg)
+            assert_allclose(conf_dist_matrix[0, i], rmsd[2], atol=1e-03, err_msg=err_msg)
 
     def test_rmsd_matrix_with_superimposition_custom_weights(self, ens1):
         conf_dist_matrix = encore.confdistmatrix.conformational_distance_matrix(
@@ -173,7 +173,7 @@ inconsistent results")
             n_jobs=1)
 
         for i in range(conf_dist_matrix_custom.size):
-            assert_almost_equal(conf_dist_matrix_custom[0, i], conf_dist_matrix[0, i])
+            assert_allclose(conf_dist_matrix_custom[0, i], conf_dist_matrix[0, i])
 
     def test_rmsd_matrix_without_superimposition(self, ens1):
         selection_string = "name CA"
@@ -192,7 +192,7 @@ inconsistent results")
             n_jobs=1)
 
         print(repr(confdist_matrix.as_array()[0, :]))
-        assert_almost_equal(confdist_matrix.as_array()[0,:], reference_rmsd, decimal=3,
+        assert_allclose(confdist_matrix.as_array()[0,:], reference_rmsd, atol=1e-03,
                             err_msg="calculated RMSD values differ from reference")
 
     def test_ensemble_superimposition(self):
@@ -252,7 +252,7 @@ inconsistent results")
         covariance = encore.covariance.covariance_matrix(ens1,
                                                          select="name CA and resnum 1:3",
                                                          estimator=encore.covariance.shrinkage_covariance_estimator)
-        assert_almost_equal(covariance, reference_cov, decimal=4,
+        assert_allclose(covariance, reference_cov, atol=1e-04,
                             err_msg="Covariance matrix from covariance estimation not as expected")
 
     def test_covariance_matrix_with_reference(self, ens1):
@@ -271,16 +271,15 @@ inconsistent results")
                                                          select="name CA and resnum 1:3",
                                                          estimator=encore.covariance.shrinkage_covariance_estimator,
                                                          reference=ens1)
-        err_msg = (
-                "Covariance matrix from covariance estimation not as expected"
-                )
-        assert_almost_equal(covariance, reference_cov, 4, err_msg)
+
+
+        assert_allclose(covariance, reference_cov, 4, err_msg="Covariance matrix from covariance estimation not as expected")
 
     def test_hes_to_self(self, ens1):
         results, details = encore.hes([ens1, ens1])
         result_value = results[0, 1]
         expected_value = 0.
-        assert_almost_equal(result_value, expected_value,
+        assert_allclose(result_value, expected_value,
                             err_msg="Harmonic Ensemble Similarity to itself\
                                  not zero:{0:f}".format(result_value))
 
@@ -298,7 +297,7 @@ inconsistent results")
                                                              ens2.select_atoms('name CA').masses))
         result_value = results[0, 1]
         result_value_custom = results_custom[0, 1]
-        assert_almost_equal(result_value, result_value_custom)
+        assert_allclose(result_value, result_value_custom)
 
     def test_hes_align(self, ens1, ens2):
         # This test is massively sensitive!
@@ -306,7 +305,7 @@ inconsistent results")
         results, details = encore.hes([ens1, ens2], align=True)
         result_value = results[0,1]
         expected_value = 2047.05
-        assert_almost_equal(result_value, expected_value, decimal=-3,
+        assert_almost_equal(result_value, expected_value, atol=-3,
                             err_msg="Unexpected value for Harmonic Ensemble Similarity: {0:f}. Expected {1:f}.".format(result_value, expected_value))
 
     def test_ces_to_self(self, ens1):
@@ -315,21 +314,21 @@ inconsistent results")
             clustering_method=encore.AffinityPropagationNative(preference = -3.0))
         result_value = results[0,1]
         expected_value = 0.
-        assert_almost_equal(result_value, expected_value,
+        assert_allclose(result_value, expected_value,
                             err_msg="ClusteringEnsemble Similarity to itself not zero: {0:f}".format(result_value))
 
     def test_ces(self, ens1, ens2):
         results, details = encore.ces([ens1, ens2])
         result_value = results[0,1]
         expected_value = 0.51
-        assert_almost_equal(result_value, expected_value, decimal=2,
+        assert_allclose(result_value, expected_value, atol=1e-02,
                             err_msg="Unexpected value for Cluster Ensemble Similarity: {0:f}. Expected {1:f}.".format(result_value, expected_value))
 
     def test_dres_to_self(self, ens1):
         results, details = encore.dres([ens1, ens1])
         result_value = results[0,1]
         expected_value = 0.
-        assert_almost_equal(result_value, expected_value, decimal=2,
+        assert_allclose(result_value, expected_value, atol=1e-02,
                             err_msg="Dim. Reduction Ensemble Similarity to itself not zero: {0:f}".format(result_value))
 
     def test_dres(self, ens1, ens2):
@@ -348,14 +347,14 @@ inconsistent results")
                                        distance_matrix = distance_matrix)
         result_value = results[0,1]
         expected_value = 0.68
-        assert_almost_equal(result_value, expected_value, decimal=1,
+        assert_allclose(result_value, expected_value, atol=1e-01,
                             err_msg="Unexpected value for Dim. reduction Ensemble Similarity: {0:f}. Expected {1:f}.".format(result_value, expected_value))
 
     def test_ces_convergence(self, ens1):
         expected_values = [0.3443593, 0.1941854, 0.06857104,  0.]
         results = encore.ces_convergence(ens1, 5)
         for i,ev in enumerate(expected_values):
-            assert_almost_equal(ev, results[i], decimal=2,
+            assert_allclose(ev, results[i], atol=1e-02,
                                 err_msg="Unexpected value for Clustering Ensemble similarity in convergence estimation")
 
     def test_dres_convergence(self, ens1):
@@ -365,7 +364,7 @@ inconsistent results")
         expected_values = [0.3, 0.]
         results = encore.dres_convergence(ens1, 10)
         try:
-            assert_almost_equal(results[:,0], expected_values, decimal=1)
+            assert_allclose(results[:,0], expected_values, atol=1e-01)
         except AssertionError:
             # Random test failure is very rare, but repeating the failed test
             # just once would only assert that the test passes with 50%
@@ -376,7 +375,7 @@ inconsistent results")
                           category=RuntimeWarning)
             for i in range(10):
                 results = encore.dres_convergence(ens1, 10)
-                assert_almost_equal(results[:,0], expected_values, decimal=1,
+                assert_allclose(results[:,0], expected_values, atol=1e-01,
                                     err_msg="Unexpected value for Dim. "
                                             "reduction Ensemble similarity in "
                                             "convergence estimation")
@@ -396,8 +395,8 @@ inconsistent results")
             "Unexpected standard deviation for bootstrapped samples in"
             " Harmonic Ensemble similarity"
         )
-        assert_almost_equal(average, expected_average, -2, err_msg)
-        assert_almost_equal(stdev, expected_stdev, -2, error_msg)
+        assert_allclose(average, expected_average, -2, err_msg)
+        assert_allclose(stdev, expected_stdev, -2, error_msg)
 
     def test_ces_error_estimation(self, ens1):
         expected_average = 0.03
@@ -410,9 +409,9 @@ inconsistent results")
         average = averages[0,1]
         stdev = stdevs[0,1]
 
-        assert_almost_equal(average, expected_average, decimal=1,
+        assert_allclose(average, expected_average, atol=1e-01,
                             err_msg="Unexpected average value for bootstrapped samples in Clustering Ensemble similarity")
-        assert_almost_equal(stdev, expected_stdev, decimal=0,
+        assert_allclose(stdev, expected_stdev, atol=0,
                             err_msg="Unexpected standard daviation  for bootstrapped samples in Clustering Ensemble similarity")
 
     def test_ces_error_estimation_ensemble_bootstrap(self, ens1):
@@ -434,7 +433,7 @@ inconsistent results")
         err_msg = (
             "Unexpected average value for bootstrapped samples in"
             " Clustering Ensemble similarity")
-        assert_almost_equal(
+        assert_allclose(
             average,
             expected_average,
             1,
@@ -443,7 +442,7 @@ inconsistent results")
             "Unexpected standard deviation for bootstrapped samples in"
             " Clustering Ensemble similarity"
             )
-        assert_almost_equal(
+        assert_allclose(
             stdev,
             expected_stdev,
             1,
@@ -820,7 +819,7 @@ class TestEncoreDimensionalityReduction(object):
             encore.reduce_dimensionality([ens1, ens2, ens1])
         coordinates_ens1 = coordinates[:,np.where(details["ensemble_membership"]==1)]
         coordinates_ens3 = coordinates[:,np.where(details["ensemble_membership"]==3)]
-        assert_almost_equal(coordinates_ens1, coordinates_ens3, decimal=0,
+        assert_allclose(coordinates_ens1, coordinates_ens3, atol=0,
                      err_msg="Unexpected result in dimensionality reduction: {0}".format(coordinates))
 
 

--- a/testsuite/MDAnalysisTests/analysis/test_gnm.py
+++ b/testsuite/MDAnalysisTests/analysis/test_gnm.py
@@ -26,7 +26,7 @@ from unittest.mock import patch
 import MDAnalysis as mda
 import MDAnalysis.analysis.gnm
 
-from numpy.testing import assert_almost_equal
+from numpy.testing import assert_allclose
 import numpy as np
 import pytest
 
@@ -44,8 +44,8 @@ def test_gnm(universe, tmpdir):
     gnm.run()
     result = gnm.results
     assert len(result.times) == 10
-    assert_almost_equal(gnm.results.times, np.arange(0, 1000, 100), decimal=4)
-    assert_almost_equal(gnm.results.eigenvalues,
+    assert_allclose(gnm.results.times, np.arange(0, 1000, 100), atol=1e-04)
+    assert_allclose(gnm.results.eigenvalues,
       [2.0287113e-15, 4.1471575e-15, 1.8539533e-15, 4.3810359e-15,
        3.9607304e-15, 4.1289113e-15, 2.5501084e-15, 4.0498182e-15,
        4.2058769e-15, 3.9839431e-15])
@@ -56,15 +56,15 @@ def test_gnm_run_step(universe):
     gnm.run(step=3)
     result = gnm.results
     assert len(result.times) == 4
-    assert_almost_equal(gnm.results.times, np.arange(0, 1200, 300), decimal=4)
-    assert_almost_equal(gnm.results.eigenvalues,
+    assert_allclose(gnm.results.times, np.arange(0, 1200, 300), atol=1e-04)
+    assert_allclose(gnm.results.eigenvalues,
       [2.0287113e-15, 4.3810359e-15, 2.5501084e-15, 3.9839431e-15])
 
 
 def test_generate_kirchoff(universe):
     gnm = mda.analysis.gnm.GNMAnalysis(universe)
     gen = gnm.generate_kirchoff()
-    assert_almost_equal(gen[0],
+    assert_allclose(gen[0],
       [7,-1,-1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
        0, 0, 0, 0, 0,-1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -93,10 +93,10 @@ def test_closeContactGNMAnalysis(universe):
     gnm.run(stop=2)
     result = gnm.results
     assert len(result.times) == 2
-    assert_almost_equal(gnm.results.times, (0,  100), decimal=4)
-    assert_almost_equal(gnm.results.eigenvalues, [0.1502614,  0.1426407])
+    assert_allclose(gnm.results.times, (0,  100), atol=1e-04)
+    assert_allclose(gnm.results.eigenvalues, [0.1502614,  0.1426407])
     gen = gnm.generate_kirchoff()
-    assert_almost_equal(gen[0],
+    assert_allclose(gen[0],
       [16.326744128018923, -2.716098853586913, -1.94736842105263, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
        0.0, 0.0, 0.0, 0.0, -0.05263157894736842, 0.0, 0.0, 0.0, -3.3541953679557905, 0.0, -1.4210526315789465, 0.0, 0.0, 0.0, 0.0,
        0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
@@ -119,10 +119,10 @@ def test_closeContactGNMAnalysis_weights_None(universe):
     gnm.run(stop=2)
     result = gnm.results
     assert len(result.times) == 2
-    assert_almost_equal(gnm.results.times, (0, 100), decimal=4)
-    assert_almost_equal(gnm.results.eigenvalues, [2.4328739,  2.2967251])
+    assert_allclose(gnm.results.times, (0, 100), atol=1e-04)
+    assert_allclose(gnm.results.eigenvalues, [2.4328739,  2.2967251])
     gen = gnm.generate_kirchoff()
-    assert_almost_equal(gen[0],
+    assert_allclose(gen[0],
       [303.0, -58.0, -37.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -1.0,
        0.0, 0.0, 0.0, -67.0, 0.0, -27.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
        0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,

--- a/testsuite/MDAnalysisTests/analysis/test_helix_analysis.py
+++ b/testsuite/MDAnalysisTests/analysis/test_helix_analysis.py
@@ -24,7 +24,7 @@ import re
 
 import numpy as np
 import pytest
-from numpy.testing import assert_equal, assert_almost_equal, assert_allclose
+from numpy.testing import assert_equal, assert_allclose
 
 import MDAnalysis as mda
 from MDAnalysis.analysis import helix_analysis as hel
@@ -119,7 +119,7 @@ def test_local_screw_angles_plane_circle():
     screw = hel.local_screw_angles([1, 0, 0], [0, 1, 0], xyz)
     correct = np.zeros_like(angdeg)
     correct[(angdeg > 180)] = 180
-    assert_almost_equal(screw, correct)
+    assert_allclose(screw, correct)
 
 
 def test_local_screw_angles_ortho_circle():
@@ -138,7 +138,7 @@ def test_local_screw_angles_ortho_circle():
     correct[(angdeg < 180)] = 90
     correct[(angdeg > 180)] = -90
     correct[0] = correct[15] = 0
-    assert_almost_equal(screw, correct)
+    assert_allclose(screw, correct)
 
 
 def test_local_screw_angles_around_circle():
@@ -154,7 +154,7 @@ def test_local_screw_angles_around_circle():
     screw = hel.local_screw_angles([0, 1, 0], [1, 0, 0], xyz)
     angdeg[-14:] = -angdeg[1:15][::-1]
     angdeg[-15] = 180
-    assert_almost_equal(screw, angdeg)
+    assert_allclose(screw, angdeg)
 
 
 def test_local_screw_angles_around_circle_rising():
@@ -172,7 +172,7 @@ def test_local_screw_angles_around_circle_rising():
     screw = hel.local_screw_angles([0, 1, 0], [1, 0, 0], xyz)
     angdeg[-14:] = -angdeg[1:15][::-1]
     angdeg[-15] = 180
-    assert_almost_equal(screw, angdeg)
+    assert_allclose(screw, angdeg)
 
 
 def test_local_screw_angles_parallel_axes():
@@ -184,7 +184,7 @@ def test_local_screw_angles_parallel_axes():
     """
     xyz = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
     angles = hel.local_screw_angles([1, 0, 0], [-1, 0, 0], xyz)
-    assert_almost_equal(angles, [0, 90, 0])
+    assert_allclose(angles, [0, 90, 0])
 
 
 @pytest.fixture()
@@ -230,24 +230,24 @@ def zigzag():
 def test_helix_analysis_zigzag(zigzag, ref_axis, screw_angles):
     properties = hel.helix_analysis(zigzag.atoms.positions,
                                     ref_axis=ref_axis)
-    assert_almost_equal(properties['local_twists'], 180, decimal=4)
-    assert_almost_equal(properties['local_nres_per_turn'], 2, decimal=4)
-    assert_almost_equal(properties['global_axis'],
-                        [0, 0, -1], decimal=4)
+    assert_allclose(properties['local_twists'], 180, atol=1e-04)
+    assert_allclose(properties['local_nres_per_turn'], 2, atol=1e-04)
+    assert_allclose(properties['global_axis'],
+                        [0, 0, -1], atol=1e-04)
     # all 0 vectors
-    assert_almost_equal(properties['local_axes'], 0, decimal=4)
-    assert_almost_equal(properties['local_bends'], 0, decimal=4)
-    assert_almost_equal(properties['all_bends'], 0, decimal=4)
-    assert_almost_equal(properties['local_heights'], 0, decimal=4)
-    assert_almost_equal(properties['local_helix_directions'][0::2],
-                        [[-1, 0, 0]]*49, decimal=4)
-    assert_almost_equal(properties['local_helix_directions'][1::2],
-                        [[1, 0, 0]]*49, decimal=4)
+    assert_allclose(properties['local_axes'], 0, atol=1e-04)
+    assert_allclose(properties['local_bends'], 0, atol=1e-04)
+    assert_allclose(properties['all_bends'], 0, atol=1e-04)
+    assert_allclose(properties['local_heights'], 0, atol=1e-04)
+    assert_allclose(properties['local_helix_directions'][0::2],
+                        [[-1, 0, 0]]*49, atol=1e-04)
+    assert_allclose(properties['local_helix_directions'][1::2],
+                        [[1, 0, 0]]*49, atol=1e-04)
     origins = zigzag.atoms.positions[1:-1].copy()
     origins[:, 0] = 0
-    assert_almost_equal(properties['local_origins'], origins, decimal=4)
-    assert_almost_equal(properties['local_screw_angles'],
-                        screw_angles*49, decimal=4)
+    assert_allclose(properties['local_origins'], origins, atol=1e-04)
+    assert_allclose(properties['local_screw_angles'],
+                        screw_angles*49, atol=1e-04)
 
 
 def square_oct(n_rep=10):
@@ -280,18 +280,18 @@ def test_helix_analysis_square_oct():
                                     ref_axis=[0, 0, 1])
     twist_trans = [102.76438, 32.235607]
     twists = ([90]*2 + twist_trans + [45]*6 + twist_trans[::-1]) * n_rep
-    assert_almost_equal(properties['local_twists'], twists[:n_atoms-3],
-                        decimal=4)
+    assert_allclose(properties['local_twists'], twists[:n_atoms-3],
+                        atol=1e-04)
     res_trans = [3.503159, 11.167775]
     res = ([4]*2 + res_trans + [8]*6 + res_trans[::-1]) * n_rep
-    assert_almost_equal(properties['local_nres_per_turn'], res[:n_atoms-3],
-                        decimal=4)
-    assert_almost_equal(properties['global_axis'],
-                        [-1, 0, 0], decimal=3)
-    assert_almost_equal(properties['local_axes']-[1, 0, 0], 0, decimal=4)
-    assert_almost_equal(properties['local_bends'], 0, decimal=4)
-    assert_almost_equal(properties['all_bends'], 0, decimal=4)
-    assert_almost_equal(properties['local_heights'], 1, decimal=4)
+    assert_allclose(properties['local_nres_per_turn'], res[:n_atoms-3],
+                        atol=1e-04)
+    assert_allclose(properties['global_axis'],
+                        [-1, 0, 0], atol=1e-03)
+    assert_allclose(properties['local_axes']-[1, 0, 0], 0, atol=1e-04)
+    assert_allclose(properties['local_bends'], 0, atol=1e-04)
+    assert_allclose(properties['all_bends'], 0, atol=1e-04)
+    assert_allclose(properties['local_heights'], 1, atol=1e-04)
 
     loc_rot = [[0.,  0.,  1.],
                [0., -1.,  0.],
@@ -305,8 +305,8 @@ def test_helix_analysis_square_oct():
                [0.,  0., -1.],
                [0.,  0.70710677, -0.70710677],
                [0.,  0.97528684, -0.2209424]] * n_rep
-    assert_almost_equal(properties['local_helix_directions'],
-                        loc_rot[:n_atoms-2], decimal=4)
+    assert_allclose(properties['local_helix_directions'],
+                        loc_rot[:n_atoms-2], atol=1e-04)
 
     origins = u.atoms.positions.copy()[1:-1]
     origins[:, 1:] = ([[0.,   0.],  # square
@@ -321,8 +321,8 @@ def test_helix_analysis_square_oct():
                        [0.,   0.],
                        [-1.3141878,   1.3141878],  # octagon -> square
                        [0.34966463,   0.14732757]]*n_rep)[:len(origins)]
-    assert_almost_equal(properties['local_origins'], origins,
-                        decimal=4)
+    assert_allclose(properties['local_origins'], origins,
+                        atol=1e-04)
 
     # calculated to the x-y plane
     # all input vectors (loc_rot) are in y-z plane
@@ -332,8 +332,8 @@ def test_helix_analysis_square_oct():
              -102.764]*n_rep
 
     # not quite 0, comes out as 1.32e-06
-    assert_almost_equal(properties['local_screw_angles'], screw[:-2],
-                        decimal=3)
+    assert_allclose(properties['local_screw_angles'], screw[:-2],
+                        atol=1e-03)
 
 
 class TestHELANAL(object):
@@ -353,12 +353,12 @@ class TestHELANAL(object):
     def test_regression_summary(self, helanal):
         bends = helanal.results.summary['all_bends']
         old_helanal = read_bending_matrix(HELANAL_BENDING_MATRIX_SUBSET)
-        assert_almost_equal(np.triu(bends['mean'], 1), old_helanal['Mean'],
-                            decimal=1)
-        assert_almost_equal(np.triu(bends['sample_sd'], 1), old_helanal['SD'],
-                            decimal=1)
-        assert_almost_equal(np.triu(bends['abs_dev'], 1), old_helanal['ABDEV'],
-                            decimal=1)
+        assert_allclose(np.triu(bends['mean'], 1), old_helanal['Mean'],
+                            atol=1e-01)
+        assert_allclose(np.triu(bends['sample_sd'], 1), old_helanal['SD'],
+                            atol=1e-01)
+        assert_allclose(np.triu(bends['abs_dev'], 1), old_helanal['ABDEV'],
+                            atol=1e-01)
 
     def test_regression_values(self):
         u = mda.Universe(PDB_small)
@@ -375,8 +375,8 @@ class TestHELANAL(object):
                 calculated = ha.results[key][0]
 
             msg = 'Mismatch between calculated and reference {}'
-            assert_almost_equal(calculated, value,
-                                decimal=4,
+            assert_allclose(calculated, value,
+                                atol=1e-04,
                                 err_msg=msg.format(key))
 
     def test_multiple_selections(self, psf_ca):
@@ -464,23 +464,23 @@ class TestHELANAL(object):
     def test_helanal_zigzag(self, zigzag, ref_axis, screw_angles):
         ha = hel.HELANAL(zigzag, select="all", ref_axis=ref_axis,
                          flatten_single_helix=True).run()
-        assert_almost_equal(ha.results.local_twists, 180, decimal=4)
-        assert_almost_equal(ha.results.local_nres_per_turn, 2, decimal=4)
-        assert_almost_equal(ha.results.global_axis, [[0, 0, -1]], decimal=4)
+        assert_allclose(ha.results.local_twists, 180, atol=1e-04)
+        assert_allclose(ha.results.local_nres_per_turn, 2, atol=1e-04)
+        assert_allclose(ha.results.global_axis, [[0, 0, -1]], atol=1e-04)
         # all 0 vectors
-        assert_almost_equal(ha.results.local_axes, 0, decimal=4)
-        assert_almost_equal(ha.results.local_bends, 0, decimal=4)
-        assert_almost_equal(ha.results.all_bends, 0, decimal=4)
-        assert_almost_equal(ha.results.local_heights, 0, decimal=4)
-        assert_almost_equal(ha.results.local_helix_directions[0][0::2],
-                            [[-1, 0, 0]]*49, decimal=4)
-        assert_almost_equal(ha.results.local_helix_directions[0][1::2],
-                            [[1, 0, 0]]*49, decimal=4)
+        assert_allclose(ha.results.local_axes, 0, atol=1e-04)
+        assert_allclose(ha.results.local_bends, 0, atol=1e-04)
+        assert_allclose(ha.results.all_bends, 0, atol=1e-04)
+        assert_allclose(ha.results.local_heights, 0, atol=1e-04)
+        assert_allclose(ha.results.local_helix_directions[0][0::2],
+                            [[-1, 0, 0]]*49, atol=1e-04)
+        assert_allclose(ha.results.local_helix_directions[0][1::2],
+                            [[1, 0, 0]]*49, atol=1e-04)
         origins = zigzag.atoms.positions[1:-1].copy()
         origins[:, 0] = 0
-        assert_almost_equal(ha.results.local_origins[0], origins, decimal=4)
-        assert_almost_equal(ha.results.local_screw_angles[0],
-                            screw_angles*49, decimal=4)
+        assert_allclose(ha.results.local_origins[0], origins, atol=1e-04)
+        assert_allclose(ha.results.local_screw_angles[0],
+                            screw_angles*49, atol=1e-04)
 
 
 def test_vector_of_best_fit():
@@ -492,4 +492,4 @@ def test_vector_of_best_fit():
 
     vector = hel.vector_of_best_fit(data)
     cos = np.dot(vector, unit)
-    assert_almost_equal(abs(cos), 1.0, decimal=5)
+    assert_allclose(abs(cos), 1.0, atol=1e-05)

--- a/testsuite/MDAnalysisTests/analysis/test_hole2.py
+++ b/testsuite/MDAnalysisTests/analysis/test_hole2.py
@@ -32,7 +32,6 @@ import matplotlib
 import mpl_toolkits.mplot3d
 import errno
 from numpy.testing import (
-    assert_almost_equal,
     assert_equal,
     assert_allclose,
 )
@@ -167,10 +166,10 @@ class TestHole(object):
         profile = values[0]
         assert_equal(len(profile), self.profile_length,
                      err_msg='Wrong number of points in HOLE profile')
-        assert_almost_equal(profile.rxn_coord.mean(),
+        assert_allclose(profile.rxn_coord.mean(),
                             self.rxn_coord_mean,
                             err_msg='Wrong mean HOLE rxn_coord')
-        assert_almost_equal(profile.radius.min(),
+        assert_allclose(profile.radius.min(),
                             self.radius_min,
                             err_msg='Wrong minimum HOLE radius')
 
@@ -305,15 +304,15 @@ class TestHoleAnalysis(BaseTestHole):
         data = np.transpose([(len(p), p.rxn_coord.mean(), p.radius.min())
                              for p in hole.results.profiles.values()])
         assert_equal(data[0], [401, 399], err_msg="incorrect profile lengths")
-        assert_almost_equal(data[1], [1.98767,  0.0878],
+        assert_allclose(data[1], [1.98767,  0.0878],
                             err_msg="wrong mean HOLE rxn_coord")
-        assert_almost_equal(data[2], [1.19819, 1.29628],
+        assert_allclose(data[2], [1.19819, 1.29628],
                             err_msg="wrong minimum radius")
 
     def test_min_radius(self, hole):
         values = np.array([[5., 1.19819],
                            [6., 1.29628]])
-        assert_almost_equal(hole.min_radius(), values,
+        assert_allclose(hole.min_radius(), values,
                             err_msg="min_radius() array not correct")
 
     def test_context_manager(self, universe, tmpdir):
@@ -385,7 +384,7 @@ class TestHoleAnalysis(BaseTestHole):
                 with open(file, 'r') as f:
                     line = f.read().split('CPOINT')[1].split('\n')[0]
                 arr = np.array(list(map(float, line.split())))
-                assert_almost_equal(arr, cog)
+                assert_allclose(arr, cog)
 
     # plotting
     def test_plot(self, hole, frames, profiles):
@@ -396,8 +395,8 @@ class TestHoleAnalysis(BaseTestHole):
         assert len(lines) == hole.n_frames
         for i, (line, frame, profile) in enumerate(zip(lines, frames, profiles)):
             x, y = line.get_data()
-            assert_almost_equal(x, profile.rxn_coord)
-            assert_almost_equal(y, profile.radius + i)
+            assert_allclose(x, profile.rxn_coord)
+            assert_allclose(y, profile.radius + i)
             assert line.get_label() == str(frame)
 
     def test_plot_mean_profile(self, hole, frames, profiles):
@@ -426,15 +425,15 @@ class TestHoleAnalysis(BaseTestHole):
                 poly.append(x)
         assert len(poly) == 1
         xp, yp = poly[0].get_paths()[0].vertices.T
-        assert_almost_equal(np.unique(xp), np.unique(midpoints))
-        assert_almost_equal(np.unique(yp), np.unique(ylow+yhigh))
+        assert_allclose(np.unique(xp), np.unique(midpoints))
+        assert_allclose(np.unique(yp), np.unique(ylow+yhigh))
 
         # test mean line
         lines = ax.get_lines()
         assert len(lines) == 1
         xl, yl = lines[0].get_data()
-        assert_almost_equal(xl, midpoints)
-        assert_almost_equal(yl, mean)
+        assert_allclose(xl, midpoints)
+        assert_allclose(yl, mean)
 
     @pytest.mark.skipif(sys.version_info < (3, 1),
                         reason="get_data_3d requires 3.1 or higher")
@@ -447,9 +446,9 @@ class TestHoleAnalysis(BaseTestHole):
 
         for line, frame, profile in zip(lines, frames, profiles):
             x, y, z = line.get_data_3d()
-            assert_almost_equal(x, profile.rxn_coord)
-            assert_almost_equal(np.unique(y), [frame])
-            assert_almost_equal(z, profile.radius)
+            assert_allclose(x, profile.rxn_coord)
+            assert_allclose(np.unique(y), [frame])
+            assert_allclose(z, profile.radius)
             assert line.get_label() == str(frame)
 
     @pytest.mark.skipif(sys.version_info < (3, 1),
@@ -463,10 +462,10 @@ class TestHoleAnalysis(BaseTestHole):
 
         for line, frame, profile in zip(lines, frames, profiles):
             x, y, z = line.get_data_3d()
-            assert_almost_equal(x, profile.rxn_coord)
-            assert_almost_equal(np.unique(y), [frame])
+            assert_allclose(x, profile.rxn_coord)
+            assert_allclose(np.unique(y), [frame])
             radius = np.where(profile.radius > 2.5, np.nan, profile.radius)
-            assert_almost_equal(z, radius)
+            assert_allclose(z, radius)
             assert line.get_label() == str(frame)
 
     def test_none_filename(self, tmpdir):
@@ -494,18 +493,18 @@ class TestHoleAnalysisLong(BaseTestHole):
     def test_gather(self, hole):
         gd = hole.gather(flat=False)
         for i, p in enumerate(hole.results.profiles.values()):
-            assert_almost_equal(p.rxn_coord, gd['rxn_coord'][i])
-            assert_almost_equal(p.radius, gd['radius'][i])
-            assert_almost_equal(p.cen_line_D, gd['cen_line_D'][i])
+            assert_allclose(p.rxn_coord, gd['rxn_coord'][i])
+            assert_allclose(p.radius, gd['radius'][i])
+            assert_allclose(p.cen_line_D, gd['cen_line_D'][i])
 
     def test_gather_flat(self, hole):
         gd = hole.gather(flat=True)
         i = 0
         for p in hole.results.profiles.values():
             j = i+len(p.rxn_coord)
-            assert_almost_equal(p.rxn_coord, gd['rxn_coord'][i:j])
-            assert_almost_equal(p.radius, gd['radius'][i:j])
-            assert_almost_equal(p.cen_line_D, gd['cen_line_D'][i:j])
+            assert_allclose(p.rxn_coord, gd['rxn_coord'][i:j])
+            assert_allclose(p.radius, gd['radius'][i:j])
+            assert_allclose(p.cen_line_D, gd['cen_line_D'][i:j])
             i = j
         assert_equal(i, len(gd['rxn_coord']))
 
@@ -513,7 +512,7 @@ class TestHoleAnalysisLong(BaseTestHole):
         rad = hole.min_radius()
         for (f1, p), (f2, r) in zip(hole.results.profiles.items(), rad):
             assert_equal(f1, f2)
-            assert_almost_equal(min(p.radius), r)
+            assert_allclose(min(p.radius), r)
 
     def test_over_order_parameters(self, hole):
         op = self.rmsd
@@ -577,8 +576,8 @@ class TestHoleAnalysisLong(BaseTestHole):
         coords = dct['rxn_coord']
 
         assert len(bins) == 101
-        assert_almost_equal(bins[0], coords.min())
-        assert_almost_equal(bins[-1], coords.max())
+        assert_allclose(bins[0], coords.min())
+        assert_allclose(bins[-1], coords.max())
         assert len(radii) == (len(bins)-1)
 
         # check first frame profile
@@ -603,8 +602,8 @@ class TestHoleAnalysisLong(BaseTestHole):
         assert len(bins) == 101
         low = midpoint - 0.5
         high = midpoint + 0.5
-        assert_almost_equal(bins[0], low)
-        assert_almost_equal(bins[-1], high)
+        assert_allclose(bins[0], low)
+        assert_allclose(bins[-1], high)
         assert len(radii) == (len(bins)-1)
 
         # check first frame profile
@@ -627,9 +626,9 @@ class TestHoleAnalysisLong(BaseTestHole):
         moved = brange[30:] + brange[10:30] + brange[:10]
         e_radii, e_bins = hole.bin_radii(bins=moved, range=(0.0, 0.0))
         r_radii, r_bins = hole.bin_radii(bins=100, range=(1.5, 1.5))
-        assert_almost_equal(e_bins, r_bins)
+        assert_allclose(e_bins, r_bins)
         for e, r in zip(e_radii, r_radii):
-            assert_almost_equal(e, r)
+            assert_allclose(e, r)
 
     def test_histogram_radii(self, hole):
         means, _ = hole.histogram_radii(aggregator=np.mean,
@@ -637,7 +636,7 @@ class TestHoleAnalysisLong(BaseTestHole):
         radii, _ = hole.bin_radii(bins=100)
         assert means.shape == (100,)
         for r, m in zip(radii, means):
-            assert_almost_equal(r.mean(), m)
+            assert_allclose(r.mean(), m)
 
     # plotting
 
@@ -649,8 +648,8 @@ class TestHoleAnalysisLong(BaseTestHole):
         assert len(lines) == 2
         for i, (line, frame, profile) in enumerate(zip(lines, frames[2:4], profiles[2:4])):
             x, y = line.get_data()
-            assert_almost_equal(x, profile.rxn_coord)
-            assert_almost_equal(y, profile.radius + i)
+            assert_allclose(x, profile.rxn_coord)
+            assert_allclose(y, profile.radius + i)
             assert line.get_label() == str(frame)
 
     @pytest.mark.parametrize('agg', [np.max, np.mean, np.std, np.min])
@@ -666,8 +665,8 @@ class TestHoleAnalysisLong(BaseTestHole):
         lines = ax.get_lines()
         assert len(lines) == 1
         x, y = lines[0].get_data()
-        assert_almost_equal(x, opx)
-        assert_almost_equal(y, opy)
+        assert_allclose(x, opx)
+        assert_allclose(y, opy)
 
     @pytest.mark.skipif(sys.version_info < (3, 1),
                         reason="get_data_3d requires 3.1 or higher")
@@ -683,9 +682,9 @@ class TestHoleAnalysisLong(BaseTestHole):
         assert len(lines) == hole.n_frames
         for line, opx_, profile in zip(lines, opx, profiles):
             x, y, z = line.get_data_3d()
-            assert_almost_equal(x, profile.rxn_coord)
-            assert_almost_equal(np.unique(y), np.array([opx_]))
-            assert_almost_equal(z, profile.radius)
+            assert_allclose(x, profile.rxn_coord)
+            assert_allclose(np.unique(y), np.array([opx_]))
+            assert_allclose(z, profile.radius)
 
     @pytest.mark.skipif(sys.version_info > (3, 1),
                         reason="get_data_3d requires 3.1 or higher")
@@ -701,8 +700,8 @@ class TestHoleAnalysisLong(BaseTestHole):
         assert len(lines) == hole.n_frames
         for line, opx_, profile in zip(lines, opx, profiles):
             x, y = line.get_data()
-            assert_almost_equal(x, profile.rxn_coord)
-            assert_almost_equal(np.unique(y), np.array([opx_]))
+            assert_allclose(x, profile.rxn_coord)
+            assert_allclose(np.unique(y), np.array([opx_]))
 
 @pytest.mark.skipif(executable_not_found("hole"),
                     reason="Test skipped because HOLE not found")

--- a/testsuite/MDAnalysisTests/analysis/test_hydrogenbondautocorrel.py
+++ b/testsuite/MDAnalysisTests/analysis/test_hydrogenbondautocorrel.py
@@ -27,7 +27,7 @@ from MDAnalysisTests.datafiles import (
     waterPSF, waterDCD,
     XYZ_mini,
 )
-from numpy.testing import assert_almost_equal
+from numpy.testing import assert_allclose
 import numpy as np
 from unittest import mock
 from importlib import reload
@@ -65,7 +65,7 @@ class TestHydrogenBondAutocorrel(object):
         )
         hbond.run()
 
-        assert_almost_equal(
+        assert_allclose(
             hbond.solution['results'],
             np.array([ 1.        ,  0.92668623,  0.83137828,
                        0.74486804,  0.67741936,  0.60263932],
@@ -84,7 +84,7 @@ class TestHydrogenBondAutocorrel(object):
         )
         hbond.run()
 
-        assert_almost_equal(
+        assert_allclose(
             hbond.solution['results'],
             np.array([ 1.        ,  0.92668623,  0.83137828,
                        0.74486804,  0.67741936,  0.60263932],
@@ -102,7 +102,7 @@ class TestHydrogenBondAutocorrel(object):
         )
         hbond.run()
 
-        assert_almost_equal(
+        assert_allclose(
             hbond.solution['results'],
             np.array([ 1.        ,  0.92668623,  0.84310848,
                        0.79325515,  0.76392961,  0.72287393],
@@ -121,7 +121,7 @@ class TestHydrogenBondAutocorrel(object):
         )
         hbond.run()
 
-        assert_almost_equal(
+        assert_allclose(
             hbond.solution['results'],
             np.array([ 1.        ,  0.92668623,  0.83137828,
                        0.74486804,  0.67741936,  0.60263932],
@@ -140,7 +140,7 @@ class TestHydrogenBondAutocorrel(object):
         )
         hbond.run()
 
-        assert_almost_equal(
+        assert_allclose(
             hbond.solution['results'],
             np.array([ 1.        ,  0.92668623,  0.84310848,
                        0.79325515,  0.76392961,  0.72287393],
@@ -169,7 +169,7 @@ class TestHydrogenBondAutocorrel(object):
 
         hbond.solve()
 
-        assert_almost_equal(
+        assert_allclose(
             hbond.solution['fit'],
             np.array([0.75, 0.5, 0.1]),
         )
@@ -196,7 +196,7 @@ class TestHydrogenBondAutocorrel(object):
 
         hbond.solve()
 
-        assert_almost_equal(
+        assert_allclose(
             hbond.solution['fit'],
             np.array([0.33, 0.33, 5, 1, 0.1]),
         )

--- a/testsuite/MDAnalysisTests/analysis/test_hydrogenbondautocorrel_deprecated.py
+++ b/testsuite/MDAnalysisTests/analysis/test_hydrogenbondautocorrel_deprecated.py
@@ -27,7 +27,7 @@ from MDAnalysisTests.datafiles import (
     waterPSF, waterDCD,
     XYZ_mini,
 )
-from numpy.testing import assert_almost_equal
+from numpy.testing import assert_allclose
 import numpy as np
 from unittest import mock
 from importlib import reload
@@ -68,7 +68,7 @@ class TestHydrogenBondAutocorrel(object):
         )
         hbond.run()
 
-        assert_almost_equal(
+        assert_allclose(
             hbond.solution['results'],
             np.array([ 1.        ,  0.92668623,  0.83137828,
                        0.74486804,  0.67741936,  0.60263932],
@@ -87,7 +87,7 @@ class TestHydrogenBondAutocorrel(object):
         )
         hbond.run()
 
-        assert_almost_equal(
+        assert_allclose(
             hbond.solution['results'],
             np.array([ 1.        ,  0.92668623,  0.83137828,
                        0.74486804,  0.67741936,  0.60263932],
@@ -105,7 +105,7 @@ class TestHydrogenBondAutocorrel(object):
         )
         hbond.run()
 
-        assert_almost_equal(
+        assert_allclose(
             hbond.solution['results'],
             np.array([ 1.        ,  0.92668623,  0.84310848,
                        0.79325515,  0.76392961,  0.72287393],
@@ -124,7 +124,7 @@ class TestHydrogenBondAutocorrel(object):
         )
         hbond.run()
 
-        assert_almost_equal(
+        assert_allclose(
             hbond.solution['results'],
             np.array([ 1.        ,  0.92668623,  0.83137828,
                        0.74486804,  0.67741936,  0.60263932],
@@ -143,7 +143,7 @@ class TestHydrogenBondAutocorrel(object):
         )
         hbond.run()
 
-        assert_almost_equal(
+        assert_allclose(
             hbond.solution['results'],
             np.array([ 1.        ,  0.92668623,  0.84310848,
                        0.79325515,  0.76392961,  0.72287393],
@@ -172,7 +172,7 @@ class TestHydrogenBondAutocorrel(object):
 
         hbond.solve()
 
-        assert_almost_equal(
+        assert_allclose(
             hbond.solution['fit'],
             np.array([0.75, 0.5, 0.1]),
         )
@@ -199,7 +199,7 @@ class TestHydrogenBondAutocorrel(object):
 
         hbond.solve()
 
-        assert_almost_equal(
+        assert_allclose(
             hbond.solution['fit'],
             np.array([0.33, 0.33, 5, 1, 0.1]),
         )

--- a/testsuite/MDAnalysisTests/analysis/test_hydrogenbonds_analysis.py
+++ b/testsuite/MDAnalysisTests/analysis/test_hydrogenbonds_analysis.py
@@ -26,8 +26,8 @@ import pytest
 import copy
 
 from numpy.testing import (assert_allclose, assert_equal,
-                           assert_array_almost_equal, assert_array_equal,
-                           assert_almost_equal)
+                           assert_array_equal,
+                           )
 
 import MDAnalysis
 from MDAnalysis.analysis.hydrogenbonds.hbond_analysis import (
@@ -236,8 +236,8 @@ class TestHydrogenBondAnalysisIdeal(object):
         assert_equal(donor_index, 0)
         assert_equal(hydrogen_index, 2)
         assert_equal(acceptor_index, 3)
-        assert_almost_equal(da_dst, 2.5)
-        assert_almost_equal(angle, 180)
+        assert_allclose(da_dst, 2.5)
+        assert_allclose(angle, 180)
 
     def test_count_by_time(self, hydrogen_bonds):
         ref_times = np.array([0, 1, 2]) # u.trajectory.dt is 1

--- a/testsuite/MDAnalysisTests/analysis/test_leaflet.py
+++ b/testsuite/MDAnalysisTests/analysis/test_leaflet.py
@@ -23,7 +23,7 @@
 import MDAnalysis
 import pytest
 
-from numpy.testing import assert_equal, assert_almost_equal
+from numpy.testing import assert_equal, assert_allclose
 import numpy as np
 import networkx as NX
 
@@ -70,7 +70,7 @@ def test_string_vs_atomgroup_proper(universe, lipid_heads):
 def test_optimize_cutoff(universe, lipid_heads):
     cutoff, N = optimize_cutoff(universe, lipid_heads, pbc=True)
     assert N == 2
-    assert_almost_equal(cutoff, 10.5, decimal=4)
+    assert_allclose(cutoff, 10.5, atol=1e-04)
 
 
 def test_pbc_on_off(universe, lipid_heads):
@@ -93,21 +93,21 @@ def test_pbc_on_off_difference(universe, lipid_heads):
 def test_sparse_on_off_none(universe, lipid_heads, sparse):
     lfls_ag = LeafletFinder(universe, lipid_heads, cutoff=15.0, pbc=True,
                                 sparse=sparse)
-    assert_almost_equal(len(lfls_ag.graph.edges), 1903, decimal=4)
+    assert_allclose(len(lfls_ag.graph.edges), 1903, atol=1e-04)
 
 
 def test_cutoff_update(universe, lipid_heads):
     lfls_ag = LeafletFinder(universe, lipid_heads, cutoff=15.0, pbc=True)
     lfls_ag.update(cutoff=1.0)
-    assert_almost_equal(lfls_ag.cutoff, 1.0, decimal=4)
-    assert_almost_equal(len(lfls_ag.groups()), 360, decimal=4)
+    assert_allclose(lfls_ag.cutoff, 1.0, atol=1e-04)
+    assert_allclose(len(lfls_ag.groups()), 360, atol=1e-04)
 
 
 def test_cutoff_update_default(universe, lipid_heads):
     lfls_ag = LeafletFinder(universe, lipid_heads, cutoff=15.0, pbc=True)
     lfls_ag.update()
-    assert_almost_equal(lfls_ag.cutoff, 15.0, decimal=4)
-    assert_almost_equal(len(lfls_ag.groups()), 2, decimal=4)
+    assert_allclose(lfls_ag.cutoff, 15.0, atol=1e-04)
+    assert_allclose(len(lfls_ag.groups()), 2, atol=1e-04)
 
 
 def test_write_selection(universe, lipid_heads, tmpdir):
@@ -172,4 +172,4 @@ def test_write_selection(universe, lipid_heads, tmpdir):
 
 def test_component_index_is_not_none(universe, lipid_heads):
     lfls_ag = LeafletFinder(universe, lipid_heads, cutoff=15.0, pbc=True)
-    assert_almost_equal(len(lfls_ag.groups(component_index=0)), 180, decimal=4)
+    assert_allclose(len(lfls_ag.groups(component_index=0)), 180, atol=1e-04)

--- a/testsuite/MDAnalysisTests/analysis/test_msd.py
+++ b/testsuite/MDAnalysisTests/analysis/test_msd.py
@@ -25,7 +25,7 @@
 from MDAnalysis.analysis.msd import EinsteinMSD as MSD
 import MDAnalysis as mda
 
-from numpy.testing import (assert_almost_equal, assert_equal)
+from numpy.testing import (assert_allclose, assert_equal)
 import numpy as np
 
 from MDAnalysisTests.datafiles import PSF, DCD, RANDOM_WALK, RANDOM_WALK_TOPO
@@ -123,7 +123,7 @@ class TestMSDSimple(object):
         m_simple = MSD(step_traj, 'all', msd_type=dim, fft=False)
         m_simple.run()
         poly = characteristic_poly(NSTEP, dim_factor)
-        assert_almost_equal(m_simple.results.timeseries, poly, decimal=4)
+        assert_allclose(m_simple.results.timeseries, poly, atol=1e-04)
 
     @pytest.mark.parametrize("dim, dim_factor", [
         ('xyz', 3), ('xy', 2), ('xz', 2), ('yz', 2), ('x', 1), ('y', 1),
@@ -137,8 +137,8 @@ class TestMSDSimple(object):
         m_simple.run(start=10, stop=1000, step=10)
         poly = characteristic_poly(NSTEP, dim_factor)
         # polynomial must take offset start into account
-        assert_almost_equal(m_simple.results.timeseries, poly[0:990:10],
-                            decimal=4)
+        assert_allclose(m_simple.results.timeseries, poly[0:990:10],
+                            atol=1e-04)
 
     def test_random_walk_u_simple(self, random_walk_u):
         # regress against random_walk test data
@@ -146,7 +146,7 @@ class TestMSDSimple(object):
         msd_rw.run()
         norm = np.linalg.norm(msd_rw.results.timeseries)
         val = 3932.39927487146
-        assert_almost_equal(norm, val, decimal=5)
+        assert_allclose(norm, val, atol=1e-05)
 
 
 @pytest.mark.skipif(import_not_available("tidynamics"),
@@ -164,13 +164,13 @@ class TestMSDFFT(object):
         # testing on the  PSF, DCD trajectory
         timeseries_simple = msd.results.timeseries
         timeseries_fft = msd_fft.results.timeseries
-        assert_almost_equal(timeseries_simple, timeseries_fft, decimal=4)
+        assert_allclose(timeseries_simple, timeseries_fft, atol=1e-04)
 
     def test_fft_vs_simple_default_per_particle(self, msd, msd_fft):
         # check fft and simple give same result per particle
         per_particle_simple = msd.results.msds_by_particle
         per_particle_fft = msd_fft.results.msds_by_particle
-        assert_almost_equal(per_particle_simple, per_particle_fft, decimal=4)
+        assert_allclose(per_particle_simple, per_particle_fft, atol=1e-04)
 
     @pytest.mark.parametrize("dim", ['xyz', 'xy', 'xz', 'yz', 'x', 'y', 'z'])
     def test_fft_vs_simple_all_dims(self, u, SELECTION, dim):
@@ -181,7 +181,7 @@ class TestMSDFFT(object):
         m_fft = MSD(u, SELECTION, msd_type=dim, fft=True)
         m_fft.run()
         timeseries_fft = m_fft.results.timeseries
-        assert_almost_equal(timeseries_simple, timeseries_fft, decimal=4)
+        assert_allclose(timeseries_simple, timeseries_fft, atol=1e-04)
 
     @pytest.mark.parametrize("dim", ['xyz', 'xy', 'xz', 'yz', 'x', 'y', 'z'])
     def test_fft_vs_simple_all_dims_per_particle(self, u, SELECTION, dim):
@@ -193,7 +193,7 @@ class TestMSDFFT(object):
         m_fft = MSD(u, SELECTION, msd_type=dim, fft=True)
         m_fft.run()
         per_particle_fft = m_fft.results.msds_by_particle
-        assert_almost_equal(per_particle_simple, per_particle_fft, decimal=4)
+        assert_allclose(per_particle_simple, per_particle_fft, atol=1e-04)
 
     @pytest.mark.parametrize("dim, dim_factor", [
         ('xyz', 3), ('xy', 2), ('xz', 2), ('yz', 2), ('x', 1), ('y', 1),
@@ -208,8 +208,8 @@ class TestMSDFFT(object):
         m_simple = MSD(step_traj, 'all', msd_type=dim, fft=True)
         m_simple.run()
         poly = characteristic_poly(NSTEP, dim_factor)
-        # this was relaxed from decimal=4 for numpy=1.13 test
-        assert_almost_equal(m_simple.results.timeseries, poly, decimal=3)
+        # this was relaxed from atol=1e-04 for numpy=1.13 test
+        assert_allclose(m_simple.results.timeseries, poly, atol=1e-03)
 
     @pytest.mark.parametrize("dim, dim_factor", [(
         'xyz', 3), ('xy', 2), ('xz', 2), ('yz', 2), ('x', 1), ('y', 1),
@@ -223,8 +223,8 @@ class TestMSDFFT(object):
         m_simple.run(start=10, stop=1000, step=10)
         poly = characteristic_poly(NSTEP, dim_factor)
         # polynomial must take offset start into account
-        assert_almost_equal(m_simple.results.timeseries, poly[0:990:10],
-                            decimal=3)
+        assert_allclose(m_simple.results.timeseries, poly[0:990:10],
+                            atol=1e-03)
 
     def test_random_walk_u_fft(self, random_walk_u):
         # regress against random_walk test data
@@ -232,4 +232,4 @@ class TestMSDFFT(object):
         msd_rw.run()
         norm = np.linalg.norm(msd_rw.results.timeseries)
         val = 3932.39927487146
-        assert_almost_equal(norm, val, decimal=5)
+        assert_allclose(norm, val, atol=1e-05)

--- a/testsuite/MDAnalysisTests/analysis/test_nuclinfo.py
+++ b/testsuite/MDAnalysisTests/analysis/test_nuclinfo.py
@@ -25,7 +25,6 @@ import pytest
 from MDAnalysis.analysis import nuclinfo
 from MDAnalysisTests.datafiles import RNA_PSF, RNA_PDB
 from numpy.testing import (
-    assert_almost_equal,
     assert_allclose,
 )
 
@@ -41,7 +40,7 @@ def u():
 ))
 def test_wc_pair(u, i, bp, seg1, seg2, expected_value):
     val = nuclinfo.wc_pair(u, i, bp, seg1=seg1, seg2=seg2)
-    assert_almost_equal(val, expected_value, decimal=3)
+    assert_allclose(val, expected_value, atol=1e-03)
 
 
 @pytest.mark.parametrize('i, bp, seg1, seg2, expected_value', (
@@ -50,7 +49,7 @@ def test_wc_pair(u, i, bp, seg1, seg2, expected_value):
 ))
 def test_minor_pair(u, i, bp, seg1, seg2, expected_value):
     val = nuclinfo.minor_pair(u, i, bp, seg1=seg1, seg2=seg2)
-    assert_almost_equal(val, expected_value, decimal=3)
+    assert_allclose(val, expected_value, atol=1e-03)
 
 
 @pytest.mark.parametrize('i, bp, seg1, seg2, expected_value', (
@@ -59,7 +58,7 @@ def test_minor_pair(u, i, bp, seg1, seg2, expected_value):
 ))
 def test_major_pair(u, i, bp, seg1, seg2, expected_value):
     val = nuclinfo.major_pair(u, i, bp, seg1=seg1, seg2=seg2)
-    assert_almost_equal(val, expected_value, decimal=3)
+    assert_allclose(val, expected_value, atol=1e-03)
 
 
 @pytest.mark.parametrize('seg, i, expected_value', (
@@ -68,7 +67,7 @@ def test_major_pair(u, i, bp, seg1, seg2, expected_value):
 ))
 def test_phase_cp(u, seg, i, expected_value):
     val = nuclinfo.phase_cp(u, seg=seg, i=i)
-    assert_almost_equal(val, expected_value, decimal=3)
+    assert_allclose(val, expected_value, atol=1e-03)
 
 
 @pytest.mark.parametrize('seg, i, expected_value', (
@@ -77,7 +76,7 @@ def test_phase_cp(u, seg, i, expected_value):
 ))
 def test_phase_as(u, seg, i, expected_value):
     val = nuclinfo.phase_as(u, seg=seg, i=i)
-    assert_almost_equal(val, expected_value, decimal=3)
+    assert_allclose(val, expected_value, atol=1e-03)
 
 
 @pytest.mark.parametrize('seg, i, expected_value', (
@@ -97,7 +96,7 @@ def test_tors(u, seg, i, expected_value):
 ))
 def test_tors_alpha(u, seg, i, expected_value):
     val = nuclinfo.tors_alpha(u, seg=seg, i=i)
-    assert_almost_equal(val, expected_value, decimal=3)
+    assert_allclose(val, expected_value, atol=1e-03)
 
 
 @pytest.mark.parametrize('seg, i, expected_value', (
@@ -106,7 +105,7 @@ def test_tors_alpha(u, seg, i, expected_value):
 ))
 def test_tors_beta(u, seg, i, expected_value):
     val = nuclinfo.tors_beta(u, seg=seg, i=i)
-    assert_almost_equal(val, expected_value, decimal=3)
+    assert_allclose(val, expected_value, atol=1e-03)
 
 
 @pytest.mark.parametrize('seg, i, expected_value', (
@@ -115,7 +114,7 @@ def test_tors_beta(u, seg, i, expected_value):
 ))
 def test_tors_gamma(u, seg, i, expected_value):
     val = nuclinfo.tors_gamma(u, seg=seg, i=i)
-    assert_almost_equal(val, expected_value, decimal=3)
+    assert_allclose(val, expected_value, atol=1e-03)
 
 
 @pytest.mark.parametrize('seg, i, expected_value', (
@@ -124,7 +123,7 @@ def test_tors_gamma(u, seg, i, expected_value):
 ))
 def test_tors_delta(u, seg, i, expected_value):
     val = nuclinfo.tors_delta(u, seg=seg, i=i)
-    assert_almost_equal(val, expected_value, decimal=3)
+    assert_allclose(val, expected_value, atol=1e-03)
 
 
 @pytest.mark.parametrize('seg, i, expected_value', (
@@ -133,7 +132,7 @@ def test_tors_delta(u, seg, i, expected_value):
 ))
 def test_tors_eps(u, seg, i, expected_value):
     val = nuclinfo.tors_eps(u, seg=seg, i=i)
-    assert_almost_equal(val, expected_value, decimal=3)
+    assert_allclose(val, expected_value, atol=1e-03)
 
 
 @pytest.mark.parametrize('seg, i, expected_value', (
@@ -142,7 +141,7 @@ def test_tors_eps(u, seg, i, expected_value):
 ))
 def test_tors_zeta(u, seg, i, expected_value):
     val = nuclinfo.tors_zeta(u, seg=seg, i=i)
-    assert_almost_equal(val, expected_value, decimal=3)
+    assert_allclose(val, expected_value, atol=1e-03)
 
 
 @pytest.mark.parametrize('seg, i, expected_value', (
@@ -153,7 +152,7 @@ def test_tors_zeta(u, seg, i, expected_value):
 ))
 def test_tors_chi(u, seg, i, expected_value):
     val = nuclinfo.tors_chi(u, seg=seg, i=i)
-    assert_almost_equal(val, expected_value, decimal=3)
+    assert_allclose(val, expected_value, atol=1e-03)
 
 
 @pytest.mark.parametrize('seg, i, expected_value', (
@@ -164,7 +163,7 @@ def test_tors_chi(u, seg, i, expected_value):
 ))
 def test_hydroxyl(u, seg, i, expected_value):
     val = nuclinfo.hydroxyl(u, seg=seg, i=i)
-    assert_almost_equal(val, expected_value, decimal=3)
+    assert_allclose(val, expected_value, atol=1e-03)
 
 
 @pytest.mark.parametrize('bp1, bp2, i, seg1, seg2, seg3, expected_value', (
@@ -173,4 +172,4 @@ def test_hydroxyl(u, seg, i, expected_value):
 ))
 def test_pseudo_dihe_baseflip(u, bp1, bp2, i, seg1, seg2, seg3, expected_value):
     val = nuclinfo.pseudo_dihe_baseflip(u, bp1, bp2, i, seg1, seg2, seg3)
-    assert_almost_equal(val, expected_value, decimal=3)
+    assert_allclose(val, expected_value, atol=1e-03)

--- a/testsuite/MDAnalysisTests/analysis/test_pca.py
+++ b/testsuite/MDAnalysisTests/analysis/test_pca.py
@@ -26,8 +26,8 @@ from MDAnalysis.analysis import align
 from MDAnalysis.analysis.pca import (PCA, cosine_content,
                                      rmsip, cumulative_overlap)
 
-from numpy.testing import (assert_almost_equal, assert_equal,
-                           assert_array_almost_equal, assert_allclose,)
+from numpy.testing import (assert_equal,
+                           assert_allclose,)
 
 from MDAnalysisTests.datafiles import (PSF, DCD, RANDOM_WALK, RANDOM_WALK_TOPO,
                                        waterPSF, waterDCD)
@@ -77,10 +77,10 @@ def test_cov(pca, u):
 
 
 def test_cum_var(pca):
-    assert_almost_equal(pca.results.cumulated_variance[-1], 1)
+    assert_allclose(pca.results.cumulated_variance[-1], 1)
     cum_var = pca.results.cumulated_variance
     cum_var = np.sort(cum_var)
-    assert_almost_equal(pca.results.cumulated_variance, cum_var, 5)
+    assert_allclose(pca.results.cumulated_variance, cum_var, 5)
 
 
 def test_pcs(pca):
@@ -260,7 +260,7 @@ def test_cosine_content():
     pca_random = PCA(rand).run()
     dot = pca_random.transform(rand.atoms)
     content = cosine_content(dot, 0)
-    assert_almost_equal(content, .99, 1)
+    assert_allclose(content, .99, 1)
 
 
 def test_mean_shape(pca_aligned, u):
@@ -272,14 +272,14 @@ def test_mean_shape(pca_aligned, u):
 def test_calculate_mean(pca_aligned, u, u_aligned):
     ag = u_aligned.select_atoms(SELECTION)
     coords = u_aligned.trajectory.coordinate_array[:, ag.ix]
-    assert_almost_equal(pca_aligned.mean, coords.mean(
-        axis=0), decimal=5)
+    assert_allclose(pca_aligned.mean, coords.mean(
+        axis=0), atol=1e-05)
 
 
 def test_given_mean(pca, u):
     pca = PCA(u, select=SELECTION, align=False,
               mean=pca.mean).run()
-    assert_almost_equal(pca.cov, pca.cov, decimal=5)
+    assert_allclose(pca.cov, pca.cov, atol=1e-05)
 
 
 def test_wrong_num_given_mean(u):
@@ -290,22 +290,22 @@ def test_wrong_num_given_mean(u):
 
 def test_alignment(pca_aligned, u, u_aligned):
     pca_pre_align = PCA(u_aligned, select=SELECTION, align=False).run()
-    assert_almost_equal(pca_aligned.mean, pca_pre_align.mean)
-    assert_almost_equal(pca_aligned.cov, pca_pre_align.cov)
+    assert_allclose(pca_aligned.mean, pca_pre_align.mean)
+    assert_allclose(pca_aligned.cov, pca_pre_align.cov)
 
 
 def test_covariance_norm(pca_aligned, u):
-    assert_almost_equal(np.linalg.norm(pca_aligned.cov), 0.96799758, decimal=5)
+    assert_allclose(np.linalg.norm(pca_aligned.cov), 0.96799758, atol=1e-05)
 
 
 def test_pca_rmsip_self(pca):
-    assert_almost_equal(pca.rmsip(pca), 1.0)
+    assert_allclose(pca.rmsip(pca), 1.0)
 
 
 def test_rmsip_ortho(pca):
     value = rmsip(pca.results.p_components[:, :10].T,
                   pca.results.p_components[:, 10:20].T)
-    assert_almost_equal(value, 0.0)
+    assert_allclose(value, 0.0)
 
 
 def test_pytest_too_many_components(pca):
@@ -319,18 +319,18 @@ def test_asymmetric_rmsip(pca):
     b = pca.rmsip(pca, n_components=(4, 10))
 
     assert abs(a-b) > 0.1, 'RMSIP should be asymmetric'
-    assert_almost_equal(b, 1.0)
+    assert_allclose(b, 1.0)
 
 
 def test_pca_cumulative_overlap_self(pca):
     value = pca.cumulative_overlap(pca, i=1)
-    assert_almost_equal(value, 1.0)
+    assert_allclose(value, 1.0)
 
 
 def test_cumulative_overlap_ortho(pca):
     pcs = pca.results.p_components
     value = cumulative_overlap(pcs[:, 11].T, pcs.T, n_components=10)
-    assert_almost_equal(value, 0.0)
+    assert_allclose(value, 0.0)
 
 
 @pytest.mark.parametrize(

--- a/testsuite/MDAnalysisTests/analysis/test_persistencelength.py
+++ b/testsuite/MDAnalysisTests/analysis/test_persistencelength.py
@@ -31,7 +31,7 @@ import numpy as np
 import matplotlib
 import matplotlib.pyplot as plt
 
-from numpy.testing import assert_almost_equal, assert_equal
+from numpy.testing import assert_allclose, assert_equal
 
 from MDAnalysisTests.datafiles import Plength, TRZ_psf, TRZ
 
@@ -65,10 +65,10 @@ class TestPersistenceLength(object):
         assert len(p_run.results.bond_autocorrelation) == 280
 
     def test_lb(self, p_run):
-        assert_almost_equal(p_run.results.lb, 1.485, 3)
+        assert_allclose(p_run.results.lb, 1.485, 3)
 
     def test_fit(self, p_run):
-        assert_almost_equal(p_run.results.lp, 6.504, 3)
+        assert_allclose(p_run.results.lp, 6.504, 3)
         assert len(p_run.results.fit) == len(p_run.results.bond_autocorrelation)
 
     def test_raise_NoDataError(self, p):
@@ -119,7 +119,7 @@ class TestFitExponential(object):
 
         a = polymer.fit_exponential_decay(self.x, y2)
 
-        assert_almost_equal(a, self.a_ref, decimal=3)
+        assert_allclose(a, self.a_ref, atol=1e-03)
         # assert np.rint(a) == self.a_ref
 
 

--- a/testsuite/MDAnalysisTests/analysis/test_psa.py
+++ b/testsuite/MDAnalysisTests/analysis/test_psa.py
@@ -26,7 +26,7 @@ import MDAnalysis as mda
 import MDAnalysis.analysis.psa as PSA
 
 from numpy.testing import (assert_array_less,
-                           assert_almost_equal, assert_equal)
+                           assert_allclose, assert_equal)
 import numpy as np
 import scipy
 import scipy.spatial
@@ -124,9 +124,9 @@ class TestPSAnalysis(object):
     def test_reversal_hausdorff(self, hausd_matrix):
         """Test whether Hausdorff distances are invariant to path reversal"""
         err_msg = "Hausdorff distances changed after path reversal"
-        assert_almost_equal(hausd_matrix[1,2],
-                            hausd_matrix[0,1],
-                            decimal=3, err_msg=err_msg)
+        assert_allclose(hausd_matrix[1,2],
+                        hausd_matrix[0,1],
+                        atol=1e-03, err_msg=err_msg)
 
     def test_reversal_frechet(self, frech_matrix):
         """Test whether Frechet distances are same/larger after path reversal"""
@@ -200,8 +200,8 @@ class TestPSAnalysis(object):
 
         for ipath, (observed, expected) in enumerate(zip(psa2.paths,
                                                          expected_paths)):
-            assert_almost_equal(observed, expected, decimal=6,
-                                err_msg=("loaded path {} does not agree with "
+            assert_allclose(observed, expected, atol=1e-06,
+                            err_msg=("loaded path {} does not agree with "
                                          "input").format(ipath))
 
     def test_load_nofile(self, psa):
@@ -265,8 +265,8 @@ class TestPSAnalysis(object):
         identical to those from standard Hausdorff metric"""
         err_msg = ("Some Hausdorff distances from pairs analysis vary "
                    "significantly from usual Hausdorff calculation")
-        assert_almost_equal(hausd_dists, hausd_pairs_dists,
-                            decimal=6, err_msg=err_msg)
+        assert_allclose(hausd_dists, hausd_pairs_dists,
+                        atol=1e-06, err_msg=err_msg)
 
     def test_distances_from_hausdorff_pairs_frames(self, psa):
         """Test whether actual distances between frames of Hausdorff
@@ -288,9 +288,9 @@ class TestPSAnalysis(object):
                 dists[i,j] = (PSA.sqnorm(psa.paths[i][p,:,:] -
                                          psa.paths[j][q,:,:]) /
                                          psa.natoms)**0.5
-        assert_almost_equal(hausd_pairs_dists2,
-                            dists[self.iu1],
-                            decimal=6, err_msg=err_msg)
+        assert_allclose(hausd_pairs_dists2,
+                        dists[self.iu1],
+                        atol=1e-06, err_msg=err_msg)
 
 class TestPSAExceptions(object):
     '''Tests for exceptions that should be raised
@@ -388,7 +388,7 @@ class _BaseHausdorffDistance(object):
         forward = h(path_1, path_2)
         reverse = h(path_2, path_1)
         # lower precision on 32bit
-        assert_almost_equal(forward, reverse, decimal=15)
+        assert_allclose(forward, reverse, atol=1e-15)
 
     def test_hausdorff_value(self, path_1, path_2, h, expected):
         '''Test that the undirected Hausdorff
@@ -397,7 +397,7 @@ class _BaseHausdorffDistance(object):
         actual = h(path_1, path_2)
         # unless I pin down the random generator
         # seems unstable to use decimal > 2
-        assert_almost_equal(actual, expected, decimal=2)
+        assert_allclose(actual, expected, atol=1e-02)
 
 
 class TestHausdorffSymmetric(_BaseHausdorffDistance):
@@ -437,7 +437,7 @@ class TestWeightedAvgHausdorffSymmetric(_BaseHausdorffDistance):
         inflated_path_2 = np.concatenate((path_2, path_2))
         d_inner_inflation = h(inflated_path_1, path_2)
         d_outer_inflation = h(path_1, inflated_path_2)
-        assert_almost_equal(d_inner_inflation, d_outer_inflation)
+        assert_allclose(d_inner_inflation, d_outer_inflation)
 
 
 class TestAvgHausdorffSymmetric(_BaseHausdorffDistance):
@@ -499,4 +499,4 @@ class DiscreteFrechetDistance(object):
 
         expected = 4.5
         actual = PSA.discrete_frechet(path_1, path_2)
-        assert_almost_equal(actual, expected)
+        assert_allclose(actual, expected)

--- a/testsuite/MDAnalysisTests/analysis/test_rdf_s.py
+++ b/testsuite/MDAnalysisTests/analysis/test_rdf_s.py
@@ -22,7 +22,7 @@
 #
 import pytest
 
-from numpy.testing import assert_allclose, assert_almost_equal
+from numpy.testing import assert_allclose
 
 import MDAnalysis as mda
 from MDAnalysis.analysis.rdf import InterRDF_s, InterRDF
@@ -111,13 +111,13 @@ def test_cdf(rdf):
 def test_density(u, sels, density, value):
     kwargs = {'density': density} if density is not None else {}
     rdf = InterRDF_s(u, sels, **kwargs).run()
-    assert_almost_equal(max(rdf.results.rdf[0][0][0]), value)
+    assert_allclose(max(rdf.results.rdf[0][0][0]), value)
     if not density:
         s1 = u.select_atoms('name ZND and resid 289')
         s2 = u.select_atoms(
                 'name OD1 and resid 51 and sphzone 5.0 (resid 289)')
         rdf_ref = InterRDF(s1, s2).run()
-        assert_almost_equal(rdf_ref.results.rdf, rdf.results.rdf[0][0][0])
+        assert_allclose(rdf_ref.results.rdf, rdf.results.rdf[0][0][0])
 
 
 def test_overwrite_norm(u, sels):
@@ -137,7 +137,7 @@ def test_norm(u, sels, norm, value):
         s2 = u.select_atoms(
                 'name OD1 and resid 51 and sphzone 5.0 (resid 289)')
         rdf_ref = InterRDF(s1, s2).run()
-        assert_almost_equal(rdf_ref.results.rdf, rdf.results.rdf[0][0][0])
+        assert_allclose(rdf_ref.results.rdf, rdf.results.rdf[0][0][0])
 
 
 @pytest.mark.parametrize("norm, norm_required", [

--- a/testsuite/MDAnalysisTests/analysis/test_rms.py
+++ b/testsuite/MDAnalysisTests/analysis/test_rms.py
@@ -26,7 +26,7 @@ import MDAnalysis
 import MDAnalysis as mda
 from MDAnalysis.analysis import rms, align
 
-from numpy.testing import assert_equal, assert_almost_equal
+from numpy.testing import assert_equal,assert_allclose
 
 import numpy as np
 import pytest
@@ -76,17 +76,17 @@ class Testrmsd(object):
 
     def test_no_center(self, a, b):
         rmsd = rms.rmsd(a, b, center=False)
-        assert_almost_equal(rmsd, 1.0)
+        assert_allclose(rmsd, 1.0)
 
     def test_center(self, a, b):
         rmsd = rms.rmsd(a, b, center=True)
-        assert_almost_equal(rmsd, 0.0)
+        assert_allclose(rmsd, 0.0)
 
     def test_list(self, a, b):
         rmsd = rms.rmsd(a.tolist(),
                         b.tolist(),
                         center=False)
-        assert_almost_equal(rmsd, 1.0)
+        assert_allclose(rmsd, 1.0)
 
     def test_superposition(self, a, b, u):
         bb = u.atoms.select_atoms('backbone')
@@ -94,7 +94,7 @@ class Testrmsd(object):
         u.trajectory[-1]
         b = bb.positions.copy()
         rmsd = rms.rmsd(a, b, superposition=True)
-        assert_almost_equal(rmsd, 6.820321761927005)
+        assert_allclose(rmsd, 6.820321761927005)
 
     def test_weights(self, a, b):
         weights = np.zeros(len(a))
@@ -102,7 +102,7 @@ class Testrmsd(object):
         weights[1] = 1
         weighted = rms.rmsd(a, b, weights=weights)
         firstCoords = rms.rmsd(a[:2], b[:2])
-        assert_almost_equal(weighted, firstCoords)
+        assert_allclose(weighted, firstCoords)
 
     def test_weights_and_superposition_1(self, u):
         weights = np.ones(len(u.trajectory[0]))
@@ -110,7 +110,7 @@ class Testrmsd(object):
                             weights=weights, superposition=True)
         firstCoords = rms.rmsd(u.trajectory[0], u.trajectory[1],
                                superposition=True)
-        assert_almost_equal(weighted, firstCoords, decimal=5)
+        assert_allclose(weighted, firstCoords, atol=1e-05)
 
     def test_weights_and_superposition_2(self, u):
         weights = np.zeros(len(u.trajectory[0]))
@@ -121,7 +121,7 @@ class Testrmsd(object):
                                u.trajectory[-1][:100],
                                superposition=True)
         # very close to zero, change significant decimal places to 5
-        assert_almost_equal(weighted, firstCoords, decimal=5)
+        assert_allclose(weighted, firstCoords, atol=1e-05)
 
     def test_unequal_shape(self):
         a = np.ones((4, 3))
@@ -148,7 +148,7 @@ class Testrmsd(object):
         B = p_last.positions
         rmsd = rms.rmsd(A, B)
         rmsd_superposition = rms.rmsd(A, B, center=True, superposition=True)
-        assert_almost_equal(rmsd, rmsd_superposition, decimal=6)
+        assert_allclose(rmsd, rmsd_superposition, atol=1e-06)
 
 
 class TestRMSD(object):
@@ -185,21 +185,21 @@ class TestRMSD(object):
     def test_rmsd(self, universe, correct_values):
         RMSD = MDAnalysis.analysis.rms.RMSD(universe, select='name CA')
         RMSD.run(step=49)
-        assert_almost_equal(RMSD.results.rmsd, correct_values, 4,
+        assert_allclose(RMSD.results.rmsd, correct_values, 4,
                             err_msg="error: rmsd profile should match" +
                             "test values")
 
     def test_rmsd_frames(self, universe, correct_values):
         RMSD = MDAnalysis.analysis.rms.RMSD(universe, select='name CA')
         RMSD.run(frames=[0, 49])
-        assert_almost_equal(RMSD.results.rmsd, correct_values, 4,
+        assert_allclose(RMSD.results.rmsd, correct_values, 4,
                             err_msg="error: rmsd profile should match" +
                             "test values")
 
     def test_rmsd_unicode_selection(self, universe, correct_values):
         RMSD = MDAnalysis.analysis.rms.RMSD(universe, select=u'name CA')
         RMSD.run(step=49)
-        assert_almost_equal(RMSD.results.rmsd, correct_values, 4,
+        assert_allclose(RMSD.results.rmsd, correct_values, 4,
                             err_msg="error: rmsd profile should match" +
                             "test values")
 
@@ -215,7 +215,7 @@ class TestRMSD(object):
         RMSD = MDAnalysis.analysis.rms.RMSD(universe, select='name CA',
                                             ).run(start=5, stop=6)
         single_frame = [[5, 6, 0.91544906]]
-        assert_almost_equal(RMSD.results.rmsd, single_frame, 4,
+        assert_allclose(RMSD.results.rmsd, single_frame, 4,
                             err_msg="error: rmsd profile should match" +
                             "test values")
 
@@ -225,14 +225,14 @@ class TestRMSD(object):
         RMSD = MDAnalysis.analysis.rms.RMSD(universe, select='name CA',
                                             weights='mass').run(step=49)
 
-        assert_almost_equal(RMSD.results.rmsd, correct_values, 4,
+        assert_allclose(RMSD.results.rmsd, correct_values, 4,
                             err_msg="error: rmsd profile should match"
                             "test values")
 
     def test_custom_weighted(self, universe, correct_values_mass):
         RMSD = MDAnalysis.analysis.rms.RMSD(universe, weights="mass").run(step=49)
 
-        assert_almost_equal(RMSD.results.rmsd, correct_values_mass, 4,
+        assert_allclose(RMSD.results.rmsd, correct_values_mass, 4,
                             err_msg="error: rmsd profile should match"
                             "test values")
 
@@ -241,7 +241,7 @@ class TestRMSD(object):
                                                  weights="mass").run(step=49)
         RMSD_cust = MDAnalysis.analysis.rms.RMSD(universe,
                                                  weights=universe.atoms.masses).run(step=49)
-        assert_almost_equal(RMSD_mass.results.rmsd, RMSD_cust.results.rmsd, 4,
+        assert_allclose(RMSD_mass.results.rmsd, RMSD_cust.results.rmsd, 4,
                             err_msg="error: rmsd profiles should match for 'mass' "
                             "and universe.atoms.masses")
 
@@ -249,7 +249,7 @@ class TestRMSD(object):
         weights = universe.atoms.masses
         RMSD = MDAnalysis.analysis.rms.RMSD(universe,
                                             weights=list(weights)).run(step=49)
-        assert_almost_equal(RMSD.results.rmsd, correct_values_mass, 4,
+        assert_allclose(RMSD.results.rmsd, correct_values_mass, 4,
                             err_msg="error: rmsd profile should match" +
                             "test values")
 
@@ -260,7 +260,7 @@ class TestRMSD(object):
                                             weights=None,
                                             weights_groupselections=[[1, 0, 0, 0, 0], None]).run(step=49)
 
-        assert_almost_equal(RMSD.results.rmsd.T[3], RMSD.results.rmsd.T[4], 4,
+        assert_allclose(RMSD.results.rmsd.T[3], RMSD.results.rmsd.T[4], 4,
                             err_msg="error: rmsd profile should match "
                             "for applied weight array and selected resid")
 
@@ -272,7 +272,7 @@ class TestRMSD(object):
                                             weights_groupselections=['mass',
                                                                      universe.atoms.masses]).run(step=49)
 
-        assert_almost_equal(RMSD.results.rmsd.T[3], RMSD.results.rmsd.T[4], 4,
+        assert_allclose(RMSD.results.rmsd.T[3], RMSD.results.rmsd.T[4], 4,
                             err_msg="error: rmsd profile should match "
                             "between applied mass and universe.atoms.masses")
 
@@ -315,7 +315,7 @@ class TestRMSD(object):
         RMSD = MDAnalysis.analysis.rms.RMSD(universe,
                                             groupselections=['backbone', 'name CA']
                                             ).run(step=49)
-        assert_almost_equal(RMSD.results.rmsd, correct_values_group, 4,
+        assert_allclose(RMSD.results.rmsd, correct_values_group, 4,
                             err_msg="error: rmsd profile should match"
                             "test values")
 
@@ -327,7 +327,7 @@ class TestRMSD(object):
             select="backbone",
             groupselections=['backbone and resid 1:10',
                              'backbone and resid 10:20']).run(step=49)
-        assert_almost_equal(
+        assert_allclose(
             RMSD.results.rmsd, correct_values_backbone_group, 4,
             err_msg="error: rmsd profile should match test values")
 
@@ -354,7 +354,7 @@ class TestRMSD(object):
                                                 weights='mass',
                                                 tol_mass=100)
         RMSD.run(step=49)
-        assert_almost_equal(RMSD.results.rmsd, correct_values_mass_add_ten, 4,
+        assert_allclose(RMSD.results.rmsd, correct_values_mass_add_ten, 4,
                             err_msg="error: rmsd profile should match "
                             "between true values and calculated values")
 
@@ -385,14 +385,14 @@ class TestRMSF(object):
         rmsfs.run()
         test_rmsfs = np.load(rmsfArray)
 
-        assert_almost_equal(rmsfs.results.rmsf, test_rmsfs, 5,
+        assert_allclose(rmsfs.results.rmsf, test_rmsfs, 5,
                             err_msg="error: rmsf profile should match test "
                             "values")
 
     def test_rmsf_single_frame(self, universe):
         rmsfs = rms.RMSF(universe.select_atoms('name CA')).run(start=5, stop=6)
 
-        assert_almost_equal(rmsfs.results.rmsf, 0, 5,
+        assert_allclose(rmsfs.results.rmsf, 0, 5,
                             err_msg="error: rmsfs should all be zero")
 
     def test_rmsf_identical_frames(self, universe, tmpdir):
@@ -407,7 +407,7 @@ class TestRMSF(object):
         universe = mda.Universe(GRO, outfile)
         rmsfs = rms.RMSF(universe.select_atoms('name CA'))
         rmsfs.run()
-        assert_almost_equal(rmsfs.results.rmsf, 0, 5,
+        assert_allclose(rmsfs.results.rmsf, 0, 5,
                             err_msg="error: rmsfs should all be 0")
 
     def test_rmsf_attr_warning(self, universe):

--- a/testsuite/MDAnalysisTests/auxiliary/base.py
+++ b/testsuite/MDAnalysisTests/auxiliary/base.py
@@ -24,7 +24,7 @@ import MDAnalysis as mda
 import numpy as np
 import pytest
 from MDAnalysisTests.datafiles import (COORDINATES_XTC, COORDINATES_TOPOLOGY)
-from numpy.testing import assert_almost_equal, assert_equal
+from numpy.testing import assert_allclose, assert_equal
 
 
 def test_get_bad_auxreader_format_raises_ValueError():
@@ -271,7 +271,7 @@ class BaseAuxReaderTest(object):
         ts = ref.lower_freq_ts
         reader.update_ts(ts)
         # check the value set in ts is as we expect
-        assert_almost_equal(ts.aux.test, ref.lowf_closest_rep,
+        assert_allclose(ts.aux.test, ref.lowf_closest_rep,
                             err_msg="Representative value in ts.aux does not match")
 
     def test_represent_as_average(self, ref, reader):
@@ -282,7 +282,7 @@ class BaseAuxReaderTest(object):
         ts = ref.lower_freq_ts
         reader.update_ts(ts)
         # check the representative value set in ts is as expected
-        assert_almost_equal(ts.aux.test, ref.lowf_average_rep,
+        assert_allclose(ts.aux.test, ref.lowf_average_rep,
                             err_msg="Representative value does not match when "
                                     "using with option 'average'")
 
@@ -294,7 +294,7 @@ class BaseAuxReaderTest(object):
         ts = ref.lower_freq_ts
         reader.update_ts(ts)
         # check representative value set in ts is as expected
-        assert_almost_equal(ts.aux.test, ref.lowf_cutoff_average_rep,
+        assert_allclose(ts.aux.test, ref.lowf_cutoff_average_rep,
                             err_msg="Representative value does not match when "
                                     "applying cutoff")
 
@@ -302,7 +302,7 @@ class BaseAuxReaderTest(object):
         # try reading a timestep offset from auxiliary
         ts = ref.offset_ts
         reader.update_ts(ts)
-        assert_almost_equal(ts.aux.test, ref.offset_closest_rep,
+        assert_allclose(ts.aux.test, ref.offset_closest_rep,
                             err_msg="Representative value in ts.aux does not match")
 
     def test_represent_as_closest_with_cutoff(self, ref, reader):
@@ -313,7 +313,7 @@ class BaseAuxReaderTest(object):
         ts = ref.offset_ts
         reader.update_ts(ts)
         # check representative value set in ts is as expected
-        assert_almost_equal(ts.aux.test, ref.offset_cutoff_closest_rep,
+        assert_allclose(ts.aux.test, ref.offset_cutoff_closest_rep,
                             err_msg="Representative value does not match when "
                                     "applying cutoff")
 
@@ -321,7 +321,7 @@ class BaseAuxReaderTest(object):
         # try reading a timestep with higher frequency
         ts = ref.higher_freq_ts
         reader.update_ts(ts)
-        assert_almost_equal(ts.aux.test, ref.highf_rep,
+        assert_allclose(ts.aux.test, ref.highf_rep,
                             err_msg="Representative value in ts.aux does not match")
 
     def test_get_auxreader_for(self, ref, reader):
@@ -394,7 +394,7 @@ class BaseAuxReaderTest(object):
             frame, time_diff = reader.step_to_frame(idx, ts, return_time_diff=True)
 
             assert frame == idx
-            np.testing.assert_almost_equal(time_diff, idx * 0.1)
+            np.testing.assert_allclose(time_diff, idx * 0.1)
 
     def test_go_to_step_fail(self, reader):
 
@@ -427,7 +427,7 @@ def assert_auxstep_equal(A, B):
                              'B.time = {}'.format(A.time, B.time))
     if isinstance(A.data, dict):
         for term in A.data:
-            assert_almost_equal(A.data[term], B.data[term])
+            assert_allclose(A.data[term], B.data[term])
     else:
         if any(A.data != B.data):
             # e.g. XVGReader

--- a/testsuite/MDAnalysisTests/coordinates/test_chainreader.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_chainreader.py
@@ -28,7 +28,7 @@ import os
 
 import pytest
 
-from numpy.testing import (assert_equal, assert_almost_equal)
+from numpy.testing import (assert_equal,assert_allclose)
 
 import MDAnalysis as mda
 from MDAnalysis.transformations import translate
@@ -115,7 +115,7 @@ class TestChainReader(object):
 
     def test_time(self, universe):
         universe.trajectory[30]  # index and frames 0-based
-        assert_almost_equal(
+        assert_allclose(
             universe.trajectory.time, 30.0, 5, err_msg="Wrong time of frame")
 
     def test_write_dcd(self, universe, tmpdir):
@@ -128,7 +128,7 @@ class TestChainReader(object):
         universe.trajectory.rewind()
         u = mda.Universe(PSF, outfile)
         for (ts_orig, ts_new) in zip(universe.trajectory, u.trajectory):
-            assert_almost_equal(
+            assert_allclose(
                 ts_orig._pos,
                 ts_new._pos,
                 self.prec,
@@ -143,12 +143,12 @@ class TestChainReader(object):
         for ts in transformed.trajectory:
             frame = ts.frame
             ref = universe.trajectory[frame].positions + vector
-            assert_almost_equal(ts.positions, ref, decimal = 6)
+            assert_allclose(ts.positions, ref, atol = 1e-06)
         # iterate again:
         for ts in transformed.trajectory:
             frame = ts.frame
             ref = universe.trajectory[frame].positions + vector
-            assert_almost_equal(ts.positions, ref, decimal = 6)
+            assert_allclose(ts.positions, ref, atol = 1e-06)
     
     def test_transform_slice(self, universe, transformed):
         vector = np.float32([10,10,10])
@@ -156,24 +156,24 @@ class TestChainReader(object):
         for ts in transformed.trajectory[5:17:3]:
             frame = ts.frame
             ref = universe.trajectory[frame].positions + vector
-            assert_almost_equal(ts.positions, ref, decimal = 6)
+            assert_allclose(ts.positions, ref, atol = 1e-06)
     
     def test_transform_switch(self, universe, transformed):
         vector = np.float32([10,10,10])
         # grab a frame:
         ref = universe.trajectory[2].positions + vector
-        assert_almost_equal(transformed.trajectory[2].positions, ref, decimal = 6)
+        assert_allclose(transformed.trajectory[2].positions, ref, atol = 1e-06)
         # now switch to another frame
         newref = universe.trajectory[10].positions + vector
-        assert_almost_equal(transformed.trajectory[10].positions, newref, decimal = 6)
+        assert_allclose(transformed.trajectory[10].positions, newref, atol = 1e-06)
         # what happens when we comeback to the previous frame?
-        assert_almost_equal(transformed.trajectory[2].positions, ref, decimal = 6)
+        assert_allclose(transformed.trajectory[2].positions, ref, atol = 1e-06)
     
     def test_transfrom_rewind(self, universe, transformed):
         vector = np.float32([10,10,10])
         ref = universe.trajectory[0].positions + vector
         transformed.trajectory.rewind()
-        assert_almost_equal(transformed.trajectory.ts.positions, ref, decimal = 6)
+        assert_allclose(transformed.trajectory.ts.positions, ref, atol = 1e-06)
 
 
 class TestChainReaderCommonDt(object):
@@ -190,7 +190,7 @@ class TestChainReaderCommonDt(object):
         # We test this for the beginning, middle and end of the trajectory.
         for frame_n in (0, trajectory.n_frames // 2, -1):
             trajectory[frame_n]
-            assert_almost_equal(
+            assert_allclose(
                 trajectory.time,
                 trajectory.frame * self.common_dt,
                 5,
@@ -309,7 +309,7 @@ class TestChainReaderContinuous(object):
         u = mda.Universe(utop._topology, fnames, continuous=True)
         assert u.trajectory.n_frames == seq_info.n_frames
         for i, ts in enumerate(u.trajectory):
-            assert_almost_equal(i, ts.time, decimal=4)
+            assert_allclose(i, ts.time, atol=1e-04)
             # check we have used the right trajectory
             assert seq_info.order[i] == int(ts.positions[0, 0])
 

--- a/testsuite/MDAnalysisTests/coordinates/test_copying.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_copying.py
@@ -26,7 +26,7 @@ try:
 except ImportError:
     shares_memory = False
 
-from numpy.testing import assert_equal, assert_almost_equal
+from numpy.testing import assert_equal,assert_allclose
 import pytest
 import MDAnalysis as mda
 
@@ -265,7 +265,7 @@ def test_timestep_copied(ref_reader):
     new = ref_reader.copy()
 
     assert_equal(ref_reader.ts.positions, new.ts.positions)
-    assert_almost_equal(new.ts.dimensions, newbox, decimal=4)
+    assert_allclose(new.ts.dimensions, newbox, atol=1e-04)
     assert ref_reader.ts.positions.dtype == np.float32
     assert new.ts.positions.dtype == np.float32
 

--- a/testsuite/MDAnalysisTests/coordinates/test_fhiaims.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_fhiaims.py
@@ -31,8 +31,7 @@ from MDAnalysisTests.coordinates.base import (
     _SingleFrameReader, BaseWriterTest)
 from MDAnalysisTests.datafiles import FHIAIMS
 from numpy.testing import (assert_equal,
-                           assert_array_almost_equal,
-                           assert_almost_equal)
+                           assert_allclose)
 
 
 @pytest.fixture(scope='module')
@@ -115,7 +114,7 @@ class TestFHIAIMSReader(object):
         return StringIO(buffer)
 
     def test_single_file(self, universe, universe_from_one_file):
-        assert_almost_equal(universe.atoms.positions, universe_from_one_file.atoms.positions,
+        assert_allclose(universe.atoms.positions, universe_from_one_file.atoms.positions,
                             self.prec, "FHIAIMSReader failed to load universe from single file")
 
     def test_uses_FHIAIMSReader(self, universe):
@@ -125,7 +124,7 @@ class TestFHIAIMSReader(object):
                           FHIAIMSReader), "failed to choose FHIAIMSReader"
 
     def test_dimensions(self, ref, universe):
-        assert_almost_equal(
+        assert_allclose(
             ref.dimensions, universe.dimensions,
             self.prec, "FHIAIMSReader failed to get unitcell dimensions")
 
@@ -136,7 +135,7 @@ class TestFHIAIMSReader(object):
 
     def test_fhiaims_positions(self, ref, universe):
         # first particle
-        assert_almost_equal(ref.pos_atom1,
+        assert_allclose(ref.pos_atom1,
                             universe.atoms.positions[0],
                             self.prec,
                             "FHIAIMSReader failed to read coordinates properly")
@@ -173,7 +172,7 @@ class TestFHIAIMSReader(object):
 
     def test_good_input_with_velocity(self, good_input_with_velocity):
         u = mda.Universe(good_input_with_velocity, format="FHIAIMS")
-        assert_almost_equal(u.atoms.velocities[0],
+        assert_allclose(u.atoms.velocities[0],
                             np.asarray([0.1, 0.1, 0.1]),
                             self.prec,
                             "FHIAIMSReader failed to read velocities properly")
@@ -183,7 +182,7 @@ class TestFHIAIMSReader(object):
         u_mixed = mda.Universe(good_input_mixed_units, format="FHIAIMS")
         print(u_natural.atoms.positions)
         print(u_mixed.atoms.positions)
-        assert_almost_equal(u_natural.atoms.positions,
+        assert_allclose(u_natural.atoms.positions,
                             u_mixed.atoms.positions,
                             self.prec,
                             "FHIAIMSReader failed to read positions in lattice units properly")
@@ -202,7 +201,7 @@ class TestFHIAIMSWriter(BaseWriterTest):
         """
         universe.atoms.write(outfile)
         u = mda.Universe(FHIAIMS, outfile)
-        assert_almost_equal(u.atoms.positions,
+        assert_allclose(u.atoms.positions,
                             universe.atoms.positions, self.prec,
                             err_msg="Writing FHIAIMS file with FHIAIMSWriter "
                                     "does not reproduce original coordinates")
@@ -213,7 +212,7 @@ class TestFHIAIMSWriter(BaseWriterTest):
         universe_in = mda.Universe(good_input_with_velocity, format="FHIAIMS")
         universe_in.atoms.write(outfile)
         u = mda.Universe(outfile)
-        assert_almost_equal(u.atoms.velocities,
+        assert_allclose(u.atoms.velocities,
                             universe_in.atoms.velocities, self.prec,
                             err_msg="Writing FHIAIMS file with FHIAIMSWriter "
                                     "does not reproduce original velocities")
@@ -235,6 +234,6 @@ class TestFHIAIMSWriter(BaseWriterTest):
                 assert line.endswith(
                     'H'), "Line written incorrectly with FHIAIMSWriter"
                 line = np.asarray(line.split()[1:-1], dtype=np.float32)
-                assert_almost_equal(line, [0.1, 0.2, 0.3], self.prec,
+                assert_allclose(line, [0.1, 0.2, 0.3], self.prec,
                                     err_msg="Writing FHIAIMS file with FHIAIMSWriter "
                                     "does not reproduce original positions")

--- a/testsuite/MDAnalysisTests/coordinates/test_gms.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_gms.py
@@ -23,7 +23,7 @@
 import pytest
 
 import numpy as np
-from numpy.testing import (assert_equal, assert_almost_equal)
+from numpy.testing import (assert_equal,assert_allclose)
 
 import MDAnalysis as mda
 from MDAnalysis.coordinates.GMS import GMSReader
@@ -77,13 +77,13 @@ class _GMSBase(object):
         assert_equal(u.trajectory.ts.frame, 1, "loading frame 1")
 
     def test_dt(self, u):
-        assert_almost_equal(u.trajectory.dt,
+        assert_allclose(u.trajectory.dt,
                             1.0,
                             4,
                             err_msg="wrong timestep dt")
 
     def test_step5distances(self, u):
-        assert_almost_equal(self._calcFD(u), self.step5d, decimal=5,
+        assert_allclose(self._calcFD(u), self.step5d, atol=1e-05,
                             err_msg="Wrong 1-4 atom distance change after "
                                     "5 steps for {}".format(self.flavour))
 

--- a/testsuite/MDAnalysisTests/coordinates/test_gro.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_gro.py
@@ -42,7 +42,7 @@ from MDAnalysisTests.datafiles import (
     PDB_closed,
 )
 from numpy.testing import (
-    assert_almost_equal,
+    assert_allclose,
     assert_equal,
 )
 import pytest
@@ -66,7 +66,7 @@ class TestGROReaderOld(RefAdK):
 
     def test_coordinates(self, universe):
         A10CA = universe.select_atoms('name CA')[10]
-        assert_almost_equal(A10CA.position,
+        assert_allclose(A10CA.position,
                             self.ref_coordinates['A10CA'],
                             self.prec,
                             err_msg="wrong coordinates for A10:CA")
@@ -78,7 +78,7 @@ class TestGROReaderOld(RefAdK):
         NTERM = universe.select_atoms('name N')[0]
         CTERM = universe.select_atoms('name C')[-1]
         d = mda.lib.mdamath.norm(NTERM.position - CTERM.position)
-        assert_almost_equal(d, self.ref_distances['endtoend'], self.prec - 1,
+        assert_allclose(d, self.ref_distances['endtoend'], self.prec - 1,
                             err_msg="distance between M1:N and G214:C")
 
     def test_selection(self, universe):
@@ -87,7 +87,7 @@ class TestGROReaderOld(RefAdK):
                      "Atom selection of last atoms in file")
 
     def test_unitcell(self, universe):
-        assert_almost_equal(
+        assert_allclose(
             universe.trajectory.ts.dimensions,
             self.ref_unitcell,
             self.prec,
@@ -106,7 +106,7 @@ class TestGROReaderNoConversionOld(RefAdK):
         # we loaded with convert_units=False
         A10CA = universe.select_atoms('name CA')[10]
         # coordinates in nm
-        assert_almost_equal(A10CA.position,
+        assert_allclose(A10CA.position,
                             RefAdK.ref_coordinates['A10CA'] / 10.0,
                             self.prec, err_msg="wrong native coordinates "
                                                "(in nm) for A10:CA")
@@ -122,19 +122,19 @@ class TestGROReaderNoConversionOld(RefAdK):
         CTERM = universe.select_atoms('name C')[-1]
         d = mda.lib.mdamath.norm(NTERM.position - CTERM.position)
         # coordinates in nm
-        assert_almost_equal(d, RefAdK.ref_distances['endtoend'] / 10.0,
+        assert_allclose(d, RefAdK.ref_distances['endtoend'] / 10.0,
                             self.prec - 1, err_msg="distance between M1:N "
                                                    "and G214:C")
 
     def test_unitcell(self, universe):
         # lengths in A : convert to nm
-        assert_almost_equal(
+        assert_allclose(
             universe.trajectory.ts.dimensions[:3],
             self.ref_unitcell[:3] / 10.0,
             self.prec,
             err_msg="unit cell A,B,C (rhombic dodecahedron)")
         # angles should not have changed
-        assert_almost_equal(
+        assert_allclose(
             universe.trajectory.ts.dimensions[3:],
             self.ref_unitcell[3:],
             self.prec,
@@ -142,7 +142,7 @@ class TestGROReaderNoConversionOld(RefAdK):
 
     def test_volume(self, universe):
         # ref lengths in A (which was originally converted from nm)
-        assert_almost_equal(
+        assert_allclose(
             universe.trajectory.ts.volume,
             self.ref_volume / 1000.,
             3,
@@ -201,7 +201,7 @@ class TestGROWriter(BaseWriterTest):
             u.atoms.write(outfile)
 
             u2 = mda.Universe(outfile)
-            assert_almost_equal(u.atoms.velocities,
+            assert_allclose(u.atoms.velocities,
                                 u2.atoms.velocities)
 
     def test_write_no_resnames(self, u_no_resnames, ref, tmpdir):

--- a/testsuite/MDAnalysisTests/coordinates/test_gsd.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_gsd.py
@@ -23,7 +23,7 @@
 import os
 
 import pytest
-from numpy.testing import assert_almost_equal
+from numpy.testing import assert_allclose
 
 import MDAnalysis as mda
 from MDAnalysis.coordinates.GSD import GSDReader
@@ -38,11 +38,11 @@ def GSD_U():
 def test_gsd_positions(GSD_U):
     # first frame first particle
     ts = GSD_U.trajectory[0]
-    assert_almost_equal(GSD_U.atoms.positions[0],
+    assert_allclose(GSD_U.atoms.positions[0],
                         [ -5.4000001 , -10.19999981, -10.19999981])
     # second frame first particle
     ts = GSD_U.trajectory[1]
-    assert_almost_equal(GSD_U.atoms.positions[0],
+    assert_allclose(GSD_U.atoms.positions[0],
                         [ -5.58348083,  -9.98546982, -10.17657185])
 
 
@@ -52,7 +52,7 @@ def test_gsd_n_frames(GSD_U):
 
 def test_gsd_dimensions(GSD_U):
     ts = GSD_U.trajectory[0]
-    assert_almost_equal(ts.dimensions,
+    assert_allclose(ts.dimensions,
                         [ 21.60000038,21.60000038,21.60000038,90.,90.,90.])
 
 

--- a/testsuite/MDAnalysisTests/coordinates/test_h5md.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_h5md.py
@@ -1,5 +1,5 @@
 import pytest
-from numpy.testing import assert_almost_equal, assert_equal, assert_allclose
+from numpy.testing import assert_equal, assert_allclose
 import numpy as np
 import sys
 import os
@@ -29,7 +29,7 @@ class H5MDReference(BaseReference):
         self.reader = mda.coordinates.H5MD.H5MDReader
         self.writer = mda.coordinates.H5MD.H5MDWriter
         self.ext = 'h5md'
-        self.prec = 3
+        self.prec = 1e-03
         self.changing_dimensions = True
 
         self.first_frame.velocities = self.first_frame.positions / 10
@@ -140,7 +140,7 @@ class TestH5MDWriterBaseAPI(BaseWriterTest):
 @pytest.mark.skipif(not HAS_H5PY, reason="h5py not installed")
 class TestH5MDReaderWithRealTrajectory(object):
 
-    prec = 3
+    prec = 1e-03
     ext = 'h5md'
 
     @pytest.fixture(scope='class')
@@ -160,78 +160,78 @@ class TestH5MDReaderWithRealTrajectory(object):
 
     def test_positions(self, universe):
         universe.trajectory[0]
-        assert_almost_equal(universe.atoms.positions[0],
+        assert_allclose(universe.atoms.positions[0],
                             [32.309906, 13.77798, 14.372463],
-                            decimal=self.prec)
-        assert_almost_equal(universe.atoms.positions[42],
+                            atol=self.prec)
+        assert_allclose(universe.atoms.positions[42],
                             [28.116928, 19.405945, 19.647358],
-                            decimal=self.prec)
-        assert_almost_equal(universe.atoms.positions[10000],
+                            atol=self.prec)
+        assert_allclose(universe.atoms.positions[10000],
                             [44.117805, 50.442093, 23.299038],
-                            decimal=self.prec)
+                            atol=self.prec)
 
         universe.trajectory[1]
-        assert_almost_equal(universe.atoms.positions[0],
+        assert_allclose(universe.atoms.positions[0],
                             [30.891968, 13.678971, 13.6000595],
-                            decimal=self.prec)
-        assert_almost_equal(universe.atoms.positions[42],
+                            atol=self.prec)
+        assert_allclose(universe.atoms.positions[42],
                             [27.163246, 19.846561, 19.3582],
-                            decimal=self.prec)
-        assert_almost_equal(universe.atoms.positions[10000],
+                            atol=self.prec)
+        assert_allclose(universe.atoms.positions[10000],
                             [45.869278, 5.0342298, 25.460655],
-                            decimal=self.prec)
+                            atol=self.prec)
         universe.trajectory[2]
-        assert_almost_equal(universe.atoms.positions[0],
+        assert_allclose(universe.atoms.positions[0],
                             [31.276512, 13.89617, 15.015897],
-                            decimal=self.prec)
-        assert_almost_equal(universe.atoms.positions[42],
+                            atol=self.prec)
+        assert_allclose(universe.atoms.positions[42],
                             [28.567991, 20.56532, 19.40814],
-                            decimal=self.prec)
-        assert_almost_equal(universe.atoms.positions[10000],
+                            atol=self.prec)
+        assert_allclose(universe.atoms.positions[10000],
                             [39.713223,  6.127234, 18.284992],
-                            decimal=self.prec)
+                            atol=self.prec)
 
     def test_h5md_velocities(self, universe):
         universe.trajectory[0]
-        assert_almost_equal(universe.atoms.velocities[0],
+        assert_allclose(universe.atoms.velocities[0],
                             [-2.697732, 0.613568, 0.14334752],
-                            decimal=self.prec)
+                            atol=self.prec)
         universe.trajectory[1]
-        assert_almost_equal(universe.atoms.velocities[42],
+        assert_allclose(universe.atoms.velocities[42],
                             [-6.8698354, 7.834235, -8.114698],
-                            decimal=self.prec)
+                            atol=self.prec)
         universe.trajectory[2]
-        assert_almost_equal(universe.atoms.velocities[10000],
+        assert_allclose(universe.atoms.velocities[10000],
                             [9.799492, 5.631466, 6.852126],
-                            decimal=self.prec)
+                            atol=self.prec)
 
     def test_h5md_forces(self, universe):
         universe.trajectory[0]
-        assert_almost_equal(universe.atoms.forces[0],
+        assert_allclose(universe.atoms.forces[0],
                             [20.071287, -155.2285, -96.72112],
-                            decimal=self.prec)
+                            atol=self.prec)
         universe.trajectory[1]
-        assert_almost_equal(universe.atoms.forces[42],
+        assert_allclose(universe.atoms.forces[42],
                             [-4.1959066, -31.31548, 22.663044],
-                            decimal=self.prec)
+                            atol=self.prec)
         universe.trajectory[2]
-        assert_almost_equal(universe.atoms.forces[10000],
+        assert_allclose(universe.atoms.forces[10000],
                             [-41.43743, 83.35207, 62.94751],
-                            decimal=self.prec)
+                            atol=self.prec)
 
     def test_h5md_dimensions(self, universe):
         universe.trajectory[0]
-        assert_almost_equal(universe.trajectory.ts.dimensions,
+        assert_allclose(universe.trajectory.ts.dimensions,
                             [52.763, 52.763, 52.763, 90., 90., 90.],
-                            decimal=self.prec)
+                            atol=self.prec)
         universe.trajectory[1]
-        assert_almost_equal(universe.trajectory.ts.dimensions,
+        assert_allclose(universe.trajectory.ts.dimensions,
                             [52.807877, 52.807877, 52.807877, 90., 90., 90.],
-                            decimal=self.prec)
+                            atol=self.prec)
         universe.trajectory[2]
-        assert_almost_equal(universe.trajectory.ts.dimensions,
+        assert_allclose(universe.trajectory.ts.dimensions,
                             [52.839806, 52.839806, 52.839806, 90., 90., 90.],
-                            decimal=self.prec)
+                            atol=self.prec)
 
     def test_h5md_data_step(self, universe):
         for ts, step in zip(universe.trajectory, (0, 25000, 50000)):
@@ -454,7 +454,7 @@ class TestH5MDReaderWithRealTrajectory(object):
 @pytest.mark.skipif(not HAS_H5PY, reason="h5py not installed")
 class TestH5MDWriterWithRealTrajectory(object):
 
-    prec = 3
+    prec = 1e-03
 
     @pytest.fixture()
     def universe(self):
@@ -576,22 +576,22 @@ class TestH5MDWriterWithRealTrajectory(object):
 
             # check the trajectory contents match reference universes
             for ts, ref_ts in zip(uw.trajectory, universe.trajectory):
-                assert_almost_equal(ts.dimensions, ref_ts.dimensions, self.prec)
+                assert_allclose(ts.dimensions, ref_ts.dimensions, self.prec)
                 if pos:
-                    assert_almost_equal(ts._pos, ref_ts._pos, self.prec)
+                    assert_allclose(ts._pos, ref_ts._pos, self.prec)
                 else:
                     with pytest.raises(NoDataError,
                                        match="This Timestep has no"):
                         getattr(ts, 'positions')
                 if vel:
-                    assert_almost_equal(ts._velocities, ref_ts._velocities,
+                    assert_allclose(ts._velocities, ref_ts._velocities,
                                         self.prec)
                 else:
                     with pytest.raises(NoDataError,
                                        match="This Timestep has no"):
                         getattr(ts, 'velocities')
                 if force:
-                    assert_almost_equal(ts._forces, ref_ts._forces, self.prec)
+                    assert_allclose(ts._forces, ref_ts._forces, self.prec)
                 else:
                     with pytest.raises(NoDataError,
                                        match="This Timestep has no"):
@@ -624,9 +624,9 @@ class TestH5MDWriterWithRealTrajectory(object):
 
         for orig_ts, written_ts in zip(universe.trajectory,
                                        uw.trajectory):
-            assert_almost_equal(ca.positions, caw.positions, self.prec)
-            assert_almost_equal(orig_ts.time, written_ts.time, self.prec)
-            assert_almost_equal(written_ts.dimensions,
+            assert_allclose(ca.positions, caw.positions, self.prec)
+            assert_allclose(orig_ts.time, written_ts.time, self.prec)
+            assert_allclose(written_ts.dimensions,
                                 orig_ts.dimensions,
                                 self.prec)
 
@@ -646,9 +646,9 @@ class TestH5MDWriterWithRealTrajectory(object):
         assert_equal(n_frames, len(uw.trajectory))
         for orig_ts, written_ts in zip(universe.trajectory,
                                        uw.trajectory):
-            assert_almost_equal(ca.positions, caw.positions, self.prec)
-            assert_almost_equal(orig_ts.time, written_ts.time, self.prec)
-            assert_almost_equal(written_ts.dimensions,
+            assert_allclose(ca.positions, caw.positions, self.prec)
+            assert_allclose(orig_ts.time, written_ts.time, self.prec)
+            assert_allclose(written_ts.dimensions,
                                 orig_ts.dimensions,
                                 self.prec)
 

--- a/testsuite/MDAnalysisTests/coordinates/test_memory.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_memory.py
@@ -29,7 +29,7 @@ from MDAnalysisTests.datafiles import DCD, PSF
 from MDAnalysisTests.coordinates.base import (BaseReference,
                                               MultiframeReaderTest)
 from MDAnalysis.coordinates.memory import Timestep
-from numpy.testing import assert_equal, assert_almost_equal
+from numpy.testing import assert_equal,assert_allclose
 
 
 class MemoryReference(BaseReference):
@@ -195,7 +195,7 @@ class TestMemoryReader(MultiframeReaderTest):
         new_positions = np.ones_like(reader.ts.positions, dtype=np.float32)
         reader.ts.positions = new_positions
         reader[0]
-        assert_almost_equal(reader.ts.positions, new_positions)
+        assert_allclose(reader.ts.positions, new_positions)
 
     def test_timeseries_warns_deprecation(self, reader):
         with pytest.warns(DeprecationWarning, match="MemoryReader.timeseries "
@@ -340,7 +340,7 @@ class TestMemoryReaderModifications(object):
         ts = mr2.ts
         setattr(ts, attr, 7)
         # check the change worked
-        assert_almost_equal(getattr(ts, attr), 7)
+        assert_allclose(getattr(ts, attr), 7)
         assert ts.positions.shape == (self.n_atoms, 3)
         assert ts.velocities.shape == (self.n_atoms, 3)
         assert ts.forces.shape == (self.n_atoms, 3)
@@ -349,7 +349,7 @@ class TestMemoryReaderModifications(object):
         ts = mr2[2]
         ts = mr2[0]
         # check our old change is still there
-        assert_almost_equal(getattr(ts, attr), 7)
+        assert_allclose(getattr(ts, attr), 7)
 
     @pytest.mark.parametrize('attr', ['positions', 'velocities', 'forces', 'dimensions'])
     def test_attr_set(self, mr_universe, attr):
@@ -359,12 +359,12 @@ class TestMemoryReaderModifications(object):
 
         setattr(ts, attr, 7)
 
-        assert_almost_equal(getattr(ts, attr), 7)
+        assert_allclose(getattr(ts, attr), 7)
 
         ts = u.trajectory[2]
         ts = u.trajectory[0]
 
-        assert_almost_equal(getattr(ts, attr), 7)
+        assert_allclose(getattr(ts, attr), 7)
         assert u.atoms.positions.shape == (self.n_atoms, 3)
         assert u.atoms.velocities.shape == (self.n_atoms, 3)
         assert u.atoms.forces.shape == (self.n_atoms, 3)

--- a/testsuite/MDAnalysisTests/coordinates/test_mmtf.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_mmtf.py
@@ -23,7 +23,7 @@
 import pytest
 import numpy as np
 from numpy.testing import (
-    assert_almost_equal,
+    assert_allclose,
 )
 
 from MDAnalysisTests.datafiles import MMTF, MMTF_gz, MMTF_skinny2
@@ -40,12 +40,12 @@ class TestMMTFReader(object):
         assert r.ts.n_atoms == 512
 
     def test_read_positions(self, r):
-        assert_almost_equal(r.ts.positions[0],
+        assert_allclose(r.ts.positions[0],
                             np.array([-0.798, 12.632, 23.231]),
-                            decimal=4)
-        assert_almost_equal(r.ts.positions[-1],
+                            atol=1e-04)
+        assert_allclose(r.ts.positions[-1],
                             np.array([10.677, 15.517, 11.1]),
-                            decimal=4)
+                            atol=1e-04)
 
     def test_velocities(self, r):
         assert not r.ts.has_velocities
@@ -67,12 +67,12 @@ class TestMMTFReaderGZ(object):
         assert r.ts.n_atoms == 1140
 
     def test_read_positions(self, r):
-        assert_almost_equal(r.ts.positions[0],
+        assert_allclose(r.ts.positions[0],
                             np.array([38.428, 16.440, 28.841]),
-                            decimal=4)
-        assert_almost_equal(r.ts.positions[-1],
+                            atol=1e-04)
+        assert_allclose(r.ts.positions[-1],
                             np.array([36.684, 27.024, 20.468]),
-                            decimal=4)
+                            atol=1e-04)
 
     def test_velocities(self, r):
         assert not r.ts.has_velocities

--- a/testsuite/MDAnalysisTests/coordinates/test_mol2.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_mol2.py
@@ -26,7 +26,7 @@ import os
 from numpy.testing import (
     assert_equal, assert_array_equal,
     assert_array_almost_equal, TestCase,
-    assert_almost_equal
+    assert_allclose
 )
 
 from MDAnalysisTests.datafiles import (
@@ -213,6 +213,6 @@ def test_mol2_universe_write(tmpdir):
 
         u2 = mda.Universe(outfile)
 
-        assert_almost_equal(u.atoms.positions, u2.atoms.positions)
+        assert_allclose(u.atoms.positions, u2.atoms.positions)
         # MDA does not current implement @<TRIPOS>CRYSIN reading
         assert u2.dimensions is None

--- a/testsuite/MDAnalysisTests/coordinates/test_netcdf.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_netcdf.py
@@ -29,7 +29,7 @@ from scipy.io import netcdf_file
 import pytest
 from numpy.testing import (
     assert_equal,
-    assert_almost_equal
+    assert_allclose
 )
 from MDAnalysis.coordinates.TRJ import NCDFReader, NCDFWriter
 
@@ -62,8 +62,8 @@ class _NCDFReaderTest(_TRJReaderTest):
 
     def test_dt(self, universe):
         ref = 0.0
-        assert_almost_equal(ref, universe.trajectory.dt, self.prec)
-        assert_almost_equal(ref, universe.trajectory.ts.dt, self.prec)
+        assert_allclose(ref, universe.trajectory.dt, self.prec)
+        assert_allclose(ref, universe.trajectory.ts.dt, self.prec)
 
     def test_get_writer(self, universe):
         with universe.trajectory.Writer('out.ncdf') as w:
@@ -156,7 +156,7 @@ class TestNCDFReader2(object):
                            ], [-0.44717646, 18.61727142, 12.59919548],
                           [-0.60952115, 19.47885513, 11.22137547]],
                          dtype=np.float32)
-        assert_almost_equal(ref_1, u.atoms.positions[:3], self.prec)
+        assert_allclose(ref_1, u.atoms.positions[:3], self.prec)
 
     def test_positions_2(self, u):
         """Check positions on second frame"""
@@ -165,7 +165,7 @@ class TestNCDFReader2(object):
                            ], [-0.46643803, 18.60186768, 12.646698],
                           [-0.46567637, 19.49173927, 11.21922874]],
                          dtype=np.float32)
-        assert_almost_equal(ref_2, u.atoms.positions[:3], self.prec)
+        assert_allclose(ref_2, u.atoms.positions[:3], self.prec)
 
     def test_forces_1(self, u):
         """Check forces on first frame"""
@@ -174,7 +174,7 @@ class TestNCDFReader2(object):
                            ], [2.97547197, 29.84169388, 11.12069607],
                           [-15.93093777, 14.43616867, 30.25889015]],
                          dtype=np.float32)
-        assert_almost_equal(ref_1, u.atoms.forces[:3], self.prec)
+        assert_allclose(ref_1, u.atoms.forces[:3], self.prec)
 
     def test_forces_2(self, u):
         """Check forces on second frame"""
@@ -183,22 +183,22 @@ class TestNCDFReader2(object):
                            ], [-18.90058327, 27.20145798, 1.95245135],
                           [-31.08556366, 14.95863628, 41.10367966]],
                          dtype=np.float32)
-        assert_almost_equal(ref_2, u.atoms.forces[:3], self.prec)
+        assert_allclose(ref_2, u.atoms.forces[:3], self.prec)
 
     def test_time_1(self, u):
         """Check time on first frame"""
         ref = 35.02
-        assert_almost_equal(ref, u.trajectory[0].time, self.prec)
+        assert_allclose(ref, u.trajectory[0].time, self.prec)
 
     def test_time_2(self, u):
         """Check time on second frame"""
         ref = 35.04
-        assert_almost_equal(ref, u.trajectory[1].time, self.prec)
+        assert_allclose(ref, u.trajectory[1].time, self.prec)
 
     def test_dt(self, u):
         ref = 0.02
-        assert_almost_equal(ref, u.trajectory.dt, self.prec)
-        assert_almost_equal(ref, u.trajectory.ts.dt, self.prec)
+        assert_allclose(ref, u.trajectory.dt, self.prec)
+        assert_allclose(ref, u.trajectory.ts.dt, self.prec)
 
     def test_box(self, u):
         for ts in u.trajectory:
@@ -257,7 +257,7 @@ class TestNCDFReader3(object):
     @pytest.mark.parametrize('index,expected', ((0, 0), (8, 1)))
     def test_positions(self, universe, index, expected):
         universe.trajectory[index]
-        assert_almost_equal(self.coord_refs[expected],
+        assert_allclose(self.coord_refs[expected],
                             universe.atoms.positions[:3], self.prec)
 
     @pytest.mark.parametrize('index,expected', ((0, 0), (8, 1)))
@@ -267,7 +267,7 @@ class TestNCDFReader3(object):
         and converted the units from those stored in the NetCDF file.
         """
         universe.trajectory[index]
-        assert_almost_equal(self.frc_refs[expected] * 4.184,
+        assert_allclose(self.frc_refs[expected] * 4.184,
                             universe.atoms.forces[:3], self.prec)
 
     @pytest.mark.parametrize('index,expected', ((0, 0), (8, 1)))
@@ -277,12 +277,12 @@ class TestNCDFReader3(object):
         should change the values from Angstrom/AKMA time unit to Angstrom/ps.
         """
         universe.trajectory[index]
-        assert_almost_equal(self.vel_refs[expected] * 20.455,
+        assert_allclose(self.vel_refs[expected] * 20.455,
                             universe.atoms.velocities[:3], self.prec)
 
     @pytest.mark.parametrize('index,expected', ((0, 1.0), (8, 9.0)))
     def test_time(self, universe, index, expected):
-        assert_almost_equal(expected, universe.trajectory[index].time,
+        assert_allclose(expected, universe.trajectory[index].time,
                             self.prec)
 
     def test_nframes(self, universe):
@@ -290,13 +290,13 @@ class TestNCDFReader3(object):
 
     def test_dt(self, universe):
         ref = 1.0
-        assert_almost_equal(ref, universe.trajectory.dt, self.prec)
-        assert_almost_equal(ref, universe.trajectory.ts.dt, self.prec)
+        assert_allclose(ref, universe.trajectory.dt, self.prec)
+        assert_allclose(ref, universe.trajectory.ts.dt, self.prec)
 
     @pytest.mark.parametrize('index,expected', ((0, 0), (8, 1)))
     def test_box(self, universe, index, expected):
         universe.trajectory[index]
-        assert_almost_equal(self.box_refs[expected], universe.dimensions)
+        assert_allclose(self.box_refs[expected], universe.dimensions)
 
 
 class _NCDFGenerator(object):
@@ -465,7 +465,7 @@ class TestScaleFactorImplementation(_NCDFGenerator):
             self.create_ncdf(params)
             u = mda.Universe(params['filename'])
             for ts in u.trajectory:
-                assert_almost_equal(ts.positions[0], expected, self.prec)
+                assert_allclose(ts.positions[0], expected, self.prec)
 
     def test_scale_factor_velocities(self, tmpdir):
         mutation = {'scale_factor': 'velocities', 'scale_factor_value': 3.0}
@@ -475,7 +475,7 @@ class TestScaleFactorImplementation(_NCDFGenerator):
             self.create_ncdf(params)
             u = mda.Universe(params['filename'])
             for ts in u.trajectory:
-                assert_almost_equal(ts.velocities[0], expected, self.prec)
+                assert_allclose(ts.velocities[0], expected, self.prec)
 
     def test_scale_factor_forces(self, tmpdir):
         mutation = {'scale_factor': 'forces', 'scale_factor_value': 10.0}
@@ -485,7 +485,7 @@ class TestScaleFactorImplementation(_NCDFGenerator):
             self.create_ncdf(params)
             u = mda.Universe(params['filename'])
             for ts in u.trajectory:
-                assert_almost_equal(ts.forces[0], expected, self.prec)
+                assert_allclose(ts.forces[0], expected, self.prec)
 
     @pytest.mark.parametrize('mutation,expected', (
         ({'scale_factor': 'cell_lengths', 'scale_factor_value': 0.75},
@@ -499,7 +499,7 @@ class TestScaleFactorImplementation(_NCDFGenerator):
             self.create_ncdf(params)
             u = mda.Universe(params['filename'])
             for ts in u.trajectory:
-                assert_almost_equal(ts.dimensions, expected, self.prec)
+                assert_allclose(ts.dimensions, expected, self.prec)
 
     def test_scale_factor_not_float(self, tmpdir):
         mutation = {'scale_factor': 'coordinates',
@@ -699,17 +699,17 @@ class _NCDFWriterTest(object):
         # check that the trajectories are identical for each time step
         for orig_ts, written_ts in zip(universe.trajectory,
                                        uw.trajectory):
-            assert_almost_equal(written_ts._pos, orig_ts._pos, self.prec,
+            assert_allclose(written_ts._pos, orig_ts._pos, self.prec,
                                       err_msg="coordinate mismatch between "
                                               "original and written trajectory at "
                                               "frame %d (orig) vs %d (written)" % (
                                                   orig_ts.frame,
                                                   written_ts.frame))
             # not a good test because in the example trajectory all times are 0
-            assert_almost_equal(orig_ts.time, written_ts.time, self.prec,
+            assert_allclose(orig_ts.time, written_ts.time, self.prec,
                                 err_msg="Time for step {0} are not the "
                                         "same.".format(orig_ts.frame))
-            assert_almost_equal(written_ts.dimensions,
+            assert_allclose(written_ts.dimensions,
                                       orig_ts.dimensions,
                                       self.prec,
                                       err_msg="unitcells are not identical")
@@ -737,7 +737,7 @@ class _NCDFWriterTest(object):
                                      "variable '{0}'".format(k))
             else:
                 try:
-                    assert_almost_equal(v[:], v_new[:], self.prec,
+                    assert_allclose(v[:], v_new[:], self.prec,
                                               err_msg="Variable '{0}' not "
                                                       "written correctly".format(
                                                   k))
@@ -757,21 +757,21 @@ class _NCDFWriterTest(object):
 
         for orig_ts, written_ts in zip(trr.trajectory,
                                        uw.trajectory):
-            assert_almost_equal(written_ts._pos, orig_ts._pos, self.prec,
+            assert_allclose(written_ts._pos, orig_ts._pos, self.prec,
                                       err_msg="coordinate mismatch between "
                                               "original and written trajectory at "
                                               "frame {0} (orig) vs {1} (written)".format(
                                           orig_ts.frame, written_ts.frame))
-            assert_almost_equal(written_ts._velocities,
+            assert_allclose(written_ts._velocities,
                                       orig_ts._velocities, self.prec,
                                       err_msg="velocity mismatch between "
                                               "original and written trajectory at "
                                               "frame {0} (orig) vs {1} (written)".format(
                                           orig_ts.frame, written_ts.frame))
-            assert_almost_equal(orig_ts.time, written_ts.time, self.prec,
+            assert_allclose(orig_ts.time, written_ts.time, self.prec,
                                 err_msg="Time for step {0} are not the "
                                         "same.".format(orig_ts.frame))
-            assert_almost_equal(written_ts.dimensions,
+            assert_allclose(written_ts.dimensions,
                                       orig_ts.dimensions,
                                       self.prec,
                                       err_msg="unitcells are not identical")
@@ -790,16 +790,16 @@ class _NCDFWriterTest(object):
 
         for orig_ts, written_ts in zip(universe.trajectory,
                                        uw.trajectory):
-            assert_almost_equal(p.positions, pw.positions, self.prec,
+            assert_allclose(p.positions, pw.positions, self.prec,
                                       err_msg="coordinate mismatch between "
                                               "original and written trajectory at "
                                               "frame %d (orig) vs %d (written)" % (
                                                   orig_ts.frame,
                                                   written_ts.frame))
-            assert_almost_equal(orig_ts.time, written_ts.time, self.prec,
+            assert_allclose(orig_ts.time, written_ts.time, self.prec,
                                 err_msg="Time for step {0} are not the "
                                         "same.".format(orig_ts.frame))
-            assert_almost_equal(written_ts.dimensions,
+            assert_allclose(written_ts.dimensions,
                                       orig_ts.dimensions,
                                       self.prec,
                                       err_msg="unitcells are not identical")
@@ -860,26 +860,26 @@ class TestNCDFWriterVelsForces(object):
 
         # test that the two reference states differ
         for ts1, ts2 in zip(u1.trajectory, u2.trajectory):
-            assert_almost_equal(ts1._pos + 300, ts2._pos)
-            assert_almost_equal(ts1._velocities + 300, ts2._velocities)
-            assert_almost_equal(ts1._forces + 300, ts2._forces)
+            assert_allclose(ts1._pos + 300, ts2._pos)
+            assert_allclose(ts1._velocities + 300, ts2._velocities)
+            assert_allclose(ts1._forces + 300, ts2._forces)
 
         u = mda.Universe(self.top, outfile)
         # check the trajectory contents match reference universes
         for ts, ref_ts in zip(u.trajectory, [u1.trajectory.ts, u2.trajectory.ts]):
             if pos:
-                assert_almost_equal(ts._pos, ref_ts._pos, self.prec)
+                assert_allclose(ts._pos, ref_ts._pos, self.prec)
             else:
                 with pytest.raises(mda.NoDataError):
                     getattr(ts, 'positions')
             if vel:
-                assert_almost_equal(ts._velocities, ref_ts._velocities,
+                assert_allclose(ts._velocities, ref_ts._velocities,
                                     self.prec)
             else:
                 with pytest.raises(mda.NoDataError):
                     getattr(ts, 'velocities')
             if force:
-                assert_almost_equal(ts._forces, ref_ts._forces, self.prec)
+                assert_allclose(ts._forces, ref_ts._forces, self.prec)
             else:
                 with pytest.raises(mda.NoDataError):
                     getattr(ts, 'forces')
@@ -976,29 +976,29 @@ class TestNCDFWriterScaleFactors:
         assert sfactors1['forces'] == sfrcs
 
         # check that the stored values are indeed scaled
-        assert_almost_equal(universe.trajectory.time / stime,
+        assert_allclose(universe.trajectory.time / stime,
                             self.get_variable(outfile, 'time', 0), 4)
-        assert_almost_equal(universe.dimensions[:3] / slengths,
+        assert_allclose(universe.dimensions[:3] / slengths,
                             self.get_variable(outfile, 'cell_lengths', 0), 4)
-        assert_almost_equal(universe.dimensions[3:] / sangles,
+        assert_allclose(universe.dimensions[3:] / sangles,
                             self.get_variable(outfile, 'cell_angles', 0), 4)
-        assert_almost_equal(universe.atoms.positions / scoords,
+        assert_allclose(universe.atoms.positions / scoords,
                             self.get_variable(outfile, 'coordinates', 0), 4)
-        assert_almost_equal(universe.atoms.velocities / svels,
+        assert_allclose(universe.atoms.velocities / svels,
                             self.get_variable(outfile, 'velocities', 0), 4)
         # note: kJ/mol -> kcal/mol = 4.184 conversion
-        assert_almost_equal(universe.atoms.forces / (sfrcs * 4.184),
+        assert_allclose(universe.atoms.forces / (sfrcs * 4.184),
                             self.get_variable(outfile, 'forces', 0), 4)
 
         # check that the individual components were saved/read properly
         for ts1, ts3 in zip(universe.trajectory, universe3.trajectory):
-            assert_almost_equal(ts1.time, ts3.time)
-            assert_almost_equal(ts1.dimensions, ts3.dimensions)
-            assert_almost_equal(universe.atoms.positions,
+            assert_allclose(ts1.time, ts3.time)
+            assert_allclose(ts1.dimensions, ts3.dimensions)
+            assert_allclose(universe.atoms.positions,
                                 universe3.atoms.positions, 4)
-            assert_almost_equal(universe.atoms.velocities,
+            assert_allclose(universe.atoms.velocities,
                                 universe3.atoms.velocities, 4)
-            assert_almost_equal(universe.atoms.forces,
+            assert_allclose(universe.atoms.forces,
                                 universe3.atoms.forces, 4)
 
 

--- a/testsuite/MDAnalysisTests/coordinates/test_pdb.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_pdb.py
@@ -40,8 +40,7 @@ from MDAnalysisTests.datafiles import (PDB, PDB_small, PDB_multiframe,
                                        PDB_HOLE, mol2_molecule, PDB_charges,
                                        CONECT_ERROR,)
 from numpy.testing import (assert_equal,
-                           assert_array_almost_equal,
-                           assert_almost_equal)
+                           assert_allclose)
 
 IGNORE_NO_INFORMATION_WARNING = 'ignore:Found no information for attr:UserWarning'
 
@@ -72,7 +71,7 @@ class TestPDBReader(_SingleFrameReader):
         assert isinstance(self.universe.trajectory, PDBReader), "failed to choose PDBReader"
 
     def test_dimensions(self):
-        assert_almost_equal(
+        assert_allclose(
             self.universe.trajectory.ts.dimensions, RefAdKSmall.ref_unitcell,
             self.prec,
             "PDBReader failed to get unitcell dimensions from CRYST1")
@@ -259,7 +258,7 @@ class TestPDBWriter(object):
         "Test writing from a single frame PDB file to a PDB file." ""
         universe.atoms.write(outfile)
         u = mda.Universe(PSF, outfile)
-        assert_almost_equal(u.atoms.positions,
+        assert_allclose(u.atoms.positions,
                             universe.atoms.positions, self.prec,
                             err_msg="Writing PDB file with PDBWriter "
                                     "does not reproduce original coordinates")
@@ -334,7 +333,7 @@ class TestPDBWriter(object):
         assert_equal(u2.trajectory.n_frames,
                      1,
                      err_msg="Output PDB should only contain a single frame")
-        assert_almost_equal(u2.atoms.positions, u.atoms.positions,
+        assert_allclose(u2.atoms.positions, u.atoms.positions,
                             self.prec, err_msg="Written coordinates do not "
                                                "agree with original coordinates from frame %d" %
                                                u.trajectory.frame)
@@ -371,7 +370,7 @@ class TestPDBWriter(object):
             err_msg="Output PDB should only contain a single frame"
         )
 
-        assert_almost_equal(
+        assert_allclose(
             u.atoms.positions, uout.atoms.positions,
             self.prec,
             err_msg="Written coordinates do not "
@@ -497,7 +496,7 @@ class TestPDBWriter(object):
 
         assert len(u_hetatms) == len(written_atoms), \
             "mismatched HETATM number"
-        assert_almost_equal(u_hetatms.atoms.positions,
+        assert_allclose(u_hetatms.atoms.positions,
                             written_atoms.atoms.positions)
 
     def test_default_atom_record_type_written(self, universe5, tmpdir,
@@ -924,7 +923,7 @@ class TestPDBReaderBig(RefAdK):
 
     def test_coordinates(self, universe):
         A10CA = universe.select_atoms('name CA')[10]
-        assert_almost_equal(A10CA.position,
+        assert_allclose(A10CA.position,
                             self.ref_coordinates['A10CA'],
                             self.prec,
                             err_msg="wrong coordinates for A10:CA")
@@ -933,7 +932,7 @@ class TestPDBReaderBig(RefAdK):
         NTERM = universe.select_atoms('name N')[0]
         CTERM = universe.select_atoms('name C')[-1]
         d = mda.lib.mdamath.norm(NTERM.position - CTERM.position)
-        assert_almost_equal(d, self.ref_distances['endtoend'], self.prec,
+        assert_allclose(d, self.ref_distances['endtoend'], self.prec,
                             err_msg="wrong distance between M1:N and G214:C")
 
     def test_selection(self, universe):
@@ -949,7 +948,7 @@ class TestPDBReaderBig(RefAdK):
             err_msg="unit cell dimensions (rhombic dodecahedron), issue 60")
 
     def test_volume(self, universe):
-        assert_almost_equal(
+        assert_allclose(
             universe.coord.volume,
             self.ref_volume,
             0,
@@ -1143,24 +1142,24 @@ class TestCrystModelOrder(object):
 
         for ts, refbox, refpos in zip(
                 u.trajectory, self.boxsize, self.position):
-            assert_almost_equal(u.dimensions[0], refbox)
-            assert_almost_equal(u.atoms[0].position[0], refpos)
+            assert_allclose(u.dimensions[0], refbox)
+            assert_allclose(u.atoms[0].position[0], refpos)
 
     def test_seekaround(self, pdbfile):
         u = mda.Universe(pdbfile)
 
         for frame in [2, 0, 2, 1]:
             u.trajectory[frame]
-            assert_almost_equal(u.dimensions[0], self.boxsize[frame])
-            assert_almost_equal(u.atoms[0].position[0], self.position[frame])
+            assert_allclose(u.dimensions[0], self.boxsize[frame])
+            assert_allclose(u.atoms[0].position[0], self.position[frame])
 
     def test_rewind(self, pdbfile):
         u = mda.Universe(pdbfile)
 
         u.trajectory[2]
         u.trajectory.rewind()
-        assert_almost_equal(u.dimensions[0], self.boxsize[0])
-        assert_almost_equal(u.atoms[0].position[0], self.position[0])
+        assert_allclose(u.dimensions[0], self.boxsize[0])
+        assert_allclose(u.atoms[0].position[0], self.position[0])
 
 
 def test_standalone_pdb():

--- a/testsuite/MDAnalysisTests/coordinates/test_pqr.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_pqr.py
@@ -25,7 +25,7 @@ import os
 import pytest
 
 from numpy.testing import (
-    assert_almost_equal,
+    assert_allclose,
     assert_equal,
 )
 
@@ -44,12 +44,12 @@ class TestPQRReader(_SingleFrameReader):
         self.prec = 3
 
     def test_total_charge(self):
-        assert_almost_equal(
+        assert_allclose(
             self.universe.atoms.total_charge(), self.ref_charmm_totalcharge, 3,
             "Total charge (in CHARMM) does not match expected value.")
 
     def test_hydrogenCharges(self):
-        assert_almost_equal(self.universe.select_atoms('name H').charges,
+        assert_allclose(self.universe.select_atoms('name H').charges,
                             self.ref_charmm_Hcharges, 3,
                             "Charges for H atoms do not match.")
 
@@ -57,13 +57,13 @@ class TestPQRReader(_SingleFrameReader):
     # read with a PSF it is 's4AKE')
     def test_ArgCACharges(self):
         ag = self.universe.select_atoms('resname ARG and name CA')
-        assert_almost_equal(
+        assert_allclose(
             ag.charges, self.ref_charmm_ArgCAcharges,
             3, "Charges for CA atoms in Arg residues do not match.")
 
     def test_ProNCharges(self):
         ag = self.universe.select_atoms('resname PRO and name N')
-        assert_almost_equal(
+        assert_allclose(
             ag.charges, self.ref_charmm_ProNcharges, 3,
             "Charges for N atoms in Pro residues do not match.")
 
@@ -87,14 +87,14 @@ class TestPQRWriter(RefAdKSmall):
         universe.atoms.write(outfile)
         u = mda.Universe(outfile)
         assert_equal(u.segments.segids[0], 'SYSTEM')
-        assert_almost_equal(u.atoms.positions,
+        assert_allclose(u.atoms.positions,
                             universe.atoms.positions, self.prec,
                             err_msg="Writing PQR file with PQRWriter does "
                             "not reproduce original coordinates")
-        assert_almost_equal(u.atoms.charges, universe.atoms.charges,
+        assert_allclose(u.atoms.charges, universe.atoms.charges,
                             self.prec, err_msg="Writing PQR file with "
                             "PQRWriter does not reproduce original charges")
-        assert_almost_equal(u.atoms.radii, universe.atoms.radii,
+        assert_allclose(u.atoms.radii, universe.atoms.radii,
                             self.prec, err_msg="Writing PQR file with "
                             "PQRWriter does not reproduce original radii")
 
@@ -109,14 +109,14 @@ class TestPQRWriter(RefAdKSmall):
         universe.atoms.write(outfile)
         u = mda.Universe(outfile)
         assert_equal(u.segments.segids[0], 'A')
-        assert_almost_equal(u.atoms.positions,
+        assert_allclose(u.atoms.positions,
                             universe.atoms.positions, self.prec,
                             err_msg="Writing PQR file with PQRWriter does "
                             "not reproduce original coordinates")
-        assert_almost_equal(u.atoms.charges, universe.atoms.charges,
+        assert_allclose(u.atoms.charges, universe.atoms.charges,
                             self.prec, err_msg="Writing PQR file with "
                             "PQRWriter does not reproduce original charges")
-        assert_almost_equal(u.atoms.radii, universe.atoms.radii,
+        assert_allclose(u.atoms.radii, universe.atoms.radii,
                             self.prec, err_msg="Writing PQR file with "
                             "PQRWriter does not reproduce original radii")
 
@@ -133,7 +133,7 @@ class TestPQRWriter(RefAdKSmall):
         outfile = str(tmpdir.join('pqr-test.pqr'))
         universe.atoms.write(outfile)
         u = mda.Universe(outfile)
-        assert_almost_equal(
+        assert_allclose(
             u.atoms.total_charge(), self.ref_charmm_totalcharge, 3,
             "Total charge (in CHARMM) does not match expected value.")
 

--- a/testsuite/MDAnalysisTests/coordinates/test_timestep_api.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_timestep_api.py
@@ -28,7 +28,7 @@ _TestTimestepInterface tests the Readers are correctly using Timesteps
 """
 import itertools
 import numpy as np
-from numpy.testing import assert_equal, assert_allclose, assert_array_almost_equal
+from numpy.testing import assert_equal, assert_allclose
 
 from MDAnalysis.lib.mdamath import triclinic_vectors
 import MDAnalysis as mda
@@ -390,7 +390,7 @@ class TestTimestep(object):
 
         if not ref_ts.dimensions is None:
             assert_array_almost_equal(ref_ts.dimensions, ts2.dimensions,
-                                      decimal=4)
+                                      atol=1e-04)
         else:
             assert ref_ts.dimensions == ts2.dimensions
 

--- a/testsuite/MDAnalysisTests/coordinates/test_trj.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_trj.py
@@ -25,7 +25,7 @@ import pytest
 
 from numpy.testing import (
     assert_equal,
-    assert_almost_equal
+    assert_allclose
 )
 
 import MDAnalysis as mda
@@ -62,7 +62,7 @@ class _TRJReaderTest(object):
         protein = universe.select_atoms('protein')
         total = np.sum([protein.center_of_geometry() for ts in
                         universe.trajectory])
-        assert_almost_equal(total, self.ref_sum_centre_of_geometry, self.prec,
+        assert_allclose(total, self.ref_sum_centre_of_geometry, self.prec,
                             err_msg="sum of centers of geometry over the "
                                     "trajectory do not match")
 

--- a/testsuite/MDAnalysisTests/coordinates/test_trz.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_trz.py
@@ -26,7 +26,6 @@ import os
 
 from numpy.testing import (
     assert_equal,
-    assert_almost_equal,
     assert_allclose
 )
 import numpy as np
@@ -73,44 +72,44 @@ class TestTRZReader(RefTRZ):
         assert_equal(universe.trajectory.ts.frame, 4, "loading frame 4")
         universe.trajectory[3]
 
-        assert_almost_equal(universe.atoms[0:3].positions, orig,
+        assert_allclose(universe.atoms[0:3].positions, orig,
                             self.prec)
 
         universe.trajectory[0]
         assert_equal(universe.trajectory.ts.frame, 0, "loading frame 0")
         universe.trajectory[3]
 
-        assert_almost_equal(universe.atoms[0:3].positions, orig,
+        assert_allclose(universe.atoms[0:3].positions, orig,
                             self.prec)
 
     def test_volume(self, universe):
         # Lower precision here because errors seem to accumulate and
         # throw this off (is rounded value**3)
-        assert_almost_equal(universe.trajectory.ts.volume, self.ref_volume, 1,
+        assert_allclose(universe.trajectory.ts.volume, self.ref_volume, 1,
                             "wrong volume for trz")
 
     def test_unitcell(self, universe):
-        assert_almost_equal(universe.trajectory.ts.dimensions,
+        assert_allclose(universe.trajectory.ts.dimensions,
                             self.ref_dimensions, self.prec,
                             "wrong dimensions for trz")
 
     def test_coordinates(self, universe):
         fortytwo = universe.atoms[41]  # 41 because is 0 based
-        assert_almost_equal(fortytwo.position, self.ref_coordinates, self.prec,
+        assert_allclose(fortytwo.position, self.ref_coordinates, self.prec,
                             "wrong coordinates in trz")
 
     def test_velocities(self, universe):
         fortytwo = universe.select_atoms('bynum 42')
-        assert_almost_equal(fortytwo.velocities, self.ref_velocities,
+        assert_allclose(fortytwo.velocities, self.ref_velocities,
                             self.prec, "wrong velocities in trz")
 
     def test_delta(self, universe):
-        assert_almost_equal(universe.trajectory.delta, self.ref_delta,
+        assert_allclose(universe.trajectory.delta, self.ref_delta,
                             self.prec,
                             "wrong time delta in trz")
 
     def test_time(self, universe):
-        assert_almost_equal(universe.trajectory.time, self.ref_time, self.prec,
+        assert_allclose(universe.trajectory.time, self.ref_time, self.prec,
                             "wrong time value in trz")
 
     def test_title(self, universe):
@@ -177,21 +176,21 @@ class TestTRZWriter(RefTRZ):
 
         for orig_ts, written_ts in zip(universe.trajectory,
                                        uw.trajectory):
-            assert_almost_equal(orig_ts._pos, written_ts._pos, self.prec,
+            assert_allclose(orig_ts._pos, written_ts._pos, self.prec,
                                 err_msg="Coordinate mismatch between "
                                         "orig and written at frame %d" %
                                         orig_ts.frame)
-            assert_almost_equal(orig_ts._velocities,
+            assert_allclose(orig_ts._velocities,
                                 written_ts._velocities, self.prec,
                                 err_msg="Coordinate mismatch between "
                                         "orig and written at frame %d" %
                                         orig_ts.frame)
-            assert_almost_equal(orig_ts._unitcell, written_ts._unitcell,
+            assert_allclose(orig_ts._unitcell, written_ts._unitcell,
                                 self.prec, err_msg="Unitcell mismatch "
                                                    "between orig and written at frame %d" %
                                                    orig_ts.frame)
             for att in orig_ts.data:
-                assert_almost_equal(orig_ts.data[att],
+                assert_allclose(orig_ts.data[att],
                                     written_ts.data[att], self.prec,
                                     err_msg="TS equal failed for {0!s}".format(
                                         att))
@@ -226,7 +225,7 @@ class TestTRZWriter2(object):
 
         u2 = mda.Universe(two_water_gro, outfile)
 
-        assert_almost_equal(u.atoms.positions, u2.atoms.positions, 3)
+        assert_allclose(u.atoms.positions, u2.atoms.positions, 3)
 
     def test_no_dt_warning(self, u, outfile):
         with mda.coordinates.TRZ.TRZWriter(outfile, len(u.atoms)) as W:
@@ -262,7 +261,7 @@ class TestWrite_Partial_Timestep(object):
 
         u_ag = mda.Universe(outfile)
 
-        assert_almost_equal(ag.positions,
+        assert_allclose(ag.positions,
                             u_ag.atoms.positions,
                             self.prec,
                             err_msg="Writing AtomGroup timestep failed.")

--- a/testsuite/MDAnalysisTests/coordinates/test_txyz.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_txyz.py
@@ -21,7 +21,7 @@
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
 import pytest
-from numpy.testing import assert_almost_equal
+from numpy.testing import assert_allclose
 
 from MDAnalysisTests.datafiles import TXYZ, ARC, ARC_PBC
 
@@ -44,19 +44,19 @@ def ARC_PBC_U():
 
 
 def test_txyz_positions(TXYZ_U):
-    assert_almost_equal(TXYZ_U.atoms.positions[0],
+    assert_allclose(TXYZ_U.atoms.positions[0],
                         [-6.553398, -1.854369, 0.000000])
 
 
 def test_arc_positions(ARC_U):
-    assert_almost_equal(ARC_U.atoms.positions[0],
+    assert_allclose(ARC_U.atoms.positions[0],
                         [-6.553398, -1.854369, 0.000000])
 
 
 def test_arc_positions_frame_2(ARC_U):
     ARC_U.trajectory[1]
 
-    assert_almost_equal(ARC_U.atoms.positions[0],
+    assert_allclose(ARC_U.atoms.positions[0],
                         [-0.231579, -0.350841, -0.037475])
 
 
@@ -74,5 +74,5 @@ def test_pbc_boxsize(ARC_PBC_U):
                     [ 40.860761,  40.860761,  40.860761,  90.000000,  90.000000,  90.000000]]
 
     for ref_box, ts in zip(ref_dimensions, ARC_PBC_U.trajectory):
-        assert_almost_equal(ref_box, ts.dimensions, decimal=5)
+        assert_allclose(ref_box, ts.dimensions, atol=1e-05)
 

--- a/testsuite/MDAnalysisTests/coordinates/test_windows.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_windows.py
@@ -32,7 +32,7 @@ line ending files.
 
 import numpy as np
 import pytest
-from numpy.testing import assert_almost_equal, assert_equal
+from numpy.testing import assert_allclose, assert_equal
 from MDAnalysisTests.datafiles import (
     WIN_PDB_multiframe,
     WIN_ARC,
@@ -113,11 +113,11 @@ class TestWinARC(object):
         assert len(WIN_ARC_U.trajectory) == 2
 
     def test_positions(self, WIN_ARC_U):
-        assert_almost_equal(WIN_ARC_U.atoms.positions[0],
+        assert_allclose(WIN_ARC_U.atoms.positions[0],
                             [-6.553398, -1.854369, 0.000000])
 
     def test_positions_2(self, WIN_ARC_U):
         WIN_ARC_U.trajectory[1]
 
-        assert_almost_equal(WIN_ARC_U.atoms.positions[0],
+        assert_allclose(WIN_ARC_U.atoms.positions[0],
                             [-0.231579, -0.350841, -0.037475])

--- a/testsuite/MDAnalysisTests/coordinates/test_xyz.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_xyz.py
@@ -25,7 +25,7 @@ import pytest
 import MDAnalysis as mda
 import numpy as np
 from numpy.testing import (
-    assert_almost_equal,
+    assert_allclose,
     assert_equal,
 )
 
@@ -82,7 +82,7 @@ class TestXYZWriter(BaseWriterTest):
 
             copy = ref.reader(outfile)
             for orig_ts, copy_ts in zip(universe.trajectory, copy):
-                assert_almost_equal(
+                assert_allclose(
                     copy_ts._pos, sel.atoms.positions, ref.prec,
                     err_msg="coordinate mismatch between original and written "
                             "trajectory at frame {} (orig) vs {} (copy)".format(

--- a/testsuite/MDAnalysisTests/core/test_atom.py
+++ b/testsuite/MDAnalysisTests/core/test_atom.py
@@ -30,7 +30,7 @@ from MDAnalysisTests.datafiles import (
     PSF, DCD,
     XYZ_mini,
 )
-from numpy.testing import assert_almost_equal
+from numpy.testing import assert_allclose
 
 
 class TestAtom(object):
@@ -75,10 +75,10 @@ class TestAtom(object):
         known_pos = np.array([3.94543672, -12.4060812, -7.26820087], dtype=np.float32)
         a = atom
         # new position property (mutable)
-        assert_almost_equal(a.position, known_pos)
+        assert_allclose(a.position, known_pos)
         pos = a.position + 3.14
         a.position = pos
-        assert_almost_equal(a.position, pos)
+        assert_allclose(a.position, pos)
 
     def test_atom_selection(self, universe, atom):
         asel = universe.select_atoms('atom 4AKE 67 CG').atoms[0]

--- a/testsuite/MDAnalysisTests/core/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/core/test_atomgroup.py
@@ -28,9 +28,8 @@ import pickle
 import numpy as np
 
 from numpy.testing import (
-    assert_almost_equal,
+    assert_allclose,
     assert_equal,
-    assert_array_almost_equal,
 )
 
 import MDAnalysis as mda
@@ -159,7 +158,7 @@ class TestAtomGroupWriting(object):
         new_positions = np.stack([ts.positions for ts in u_new.trajectory])
         # Most format only save 3 decimals; XTC even has only 2.
         assert_array_almost_equal(u.atoms.positions[None, ...],
-                                  new_positions, decimal=2)
+                                  new_positions, atol=1e-02)
 
     @pytest.mark.parametrize('compression', ('', '.gz', '.bz2'))
     def test_write_frames_all(self, u, tmpdir, compression):
@@ -228,7 +227,7 @@ class _WriteAtoms(object):
         outname = outfile + compression
         universe.atoms.write(outname)
         u2 = self.universe_from_tmp(outname)
-        assert_almost_equal(
+        assert_allclose(
             universe.atoms.positions, u2.atoms.positions,
             self.precision,
             err_msg=("atom coordinate mismatch between original and {0!s} "
@@ -250,7 +249,7 @@ class _WriteAtoms(object):
         sel2 = u2.atoms
         assert len(u2.atoms) == len(sel.atoms), ("written selection does not "
                                                  "match original selection")
-        assert_almost_equal(
+        assert_allclose(
             sel2.positions, sel.positions, self.precision,
             err_msg="written coordinates do not agree with original")
 
@@ -263,7 +262,7 @@ class _WriteAtoms(object):
         G2 = u2.atoms
         assert len(u2.atoms) == len(G.atoms), ("written R206 Residue does not "
                                                "match original ResidueGroup")
-        assert_almost_equal(
+        assert_allclose(
             G2.positions, G.positions, self.precision,
             err_msg="written Residue R206 coordinates do not "
                     "agree with original")
@@ -276,7 +275,7 @@ class _WriteAtoms(object):
         assert len(u2.atoms) == len(U.atoms), ("written 4AKE universe does "
                                                "not match original universe "
                                                "in size")
-        assert_almost_equal(
+        assert_allclose(
             u2.atoms.positions, U.atoms.positions, self.precision,
             err_msg="written universe 4AKE coordinates do not "
                     "agree with original")
@@ -313,7 +312,7 @@ class TestAtomGroupTransformations(object):
 
         cog = u.atoms.center_of_geometry()
         diff = cog - center_of_geometry
-        assert_almost_equal(diff, disp, decimal=5)
+        assert_allclose(diff, disp, atol=1e-05)
 
     def test_rotate(self, u, coords):
         # ensure that selection isn't centered at 0, 0, 0
@@ -323,14 +322,14 @@ class TestAtomGroupTransformations(object):
         # check identify does nothing
         R = np.eye(3)
         u.atoms.rotate(R)
-        assert_almost_equal(u.atoms.positions, coords)
+        assert_allclose(u.atoms.positions, coords)
 
         # check default rotation center is at 0, 0, 0. Changing this center
         # will break an unpredictable amount of old code.
         ag = u.atoms[:2]
         ag.positions = np.array([[1, 0, 0], [-1, 0, 0]])
         ag.rotate(transformations.rotation_matrix(1, [0, 0, 1])[:3, :3])
-        assert_almost_equal(ag.positions[0], [np.cos(1), np.sin(1), 0])
+        assert_allclose(ag.positions[0], [np.cos(1), np.sin(1), 0])
 
         # check general rotation cases
         vec = np.array([[1, 0, 0], [-1, 0, 0]])
@@ -340,21 +339,21 @@ class TestAtomGroupTransformations(object):
             ag.positions = vec.copy()
             res_ag = ag.rotate(R[:3, :3])
             assert_equal(ag, res_ag)
-            assert_almost_equal(ag.positions[0], [np.cos(angle),
+            assert_allclose(ag.positions[0], [np.cos(angle),
                                                   np.sin(angle),
                                                   0])
 
             ag.positions = vec.copy()
             ag.rotate(R[:3, :3], vec[0])
-            assert_almost_equal(ag.positions[0], vec[0])
-            assert_almost_equal(ag.positions[1], [-2*np.cos(angle) + 1,
+            assert_allclose(ag.positions[0], vec[0])
+            assert_allclose(ag.positions[1], [-2*np.cos(angle) + 1,
                                                   -2*np.sin(angle),
-                                                  0], decimal=6)
+                                                  0], atol=1e-06)
 
     def test_rotateby(self, u, coords):
         R = np.eye(3)
         u.atoms.rotate(R)
-        assert_almost_equal(u.atoms.positions, coords)
+        assert_allclose(u.atoms.positions, coords)
 
         vec = np.array([[1, 0, 0], [-1, 0, 0]])
         axis = np.array([0, 0, 1])
@@ -367,21 +366,21 @@ class TestAtomGroupTransformations(object):
             # needs to be rotated about origin
             res_ag = ag.rotateby(np.rad2deg(angle), axis)
             assert_equal(res_ag, ag)
-            assert_almost_equal(ag.positions[0], [np.cos(angle),
+            assert_allclose(ag.positions[0], [np.cos(angle),
                                                   np.sin(angle),
                                                   0])
 
             ag.positions = vec.copy()
             ag.rotateby(np.rad2deg(angle), axis, point=vec[0])
-            assert_almost_equal(ag.positions[0], vec[0])
-            assert_almost_equal(ag.positions[1], [-2*np.cos(angle) + 1,
+            assert_allclose(ag.positions[0], vec[0])
+            assert_allclose(ag.positions[1], [-2*np.cos(angle) + 1,
                                                   -2*np.sin(angle),
                                                   0])
 
     def test_transform_rotation_only(self, u, coords):
         R = np.eye(3)
         u.atoms.rotate(R)
-        assert_almost_equal(u.atoms.positions, coords)
+        assert_allclose(u.atoms.positions, coords)
 
         vec = np.array([[1, 0, 0], [-1, 0, 0]])
         axis = np.array([0, 0, 1])
@@ -393,7 +392,7 @@ class TestAtomGroupTransformations(object):
             R = transformations.rotation_matrix(angle, axis)
             ag.positions = vec.copy()
             ag.transform(R)
-            assert_almost_equal(ag.positions[0], [np.cos(angle),
+            assert_allclose(ag.positions[0], [np.cos(angle),
                                                   np.sin(angle),
                                                   0])
 
@@ -405,7 +404,7 @@ class TestAtomGroupTransformations(object):
         assert_equal(ag, u.atoms)
         cog = u.atoms.center_of_geometry()
         diff = cog - center_of_geometry
-        assert_almost_equal(diff, disp, decimal=5)
+        assert_allclose(diff, disp, atol=1e-05)
 
     def test_transform_translation_and_rotation(self, u):
         angle = np.pi / 4
@@ -418,7 +417,7 @@ class TestAtomGroupTransformations(object):
         ag.positions = [[1, 0, 0], [-1, 0, 0]]
         ag.transform(T)
 
-        assert_almost_equal(ag.positions[0], [np.cos(angle) + 1,
+        assert_allclose(ag.positions[0], [np.cos(angle) + 1,
                                               np.sin(angle) + 1,
                                               1])
 
@@ -433,12 +432,12 @@ class TestCenter(object):
     def test_center_1(self, ag):
         weights = np.zeros(ag.n_atoms)
         weights[0] = 1
-        assert_almost_equal(ag.center(weights), ag.positions[0])
+        assert_allclose(ag.center(weights), ag.positions[0])
 
     def test_center_2(self, ag):
         weights = np.zeros(ag.n_atoms)
         weights[:4] = 1. / 4.
-        assert_almost_equal(ag.center(weights), ag.positions[:4].mean(axis=0))
+        assert_allclose(ag.center(weights), ag.positions[:4].mean(axis=0))
 
     def test_center_duplicates(self, ag):
         weights = np.ones(ag.n_atoms)
@@ -447,7 +446,7 @@ class TestCenter(object):
         ag2 = ag + ag[0]
         with pytest.warns(DuplicateWarning):
             ctr = ag2.center(None)
-        assert_almost_equal(ctr, ref, decimal=6)
+        assert_allclose(ctr, ref, atol=1e-06)
 
     def test_center_wrong_length(self, ag):
         weights = np.ones(ag.n_atoms + 4)
@@ -484,7 +483,7 @@ class TestCenter(object):
                               compound=compound, unwrap=True)
 
         ref_center = u.center(compound=compound)
-        assert_almost_equal(ref_center, center, decimal=4)
+        assert_allclose(ref_center, center, atol=1e-04)
 
     def test_center_unwrap_wrap_true_group(self):
         u = UnWrapUniverse(is_triclinic=False)
@@ -650,7 +649,7 @@ class TestOrphans(object):
 
         assert atom is not u.atoms[1]
         assert len(atom.universe.atoms) == len(u.atoms)
-        assert_almost_equal(atom.position, u.atoms[1].position)
+        assert_allclose(atom.position, u.atoms[1].position)
 
     def test_atomgroup(self):
         u = mda.Universe(two_water_gro)
@@ -663,7 +662,7 @@ class TestOrphans(object):
         ag2 = u.atoms[:4]
         assert ag is not ag2
         assert len(ag.universe.atoms) == len(u.atoms)
-        assert_almost_equal(ag.positions, ag2.positions)
+        assert_allclose(ag.positions, ag2.positions)
 
 
 class TestCrossUniverse(object):
@@ -946,19 +945,19 @@ class TestDihedralSelections(object):
 
     def test_dihedral_phi(self, PSFDCD):
         phisel = PSFDCD.segments[0].residues[9].phi_selection()
-        assert_almost_equal(phisel.dihedral.value(), -168.57384, self.dih_prec)
+        assert_allclose(phisel.dihedral.value(), -168.57384, self.dih_prec)
 
     def test_dihedral_psi(self, PSFDCD):
         psisel = PSFDCD.segments[0].residues[9].psi_selection()
-        assert_almost_equal(psisel.dihedral.value(), -30.064838, self.dih_prec)
+        assert_allclose(psisel.dihedral.value(), -30.064838, self.dih_prec)
 
     def test_dihedral_omega(self, PSFDCD):
         osel = PSFDCD.segments[0].residues[7].omega_selection()
-        assert_almost_equal(osel.dihedral.value(), -179.93439, self.dih_prec)
+        assert_allclose(osel.dihedral.value(), -179.93439, self.dih_prec)
 
     def test_dihedral_chi1(self, PSFDCD):
         sel = PSFDCD.segments[0].residues[12].chi1_selection()  # LYS
-        assert_almost_equal(sel.dihedral.value(), -58.428127, self.dih_prec)
+        assert_allclose(sel.dihedral.value(), -58.428127, self.dih_prec)
 
     def test_phi_nodep(self, GRO):
         with no_deprecated_call():
@@ -1062,7 +1061,7 @@ class TestUnwrapFlag(object):
         else:
             # We test unwrap=False as the default behavior
             result = method(compound='residues')
-        assert_almost_equal(result, ref[method_name], self.prec)
+        assert_allclose(result, ref[method_name], self.prec)
 
     @pytest.mark.parametrize('unwrap, ref', ((True, ref_Unwrap),
                                              (False, ref_noUnwrap)))
@@ -1077,7 +1076,7 @@ class TestUnwrapFlag(object):
         else:
             # We test unwrap=False as the default behavior
             result = method()
-        assert_almost_equal(result, ref[method_name], self.prec)
+        assert_allclose(result, ref[method_name], self.prec)
 
 
 class TestPBCFlag(object):
@@ -1152,10 +1151,10 @@ class TestPBCFlag(object):
             result = method()
 
         if method_name == 'bsphere':
-            assert_almost_equal(result[0], ref[method_name][0], self.prec)
-            assert_almost_equal(result[1], ref[method_name][1], self.prec)
+            assert_allclose(result[0], ref[method_name][0], self.prec)
+            assert_allclose(result[1], ref[method_name][1], self.prec)
         else:
-            assert_almost_equal(result, ref[method_name], self.prec)
+            assert_allclose(result, ref[method_name], self.prec)
 
 
 class TestAtomGroup(object):
@@ -1245,12 +1244,12 @@ class TestAtomGroup(object):
         assert len(ag) == ag.n_atoms, "len and n_atoms disagree"
 
     def test_center_of_geometry(self, ag):
-        assert_almost_equal(ag.center_of_geometry(),
-                            [-0.04223963, 0.0141824, -0.03505163], decimal=5)
+        assert_allclose(ag.center_of_geometry(),
+                            [-0.04223963, 0.0141824, -0.03505163], atol=1e-05)
 
     def test_center_of_mass(self, ag):
-        assert_almost_equal(ag.center_of_mass(),
-                            [-0.01094035, 0.05727601, -0.12885778], decimal=5)
+        assert_allclose(ag.center_of_mass(),
+                            [-0.01094035, 0.05727601, -0.12885778], atol=1e-05)
 
     @pytest.mark.parametrize('method_name', ('center_of_geometry',
                                              'center_of_mass'))
@@ -1268,7 +1267,7 @@ class TestAtomGroup(object):
     def test_center_compounds(self, ag, name, compound, method_name):
         ref = [getattr(a, method_name)() for a in ag.groupby(name).values()]
         vals = getattr(ag, method_name)(wrap=False, compound=compound)
-        assert_almost_equal(vals, ref, decimal=5)
+        assert_allclose(vals, ref, atol=1e-05)
 
     @pytest.mark.parametrize('method_name', ('center_of_geometry',
                                              'center_of_mass'))
@@ -1282,7 +1281,7 @@ class TestAtomGroup(object):
                for a in ag.groupby(name).values()]
         vals = getattr(ag, method_name)(compound=compound,
                                         unwrap=unwrap)
-        assert_almost_equal(vals, ref, decimal=5)
+        assert_allclose(vals, ref, atol=1e-05)
 
     @pytest.mark.parametrize('method_name', ('center_of_geometry',
                                              'center_of_mass'))
@@ -1293,7 +1292,7 @@ class TestAtomGroup(object):
         ref = [getattr(a, method_name)()
                for a in ag_molfrg.groupby(name).values()]
         vals = getattr(ag_molfrg, method_name)(wrap=False, compound=compound)
-        assert_almost_equal(vals, ref, decimal=5)
+        assert_allclose(vals, ref, atol=1e-05)
 
     @pytest.mark.parametrize('method_name', ('center_of_geometry',
                                              'center_of_mass'))
@@ -1307,7 +1306,7 @@ class TestAtomGroup(object):
                for a in ag_molfrg.groupby(name).values()]
         vals = getattr(ag_molfrg, method_name)(compound=compound,
                                                unwrap=unwrap)
-        assert_almost_equal(vals, ref, decimal=5)
+        assert_allclose(vals, ref, atol=1e-05)
 
     def test_center_wrong_compound(self, ag):
         with pytest.raises(ValueError):
@@ -1366,7 +1365,7 @@ class TestAtomGroup(object):
                                            compound=compound))
 
     def test_coordinates(self, ag):
-        assert_almost_equal(
+        assert_allclose(
             ag.positions[1000:2000:200],
             np.array([[3.94543672, -12.4060812, -7.26820087],
                       [13.21632767, 5.879035, -14.67914867],
@@ -1376,7 +1375,7 @@ class TestAtomGroup(object):
                      dtype=np.float32))
 
     def test_principal_axes(self, ag):
-        assert_almost_equal(
+        assert_allclose(
             ag.principal_axes(),
             np.array([[1.53389276e-03, 4.41386224e-02, 9.99024239e-01],
                       [1.20986911e-02, 9.98951474e-01, -4.41539838e-02],
@@ -1456,7 +1455,7 @@ class TestAtomGroup(object):
         assert isinstance(ag.charges, np.ndarray)
 
     def test_charges(self, ag):
-        assert_almost_equal(ag.charges[1000:2000:200],
+        assert_allclose(ag.charges[1000:2000:200],
                                   np.array([-0.09, 0.09, -0.47, 0.51, 0.09]))
 
     def test_bad_add_AG(self, ag):
@@ -1525,11 +1524,11 @@ class TestAtomGroup(object):
                                   [1.73236561, 4.90658951, 0.6880455]],
                                   dtype=np.float32)
         ag.pack_into_box(box=box)
-        assert_almost_equal(ag.positions, packed_coords)
+        assert_allclose(ag.positions, packed_coords)
         # Check with duplicates:
         ag += ag
         ag.pack_into_box(box=box)
-        assert_almost_equal(ag.positions,
+        assert_allclose(ag.positions,
                             np.vstack((packed_coords, packed_coords)))
 
     def test_residues(self, universe):
@@ -1598,7 +1597,7 @@ class TestAtomGroup(object):
         u = universe
         peptbond = u.select_atoms("atom 4AKE 20 C", "atom 4AKE 21 CA",
                                   "atom 4AKE 21 N", "atom 4AKE 21 HN")
-        assert_almost_equal(peptbond.improper.value(), 168.52952575683594,
+        assert_allclose(peptbond.improper.value(), 168.52952575683594,
                             self.dih_prec,
                             "Peptide bond improper dihedral for M21 "
                             "calculated wrongly.")
@@ -1613,13 +1612,13 @@ class TestAtomGroup(object):
     def test_bond(self, universe):
         sel2 = universe.select_atoms('segid 4AKE and resid 98'
                                      ).select_atoms("name OE1", "name OE2")
-        assert_almost_equal(sel2.bond.value(), 2.1210737228393555, 3,
+        assert_allclose(sel2.bond.value(), 2.1210737228393555, 3,
                             "distance of Glu98 OE1--OE2 wrong")
 
     def test_bond_pbc(self, universe):
         sel2 = universe.select_atoms('segid 4AKE and resid 98'
                                      ).select_atoms("name OE1", "name OE2")
-        assert_almost_equal(sel2.bond.value(pbc=True), 2.1210737228393555, 3,
+        assert_allclose(sel2.bond.value(pbc=True), 2.1210737228393555, 3,
                             "distance of Glu98 OE1--OE2 wrong")
 
     def test_bond_ValueError(self, universe):
@@ -1630,7 +1629,7 @@ class TestAtomGroup(object):
     def test_angle(self, universe):
         sel3 = universe.select_atoms('segid 4AKE and resid 98').select_atoms(
                                             'name OE1', 'name CD', 'name OE2')
-        assert_almost_equal(sel3.angle.value(), 117.46187591552734, 3,
+        assert_allclose(sel3.angle.value(), 117.46187591552734, 3,
                             "angle of Glu98 OE1-CD-OE2 wrong")
 
     def test_angle_ValueError(self, universe):
@@ -1640,7 +1639,7 @@ class TestAtomGroup(object):
 
     def test_shape_parameter(self, universe):
         s = universe.select_atoms('segid 4AKE').shape_parameter()
-        assert_almost_equal(s, 0.00240753939086033, 6)
+        assert_allclose(s, 0.00240753939086033, 6)
 
     def test_shape_parameter_duplicates(self, universe):
         ag = universe.select_atoms('segid 4AKE')
@@ -1652,7 +1651,7 @@ class TestAtomGroup(object):
 
     def test_asphericity(self, universe):
         a = universe.select_atoms('segid 4AKE').asphericity()
-        assert_almost_equal(a, 0.020227504542775828, 6)
+        assert_allclose(a, 0.020227504542775828, 6)
 
     def test_asphericity_duplicates(self, universe):
         ag = universe.select_atoms('segid 4AKE')
@@ -1667,7 +1666,7 @@ class TestAtomGroup(object):
         pos = ag.positions + 3.14
         ag.positions = pos
         # should work
-        assert_almost_equal(ag.positions, pos,
+        assert_allclose(ag.positions, pos,
                             err_msg="failed to update atoms 12:42 position "
                             "to new position")
 
@@ -1705,11 +1704,11 @@ class TestAtomGroupTimestep(object):
         assert len(ag.ts._pos) == len(ag)
 
         for ts in universe.trajectory[0:20:5]:
-            assert_almost_equal(ts.positions[idx],
+            assert_allclose(ts.positions[idx],
                                 ag.ts.positions,
                                 self.prec,
                                 err_msg="Partial timestep coordinates wrong")
-            assert_almost_equal(ts.velocities[idx],
+            assert_allclose(ts.velocities[idx],
                                 ag.ts.velocities,
                                 self.prec,
                                 err_msg="Partial timestep coordinates wrong")
@@ -1803,4 +1802,4 @@ class TestAtomGroupPickle(object):
     def test_atomgroup_pickle(self, universe, selection):
         sel = universe.select_atoms(selection)
         atm = pickle.loads(pickle.dumps(sel))
-        assert_almost_equal(sel.positions, atm.positions)
+        assert_allclose(sel.positions, atm.positions)

--- a/testsuite/MDAnalysisTests/core/test_group_traj_access.py
+++ b/testsuite/MDAnalysisTests/core/test_group_traj_access.py
@@ -23,7 +23,7 @@
 import numpy as np
 import pytest
 from numpy.testing import (
-    assert_almost_equal,
+    assert_allclose,
     assert_equal,
 )
 
@@ -184,9 +184,9 @@ class TestAtomGroupTrajAccess(object):
 
         ag.positions = new
 
-        assert_almost_equal(ag.positions, new, decimal=5)
-        assert_almost_equal(u.trajectory.ts.positions[[101, 107, 109]],
-                            new, decimal=5)
+        assert_allclose(ag.positions, new, atol=1e-05)
+        assert_allclose(u.trajectory.ts.positions[[101, 107, 109]],
+                            new, atol=1e-05)
 
     def test_atomgroup_velocities_setting(self, u, vel):
         ag = u.atoms[[101, 107, 109]]
@@ -198,9 +198,9 @@ class TestAtomGroupTrajAccess(object):
         if vel:
             ag.velocities = new
 
-            assert_almost_equal(ag.velocities, new, decimal=5)
-            assert_almost_equal(
-                u.trajectory.ts.velocities[[101, 107, 109]], new, decimal=5)
+            assert_allclose(ag.velocities, new, atol=1e-05)
+            assert_allclose(
+                u.trajectory.ts.velocities[[101, 107, 109]], new, atol=1e-05)
         else:
             with pytest.raises(NoDataError):
                 setattr(ag, 'velocities', new)
@@ -217,9 +217,9 @@ class TestAtomGroupTrajAccess(object):
         if force:
             ag.forces = new
 
-            assert_almost_equal(ag.forces, new, decimal=5)
-            assert_almost_equal(u.trajectory.ts.forces[[101, 107, 109]],
-                                new, decimal=5)
+            assert_allclose(ag.forces, new, atol=1e-05)
+            assert_allclose(u.trajectory.ts.forces[[101, 107, 109]],
+                                new, atol=1e-05)
         else:
             with pytest.raises(NoDataError):
                 setattr(ag, 'forces', new)
@@ -232,8 +232,8 @@ class TestAtomGroupTrajAccess(object):
 
         at.position = new
 
-        assert_almost_equal(at.position, new, decimal=5)
-        assert_almost_equal(u.trajectory.ts.positions[94], new, decimal=5)
+        assert_allclose(at.position, new, atol=1e-05)
+        assert_allclose(u.trajectory.ts.positions[94], new, atol=1e-05)
 
     def test_atom_velocity_setting(self, u, vel):
         at = u.atoms[94]
@@ -243,9 +243,9 @@ class TestAtomGroupTrajAccess(object):
         if vel:
             at.velocity = new
 
-            assert_almost_equal(at.velocity, new, decimal=5)
-            assert_almost_equal(u.trajectory.ts.velocities[94], new,
-                                decimal=5)
+            assert_allclose(at.velocity, new, atol=1e-05)
+            assert_allclose(u.trajectory.ts.velocities[94], new,
+                                atol=1e-05)
         else:
             with pytest.raises(NoDataError):
                 setattr(at, 'velocity', new)
@@ -260,9 +260,9 @@ class TestAtomGroupTrajAccess(object):
         if force:
             at.force = new
 
-            assert_almost_equal(at.force, new, decimal=5)
-            assert_almost_equal(u.trajectory.ts.forces[94], new,
-                                decimal=5)
+            assert_allclose(at.force, new, atol=1e-05)
+            assert_allclose(u.trajectory.ts.forces[94], new,
+                                atol=1e-05)
         else:
             with pytest.raises(NoDataError):
                 setattr(at, 'force', new)
@@ -342,26 +342,26 @@ class TestGROVelocities(object):
         u = MDAnalysis.Universe(GRO_velocity)
         all_atoms = u.select_atoms('all')
         # check for read-in and unit conversion for .gro file velocities for the entire AtomGroup:
-        assert_almost_equal(all_atoms.velocities, reference_velocities,
+        assert_allclose(all_atoms.velocities, reference_velocities,
                             self.prec,
                             err_msg="problem reading .gro file velocities")
         # likewise for each individual atom (to be robust--in case someone alters the individual atom property code):
-        assert_almost_equal(all_atoms[0].velocity, reference_velocities[0],
+        assert_allclose(all_atoms[0].velocity, reference_velocities[0],
                             self.prec,
                             err_msg="problem reading .gro file velocities")
-        assert_almost_equal(all_atoms[1].velocity, reference_velocities[1],
+        assert_allclose(all_atoms[1].velocity, reference_velocities[1],
                             self.prec,
                             err_msg="problem reading .gro file velocities")
-        assert_almost_equal(all_atoms[2].velocity, reference_velocities[2],
+        assert_allclose(all_atoms[2].velocity, reference_velocities[2],
                             self.prec,
                             err_msg="problem reading .gro file velocities")
-        assert_almost_equal(all_atoms[3].velocity, reference_velocities[3],
+        assert_allclose(all_atoms[3].velocity, reference_velocities[3],
                             self.prec,
                             err_msg="problem reading .gro file velocities")
-        assert_almost_equal(all_atoms[4].velocity, reference_velocities[4],
+        assert_allclose(all_atoms[4].velocity, reference_velocities[4],
                             self.prec,
                             err_msg="problem reading .gro file velocities")
-        assert_almost_equal(all_atoms[5].velocity, reference_velocities[5],
+        assert_allclose(all_atoms[5].velocity, reference_velocities[5],
                             self.prec,
                             err_msg="problem reading .gro file velocities")
 
@@ -385,7 +385,7 @@ class TestTRRForces(object):
         assert_equal(len(protein), 918)
         mean_F = np.mean(
             [protein.forces.mean(axis=0) for ts in universe.trajectory], axis=0)
-        assert_almost_equal(mean_F, reference_mean_protein_force, self.prec,
+        assert_allclose(mean_F, reference_mean_protein_force, self.prec,
                             err_msg="mean force on protein over whole trajectory does not match")
 
 
@@ -424,14 +424,14 @@ class TestAtomGroupVelocities(object):
             [2.57792854, 3.25411797, -0.75065529],
             [13.91627216, 30.17778587, -12.16669178]])
         v = ag.velocities
-        assert_almost_equal(v, ref_v,
+        assert_allclose(v, ref_v,
                             err_msg="velocities were not read correctly")
 
     def test_set_velocities(self, ag):
         ag = ag
         v = ag.velocities - 2.7271
         ag.velocities = v
-        assert_almost_equal(ag.velocities, v,
+        assert_allclose(ag.velocities, v,
                             err_msg="messages were not set to new value")
 
 
@@ -454,10 +454,10 @@ class TestAtomGroupForces(object):
         ag = universe.atoms[1:4]
         ref_v = np.arange(9).reshape(3, 3) * .01 + .03
         v = ag.forces
-        assert_almost_equal(v, ref_v, err_msg="forces were not read correctly")
+        assert_allclose(v, ref_v, err_msg="forces were not read correctly")
 
     def test_set_forces(self, ag):
         v = ag.forces - 2.7271
         ag.forces = v
-        assert_almost_equal(ag.forces, v,
+        assert_allclose(ag.forces, v,
                             err_msg="messages were not set to new value")

--- a/testsuite/MDAnalysisTests/core/test_groups.py
+++ b/testsuite/MDAnalysisTests/core/test_groups.py
@@ -25,7 +25,7 @@ import numpy as np
 from numpy.testing import (
     assert_array_equal,
     assert_equal,
-    assert_almost_equal
+    assert_allclose
 )
 import pytest
 import operator
@@ -222,19 +222,19 @@ class TestEmptyAtomGroup(object):
 
     @pytest.mark.parametrize('ag', [u.residues[:1]])
     def test_passive_decorator(self, ag):
-        assert_almost_equal(ag.center_of_mass(), np.array([10.52567673,  9.49548312, -8.15335145]))
-        assert_almost_equal(ag.total_mass(), 133.209)
-        assert_almost_equal(ag.moment_of_inertia(), np.array([[ 657.514361 ,  104.9446833,  110.4782   ],
+        assert_allclose(ag.center_of_mass(), np.array([10.52567673,  9.49548312, -8.15335145]))
+        assert_allclose(ag.total_mass(), 133.209)
+        assert_allclose(ag.moment_of_inertia(), np.array([[ 657.514361 ,  104.9446833,  110.4782   ],
                                                               [ 104.9446833,  307.4360346, -199.1794289],
                                                               [ 110.4782   , -199.1794289,  570.2924896]]))
-        assert_almost_equal(ag.radius_of_gyration(), 2.400527938286)
-        assert_almost_equal(ag.shape_parameter(), 0.61460819)
-        assert_almost_equal(ag.asphericity(), 0.4892751412)
-        assert_almost_equal(ag.principal_axes(), np.array([[ 0.7574113, -0.113481 ,  0.643001 ],
+        assert_allclose(ag.radius_of_gyration(), 2.400527938286)
+        assert_allclose(ag.shape_parameter(), 0.61460819)
+        assert_allclose(ag.asphericity(), 0.4892751412)
+        assert_allclose(ag.principal_axes(), np.array([[ 0.7574113, -0.113481 ,  0.643001 ],
                                                            [ 0.5896252,  0.5419056, -0.5988993],
                                                            [-0.2804821,  0.8327427,  0.4773566]]))
-        assert_almost_equal(ag.center_of_charge(), np.array([11.0800112,  8.8885659, -8.9886632]))
-        assert_almost_equal(ag.total_charge(), 1)
+        assert_allclose(ag.center_of_charge(), np.array([11.0800112,  8.8885659, -8.9886632]))
+        assert_allclose(ag.total_charge(), 1)
 
     @pytest.mark.parametrize('ag', [mda.AtomGroup([],u)])
     def test_error_empty_group(self, ag):

--- a/testsuite/MDAnalysisTests/core/test_residuegroup.py
+++ b/testsuite/MDAnalysisTests/core/test_residuegroup.py
@@ -22,7 +22,7 @@
 #
 import numpy as np
 import pickle
-from numpy.testing import assert_equal, assert_almost_equal
+from numpy.testing import assert_equal,assert_allclose
 import pytest
 
 import MDAnalysis as mda
@@ -287,4 +287,4 @@ class TestResidueGroup(object):
     def test_residuegroup_pickle(self, universe, selection):
         seg_res = universe.select_atoms(selection).residues
         seg = pickle.loads(pickle.dumps(seg_res))
-        assert_almost_equal(seg_res.atoms.positions, seg.atoms.positions)
+        assert_allclose(seg_res.atoms.positions, seg.atoms.positions)

--- a/testsuite/MDAnalysisTests/core/test_topologyattrs.py
+++ b/testsuite/MDAnalysisTests/core/test_topologyattrs.py
@@ -27,7 +27,7 @@ import numpy as np
 
 from numpy.testing import (
     assert_equal,
-    assert_almost_equal,
+    assert_allclose,
 )
 import pytest
 from MDAnalysisTests.datafiles import PSF, DCD, PDB_CHECK_RIGHTHAND_PA, MMTF
@@ -258,7 +258,7 @@ class TestResidueAttr(TopologyAttrMixin):
     def test_set_residues_plural(self, attr):
         attr.set_residues(DummyGroup([3, 0, 1]),
                                np.array([23, 504, 2]))
-        assert_almost_equal(attr.get_residues(DummyGroup([3, 0, 1])),
+        assert_allclose(attr.get_residues(DummyGroup([3, 0, 1])),
                                   np.array([23, 504, 2]))
 
     def test_set_residues_VE(self, attr):
@@ -309,7 +309,7 @@ class TestResids(TestResidueAttr):
     def test_set_residues(self, attr):
         attr.set_residues(DummyGroup([3, 0, 1]),
                                np.array([23, 504, 27]))
-        assert_almost_equal(attr.get_residues(DummyGroup([3, 0, 1])),
+        assert_allclose(attr.get_residues(DummyGroup([3, 0, 1])),
                                   np.array([23, 504, 27]))
 
 
@@ -365,7 +365,7 @@ class TestAttr(object):
         return universe.atoms  # prototypical AtomGroup
 
     def test_principal_axes(self, ag):
-        assert_almost_equal(
+        assert_allclose(
             ag.principal_axes(),
             np.array([
                       [1.53389276e-03, 4.41386224e-02, 9.99024239e-01],
@@ -378,20 +378,20 @@ class TestAttr(object):
 
     def test_principal_axes_handedness(self, universe_pa):
         e_vec = universe_pa.atoms.principal_axes()
-        assert_almost_equal(np.dot(np.cross(e_vec[0], e_vec[1]), e_vec[2]), 1.0)
+        assert_allclose(np.dot(np.cross(e_vec[0], e_vec[1]), e_vec[2]), 1.0)
 
     def test_align_principal_axes_with_self(self, ag):
         pa = ag.principal_axes()
         ag.align_principal_axis(0, pa[0])
 
-        assert_almost_equal(ag.principal_axes(), pa)
+        assert_allclose(ag.principal_axes(), pa)
 
     def test_align_principal_axes_with_x(self, ag):
         ag.align_principal_axis(0, [1, 0, 0])
         # This is a very loose check that the difference is not more then 0.5.
         # This is OK here because the rounding error in the calculation really
         # is that big.
-        assert_almost_equal(np.abs(ag.principal_axes()), np.eye(3), decimal=1)
+        assert_allclose(np.abs(ag.principal_axes()), np.eye(3), atol=1e-01)
 
 
 class TestCrossLevelAttributeSetting(object):

--- a/testsuite/MDAnalysisTests/core/test_topologyobjects.py
+++ b/testsuite/MDAnalysisTests/core/test_topologyobjects.py
@@ -22,7 +22,7 @@
 #
 import numpy as np
 from numpy.testing import (
-    assert_almost_equal,
+    assert_allclose,
     assert_equal,
 )
 import pytest
@@ -141,7 +141,7 @@ class TestTopologyObjects(object):
             b.partner(a3)
 
     def test_bondlength(self, b):
-        assert_almost_equal(b.length(), 1.7661301556941993, self.precision)
+        assert_allclose(b.length(), 1.7661301556941993, self.precision)
 
     def test_bondrepr(self, b):
         assert_equal(repr(b), '<Bond between: Atom 9, Atom 12>')
@@ -150,8 +150,8 @@ class TestTopologyObjects(object):
     def test_angle(self, PSFDCD):
         angle = PSFDCD.atoms[210].angles[0]
 
-        assert_almost_equal(angle.angle(), 107.20893, self.precision)
-        assert_almost_equal(angle.value(), 107.20893, self.precision)
+        assert_allclose(angle.angle(), 107.20893, self.precision)
+        assert_allclose(angle.value(), 107.20893, self.precision)
 
     def test_angle_repr(self, PSFDCD):
         angle = PSFDCD.atoms[[30, 10, 20]].angle
@@ -169,14 +169,14 @@ class TestTopologyObjects(object):
 
         angle.atoms.positions = coords
 
-        assert_almost_equal(angle.value(), 180.0, self.precision)
+        assert_allclose(angle.value(), 180.0, self.precision)
 
     # Dihedral class check
     def test_dihedral(self, PSFDCD):
         dihedral = PSFDCD.atoms[14].dihedrals[0]
 
-        assert_almost_equal(dihedral.dihedral(), 18.317778, self.precision)
-        assert_almost_equal(dihedral.value(), 18.317778, self.precision)
+        assert_allclose(dihedral.dihedral(), 18.317778, self.precision)
+        assert_allclose(dihedral.value(), 18.317778, self.precision)
 
     def test_dihedral_repr(self, PSFDCD):
         dihedral = PSFDCD.atoms[[4, 7, 8, 1]].dihedral
@@ -188,8 +188,8 @@ class TestTopologyObjects(object):
     def test_improper(self, PSFDCD):
         imp = PSFDCD.atoms[4].impropers[0]
 
-        assert_almost_equal(imp.improper(), -3.8370631, self.precision)
-        assert_almost_equal(imp.value(), -3.8370631, self.precision)
+        assert_allclose(imp.improper(), -3.8370631, self.precision)
+        assert_allclose(imp.value(), -3.8370631, self.precision)
 
     def test_improper_repr(self, PSFDCD):
         imp = PSFDCD.atoms[[4, 7, 8, 1]].improper
@@ -213,7 +213,7 @@ class TestTopologyObjects(object):
         assert ub.partner(PSFDCD.atoms[10]) == PSFDCD.atoms[30]
 
     def test_ureybradley_distance(self, b):
-        assert_almost_equal(b.atoms.ureybradley.distance(), b.length(), self.precision)
+        assert_allclose(b.atoms.ureybradley.distance(), b.length(), self.precision)
 
     def test_cmap_repr(self, PSFDCD):
         cmap = PSFDCD.atoms[[4, 7, 8, 1, 2]].cmap
@@ -740,7 +740,7 @@ def test_bond_length_pbc():
     # move an atom a box width in all dimensions
     u.atoms[0].position += u.dimensions[:3]
 
-    assert_almost_equal(ref, u.bonds[0].length(pbc=True), decimal=6)
+    assert_allclose(ref, u.bonds[0].length(pbc=True), atol=1e-06)
 
 def test_cross_universe_eq():
     u1 = mda.Universe(PSF)

--- a/testsuite/MDAnalysisTests/core/test_universe.py
+++ b/testsuite/MDAnalysisTests/core/test_universe.py
@@ -32,7 +32,6 @@ import warnings
 import numpy as np
 from numpy.testing import (
     assert_allclose,
-    assert_almost_equal,
     assert_equal,
     assert_array_equal,
 )
@@ -291,7 +290,7 @@ class TestUniverseFromSmiles(object):
             [-0.41925883,  0.9689095 , -0.3415968 ],
             [ 0.03148226, -0.03256683,  1.1267245 ],
             [ 1.0077721 , -0.10363862, -0.41727486]]], dtype=np.float32)
-        assert_almost_equal(u.trajectory.coordinate_array, expected)
+        assert_allclose(u.trajectory.coordinate_array, expected)
 
 
 class TestUniverse(object):
@@ -333,7 +332,7 @@ class TestUniverse(object):
         ref = mda.Universe(PSF, PDB_small)
         u = mda.Universe(PDB_small)
         assert_equal(len(u.atoms), 3341, "Loading universe failed somehow")
-        assert_almost_equal(u.atoms.positions, ref.atoms.positions)
+        assert_allclose(u.atoms.positions, ref.atoms.positions)
 
     def test_load_multiple_list(self):
         # Universe(top, [trj, trj, ...])
@@ -372,14 +371,14 @@ class TestTransformations(object):
         u = mda.Universe(PSF,DCD, transformations=translate([10,10,10]))
         uref = mda.Universe(PSF,DCD)
         ref = translate([10,10,10])(uref.trajectory.ts)
-        assert_almost_equal(u.trajectory.ts.positions, ref, decimal=6)
+        assert_allclose(u.trajectory.ts.positions, ref, atol=1e-06)
 
     def test_list(self):
         workflow = [translate([10,10,0]), translate([0,0,10])]
         u = mda.Universe(PSF,DCD, transformations=workflow)
         uref = mda.Universe(PSF,DCD)
         ref = translate([10,10,10])(uref.trajectory.ts)
-        assert_almost_equal(u.trajectory.ts.positions, ref, decimal=6)
+        assert_allclose(u.trajectory.ts.positions, ref, atol=1e-06)
 
 class TestGuessMasses(object):
     """Tests the Mass Guesser in topology.guessers
@@ -580,7 +579,7 @@ class TestInMemoryUniverse(object):
         universe = MDAnalysis.Universe(PDB_small, DCD)
         dt = universe.trajectory.dt
         universe.transfer_to_memory(step=2)
-        assert_almost_equal(dt * 2, universe.trajectory.dt,
+        assert_allclose(dt * 2, universe.trajectory.dt,
                             err_msg="Unexpected in-memory timestep: "
                             + "dt not updated with step information")
 

--- a/testsuite/MDAnalysisTests/core/test_unwrap.py
+++ b/testsuite/MDAnalysisTests/core/test_unwrap.py
@@ -21,7 +21,7 @@
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
 import numpy as np
-from numpy.testing import (assert_raises, assert_almost_equal,
+from numpy.testing import (assert_raises,assert_allclose,
                            assert_array_equal)
 import pytest
 
@@ -35,7 +35,7 @@ class TestUnwrap(object):
     """Tests the functionality of *Group.unwrap() using the UnWrapUniverse,
     which is specifically designed for wrapping and unwrapping tests.
     """
-    precision = 5
+    precision = 1e-05
 
     @pytest.mark.parametrize('level', ('atoms', 'residues', 'segments'))
     @pytest.mark.parametrize('compound', ('fragments', 'molecules', 'residues',
@@ -69,8 +69,8 @@ class TestUnwrap(object):
         unwrapped_pos = group.unwrap(compound=compound, reference=reference,
                                      inplace=False)
         # check for correct result:
-        assert_almost_equal(unwrapped_pos, ref_unwrapped_pos,
-                            decimal=self.precision)
+        assert_allclose(unwrapped_pos, ref_unwrapped_pos,
+                            atol=self.precision)
         # make sure atom positions are unchanged:
         assert_array_equal(group.atoms.positions, orig_pos)
         # now, do the unwrapping inplace:
@@ -110,8 +110,8 @@ class TestUnwrap(object):
         # wrap again:
         group.wrap()
         # make sure wrapped atom positions are as before:
-        assert_almost_equal(group.atoms.positions, orig_wrapped_pos,
-                            decimal=self.precision)
+        assert_allclose(group.atoms.positions, orig_wrapped_pos,
+                            atol=self.precision)
 
     @pytest.mark.parametrize('compound', ('fragments', 'molecules', 'residues',
                                           'group', 'segments'))
@@ -129,8 +129,8 @@ class TestUnwrap(object):
         # first, do the unwrapping out-of-place:
         group.unwrap(compound=compound, reference=reference, inplace=True)
         # check for correct result:
-        assert_almost_equal(group.positions, ref_unwrapped_pos,
-                            decimal=self.precision)
+        assert_allclose(group.positions, ref_unwrapped_pos,
+                            atol=self.precision)
         # make sure the position of molecule 12's last atom is unchanged:
         assert_array_equal(u.atoms[46].position, orig_pos)
 
@@ -180,8 +180,8 @@ class TestUnwrap(object):
         # unwrap:
         group.unwrap(compound=compound, reference=reference, inplace=True)
         # check for correct result:
-        assert_almost_equal(group.atoms.positions, ref_unwrapped_pos,
-                            decimal=self.precision)
+        assert_allclose(group.atoms.positions, ref_unwrapped_pos,
+                            atol=self.precision)
         # check that the rest of the atoms are kept unmodified:
         assert_array_equal(rest.positions, orig_rest_pos)
 
@@ -204,16 +204,16 @@ class TestUnwrap(object):
         # get expected result:
         ref_unwrapped_pos = u.unwrapped_coords(compound, 'cog')[6:9]
         # check for correctness:
-        assert_almost_equal(unwrapped_pos_cog, ref_unwrapped_pos,
-                            decimal=self.precision)
+        assert_allclose(unwrapped_pos_cog, ref_unwrapped_pos,
+                            atol=self.precision)
         # unwrap with center of mass as reference:
         unwrapped_pos_com = group.unwrap(compound=compound, reference='com',
                                          inplace=False)
         # assert that the com result is shifted with respect to the cog result
         # by one box length in the x-direction:
         shift = np.array([10.0, 0.0, 0.0], dtype=np.float32)
-        assert_almost_equal(unwrapped_pos_cog, unwrapped_pos_com - shift,
-                            decimal=self.precision)
+        assert_allclose(unwrapped_pos_cog, unwrapped_pos_com - shift,
+                            atol=self.precision)
 
     @pytest.mark.parametrize('level', ('atoms', 'residues', 'segments'))
     @pytest.mark.parametrize('compound', ('fragments', 'molecules', 'residues',
@@ -373,10 +373,10 @@ def test_uncontiguous():
     u.atoms.positions -= displacement_vec
     u.atoms.pack_into_box()
     # Let's make sure we really broke the fragment
-    assert_raises(AssertionError, assert_almost_equal,
+    assert_raises(AssertionError,
                   ref_pos, ag.positions+displacement_vec,
                   decimal=precision)
     # Ok, let's make it whole again and check that we're good
     u.atoms.unwrap()
-    assert_almost_equal(ref_pos, ag.positions+displacement_vec,
-                        decimal=precision)
+    assert_allclose(ref_pos, ag.positions+displacement_vec,
+                        atol=1e-05)

--- a/testsuite/MDAnalysisTests/core/test_wrap.py
+++ b/testsuite/MDAnalysisTests/core/test_wrap.py
@@ -21,7 +21,7 @@
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
 import numpy as np
-from numpy.testing import assert_almost_equal, assert_array_equal
+from numpy.testing import assert_allclose, assert_array_equal
 import pytest
 
 import MDAnalysis as mda
@@ -34,7 +34,7 @@ class TestWrap(object):
     which is specifically designed for wrapping and unwrapping tests.
     """
 
-    precision = 5
+    precision = 1e-05
 
     @pytest.mark.parametrize('level', ('atoms', 'residues', 'segments'))
     @pytest.mark.parametrize('compound', ('atoms', 'group', 'segments',
@@ -58,8 +58,8 @@ class TestWrap(object):
         wrapped_pos = group.wrap(compound=compound, center=center,
                                  inplace=False)
         # check for correct result:
-        assert_almost_equal(wrapped_pos, ref_wrapped_pos,
-                            decimal=self.precision)
+        assert_allclose(wrapped_pos, ref_wrapped_pos,
+                            atol=self.precision)
         # make sure atom positions are unchanged:
         assert_array_equal(group.atoms.positions, orig_pos)
         # now, do the wrapping inplace:
@@ -106,8 +106,8 @@ class TestWrap(object):
         # unwrap again:
         group.unwrap()
         # make sure unwrapped atom positions are as before:
-        assert_almost_equal(group.atoms.positions, orig_unwrapped_pos,
-                            decimal=self.precision)
+        assert_allclose(group.atoms.positions, orig_unwrapped_pos,
+                            atol=self.precision)
 
     @pytest.mark.parametrize('level', ('atoms', 'residues', 'segments'))
     @pytest.mark.parametrize('compound', ('atoms', 'group', 'segments',
@@ -144,8 +144,8 @@ class TestWrap(object):
         # first, do the wrapping out-of-place:
         group.wrap(compound=compound, center=center, inplace=True)
         # check for correct result:
-        assert_almost_equal(group.atoms.positions, ref_wrapped_pos,
-                            decimal=self.precision)
+        assert_allclose(group.atoms.positions, ref_wrapped_pos,
+                            atol=self.precision)
         # make sure the positions of the missing item are unchanged:
         assert_array_equal(missing.atoms.positions, orig_pos)
 
@@ -200,8 +200,8 @@ class TestWrap(object):
         # wrap:
         group.wrap(compound=compound, center=center, inplace=True)
         # check for correct result:
-        assert_almost_equal(group.atoms.positions, ref_wrapped_pos,
-                            decimal=self.precision)
+        assert_allclose(group.atoms.positions, ref_wrapped_pos,
+                            atol=self.precision)
         # check that the rest of the atoms are kept unmodified:
         assert_array_equal(rest.positions, orig_rest_pos)
 
@@ -224,8 +224,8 @@ class TestWrap(object):
         # get expected result:
         ref_wrapped_pos = u.wrapped_coords(compound, 'cog')[6:9]
         # check for correctness:
-        assert_almost_equal(wrapped_pos_cog, ref_wrapped_pos,
-                            decimal=self.precision)
+        assert_allclose(wrapped_pos_cog, ref_wrapped_pos,
+                            atol=self.precision)
         # wrap with center='com':
         wrapped_pos_com = group.wrap(compound=compound, center='com',
                                      inplace=False)
@@ -235,8 +235,8 @@ class TestWrap(object):
         if compound == 'atoms':
             # center argument must be ignored for compound='atoms':
             shift[0] = 0.0
-        assert_almost_equal(wrapped_pos_cog, wrapped_pos_com - shift,
-                            decimal=self.precision)
+        assert_allclose(wrapped_pos_cog, wrapped_pos_com - shift,
+                            atol=self.precision)
 
     @pytest.mark.parametrize('level', ('atoms', 'residues', 'segments'))
     @pytest.mark.parametrize('compound', ('atoms', 'group', 'segments',
@@ -262,8 +262,8 @@ class TestWrap(object):
             # wrap() must not care about masses if compound == 'atoms':
             group.wrap(compound=compound, center='com', inplace=True)
             ref_wrapped_pos = u.wrapped_coords(compound, 'com')
-            assert_almost_equal(group.atoms.positions, ref_wrapped_pos,
-                                decimal=self.precision)
+            assert_allclose(group.atoms.positions, ref_wrapped_pos,
+                                atol=self.precision)
         else:
             # try to wrap:
             with pytest.raises(ValueError):
@@ -289,8 +289,8 @@ class TestWrap(object):
             # wrap() must ignore the center argument if compound == 'atoms':
             group.wrap(compound=compound, center='com', inplace=True)
             ref_wrapped_pos = u.wrapped_coords(compound, 'com')
-            assert_almost_equal(group.atoms.positions, ref_wrapped_pos,
-                                decimal=self.precision)
+            assert_allclose(group.atoms.positions, ref_wrapped_pos,
+                                atol=self.precision)
         else:
             # try to wrap:
             with pytest.raises(ValueError):
@@ -333,8 +333,8 @@ class TestWrap(object):
             # wrap() must not care about mass presence if compound == 'atoms':
             group.wrap(compound=compound, center='com', inplace=True)
             ref_wrapped_pos = u.wrapped_coords(compound, 'com')
-            assert_almost_equal(group.atoms.positions, ref_wrapped_pos,
-                                decimal=self.precision)
+            assert_allclose(group.atoms.positions, ref_wrapped_pos,
+                                atol=self.precision)
         else:
             # store original positions:
             orig_pos = group.atoms.positions
@@ -369,8 +369,8 @@ class TestWrap(object):
             # must not care about bonds if compound != 'fragments'
             group.wrap(compound=compound, center=center, inplace=True)
             ref_wrapped_pos = u.wrapped_coords(compound, center)
-            assert_almost_equal(group.atoms.positions, ref_wrapped_pos,
-                                decimal=self.precision)
+            assert_allclose(group.atoms.positions, ref_wrapped_pos,
+                                atol=self.precision)
 
     @pytest.mark.parametrize('level', ('atoms', 'residues', 'segments'))
     @pytest.mark.parametrize('compound', ('atoms', 'group', 'segments',
@@ -397,13 +397,13 @@ class TestWrap(object):
             # must not care about molnums if compound != 'molecules'
             group.wrap(compound=compound, center=center, inplace=True)
             ref_wrapped_pos = u.wrapped_coords(compound, center)
-            assert_almost_equal(group.atoms.positions, ref_wrapped_pos,
-                                decimal=self.precision)
+            assert_allclose(group.atoms.positions, ref_wrapped_pos,
+                                atol=self.precision)
 
 class TestWrapTRZ(object):
     """Tests the functionality of AtomGroup.wrap() using a TRZ universe."""
 
-    precision = 5
+    precision = 1e-05
 
     @pytest.fixture()
     def u(self):
@@ -434,7 +434,7 @@ class TestWrapTRZ(object):
         rescom = ag.wrap(compound='atoms', center='com', inplace=False)
         assert_in_box(rescom, u.dimensions)
         rescog = ag.wrap(compound='atoms', center='cog', inplace=False)
-        assert_almost_equal(rescom, rescog, decimal=self.precision)
+        assert_allclose(rescom, rescog, atol=self.precision)
 
     @pytest.mark.parametrize('center', ('com', 'cog'))
     def test_wrap_group(self, u, center):

--- a/testsuite/MDAnalysisTests/formats/test_libdcd.py
+++ b/testsuite/MDAnalysisTests/formats/test_libdcd.py
@@ -27,8 +27,10 @@ from hypothesis import example, given
 import hypothesis
 import numpy as np
 
-from numpy.testing import (assert_array_almost_equal, assert_equal,
-                           assert_array_equal, assert_almost_equal)
+from numpy.testing import (
+                           assert_equal,
+                           assert_array_equal,
+                           assert_allclose)
 
 from MDAnalysis.lib.formats.libdcd import DCDFile, DCD_IS_CHARMM, DCD_HAS_EXTRA_BLOCK
 
@@ -93,8 +95,8 @@ def _assert_compare_readers(old_reader, new_reader):
 
     assert old_reader.fname == new_reader.fname
     assert old_reader.tell() == new_reader.tell()
-    assert_almost_equal(frame.xyz, new_frame.xyz)
-    assert_almost_equal(frame.unitcell, new_frame.unitcell)
+    assert_allclose(frame.xyz, new_frame.xyz)
+    assert_allclose(frame.unitcell, new_frame.unitcell)
 
 
 def test_pickle(dcd):

--- a/testsuite/MDAnalysisTests/formats/test_libmdaxdr.py
+++ b/testsuite/MDAnalysisTests/formats/test_libmdaxdr.py
@@ -24,8 +24,8 @@ import pickle
 
 import numpy as np
 
-from numpy.testing import (assert_almost_equal, assert_array_almost_equal,
-                           assert_array_equal, assert_equal)
+from numpy.testing import (assert_allclose,assert_array_equal,
+                           assert_equal)
 
 from MDAnalysis.lib.formats.libmdaxdr import TRRFile, XTCFile
 
@@ -136,10 +136,10 @@ class TestCommonAPI(object):
         assert old_reader.tell() == new_reader.tell()
 
         assert_equal(old_reader.offsets, new_reader.offsets)
-        assert_almost_equal(frame.x, new_frame.x)
-        assert_almost_equal(frame.box, new_frame.box)
+        assert_allclose(frame.x, new_frame.x)
+        assert_allclose(frame.box, new_frame.box)
         assert frame.step == new_frame.step
-        assert_almost_equal(frame.time, new_frame.time)
+        assert_allclose(frame.time, new_frame.time)
 
     def test_pickle(self, reader):
         mid = len(reader) // 2
@@ -258,13 +258,13 @@ def test_time(xdrfile, fname):
 def test_box_xtc(xtc):
     box = np.eye(3) * 20
     for frame in xtc:
-        assert_array_almost_equal(frame.box, box, decimal=3)
+        assert_array_almost_equal(frame.box, box, atol=1e-03)
 
 
 def test_xyz_xtc(xtc):
     ones = np.ones(30).reshape(10, 3)
     for i, frame in enumerate(xtc):
-        assert_array_almost_equal(frame.x, ones * i, decimal=3)
+        assert_array_almost_equal(frame.x, ones * i, atol=1e-03)
 
 
 def test_box_trr(trr):
@@ -293,7 +293,7 @@ def test_forces_trr(trr):
 
 def test_lmbda_trr(trr):
     for i, frame in enumerate(trr):
-        assert_almost_equal(frame.lmbda, .01 * i)
+        assert_allclose(frame.lmbda, .01 * i)
 
 
 @pytest.fixture
@@ -324,13 +324,13 @@ def test_written_prec_xtc(written_xtc):
 def test_written_box_xtc(written_xtc):
     box = np.eye(3) * 20
     for frame in written_xtc:
-        assert_array_almost_equal(frame.box, box, decimal=3)
+        assert_array_almost_equal(frame.box, box, atol=1e-03)
 
 
 def test_written_xyx_xtc(written_xtc):
     ones = np.ones(30).reshape(10, 3)
     for i, frame in enumerate(written_xtc):
-        assert_array_almost_equal(frame.x, ones * i, decimal=3)
+        assert_array_almost_equal(frame.x, ones * i, atol=1e-03)
 
 
 @pytest.mark.parametrize(

--- a/testsuite/MDAnalysisTests/lib/test_augment.py
+++ b/testsuite/MDAnalysisTests/lib/test_augment.py
@@ -23,7 +23,7 @@
 import os
 import pytest
 import numpy as np
-from numpy.testing import assert_almost_equal, assert_equal
+from numpy.testing import assert_allclose, assert_equal
 
 from MDAnalysis.lib._augment import augment_coordinates, undo_augment
 from MDAnalysis.lib.distances import apply_PBC, transform_StoR
@@ -91,7 +91,7 @@ def test_augment(b, q, res):
         cs = np.sort(cs, axis=0)
     else:
         cs = list()
-    assert_almost_equal(aug, cs, decimal=5)
+    assert_allclose(aug, cs, atol=1e-05)
 
 
 @pytest.mark.parametrize('b', (

--- a/testsuite/MDAnalysisTests/lib/test_distances.py
+++ b/testsuite/MDAnalysisTests/lib/test_distances.py
@@ -22,7 +22,7 @@
 #
 import pytest
 import numpy as np
-from numpy.testing import assert_equal, assert_almost_equal, assert_allclose
+from numpy.testing import assert_equal, assert_allclose
 import itertools
 from itertools import combinations_with_replacement as comb
 
@@ -241,7 +241,7 @@ class TestCappedDistances(object):
                 assert d_ref < 0.2
                 if min_cutoff is not None:
                     assert d_ref > min_cutoff
-                assert_almost_equal(d, d_ref, decimal=6)
+                assert_allclose(d, d_ref, atol=1e-06)
         else:
             for i, j in pairs:
                 d_ref = ref[i, j]
@@ -324,7 +324,7 @@ class TestDistanceArray(object):
         _, all, ref, _ = request.getfixturevalue(pos)
 
         d = distances.distance_array(ref, all, backend=backend)
-        assert_almost_equal(d, np.array([[
+        assert_allclose(d, np.array([[
             self._dist(points[0], reference[0]),
             self._dist(points[1], reference[0]),
             self._dist(points[2], reference[0]),
@@ -341,7 +341,7 @@ class TestDistanceArray(object):
         _, points_val, _, _ = request.getfixturevalue(pos1)
         d = distances.distance_array(ref_val, points_val,
                                      backend=backend)
-        assert_almost_equal(d, np.array([[
+        assert_allclose(d, np.array([[
             self._dist(points[0], reference[0]),
             self._dist(points[1], reference[0]),
             self._dist(points[2], reference[0]),
@@ -356,7 +356,7 @@ class TestDistanceArray(object):
 
         d = distances.distance_array(ref, all, box=box, backend=backend)
 
-        assert_almost_equal(d, np.array([[0., 0., 0., self._dist(points[3],
+        assert_allclose(d, np.array([[0., 0., 0., self._dist(points[3],
                             ref=[1, 1, 2])]]))
 
     # cycle through combinations of numpy array and AtomGroup
@@ -370,7 +370,7 @@ class TestDistanceArray(object):
         d = distances.distance_array(ref_val, points_val,
                                      box=box,
                                      backend=backend)
-        assert_almost_equal(
+        assert_allclose(
             d, np.array([[0., 0., 0., self._dist(points[3], ref=[1, 1, 2])]]))
 
     def test_PBC2(self, backend):
@@ -385,7 +385,7 @@ class TestDistanceArray(object):
         ref = mindist(a, b, box[:3])
         val = distances.distance_array(a, b, box=box, backend=backend)[0, 0]
 
-        assert_almost_equal(val, ref, decimal=6,
+        assert_allclose(val, ref, atol=1e-06,
                             err_msg="Issue 151 not correct (PBC in distance array)")
 
 def test_distance_array_overflow_exception():
@@ -446,9 +446,9 @@ class TestDistanceArrayDCD_TRIC(object):
         d = distances.distance_array(x0, x1, backend=backend)
         assert_equal(d.shape, (3341, 3341), "wrong shape (should be"
                      "(Natoms,Natoms))")
-        assert_almost_equal(d.min(), 0.11981228170520701, self.prec,
+        assert_allclose(d.min(), 0.11981228170520701, self.prec,
                             err_msg="wrong minimum distance value")
-        assert_almost_equal(d.max(), 53.572192429459619, self.prec,
+        assert_allclose(d.max(), 53.572192429459619, self.prec,
                             err_msg="wrong maximum distance value")
 
     def test_outarray(self, DCD_Universe, backend):
@@ -463,9 +463,9 @@ class TestDistanceArrayDCD_TRIC(object):
         distances.distance_array(x0, x1, result=d, backend=backend)
         assert_equal(d.shape, (natoms, natoms), "wrong shape, should be"
                      " (Natoms,Natoms) entries")
-        assert_almost_equal(d.min(), 0.11981228170520701, self.prec,
+        assert_allclose(d.min(), 0.11981228170520701, self.prec,
                             err_msg="wrong minimum distance value")
-        assert_almost_equal(d.max(), 53.572192429459619, self.prec,
+        assert_allclose(d.max(), 53.572192429459619, self.prec,
                             err_msg="wrong maximum distance value")
 
     def test_periodic(self, DCD_Universe, backend):
@@ -480,9 +480,9 @@ class TestDistanceArrayDCD_TRIC(object):
                                      backend=backend)
         assert_equal(d.shape, (3341, 3341), "should be square matrix with"
                      " Natoms entries")
-        assert_almost_equal(d.min(), 0.11981228170520701, self.prec,
+        assert_allclose(d.min(), 0.11981228170520701, self.prec,
                             err_msg="wrong minimum distance value with PBC")
-        assert_almost_equal(d.max(), 53.572192429459619, self.prec,
+        assert_allclose(d.max(), 53.572192429459619, self.prec,
                             err_msg="wrong maximum distance value with PBC")
 
     def test_atomgroup_simple(self, DCD_Universe, DCD_Universe2, backend):
@@ -499,9 +499,9 @@ class TestDistanceArrayDCD_TRIC(object):
         d = distances.distance_array(x0, x1, backend=backend)
         assert_equal(d.shape, (3341, 3341), "wrong shape (should be"
                      " (Natoms,Natoms))")
-        assert_almost_equal(d.min(), 0.11981228170520701, self.prec,
+        assert_allclose(d.min(), 0.11981228170520701, self.prec,
                             err_msg="wrong minimum distance value")
-        assert_almost_equal(d.max(), 53.572192429459619, self.prec,
+        assert_allclose(d.max(), 53.572192429459619, self.prec,
                             err_msg="wrong maximum distance value")
 
     # check no box and ortho box types and some slices
@@ -555,9 +555,9 @@ class TestSelfDistanceArrayDCD_TRIC(object):
         d = distances.self_distance_array(x0, backend=backend)
         N = 3341 * (3341 - 1) / 2
         assert_equal(d.shape, (N,), "wrong shape (should be (Natoms*(Natoms-1)/2,))")
-        assert_almost_equal(d.min(), 0.92905562402529318, self.prec,
+        assert_allclose(d.min(), 0.92905562402529318, self.prec,
                             err_msg="wrong minimum distance value")
-        assert_almost_equal(d.max(), 52.4702570624190590, self.prec,
+        assert_allclose(d.max(), 52.4702570624190590, self.prec,
                             err_msg="wrong maximum distance value")
 
     def test_outarray(self, DCD_Universe, backend):
@@ -570,9 +570,9 @@ class TestSelfDistanceArrayDCD_TRIC(object):
         d = np.zeros((N,), np.float64)
         distances.self_distance_array(x0, result=d, backend=backend)
         assert_equal(d.shape, (N,), "wrong shape (should be (Natoms*(Natoms-1)/2,))")
-        assert_almost_equal(d.min(), 0.92905562402529318, self.prec,
+        assert_allclose(d.min(), 0.92905562402529318, self.prec,
                             err_msg="wrong minimum distance value")
-        assert_almost_equal(d.max(), 52.4702570624190590, self.prec,
+        assert_allclose(d.max(), 52.4702570624190590, self.prec,
                             err_msg="wrong maximum distance value")
 
     def test_periodic(self, DCD_Universe, backend):
@@ -586,9 +586,9 @@ class TestSelfDistanceArrayDCD_TRIC(object):
         d = distances.self_distance_array(x0, box=U.coord.dimensions,
                                           backend=backend)
         assert_equal(d.shape, (N,), "wrong shape (should be (Natoms*(Natoms-1)/2,))")
-        assert_almost_equal(d.min(), 0.92905562402529318, self.prec,
+        assert_allclose(d.min(), 0.92905562402529318, self.prec,
                             err_msg="wrong minimum distance value with PBC")
-        assert_almost_equal(d.max(), 52.4702570624190590, self.prec,
+        assert_allclose(d.max(), 52.4702570624190590, self.prec,
                             err_msg="wrong maximum distance value with PBC")
 
     def test_atomgroup_simple(self, DCD_Universe, backend):
@@ -600,9 +600,9 @@ class TestSelfDistanceArrayDCD_TRIC(object):
         N = 3341 * (3341 - 1) / 2
         assert_equal(d.shape, (N,), "wrong shape (should be"
                      " (Natoms*(Natoms-1)/2,))")
-        assert_almost_equal(d.min(), 0.92905562402529318, self.prec,
+        assert_allclose(d.min(), 0.92905562402529318, self.prec,
                             err_msg="wrong minimum distance value")
-        assert_almost_equal(d.max(), 52.4702570624190590, self.prec,
+        assert_allclose(d.max(), 52.4702570624190590, self.prec,
                             err_msg="wrong maximum distance value")
 
     # check no box and ortho box types and some slices
@@ -695,15 +695,15 @@ class TestTriclinicDistances(object):
         R_mol2 = distances.transform_StoR(S_mol2, box, backend=backend)
         R_np2 = np.dot(S_mol2, tri_vec_box)
 
-        assert_almost_equal(R_mol1, R_np1, self.prec, err_msg="StoR transform failed for S_mol1")
-        assert_almost_equal(R_mol2, R_np2, self.prec, err_msg="StoR transform failed for S_mol2")
+        assert_allclose(R_mol1, R_np1, self.prec, err_msg="StoR transform failed for S_mol1")
+        assert_allclose(R_mol2, R_np2, self.prec, err_msg="StoR transform failed for S_mol2")
 
         # Round trip test
         S_test1 = distances.transform_RtoS(R_mol1, box, backend=backend)
         S_test2 = distances.transform_RtoS(R_mol2, box, backend=backend)
 
-        assert_almost_equal(S_test1, S_mol1, self.prec, err_msg="Round trip 1 failed in transform")
-        assert_almost_equal(S_test2, S_mol2, self.prec, err_msg="Round trip 2 failed in transform")
+        assert_allclose(S_test1, S_mol1, self.prec, err_msg="Round trip 1 failed in transform")
+        assert_allclose(S_test2, S_mol2, self.prec, err_msg="Round trip 2 failed in transform")
 
     def test_selfdist(self, S_mol, box, tri_vec_box, backend):
         S_mol1, S_mol2 = S_mol
@@ -723,7 +723,7 @@ class TestTriclinicDistances(object):
                 manual[distpos] = Rij  # and done, phew
                 distpos += 1
 
-        assert_almost_equal(dists, manual, self.prec,
+        assert_allclose(dists, manual, self.prec,
                             err_msg="self_distance_array failed with input 1")
 
         # Do it again for input 2 (has wider separation in points)
@@ -743,7 +743,7 @@ class TestTriclinicDistances(object):
                 manual[distpos] = Rij  # and done, phew
                 distpos += 1
 
-        assert_almost_equal(dists, manual, self.prec,
+        assert_allclose(dists, manual, self.prec,
                             err_msg="self_distance_array failed with input 2")
 
     def test_distarray(self, S_mol, tri_vec_box, box, backend):
@@ -765,7 +765,7 @@ class TestTriclinicDistances(object):
                 Rij = np.linalg.norm(Rij)  # find norm of Rij vector
                 manual[i][j] = Rij
 
-        assert_almost_equal(dists, manual, self.prec,
+        assert_allclose(dists, manual, self.prec,
                             err_msg="distance_array failed with box")
 
     def test_pbc_dist(self, S_mol, box, backend):
@@ -773,7 +773,7 @@ class TestTriclinicDistances(object):
         results = np.array([[37.629944]])
         dists = distances.distance_array(S_mol1, S_mol2, box=box, backend=backend)
 
-        assert_almost_equal(dists, results, self.prec,
+        assert_allclose(dists, results, self.prec,
                             err_msg="distance_array failed to retrieve PBC distance")
 
     def test_pbc_wrong_wassenaar_distance(self, backend):
@@ -783,7 +783,7 @@ class TestTriclinicDistances(object):
         point_a = a + b
         point_b = .5 * point_a
         dist = distances.distance_array(point_a, point_b, box=box, backend=backend)
-        assert_almost_equal(dist[0, 0], 1)
+        assert_allclose(dist[0, 0], 1)
         # check that our distance is different from the wassenaar distance as
         # expected.
         assert np.linalg.norm(point_a - point_b) != dist[0, 0]
@@ -897,17 +897,17 @@ class TestCythonFunctions(object):
         assert_equal(len(dists), 4, err_msg="calc_bonds results have wrong length")
         dists_pbc = distances.calc_bonds(a, b, box=box, backend=backend)
         #tests 0 length
-        assert_almost_equal(dists[0], 0.0, self.prec, err_msg="Zero length calc_bonds fail")
-        assert_almost_equal(dists[1], 1.7320508075688772, self.prec,
+        assert_allclose(dists[0], 0.0, self.prec, err_msg="Zero length calc_bonds fail")
+        assert_allclose(dists[1], 1.7320508075688772, self.prec,
                             err_msg="Standard length calc_bonds fail")  # arbitrary length check
         # PBC checks, 2 without, 2 with
-        assert_almost_equal(dists[2], 11.0, self.prec,
+        assert_allclose(dists[2], 11.0, self.prec,
                             err_msg="PBC check #1 w/o box")  # pbc check 1, subtract single box length
-        assert_almost_equal(dists_pbc[2], 1.0, self.prec,
+        assert_allclose(dists_pbc[2], 1.0, self.prec,
                             err_msg="PBC check #1 with box")
-        assert_almost_equal(dists[3], 104.26888318, self.prec,  # pbc check 2, subtract multiple box
+        assert_allclose(dists[3], 104.26888318, self.prec,  # pbc check 2, subtract multiple box
                             err_msg="PBC check #2 w/o box")  # lengths in all directions
-        assert_almost_equal(dists_pbc[3], 3.46410072, self.prec,
+        assert_allclose(dists_pbc[3], 3.46410072, self.prec,
                             err_msg="PBC check #w with box")
 
     @pytest.mark.parametrize("backend", distopia_conditional_backend())
@@ -937,7 +937,7 @@ class TestCythonFunctions(object):
         a, b, c, d = convert_position_dtype_if_ndarray(a, b, c, d, dtype)
         dists = distances.calc_bonds(a, b, box=triclinic_box, backend=backend)
         reference = np.array([0.0, 1.7320508, 1.4142136, 2.82842712])
-        assert_almost_equal(dists, reference, self.prec, err_msg="calc_bonds with triclinic box failed")
+        assert_allclose(dists, reference, self.prec, err_msg="calc_bonds with triclinic box failed")
 
     @pytest.mark.parametrize("shift", shifts)
     @pytest.mark.parametrize("periodic", [True, False])
@@ -957,7 +957,7 @@ class TestCythonFunctions(object):
 
         reference = 2.0 if periodic else np.linalg.norm(coords[0] - coords[1])
 
-        assert_almost_equal(result, reference, decimal=self.prec)
+        assert_allclose(result, reference, atol=self.prec)
 
     @pytest.mark.parametrize("dtype", (np.float32, np.float64))
     @pytest.mark.parametrize("pos", ["positions", "positions_atomgroups"])
@@ -968,13 +968,13 @@ class TestCythonFunctions(object):
         angles = distances.calc_angles(a, b, c, backend=backend)
         # Check calculated values
         assert_equal(len(angles), 4, err_msg="calc_angles results have wrong length")
-        #        assert_almost_equal(angles[0], 0.0, self.prec,
+        #        assert_allclose(angles[0], 0.0, self.prec,
         #                           err_msg="Zero length angle calculation failed") # What should this be?
-        assert_almost_equal(angles[1], np.pi, self.prec,
+        assert_allclose(angles[1], np.pi, self.prec,
                             err_msg="180 degree angle calculation failed")
-        assert_almost_equal(np.rad2deg(angles[2]), 90., self.prec,
+        assert_allclose(np.rad2deg(angles[2]), 90., self.prec,
                             err_msg="Ninety degree angle in calc_angles failed")
-        assert_almost_equal(angles[3], 0.098174833, self.prec,
+        assert_allclose(angles[3], 0.098174833, self.prec,
                             err_msg="Small angle failed in calc_angles")
 
     @pytest.mark.parametrize("backend", ["serial", "openmp"])
@@ -1020,7 +1020,7 @@ class TestCythonFunctions(object):
         box = box if periodic else None
         result = distances.calc_angles(a, b, c, box, backend=backend)
         reference = ref if periodic else manual_angle(a, b, c)
-        assert_almost_equal(result, reference, decimal=4)
+        assert_allclose(result, reference, atol=1e-04)
 
     @pytest.mark.parametrize("dtype", (np.float32, np.float64))
     @pytest.mark.parametrize("pos", ["positions", "positions_atomgroups"])
@@ -1033,8 +1033,8 @@ class TestCythonFunctions(object):
         assert_equal(len(dihedrals), 4, err_msg="calc_dihedrals results have wrong length")
         assert np.isnan(dihedrals[0]), "Zero length dihedral failed"
         assert np.isnan(dihedrals[1]), "Straight line dihedral failed"
-        assert_almost_equal(dihedrals[2], np.pi, self.prec, err_msg="180 degree dihedral failed")
-        assert_almost_equal(dihedrals[3], -0.50714064, self.prec,
+        assert_allclose(dihedrals[2], np.pi, self.prec, err_msg="180 degree dihedral failed")
+        assert_allclose(dihedrals[3], -0.50714064, self.prec,
                             err_msg="arbitrary dihedral angle failed")
 
     @pytest.mark.parametrize("backend", ["serial", "openmp"])
@@ -1122,7 +1122,7 @@ class TestCythonFunctions(object):
         box = box if periodic else None
         result = distances.calc_dihedrals(a, b, c, d, box, backend=backend)
         reference = ref if periodic else manual_dihedral(a, b, c, d)
-        assert_almost_equal(abs(result), abs(reference), decimal=4)
+        assert_allclose(abs(result), abs(reference), atol=1e-04)
 
     @pytest.mark.parametrize("backend", distopia_conditional_backend())
     def test_numpy_compliance_bonds(self, positions, backend):
@@ -1131,7 +1131,7 @@ class TestCythonFunctions(object):
         bonds = distances.calc_bonds(a, b, backend=backend)
         bonds_numpy = np.array([mdamath.norm(y - x) for x, y in zip(a, b)])
 
-        assert_almost_equal(
+        assert_allclose(
             bonds,
             bonds_numpy,
             self.prec,
@@ -1147,7 +1147,7 @@ class TestCythonFunctions(object):
         vec2 = c - b
         angles_numpy = np.array([mdamath.angle(x, y) for x, y in zip(vec1, vec2)])
         # numpy 0 angle returns NaN rather than 0
-        assert_almost_equal(
+        assert_allclose(
             angles[1:],
             angles_numpy[1:],
             self.prec,
@@ -1163,7 +1163,7 @@ class TestCythonFunctions(object):
         bc = b - c
         cd = c - d
         dihedrals_numpy = np.array([mdamath.dihedral(x, y, z) for x, y, z in zip(ab, bc, cd)])
-        assert_almost_equal(dihedrals, dihedrals_numpy, self.prec,
+        assert_allclose(dihedrals, dihedrals_numpy, self.prec,
                             err_msg="Cython dihedrals didn't match numpy calculations")
 
 
@@ -1211,7 +1211,7 @@ class Test_apply_PBC(object):
         reference = (DCD_universe_pos -
                      np.floor(DCD_universe_pos / box[:3]) * box[:3])
 
-        assert_almost_equal(cyth2, reference, self.prec,
+        assert_allclose(cyth2, reference, self.prec,
                             err_msg="Ortho apply_PBC #2 failed comparison with np")
 
     @pytest.mark.parametrize('pos', ['Triclinic_universe_pos_box',
@@ -1235,14 +1235,14 @@ class Test_apply_PBC(object):
 
         reference = numpy_PBC(positions, box)
 
-        assert_almost_equal(cyth1, reference, decimal=4,
+        assert_allclose(cyth1, reference, atol=1e-04,
                             err_msg="Triclinic apply_PBC failed comparison with np")
 
         box = np.array([10, 7, 3, 45, 60, 90], dtype=np.float32)
         r = np.array([5.75, 0.36066014, 0.75], dtype=np.float32)
         r_in_cell = distances.apply_PBC(r, box)
 
-        assert_almost_equal([5.75, 7.3606596, 0.75], r_in_cell, self.prec)
+        assert_allclose([5.75, 7.3606596, 0.75], r_in_cell, self.prec)
 
     def test_coords_strictly_in_central_image_ortho(self, backend):
         box = np.array([10.1, 10.1, 10.1, 90.0, 90.0, 90.0], dtype=np.float32)
@@ -1325,7 +1325,7 @@ class TestPeriodicAngles(object):
         test4 = distances.calc_angles(a2, b2, c2, box=box, backend=backend)
 
         for val in [test1, test2, test3, test4]:
-            assert_almost_equal(ref, val, self.prec, err_msg="Min image in angle calculation failed")
+            assert_allclose(ref, val, self.prec, err_msg="Min image in angle calculation failed")
 
     def test_dihedrals(self, positions, backend):
         a, b, c, d, box = positions
@@ -1344,7 +1344,7 @@ class TestPeriodicAngles(object):
         test5 = distances.calc_dihedrals(a2, b2, c2, d2, box=box, backend=backend)
 
         for val in [test1, test2, test3, test4, test5]:
-            assert_almost_equal(ref, val, self.prec, err_msg="Min image in dihedral calculation failed")
+            assert_allclose(ref, val, self.prec, err_msg="Min image in dihedral calculation failed")
 
 class TestInputUnchanged(object):
     """Tests ensuring that the following functions in MDAnalysis.lib.distances

--- a/testsuite/MDAnalysisTests/lib/test_util.py
+++ b/testsuite/MDAnalysisTests/lib/test_util.py
@@ -31,8 +31,8 @@ import sys
 import copy
 
 import numpy as np
-from numpy.testing import (assert_equal, assert_almost_equal,
-                           assert_array_almost_equal, assert_array_equal,
+from numpy.testing import (assert_equal,
+                           assert_array_equal,
                            assert_allclose)
 from itertools import combinations_with_replacement as comb_wr
 
@@ -206,13 +206,13 @@ class TestGeometryFunctions(object):
         (2.3456e7 * e1, 3.4567e-6 * e1, 0.0)
     ])
     def test_angle_pi(self, x_axis, y_axis, value):
-        assert_almost_equal(mdamath.angle(x_axis, y_axis), value)
+        assert_allclose(mdamath.angle(x_axis, y_axis), value)
 
     @pytest.mark.parametrize('x', np.linspace(0, np.pi, 20))
     def test_angle_range(self, x):
         r = 1000.
         v = r * np.array([np.cos(x), np.sin(x), 0])
-        assert_almost_equal(mdamath.angle(self.e1, v), x, 6)
+        assert_allclose(mdamath.angle(self.e1, v), x, 1e-06)
 
     @pytest.mark.parametrize('vector, value', [
         (e3, 1),
@@ -226,7 +226,7 @@ class TestGeometryFunctions(object):
     def test_norm_range(self, x):
         r = 1000.
         v = r * np.array([np.cos(x), np.sin(x), 0])
-        assert_almost_equal(mdamath.norm(v), r, 6)
+        assert_allclose(mdamath.norm(v), r, 1e-6)
 
     @pytest.mark.parametrize('vec1, vec2, value', [
         (e1, e2, e3),
@@ -252,19 +252,19 @@ class TestGeometryFunctions(object):
         ab = self.e1
         bc = ab + self.e2
         cd = bc + self.e3
-        assert_almost_equal(mdamath.dihedral(ab, bc, cd), -np.pi / 2)
+        assert_allclose(mdamath.dihedral(ab, bc, cd), -np.pi / 2)
 
     def test_pdot(self):
         arr = np.random.rand(4, 3)
         matrix_dot = mdamath.pdot(arr, arr)
         list_dot = [np.dot(a, a) for a in arr]
-        assert_almost_equal(matrix_dot, list_dot)
+        assert_allclose(matrix_dot, list_dot)
 
     def test_pnorm(self):
         arr = np.random.rand(4, 3)
         matrix_norm = mdamath.pnorm(arr)
         list_norm = [np.linalg.norm(a) for a in arr]
-        assert_almost_equal(matrix_norm, list_norm)
+        assert_allclose(matrix_norm, list_norm)
 
 
 class TestMatrixOperations(object):
@@ -408,7 +408,7 @@ class TestMatrixOperations(object):
                     res = mdamath.triclinic_box(
                         *mdamath.triclinic_vectors(ref))
                     if not np.all(res == 0.0):
-                        assert_almost_equal(res, ref, 5)
+                        assert_allclose(res, ref, 5)
 
     @pytest.mark.parametrize('angles', ([70, 70, 70],
                                         [70, 70, 90],
@@ -438,9 +438,9 @@ class TestMatrixOperations(object):
                              comb_wr([-10, 0, 20, 70, 90, 120, 180], 3))
     def test_box_volume(self, lengths, angles):
         box = np.array(lengths + angles, dtype=np.float32)
-        assert_almost_equal(mdamath.box_volume(box),
+        assert_allclose(mdamath.box_volume(box),
                             np.linalg.det(self.ref_trivecs(box)),
-                            decimal=5)
+                            atol=1e-05)
 
     def test_sarrus_det(self):
         comb = comb_wr(np.linspace(-133.7, 133.7, num=5), 9)
@@ -448,13 +448,13 @@ class TestMatrixOperations(object):
         matrix = np.array(tuple(comb)).reshape((-1, 5, 3, 3))
         ref = np.linalg.det(matrix)
         res = mdamath.sarrus_det(matrix)
-        assert_almost_equal(res, ref, 7)
+        assert_allclose(res, ref, 7)
         assert ref.dtype == res.dtype == np.float64
         # test single matrices:
         matrix = matrix.reshape(-1, 3, 3)
         ref = ref.ravel()
         res = np.array([mdamath.sarrus_det(m) for m in matrix])
-        assert_almost_equal(res, ref, 7)
+        assert_allclose(res, ref, 7)
         assert ref.dtype == res.dtype == np.float64
 
     @pytest.mark.parametrize('shape', ((0,), (3, 2), (2, 3), (1, 1, 3, 1)))
@@ -592,13 +592,13 @@ class TestMakeWhole(object):
 
         assert_array_almost_equal(universe.atoms[:4].positions, refpos)
         assert_array_almost_equal(universe.atoms[4].position,
-                                  np.array([110.0, 50.0, 0.0]), decimal=self.prec)
+                                  np.array([110.0, 50.0, 0.0]), atol=self.prec)
         assert_array_almost_equal(universe.atoms[5].position,
-                                  np.array([110.0, 60.0, 0.0]), decimal=self.prec)
+                                  np.array([110.0, 60.0, 0.0]), atol=self.prec)
         assert_array_almost_equal(universe.atoms[6].position,
-                                  np.array([110.0, 40.0, 0.0]), decimal=self.prec)
+                                  np.array([110.0, 40.0, 0.0]), atol=self.prec)
         assert_array_almost_equal(universe.atoms[7].position,
-                                  np.array([120.0, 50.0, 0.0]), decimal=self.prec)
+                                  np.array([120.0, 50.0, 0.0]), atol=self.prec)
 
     def test_solve_2(self, universe, ag):
         # use but specify the center atom
@@ -609,13 +609,13 @@ class TestMakeWhole(object):
 
         assert_array_almost_equal(universe.atoms[4:8].positions, refpos)
         assert_array_almost_equal(universe.atoms[0].position,
-                                  np.array([-20.0, 50.0, 0.0]), decimal=self.prec)
+                                  np.array([-20.0, 50.0, 0.0]), atol=self.prec)
         assert_array_almost_equal(universe.atoms[1].position,
-                                  np.array([-10.0, 50.0, 0.0]), decimal=self.prec)
+                                  np.array([-10.0, 50.0, 0.0]), atol=self.prec)
         assert_array_almost_equal(universe.atoms[2].position,
-                                  np.array([-10.0, 60.0, 0.0]), decimal=self.prec)
+                                  np.array([-10.0, 60.0, 0.0]), atol=self.prec)
         assert_array_almost_equal(universe.atoms[3].position,
-                                  np.array([-10.0, 40.0, 0.0]), decimal=self.prec)
+                                  np.array([-10.0, 40.0, 0.0]), atol=self.prec)
 
     def test_solve_3(self, universe):
         # put in a chunk that doesn't need any work
@@ -676,7 +676,7 @@ class TestMakeWhole(object):
         mdamath.make_whole(u.atoms)
 
         assert_array_almost_equal(
-            u.atoms.bonds.values(), blengths, decimal=self.prec)
+            u.atoms.bonds.values(), blengths, atol=self.prec)
 
     def test_make_whole_multiple_molecules(self):
         u = mda.Universe(two_water_gro, guess_bonds=True)
@@ -1804,7 +1804,7 @@ class TestCheckCoords(object):
             assert d is not d_2d
             # Assert correct dtype conversion:
             assert d.dtype == np.float32
-            assert_almost_equal(d, d_2d, self.prec)
+            assert_allclose(d, d_2d, self.prec)
             # Assert all shapes are converted to (1, 3):
             assert a.shape == b.shape == c.shape == d.shape == (1, 3)
             return a + b + c + d
@@ -2153,7 +2153,7 @@ class TestCheckBox(object):
     def test_check_box_tri_vecs(self, box):
         boxtype, checked_box = util.check_box(box)
         assert boxtype == 'tri_vecs'
-        assert_almost_equal(checked_box, self.ref_tri_vecs, self.prec)
+        assert_allclose(checked_box, self.ref_tri_vecs, self.prec)
         assert checked_box.dtype == np.float32
         assert checked_box.flags['C_CONTIGUOUS']
 

--- a/testsuite/MDAnalysisTests/parallelism/test_pickle_transformation.py
+++ b/testsuite/MDAnalysisTests/parallelism/test_pickle_transformation.py
@@ -22,7 +22,7 @@
 #
 import pytest
 import pickle
-from numpy.testing import assert_almost_equal
+from numpy.testing import assert_allclose
 
 import MDAnalysis as mda
 
@@ -93,7 +93,7 @@ def test_add_fit_translation_pickle(fit_translation_transformation, u):
     u_p = pickle.loads(pickle.dumps(u))
     u.trajectory[0]
     for u_ts, u_p_ts in zip(u.trajectory[:5], u_p.trajectory[:5]):
-        assert_almost_equal(u_ts.positions, u_p_ts.positions)
+        assert_allclose(u_ts.positions, u_p_ts.positions)
 
 
 def test_add_fit_rot_trans_pickle(fit_rot_trans_transformation,
@@ -102,7 +102,7 @@ def test_add_fit_rot_trans_pickle(fit_rot_trans_transformation,
     u_p = pickle.loads(pickle.dumps(u))
     u.trajectory[0]
     for u_ts, u_p_ts in zip(u.trajectory[:5], u_p.trajectory[:5]):
-        assert_almost_equal(u_ts.positions, u_p_ts.positions)
+        assert_allclose(u_ts.positions, u_p_ts.positions)
 
 
 def test_add_PositionAverager_pickle(PositionAverager_transformation, u):
@@ -110,7 +110,7 @@ def test_add_PositionAverager_pickle(PositionAverager_transformation, u):
     u_p = pickle.loads(pickle.dumps(u))
     u.trajectory[0]
     for u_ts, u_p_ts in zip(u.trajectory[:5], u_p.trajectory[:5]):
-        assert_almost_equal(u_ts.positions, u_p_ts.positions)
+        assert_allclose(u_ts.positions, u_p_ts.positions)
 
 
 def test_add_rotateby_pickle(rotateby_transformation, u):
@@ -118,7 +118,7 @@ def test_add_rotateby_pickle(rotateby_transformation, u):
     u_p = pickle.loads(pickle.dumps(u))
     u.trajectory[0]
     for u_ts, u_p_ts in zip(u.trajectory[:5], u_p.trajectory[:5]):
-        assert_almost_equal(u_ts.positions, u_p_ts.positions)
+        assert_allclose(u_ts.positions, u_p_ts.positions)
 
 
 def test_add_translate_pickle(translate_transformation, u):
@@ -126,7 +126,7 @@ def test_add_translate_pickle(translate_transformation, u):
     u_p = pickle.loads(pickle.dumps(u))
     u.trajectory[0]
     for u_ts, u_p_ts in zip(u.trajectory[:5], u_p.trajectory[:5]):
-        assert_almost_equal(u_ts.positions, u_p_ts.positions)
+        assert_allclose(u_ts.positions, u_p_ts.positions)
 
 
 def test_add_center_in_box_pickle(center_in_box_transformation, u):
@@ -134,7 +134,7 @@ def test_add_center_in_box_pickle(center_in_box_transformation, u):
     u_p = pickle.loads(pickle.dumps(u))
     u.trajectory[0]
     for u_ts, u_p_ts in zip(u.trajectory[:5], u_p.trajectory[:5]):
-        assert_almost_equal(u_ts.positions, u_p_ts.positions)
+        assert_allclose(u_ts.positions, u_p_ts.positions)
 
 
 def test_add_wrap_pickle(wrap_transformation, u):
@@ -142,7 +142,7 @@ def test_add_wrap_pickle(wrap_transformation, u):
     u_p = pickle.loads(pickle.dumps(u))
     u.trajectory[0]
     for u_ts, u_p_ts in zip(u.trajectory[:5], u_p.trajectory[:5]):
-        assert_almost_equal(u_ts.positions, u_p_ts.positions)
+        assert_allclose(u_ts.positions, u_p_ts.positions)
 
 
 def test_add_unwrap_pickle(unwrap_transformation, u):
@@ -150,4 +150,4 @@ def test_add_unwrap_pickle(unwrap_transformation, u):
     u_p = pickle.loads(pickle.dumps(u))
     u.trajectory[0]
     for u_ts, u_p_ts in zip(u.trajectory[:5], u_p.trajectory[:5]):
-        assert_almost_equal(u_ts.positions, u_p_ts.positions)
+        assert_allclose(u_ts.positions, u_p_ts.positions)

--- a/testsuite/MDAnalysisTests/topology/test_fhiaims.py
+++ b/testsuite/MDAnalysisTests/topology/test_fhiaims.py
@@ -20,7 +20,7 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from numpy.testing import assert_equal, assert_almost_equal
+from numpy.testing import assert_equal,assert_allclose
 
 import MDAnalysis as mda
 
@@ -49,6 +49,6 @@ class TestFHIAIMS(ParserBase):
                      ['O', 'H', 'H', 'O', 'H', 'H'])
 
     def test_masses(self, top):
-        assert_almost_equal(top.masses.values,
+        assert_allclose(top.masses.values,
                             [15.999,  1.008,  1.008, 15.999,
                              1.008,  1.008])

--- a/testsuite/MDAnalysisTests/topology/test_hoomdxml.py
+++ b/testsuite/MDAnalysisTests/topology/test_hoomdxml.py
@@ -20,7 +20,7 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-from numpy.testing import assert_almost_equal
+from numpy.testing import assert_allclose
 
 import MDAnalysis as mda
 
@@ -77,10 +77,10 @@ class TestHoomdXMLParser(ParserBase):
         assert ((0, 250, 350, 450) not in vals)
 
     def test_read_masses(self, top):
-        assert_almost_equal(top.masses.values, 1.0)
+        assert_allclose(top.masses.values, 1.0)
 
     def test_read_charges(self, top):
         # note: the example topology file contains 0 for all charges which
         # is the same as the default so this test does not fully test
         # reading of charges from the file (#2888)
-        assert_almost_equal(top.charges.values, 0.0)
+        assert_allclose(top.charges.values, 0.0)

--- a/testsuite/MDAnalysisTests/topology/test_pqr.py
+++ b/testsuite/MDAnalysisTests/topology/test_pqr.py
@@ -21,7 +21,7 @@
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
 from io import StringIO
-from numpy.testing import assert_equal, assert_almost_equal
+from numpy.testing import assert_equal,assert_allclose
 import pytest
 import MDAnalysis as mda
 
@@ -89,7 +89,7 @@ def test_gromacs_flavour():
     assert u.atoms[0].type == 'O'
     assert u.atoms[0].segid == 'SYSTEM'
     assert not u._topology.types.is_guessed
-    assert_almost_equal(u.atoms[0].radius, 1.48, decimal=5)
-    assert_almost_equal(u.atoms[0].charge, -0.67, decimal=5)
+    assert_allclose(u.atoms[0].radius, 1.48, atol=1e-05)
+    assert_allclose(u.atoms[0].charge, -0.67, atol=1e-05)
     # coordinatey things
-    assert_almost_equal(u.atoms[0].position, [15.710, 17.670, 23.340], decimal=4)
+    assert_allclose(u.atoms[0].position, [15.710, 17.670, 23.340], atol=1e-04)

--- a/testsuite/MDAnalysisTests/transformations/test_boxdimensions.py
+++ b/testsuite/MDAnalysisTests/transformations/test_boxdimensions.py
@@ -41,7 +41,7 @@ def test_boxdimensions_dims(boxdimensions_universe):
     new_dims = np.float32([2, 2, 2, 90, 90, 90])
     set_dimensions(new_dims)(boxdimensions_universe.trajectory.ts)
     assert_array_almost_equal(boxdimensions_universe.dimensions,
-                              new_dims, decimal=6)
+                              new_dims, atol=1e-06)
 
 
 @pytest.mark.parametrize('dim_vector_shapes', (
@@ -80,4 +80,4 @@ def test_dimensions_transformations_api(boxdimensions_universe):
     boxdimensions_universe.trajectory.add_transformations(transform)
     for ts in boxdimensions_universe.trajectory:
         assert_array_almost_equal(boxdimensions_universe.dimensions,
-                                  new_dims, decimal=6)
+                                  new_dims, atol=1e-06)

--- a/testsuite/MDAnalysisTests/transformations/test_fit.py
+++ b/testsuite/MDAnalysisTests/transformations/test_fit.py
@@ -107,7 +107,7 @@ def test_fit_translation_no_options(fit_universe):
     ref_u = fit_universe[1]
     fit_translation(test_u, ref_u)(test_u.trajectory.ts)
     # what happens when no options are passed?
-    assert_array_almost_equal(test_u.trajectory.ts.positions, ref_u.trajectory.ts.positions, decimal=6)
+    assert_array_almost_equal(test_u.trajectory.ts.positions, ref_u.trajectory.ts.positions, atol=1e-06)
 
 def test_fit_translation_residue_mismatch(fit_universe):
     test_u = fit_universe[0]
@@ -120,7 +120,7 @@ def test_fit_translation_com(fit_universe):
     ref_u = fit_universe[1]
     fit_translation(test_u, ref_u, weights="mass")(test_u.trajectory.ts)
     # what happens when the center o mass is used?
-    assert_array_almost_equal(test_u.trajectory.ts.positions, ref_u.trajectory.ts.positions, decimal=6)
+    assert_array_almost_equal(test_u.trajectory.ts.positions, ref_u.trajectory.ts.positions, atol=1e-06)
 
 
 @pytest.mark.parametrize('plane', (
@@ -139,7 +139,7 @@ def test_fit_translation_plane(fit_universe, plane):
     shiftz = np.asanyarray([0, 0, 0], np.float32)
     shiftz[idx] = -10
     ref_coordinates = ref_u.trajectory.ts.positions + shiftz
-    assert_array_almost_equal(test_u.trajectory.ts.positions, ref_coordinates, decimal=6)
+    assert_array_almost_equal(test_u.trajectory.ts.positions, ref_coordinates, atol=1e-06)
 
 
 def test_fit_translation_all_options(fit_universe):
@@ -150,7 +150,7 @@ def test_fit_translation_all_options(fit_universe):
     # the reference is 10 angstrom in the z coordinate above the test universe
     shiftz = np.asanyarray([0, 0, -10], np.float32)
     ref_coordinates = ref_u.trajectory.ts.positions + shiftz
-    assert_array_almost_equal(test_u.trajectory.ts.positions, ref_coordinates, decimal=6)
+    assert_array_almost_equal(test_u.trajectory.ts.positions, ref_coordinates, atol=1e-06)
 
 
 def test_fit_translation_transformations_api(fit_universe):
@@ -158,7 +158,7 @@ def test_fit_translation_transformations_api(fit_universe):
     ref_u = fit_universe[1]
     transform = fit_translation(test_u, ref_u)
     test_u.trajectory.add_transformations(transform)
-    assert_array_almost_equal(test_u.trajectory.ts.positions, ref_u.trajectory.ts.positions, decimal=6)
+    assert_array_almost_equal(test_u.trajectory.ts.positions, ref_u.trajectory.ts.positions, atol=1e-06)
 
 
 @pytest.mark.parametrize('universe', (
@@ -229,7 +229,7 @@ def test_fit_rot_trans_no_options(fit_universe):
     ref_u.trajectory.ts.positions = np.dot(ref_u.trajectory.ts.positions, R)
     ref_u.trajectory.ts.positions += ref_com
     fit_rot_trans(test_u, ref_u)(test_u.trajectory.ts)
-    assert_array_almost_equal(test_u.trajectory.ts.positions, ref_u.trajectory.ts.positions, decimal=3)
+    assert_array_almost_equal(test_u.trajectory.ts.positions, ref_u.trajectory.ts.positions, atol=1e-03)
 
 
 @pytest.mark.parametrize('plane', (
@@ -254,7 +254,7 @@ def test_fit_rot_trans_plane(fit_universe, plane):
     ref_com[idx] = mobile_com[idx]
     ref_u.trajectory.ts.positions += ref_com
     fit_rot_trans(test_u, ref_u, plane=plane)(test_u.trajectory.ts)
-    assert_array_almost_equal(test_u.trajectory.ts.positions[:,idx], ref_u.trajectory.ts.positions[:,idx], decimal=3)
+    assert_array_almost_equal(test_u.trajectory.ts.positions[:,idx], ref_u.trajectory.ts.positions[:,idx], atol=1e-03)
 
 
 def test_fit_rot_trans_transformations_api(fit_universe):
@@ -267,4 +267,4 @@ def test_fit_rot_trans_transformations_api(fit_universe):
     ref_u.trajectory.ts.positions += ref_com
     transform = fit_rot_trans(test_u, ref_u)
     test_u.trajectory.add_transformations(transform)
-    assert_array_almost_equal(test_u.trajectory.ts.positions, ref_u.trajectory.ts.positions, decimal=3)
+    assert_array_almost_equal(test_u.trajectory.ts.positions, ref_u.trajectory.ts.positions, atol=1e-03)

--- a/testsuite/MDAnalysisTests/transformations/test_positionaveraging.py
+++ b/testsuite/MDAnalysisTests/transformations/test_positionaveraging.py
@@ -42,7 +42,7 @@ def test_posavging_fwd(posaveraging_universes):
     for ts in posaveraging_universes.trajectory:
         avgd[...,ts.frame] = ts.positions.copy()
         
-    assert_array_almost_equal(ref_matrix_fwd, avgd[1,:,-1], decimal=5)   
+    assert_array_almost_equal(ref_matrix_fwd, avgd[1,:,-1], atol=1e-05)   
 
 def test_posavging_bwd(posaveraging_universes):
     '''
@@ -56,7 +56,7 @@ def test_posavging_bwd(posaveraging_universes):
     back_avgd = np.empty(size)
     for ts in posaveraging_universes.trajectory[::-1]:
         back_avgd[...,9-ts.frame] = ts.positions.copy()
-    assert_array_almost_equal(ref_matrix_bwd, back_avgd[1,:,-1], decimal=5)
+    assert_array_almost_equal(ref_matrix_bwd, back_avgd[1,:,-1], atol=1e-05)
 
 def test_posavging_reset(posaveraging_universes):
     '''
@@ -69,7 +69,7 @@ def test_posavging_reset(posaveraging_universes):
     for ts in posaveraging_universes.trajectory:
         avgd[...,ts.frame] = ts.positions.copy()
     after_reset = ts.positions.copy()
-    assert_array_almost_equal(avgd[...,0], after_reset, decimal=5)
+    assert_array_almost_equal(avgd[...,0], after_reset, atol=1e-05)
 
 def test_posavging_specific(posaveraging_universes):
     '''
@@ -87,7 +87,7 @@ def test_posavging_specific(posaveraging_universes):
     for ts in posaveraging_universes.trajectory[fr_list]:
         specr_avgd[...,idx] = ts.positions.copy()
         idx += 1
-    assert_array_almost_equal(ref_matrix_specr, specr_avgd[1,:,-1], decimal=5) 
+    assert_array_almost_equal(ref_matrix_specr, specr_avgd[1,:,-1], atol=1e-05) 
     
 def test_posavging_specific_noreset(posaveraging_universes_noreset):
     '''
@@ -105,7 +105,7 @@ def test_posavging_specific_noreset(posaveraging_universes_noreset):
     for ts in posaveraging_universes_noreset.trajectory[fr_list]:
         specr_avgd[...,idx] = ts.positions.copy()
         idx += 1
-    assert_array_almost_equal(ref_matrix_specr, specr_avgd[1,:,-1], decimal=5) 
+    assert_array_almost_equal(ref_matrix_specr, specr_avgd[1,:,-1], atol=1e-05) 
     
 
 

--- a/testsuite/MDAnalysisTests/transformations/test_rotate.py
+++ b/testsuite/MDAnalysisTests/transformations/test_rotate.py
@@ -49,7 +49,7 @@ def test_rotation_matrix():
                              [0, -1, 0],
                              [0, 0, 1]], np.float64)
     matrix = rotation_matrix(np.deg2rad(angle), vector, pos)[:3, :3]
-    assert_array_almost_equal(matrix, ref_matrix, decimal=6)
+    assert_array_almost_equal(matrix, ref_matrix, atol=1e-06)
     # another angle in a custom axis
     angle = 60
     vector = [1, 2, 3]
@@ -58,7 +58,7 @@ def test_rotation_matrix():
                              [ 0.76579365,  0.64285714, -0.01716931],
                              [-0.35576719,  0.44574074,  0.82142857]], np.float64)
     matrix = rotation_matrix(np.deg2rad(angle), vector, pos)[:3, :3]
-    assert_array_almost_equal(matrix, ref_matrix, decimal=6)
+    assert_array_almost_equal(matrix, ref_matrix, atol=1e-06)
     
 @pytest.mark.parametrize('point', (
     np.asarray([0, 0, 0]),
@@ -76,7 +76,7 @@ def test_rotateby_custom_point(rotate_universes, point):
     matrix = rotation_matrix(np.deg2rad(angle), vector, pos)
     ref_u.atoms.transform(matrix)
     transformed = rotateby(angle, vector, point=point)(trans)
-    assert_array_almost_equal(transformed.positions, ref.positions, decimal=6)
+    assert_array_almost_equal(transformed.positions, ref.positions, atol=1e-06)
 
 
 @pytest.mark.parametrize('vector', (
@@ -95,7 +95,7 @@ def test_rotateby_vector(rotate_universes, vector):
     matrix = rotation_matrix(np.deg2rad(angle), vec, point)
     ref_u.atoms.transform(matrix)
     transformed = rotateby(angle, vector, point=point)(trans)
-    assert_array_almost_equal(transformed.positions, ref.positions, decimal=6)
+    assert_array_almost_equal(transformed.positions, ref.positions, atol=1e-06)
 
 
 def test_rotateby_atomgroup_cog_nopbc(rotate_universes):
@@ -112,7 +112,7 @@ def test_rotateby_atomgroup_cog_nopbc(rotate_universes):
     ref_u.atoms.transform(matrix)
     selection = trans_u.residues[0].atoms
     transformed = rotateby(angle, vector, ag=selection, weights=None)(trans) 
-    assert_array_almost_equal(transformed.positions, ref.positions, decimal=6)
+    assert_array_almost_equal(transformed.positions, ref.positions, atol=1e-06)
 
 
 def test_rotateby_atomgroup_com_nopbc(rotate_universes):
@@ -129,7 +129,7 @@ def test_rotateby_atomgroup_com_nopbc(rotate_universes):
     matrix = rotation_matrix(np.deg2rad(angle), vector, center_pos)
     ref_u.atoms.transform(matrix)
     transformed = rotateby(angle, vector, ag=selection, weights='mass')(trans) 
-    assert_array_almost_equal(transformed.positions, ref.positions, decimal=6)
+    assert_array_almost_equal(transformed.positions, ref.positions, atol=1e-06)
 
     
 def test_rotateby_atomgroup_cog_pbc(rotate_universes):
@@ -146,7 +146,7 @@ def test_rotateby_atomgroup_cog_pbc(rotate_universes):
     matrix = rotation_matrix(np.deg2rad(angle), vector, center_pos)
     ref_u.atoms.transform(matrix)
     transformed = rotateby(angle, vector, ag=selection, weights=None, wrap=True)(trans) 
-    assert_array_almost_equal(transformed.positions, ref.positions, decimal=6)
+    assert_array_almost_equal(transformed.positions, ref.positions, atol=1e-06)
 
 
 def test_rotateby_atomgroup_com_pbc(rotate_universes):
@@ -163,7 +163,7 @@ def test_rotateby_atomgroup_com_pbc(rotate_universes):
     matrix = rotation_matrix(np.deg2rad(angle), vector, center_pos)
     ref_u.atoms.transform(matrix)
     transformed = rotateby(angle, vector, ag=selection, weights='mass', wrap=True)(trans) 
-    assert_array_almost_equal(transformed.positions, ref.positions, decimal=6)
+    assert_array_almost_equal(transformed.positions, ref.positions, atol=1e-06)
 
 
 @pytest.mark.parametrize('ag', (

--- a/testsuite/MDAnalysisTests/transformations/test_translate.py
+++ b/testsuite/MDAnalysisTests/transformations/test_translate.py
@@ -47,7 +47,7 @@ def test_translate_coords(translate_universes):
     vector = np.float32([1, 2, 3])
     ref.positions += vector
     trans = translate(vector)(trans_u.trajectory.ts)
-    assert_array_almost_equal(trans.positions, ref.positions, decimal=6)
+    assert_array_almost_equal(trans.positions, ref.positions, atol=1e-06)
 
 
 @pytest.mark.parametrize('vector', (
@@ -73,7 +73,7 @@ def test_translate_transformations_api(translate_universes):
     vector = np.float32([1, 2, 3])
     ref.positions += vector
     trans_u.trajectory.add_transformations(translate(vector))
-    assert_array_almost_equal(trans_u.trajectory.ts.positions, ref.positions, decimal=6)
+    assert_array_almost_equal(trans_u.trajectory.ts.positions, ref.positions, atol=1e-06)
 
 
 def test_center_in_box_bad_ag(translate_universes):
@@ -141,7 +141,7 @@ def test_center_in_box_coords_no_options(translate_universes):
     ref.positions += box_center - ref_center
     ag = trans_u.residues[0].atoms
     trans = center_in_box(ag)(trans_u.trajectory.ts)
-    assert_array_almost_equal(trans.positions, ref.positions, decimal=6)
+    assert_array_almost_equal(trans.positions, ref.positions, atol=1e-06)
 
 
 def test_center_in_box_coords_with_pbc(translate_universes):
@@ -155,7 +155,7 @@ def test_center_in_box_coords_with_pbc(translate_universes):
     ref_center = np.float32([75.6, 75.8, 76.])
     ref.positions += box_center - ref_center
     trans = center_in_box(ag, wrap=True)(trans_u.trajectory.ts)
-    assert_array_almost_equal(trans.positions, ref.positions, decimal=6)
+    assert_array_almost_equal(trans.positions, ref.positions, atol=1e-06)
 
 
 def test_center_in_box_coords_with_mass(translate_universes):   
@@ -167,7 +167,7 @@ def test_center_in_box_coords_with_mass(translate_universes):
     ref_center = ag.center_of_mass()
     ref.positions += box_center - ref_center
     trans = center_in_box(ag, center="mass")(trans_u.trajectory.ts)
-    assert_array_almost_equal(trans.positions, ref.positions, decimal=6)
+    assert_array_almost_equal(trans.positions, ref.positions, atol=1e-06)
 
 
 def test_center_in_box_coords_with_box(translate_universes):   
@@ -180,7 +180,7 @@ def test_center_in_box_coords_with_box(translate_universes):
     ref_center = np.float32([6, 7, 8])
     ref.positions += box_center - ref_center
     trans = center_in_box(ag, point=newpoint)(trans_u.trajectory.ts)
-    assert_array_almost_equal(trans.positions, ref.positions, decimal=6)
+    assert_array_almost_equal(trans.positions, ref.positions, atol=1e-06)
 
 
 def test_center_in_box_coords_all_options(translate_universes):
@@ -194,7 +194,7 @@ def test_center_in_box_coords_all_options(translate_universes):
     ref_center = ag.center_of_mass(pbc=True)
     ref.positions += box_center - ref_center
     trans = center_in_box(ag, center='mass', wrap=True, point=newpoint)(trans_u.trajectory.ts)
-    assert_array_almost_equal(trans.positions, ref.positions, decimal=6)
+    assert_array_almost_equal(trans.positions, ref.positions, atol=1e-06)
 
 
 def test_center_transformations_api(translate_universes):
@@ -207,4 +207,4 @@ def test_center_transformations_api(translate_universes):
     ref.positions += box_center - ref_center
     ag = trans_u.residues[0].atoms
     trans_u.trajectory.add_transformations(center_in_box(ag))
-    assert_array_almost_equal(trans_u.trajectory.ts.positions, ref.positions, decimal=6)
+    assert_array_almost_equal(trans_u.trajectory.ts.positions, ref.positions, atol=1e-06)

--- a/testsuite/MDAnalysisTests/transformations/test_wrap.py
+++ b/testsuite/MDAnalysisTests/transformations/test_wrap.py
@@ -85,7 +85,7 @@ def test_wrap_no_options(wrap_universes):
     trans, ref = wrap_universes
     trans.dimensions = ref.dimensions
     wrap(trans.atoms)(trans.trajectory.ts)
-    assert_array_almost_equal(trans.trajectory.ts.positions, ref.trajectory.ts.positions, decimal=6)
+    assert_array_almost_equal(trans.trajectory.ts.positions, ref.trajectory.ts.positions, atol=1e-06)
 
 
 @pytest.mark.parametrize('compound', (
@@ -98,14 +98,14 @@ def test_wrap_with_compounds(compound_wrap_universes, compound):
     trans, ref= compound_wrap_universes
     ref.select_atoms("not resname SOL").wrap(compound=compound)
     wrap(trans.select_atoms("not resname SOL"), compound=compound)(trans.trajectory.ts)
-    assert_array_almost_equal(trans.trajectory.ts.positions, ref.trajectory.ts.positions, decimal=6)
+    assert_array_almost_equal(trans.trajectory.ts.positions, ref.trajectory.ts.positions, atol=1e-06)
 
 
 def test_wrap_api(wrap_universes):
     trans, ref = wrap_universes
     trans.dimensions = ref.dimensions
     trans.trajectory.add_transformations(wrap(trans.atoms))
-    assert_array_almost_equal(trans.trajectory.ts.positions, ref.trajectory.ts.positions, decimal=6)
+    assert_array_almost_equal(trans.trajectory.ts.positions, ref.trajectory.ts.positions, atol=1e-06)
 
 
 @pytest.mark.parametrize('ag', (
@@ -131,11 +131,11 @@ def test_unwrap(wrap_universes):
     ref, trans = wrap_universes
     # after rebuild the trans molecule it should match the reference
     unwrap(trans.atoms)(trans.trajectory.ts)
-    assert_array_almost_equal(trans.trajectory.ts.positions, ref.trajectory.ts.positions, decimal=6)
+    assert_array_almost_equal(trans.trajectory.ts.positions, ref.trajectory.ts.positions, atol=1e-06)
 
 
 def test_unwrap_api(wrap_universes):
     ref, trans = wrap_universes
     # after rebuild the trans molecule it should match the reference
     trans.trajectory.add_transformations(unwrap(trans.atoms))
-    assert_array_almost_equal(trans.trajectory.ts.positions, ref.trajectory.ts.positions, decimal=6)
+    assert_array_almost_equal(trans.trajectory.ts.positions, ref.trajectory.ts.positions, atol=1e-06)

--- a/testsuite/MDAnalysisTests/utils/test_qcprot.py
+++ b/testsuite/MDAnalysisTests/utils/test_qcprot.py
@@ -40,7 +40,7 @@ import numpy as np
 
 import MDAnalysis.lib.qcprot as qcp
 
-from numpy.testing import assert_almost_equal, assert_array_almost_equal
+from numpy.testing import assert_allclose
 import MDAnalysis.analysis.rms as rms
 import pytest
 
@@ -134,13 +134,13 @@ def test_CalcRMSDRotationalMatrix():
     aligned_rmsd = rmsd(frag_br.T, frag_a)
     #print 'rmsd after applying rotation: ',rmsd
 
-    assert_almost_equal(aligned_rmsd, 0.719106, 6, "RMSD between fragments A and B does not match excpected value.")
+    assert_allclose(aligned_rmsd, 0.719106, 6, "RMSD between fragments A and B does not match excpected value.")
 
     expected_rot = np.array([
         [0.72216358, -0.52038257, -0.45572112],
         [0.69118937, 0.51700833, 0.50493528],
         [-0.0271479, -0.67963547, 0.73304748]])
-    assert_almost_equal(rot.reshape((3, 3)), expected_rot, 6,
+    assert_allclose(rot.reshape((3, 3)), expected_rot, 6,
                         "Rotation matrix for aliging B to A does not have expected values.")
 
 
@@ -151,7 +151,7 @@ def test_innerproduct(atoms_a, atoms_b):
 
     e = np.zeros(9, dtype=np.float64)
     g = qcp.InnerProduct(e, atoms_a, atoms_b, number_of_atoms, None)
-    assert_almost_equal(a, g)
+    assert_allclose(a, g)
     assert_array_almost_equal(b, e)
 
 
@@ -161,10 +161,10 @@ def test_RMSDmatrix(atoms_a, atoms_b):
     rmsd = qcp.CalcRMSDRotationalMatrix(atoms_a, atoms_b, number_of_atoms, rotation, None) # no weights
 
     rmsd_ref = 20.73219522556076
-    assert_almost_equal(rmsd_ref, rmsd)
+    assert_allclose(rmsd_ref, rmsd)
 
     rotation_ref = np.array([0.9977195, 0.02926979, 0.06082009, -.0310942, 0.9990878, 0.02926979, -0.05990789, -.0310942, 0.9977195])
-    assert_array_almost_equal(rotation, rotation_ref, 6)
+    assert_array_almost_equal(rotation, rotation_ref, 1e-06)
 
 
 def test_RMSDmatrix_simple(atoms_a, atoms_b):
@@ -173,10 +173,10 @@ def test_RMSDmatrix_simple(atoms_a, atoms_b):
     rmsd = qcp.CalcRMSDRotationalMatrix(atoms_a, atoms_b, number_of_atoms, rotation, None) # no weights
 
     rmsd_ref = 20.73219522556076
-    assert_almost_equal(rmsd_ref, rmsd)
+    assert_allclose(rmsd_ref, rmsd)
 
     rotation_ref = np.array([0.9977195, 0.02926979, 0.06082009, -.0310942, 0.9990878, 0.02926979, -0.05990789, -.0310942, 0.9977195])
-    assert_array_almost_equal(rotation, rotation_ref, 6)
+    assert_array_almost_equal(rotation, rotation_ref, 1e-06)
 
     
 def test_rmsd(atoms_a, atoms_b):
@@ -184,7 +184,7 @@ def test_rmsd(atoms_a, atoms_b):
     atoms_b_aligned = np.dot(atoms_b, rotation_m)
     rmsd = rms.rmsd(atoms_b_aligned, atoms_a)
     rmsd_ref = 20.73219522556076
-    assert_almost_equal(rmsd, rmsd_ref, 6)
+    assert_allclose(rmsd, rmsd_ref, 6)
 
 
 def test_weights(atoms_a, atoms_b):
@@ -194,6 +194,6 @@ def test_weights(atoms_a, atoms_b):
     rotation = np.zeros(9, dtype=np.float64)
     rmsd = qcp.CalcRMSDRotationalMatrix(atoms_a, atoms_b, no_of_atoms, rotation, weights)
 
-    assert_almost_equal(rmsd, 32.798779202159416)
+    assert_allclose(rmsd, 32.798779202159416)
     rotation_ref = np.array([0.99861395, .022982, .04735006, -.02409085, .99944556, .022982, -.04679564, -.02409085, .99861395])
-    np.testing.assert_almost_equal(rotation_ref, rotation)
+    np.testing.assert_allclose(rotation_ref, rotation)

--- a/testsuite/MDAnalysisTests/utils/test_streamio.py
+++ b/testsuite/MDAnalysisTests/utils/test_streamio.py
@@ -26,7 +26,7 @@ from io import StringIO
 
 import pytest
 import numpy as np
-from numpy.testing import assert_equal, assert_almost_equal, assert_array_almost_equal
+from numpy.testing import assert_equal,assert_allclose
 
 
 import MDAnalysis
@@ -354,9 +354,9 @@ class TestStreamIO(RefAdKSmall):
     def test_PQRReader(self, streamData):
         u = MDAnalysis.Universe(streamData.as_NamedStream('PQR'))
         assert_equal(u.atoms.n_atoms, self.ref_n_atoms)
-        assert_almost_equal(u.atoms.total_charge(), self.ref_charmm_totalcharge, 3,
+        assert_allclose(u.atoms.total_charge(), self.ref_charmm_totalcharge, 3,
                             "Total charge (in CHARMM) does not match expected value.")
-        assert_almost_equal(u.atoms.select_atoms('name H').charges, self.ref_charmm_Hcharges, 3,
+        assert_allclose(u.atoms.select_atoms('name H').charges, self.ref_charmm_Hcharges, 3,
                             "Charges for H atoms do not match.")
 
     def test_PDBQTReader(self, streamData):
@@ -371,10 +371,10 @@ class TestStreamIO(RefAdKSmall):
     def test_GROReader(self, streamData):
         u = MDAnalysis.Universe(streamData.as_NamedStream('GRO'))
         assert_equal(u.atoms.n_atoms, 6)
-        assert_almost_equal(u.atoms[3].position,
+        assert_allclose(u.atoms[3].position,
                             10. * np.array([1.275, 0.053, 0.622]), 3,  # manually convert nm -> A
                             err_msg="wrong coordinates for water 2 OW")
-        assert_almost_equal(u.atoms[3].velocity,
+        assert_allclose(u.atoms[3].velocity,
                             10. * np.array([0.2519, 0.3140, -0.1734]), 3,  # manually convert nm/ps -> A/ps
                             err_msg="wrong velocity for water 2 OW")
 
@@ -395,5 +395,5 @@ class TestStreamIO(RefAdKSmall):
         assert_equal(u.trajectory.frame, 1)  # !!!! ???
         u.trajectory.next()  # frame 2
         assert_equal(u.trajectory.frame, 2)
-        assert_almost_equal(u.atoms[2].position, np.array([0.45600, 18.48700, 16.26500]), 3,
+        assert_allclose(u.atoms[2].position, np.array([0.45600, 18.48700, 16.26500]), 3,
                             err_msg="wrong coordinates for atom CA at frame 2")

--- a/testsuite/MDAnalysisTests/utils/test_transformations.py
+++ b/testsuite/MDAnalysisTests/utils/test_transformations.py
@@ -24,7 +24,7 @@ from itertools import permutations
 
 import numpy as np
 import pytest
-from numpy.testing import (assert_allclose, assert_equal, assert_almost_equal,
+from numpy.testing import (assert_allclose, assert_equal,
                            assert_array_equal)
 
 from MDAnalysis.lib import transformations as t
@@ -751,4 +751,4 @@ def test_rotaxis_different_vectors():
     for i, j, l in permutations(range(3)):
         x = t.rotaxis(re[i], re[j])
         # use abs since direction doesn't matter
-        assert_almost_equal(np.abs(np.dot(x, re[l])), 1)
+        assert_allclose(np.abs(np.dot(x, re[l])), 1)

--- a/testsuite/MDAnalysisTests/utils/test_units.py
+++ b/testsuite/MDAnalysisTests/utils/test_units.py
@@ -23,7 +23,7 @@
 import pytest
 
 import numpy as np
-from numpy.testing import assert_equal, assert_almost_equal
+from numpy.testing import assert_equal,assert_allclose
 
 from MDAnalysis import units
 
@@ -57,14 +57,14 @@ class TestConstants(object):
 
     @pytest.mark.parametrize('name, value', constants_reference)
     def test_constant(self, name, value):
-        assert_almost_equal(units.constants[name], value)
+        assert_allclose(units.constants[name], value)
 
 
 class TestConversion(object):
     @staticmethod
     def _assert_almost_equal_convert(value, u1, u2, ref):
         val = units.convert(value, u1, u2)
-        assert_almost_equal(val, ref,
+        assert_allclose(val, ref,
                             err_msg="Conversion {0} --> {1} failed".format(u1, u2))
 
     nm = 12.34567


### PR DESCRIPTION
Fixes #

Changes made in this Pull Request:
use numpy.testing.assert_allclose() instead of assert_almost_equal() or assert_array_almost_equal() and removed these deprecated method. There is still some library like Xdrlib which is deprecated and some library or method(like warning in test_contacts.py) which has been imported but never used. But I change the assert_almost_equal and array_almost_equal to all_close
