### PR TITLE
modernize testing code #3743

### DIFF
--- a/testsuite/MDAnalysisTests/analysis/test_align.py
+++ b/testsuite/MDAnalysisTests/analysis/test_align.py
@@ -38,10 +38,12 @@ from numpy.testing import (
     assert_allclose,
 )
 
-#Function for Parametrizing conditional raising
+
+# Function for Parametrizing conditional raising
 @contextmanager
 def does_not_raise():
     yield
+
 
 class TestRotationMatrix(object):
     a = np.array([[0.1, 0.2, 0.3], [1.1, 1.1, 1.1]])
@@ -104,8 +106,9 @@ class TestGetMatchingAtoms(object):
     @pytest.mark.parametrize("strict", (True, False))
     def test_nomatch_atoms_raise(self, universe, reference,
                                  strict, selection="protein and backbone"):
-        # one atom less but same residues; with strict=False should try
-        # to get selections (but current code fails, so we also raise SelectionError)
+        # one atom less but same residues; with strict=False
+        # should try to get selections (but current code fails,
+        # so we also raise SelectionError)
         ref = reference.select_atoms(selection).atoms[1:]
         mobile = universe.select_atoms(selection)
         if strict:
@@ -114,7 +117,8 @@ class TestGetMatchingAtoms(object):
         else:
             with pytest.warns(SelectionWarning):
                 with pytest.raises(SelectionError):
-                    groups = align.get_matching_atoms(ref, mobile, strict=strict)
+                    groups = align.get_matching_atoms(ref, mobile,
+                                                      strict=strict)
 
     @pytest.mark.parametrize("strict", (True, False))
     def test_nomatch_residues_raise_empty(self, universe, reference_small,
@@ -130,7 +134,8 @@ class TestGetMatchingAtoms(object):
         else:
             with pytest.warns(SelectionWarning):
                 with pytest.raises(SelectionError):
-                    groups = align.get_matching_atoms(ref, mobile, strict=strict)
+                    groups = align.get_matching_atoms(ref, mobile,
+                                                      strict=strict)
 
     def test_toggle_atom_mismatch_default_error(self, universe, reference):
         selection = ('resname ALA and name CA', 'resname ALA and name O')
@@ -157,7 +162,8 @@ class TestGetMatchingAtoms(object):
 
     @pytest.mark.parametrize('subselection, expectation', [
         ('resname ALA and name CA', does_not_raise()),
-        (mda.Universe(PSF, DCD).select_atoms('resname ALA and name CA'), does_not_raise()),
+        (mda.Universe(PSF, DCD).select_atoms('resname ALA and name CA'),
+         does_not_raise()),
         (1234, pytest.raises(TypeError)),
     ])
     def test_subselection_alignto(self, universe, reference, subselection, expectation):
@@ -167,7 +173,7 @@ class TestGetMatchingAtoms(object):
             assert_allclose(rmsd[1], 0.0, atol=1)
 
     def test_no_atom_masses(self, universe):
-        #if no masses are present
+        # if no masses are present
         u = mda.Universe.empty(6, 2, atom_resindex=[0, 0, 0, 1, 1, 1], trajectory=True)
         with pytest.warns(SelectionWarning):
             align.get_matching_atoms(u.atoms, u.atoms)
@@ -178,6 +184,7 @@ class TestGetMatchingAtoms(object):
         ref.add_TopologyAttr('masses')
         with pytest.warns(SelectionWarning):
             align.get_matching_atoms(u.atoms, ref.atoms)
+
 
 class TestAlign(object):
     @staticmethod
@@ -203,8 +210,9 @@ class TestAlign(object):
         # the test to 6 decimals.
         rmsd = rms.rmsd(first_frame, last_frame, superposition=True)
         assert_allclose(rms.rmsd(last_frame, first_frame, superposition=True), rmsd, 6,
-                        err_msg = "error: rmsd() is not symmetric")
-        assert_allclose(rmsd, 6.820321761927005, 5, err_msg='RMSD calculation between 1st' 
+                        err_msg="error: rmsd() is not symmetric")
+        assert_allclose(rmsd, 6.820321761927005, 5, err_msg='RMSD calculation'
+                        'between 1st'
                         'and last AdK frame gave wrong answer')
         # test masses as weights
         last_atoms_weight = universe.atoms.masses
@@ -402,6 +410,7 @@ def _get_aligned_average_positions(ref_files, ref, select="all", **kwargs):
     rmsd = sum(prealigner.results.rmsd/len(u.trajectory))
     return reference_coordinates, rmsd
 
+
 class TestAverageStructure(object):
 
     ref_files = (PSF, DCD)
@@ -437,15 +446,19 @@ class TestAverageStructure(object):
         assert_allclose(avg.results.universe.atoms.positions, ref, atol=4)
         assert_allclose(avg.results.rmsd, rmsd)
 
-    def test_average_structure_mass_weighted(self, universe, reference):
-        ref, rmsd = _get_aligned_average_positions(self.ref_files, reference, weights='mass')
+    def test_average_structure_mass_weighted(self, universe,
+                                             reference):
+        ref, rmsd = _get_aligned_average_positions(self.ref_files, reference,
+                                                   weights='mass')
         avg = align.AverageStructure(universe, reference, weights='mass').run()
         assert_allclose(avg.results.universe.atoms.positions, ref, atol=4)
         assert_allclose(avg.results.rmsd, rmsd)
 
     def test_average_structure_select(self, universe, reference):
         select = 'protein and name CA and resid 3-5'
-        ref, rmsd = _get_aligned_average_positions(self.ref_files, reference, select=select)
+        ref, rmsd = _get_aligned_average_positions(self.ref_files,
+                                                   reference,
+                                                   select=select)
         avg = align.AverageStructure(universe, reference, select=select).run()
         assert_allclose(avg.results.universe.atoms.positions, ref, atol=4)
         assert_allclose(avg.results.rmsd, rmsd)
@@ -468,18 +481,16 @@ class TestAverageStructure(object):
     def test_average_structure_ref_frame(self, universe):
         ref_frame = 3
         u = mda.Merge(universe.atoms)
-
         # change to ref_frame
-        # universe.trajectory[ref_frame]
+        universe.trajectory[ref_frame]
         u.load_new(universe.atoms.positions)
-
         # back to start
-        # universe.trajectory[0]
-        ref, rmsd = _get_aligned_average_positions(self.ref_files, 
+        universe.trajectory[0]
+        ref, rmsd = _get_aligned_average_positions(self.ref_files,
                                                    u)
-        avg = align.AverageStructure(universe, 
+        avg = align.AverageStructure(universe,
                                      ref_frame=ref_frame).run()
-        assert_allclose(avg.results.universe.atoms.positions, ref, 
+        assert_allclose(avg.results.universe.atoms.positions, ref,
                         atol=4)
         assert_allclose(avg.results.rmsd, rmsd)
 
@@ -561,7 +572,7 @@ class TestSequenceAlignmentFunction:
                      err_msg="reference sequence mismatch")
         assert mobile.residues.sequence(
             format="string") in seqB, "mobile sequence mismatch"
-        assert score  == pytest.approx(54.6)
+        assert score == pytest.approx(54.6)
         assert_array_equal([begin, end], [0, reference.n_residues])
 
     def test_sequence_alignment_deprecation(self, atomgroups):

--- a/testsuite/MDAnalysisTests/analysis/test_align.py
+++ b/testsuite/MDAnalysisTests/analysis/test_align.py
@@ -203,8 +203,8 @@ class TestAlign(object):
         # the test to 6 decimals.
         rmsd = rms.rmsd(first_frame, last_frame, superposition=True)
         assert_allclose(
-            rms.rmsd(last_frame, first_frame, superposition=True), rmsd, 6,
-            err_msg="error: rmsd() is not symmetric")
+                        rms.rmsd(last_frame, first_frame, superposition=True), rmsd, 6,
+                        err_msg="error: rmsd() is not symmetric")
         assert_allclose(rmsd, 6.820321761927005, 5,
                         err_msg="RMSD calculation between 1st and last AdK frame gave wrong answer")
         # test masses as weights
@@ -435,8 +435,7 @@ class TestAverageStructure(object):
     def test_average_structure(self, universe, reference):
         ref, rmsd = _get_aligned_average_positions(self.ref_files, reference)
         avg = align.AverageStructure(universe, reference).run()
-        assert_allclose(avg.results.universe.atoms.positions, ref,
-                        atol=4)
+        assert_allclose(avg.results.universe.atoms.positions, ref,atol=4)
         assert_allclose(avg.results.rmsd, rmsd)
 
     def test_average_structure_mass_weighted(self, universe, reference):

--- a/testsuite/MDAnalysisTests/analysis/test_align.py
+++ b/testsuite/MDAnalysisTests/analysis/test_align.py
@@ -206,7 +206,8 @@ class TestAlign(object):
                         rms.rmsd(last_frame, first_frame, superposition=True), rmsd, 6,
                         err_msg="error: rmsd() is not symmetric")
         assert_allclose(rmsd, 6.820321761927005, 5,
-                        err_msg="RMSD calculation between 1st and last AdK frame gave wrong answer")
+                        err_msg="RMSD calculation " +
+                        "between 1st and last AdK frame gave wrong answer")
         # test masses as weights
         last_atoms_weight = universe.atoms.masses
         A = universe.trajectory[0]
@@ -435,7 +436,7 @@ class TestAverageStructure(object):
     def test_average_structure(self, universe, reference):
         ref, rmsd = _get_aligned_average_positions(self.ref_files, reference)
         avg = align.AverageStructure(universe, reference).run()
-        assert_allclose(avg.results.universe.atoms.positions, ref,atol=4)
+        assert_allclose(avg.results.universe.atoms.positions, ref, atol=4)
         assert_allclose(avg.results.rmsd, rmsd)
 
     def test_average_structure_mass_weighted(self, universe, reference):

--- a/testsuite/MDAnalysisTests/analysis/test_align.py
+++ b/testsuite/MDAnalysisTests/analysis/test_align.py
@@ -470,15 +470,17 @@ class TestAverageStructure(object):
         u = mda.Merge(universe.atoms)
 
         # change to ref_frame
-        #universe.trajectory[ref_frame]
+        # universe.trajectory[ref_frame]
         u.load_new(universe.atoms.positions)
 
         # back to start
-        #universe.trajectory[0]
+        # universe.trajectory[0]
         ref, rmsd = _get_aligned_average_positions(self.ref_files, 
                                                    u)
-        avg = align.AverageStructure(universe, ref_frame=ref_frame).run()
-        assert_allclose(avg.results.universe.atoms.positions, ref, atol=4)
+        avg = align.AverageStructure(universe, 
+                                     ref_frame=ref_frame).run()
+        assert_allclose(avg.results.universe.atoms.positions, ref, 
+                        atol=4)
         assert_allclose(avg.results.rmsd, rmsd)
 
     def test_average_structure_in_memory(self, universe):

--- a/testsuite/MDAnalysisTests/analysis/test_align.py
+++ b/testsuite/MDAnalysisTests/analysis/test_align.py
@@ -170,7 +170,7 @@ class TestGetMatchingAtoms(object):
 
         with expectation:
             rmsd = align.alignto(universe, reference, subselection=subselection)
-            assert_allclose(rmsd[1], 0.0, atol=1)
+            assert_allclose(rmsd[1], 0.0, rtol=1e-09)
 
     def test_no_atom_masses(self, universe):
         # if no masses are present
@@ -203,15 +203,15 @@ class TestAlign(object):
         first_frame = bb.positions
         universe.trajectory[-1]
         last_frame = bb.positions
-        assert_allclose(rms.rmsd(first_frame, first_frame), 0.0, 5,
+        assert_allclose(rms.rmsd(first_frame, first_frame), 0.0, rtol=1e-05,
                         err_msg="error: rmsd(X,X) should be 0")
         # rmsd(A,B) = rmsd(B,A) should be exact but spurious failures in the
         # 9th decimal have been observed (see Issue 57 comment #1) so we relax
         # the test to 6 decimals.
         rmsd = rms.rmsd(first_frame, last_frame, superposition=True)
-        assert_allclose(rms.rmsd(last_frame, first_frame, superposition=True), rmsd, 6,
-                        err_msg="error: rmsd() is not symmetric")
-        assert_allclose(rmsd, 6.820321761927005, 5, err_msg='RMSD calculation'
+        assert_allclose(rms.rmsd(last_frame, first_frame, superposition=True), rmsd, 
+                        rtol=1e-06, err_msg="error: rmsd() is not symmetric")
+        assert_allclose(rmsd, 6.820321761927005, rtol=1e-05, err_msg='RMSD calculation'
                         'between 1st'
                         'and last AdK frame gave wrong answer')
         # test masses as weights
@@ -221,7 +221,7 @@ class TestAlign(object):
         rmsd = align.alignto(universe, reference, weights='mass')
         rmsd_sup_weight = rms.rmsd(A, B, weights=last_atoms_weight, center=True,
                                    superposition=True)
-        assert_allclose(rmsd[1], rmsd_sup_weight, 6)
+        assert_allclose(rmsd[1], rmsd_sup_weight, 1e-06)
 
     def test_rmsd_custom_mass_weights(self, universe, reference):
         last_atoms_weight = universe.atoms.masses
@@ -231,7 +231,7 @@ class TestAlign(object):
                              weights=reference.atoms.masses)
         rmsd_sup_weight = rms.rmsd(A, B, weights=last_atoms_weight, center=True,
                                    superposition=True)
-        assert_allclose(rmsd[1], rmsd_sup_weight, 6)
+        assert_allclose(rmsd[1], rmsd_sup_weight, rtol=1e-06)
 
     def test_rmsd_custom_weights(self, universe, reference):
         weights = np.zeros(universe.atoms.n_atoms)
@@ -239,7 +239,7 @@ class TestAlign(object):
         weights[ca.indices] = 1
         rmsd = align.alignto(universe, reference, select='name CA')
         rmsd_weights = align.alignto(universe, reference, weights=weights)
-        assert_allclose(rmsd[1], rmsd_weights[1], 6)
+        assert_allclose(rmsd[1], rmsd_weights[1], rtol=1e-06)
 
     def test_AlignTraj_outfile_default(self, universe, reference, tmpdir):
         with tmpdir.as_cwd():
@@ -289,8 +289,8 @@ class TestAlign(object):
         x = align.AlignTraj(universe, reference, filename=outfile).run()
         fitted = mda.Universe(PSF, outfile)
 
-        assert_allclose(x.results.rmsd[0], 6.9290, atol=3)
-        assert_allclose(x.results.rmsd[-1], 5.2797e-07, atol=3)
+        assert_allclose(x.results.rmsd[0], 6.9290, rtol=1e-03)
+        assert_allclose(x.results.rmsd[-1], 5.2797e-07, rtol=1e-03)
 
         # RMSD against the reference frame
         # calculated on Mac OS X x86 with MDA 0.7.2 r689
@@ -303,8 +303,8 @@ class TestAlign(object):
         x = align.AlignTraj(universe, reference,
                             filename=outfile, weights='mass').run()
         fitted = mda.Universe(PSF, outfile)
-        assert_allclose(x.results.rmsd[0], 0, atol=3)
-        assert_allclose(x.results.rmsd[-1], 6.9033, atol=3)
+        assert_allclose(x.results.rmsd[0], 0, rtol=1e-03)
+        assert_allclose(x.results.rmsd[-1], 6.9033, rtol=1e-03)
 
         self._assert_rmsd(reference, fitted, 0, 0.0,
                           weights=universe.atoms.masses)
@@ -331,8 +331,8 @@ class TestAlign(object):
                             filename=outfile,
                             weights=reference.atoms.masses).run()
         fitted = mda.Universe(PSF, outfile)
-        assert_allclose(x.results.rmsd[0], 0, atol=3)
-        assert_allclose(x.results.rmsd[-1], 6.9033, atol=3)
+        assert_allclose(x.results.rmsd[0], 0, rtol=1e-03)
+        assert_allclose(x.results.rmsd[-1], 6.9033, rtol=1e-03)
 
         self._assert_rmsd(reference, fitted, 0, 0.0,
                           weights=universe.atoms.masses)
@@ -352,8 +352,8 @@ class TestAlign(object):
         x = align.AlignTraj(universe, reference, filename=outfile,
                             in_memory=True).run()
         assert x.filename is None
-        assert_allclose(x.results.rmsd[0], 6.9290, atol=3)
-        assert_allclose(x.results.rmsd[-1], 5.2797e-07, atol=3)
+        assert_allclose(x.results.rmsd[0], 6.9290, rtol=1e-03)
+        assert_allclose(x.results.rmsd[-1], 5.2797e-07, rtol=1e-03)
 
         # check in memory trajectory
         self._assert_rmsd(reference, universe, 0, 6.929083044751061)
@@ -363,7 +363,7 @@ class TestAlign(object):
         fitted.trajectory[frame]
         rmsd = rms.rmsd(reference.atoms.positions, fitted.atoms.positions,
                         superposition=True)
-        assert_allclose(rmsd, desired, atol=5,
+        assert_allclose(rmsd, desired, rtol=1e-05,
                         err_msg="frame {0:d} of fit does not have "
                                 "expected RMSD".format(frame))
 
@@ -399,7 +399,7 @@ class TestAlign(object):
 
         align.alignto(u_free, u_bound, select=selection)
         assert_allclose(segB_bound.positions, segB_free.positions,
-                        atol=3)
+                        rtol=1e-03)
 
 
 def _get_aligned_average_positions(ref_files, ref, select="all", **kwargs):
@@ -443,7 +443,7 @@ class TestAverageStructure(object):
     def test_average_structure(self, universe, reference):
         ref, rmsd = _get_aligned_average_positions(self.ref_files, reference)
         avg = align.AverageStructure(universe, reference).run()
-        assert_allclose(avg.results.universe.atoms.positions, ref, atol=4)
+        assert_allclose(avg.results.universe.atoms.positions, ref, rtol=1e-04)
         assert_allclose(avg.results.rmsd, rmsd)
 
     def test_average_structure_mass_weighted(self, universe,
@@ -451,7 +451,7 @@ class TestAverageStructure(object):
         ref, rmsd = _get_aligned_average_positions(self.ref_files, reference,
                                                    weights='mass')
         avg = align.AverageStructure(universe, reference, weights='mass').run()
-        assert_allclose(avg.results.universe.atoms.positions, ref, atol=4)
+        assert_allclose(avg.results.universe.atoms.positions, ref, rtol=1e-04)
         assert_allclose(avg.results.rmsd, rmsd)
 
     def test_average_structure_select(self, universe, reference):
@@ -460,13 +460,13 @@ class TestAverageStructure(object):
                                                    reference,
                                                    select=select)
         avg = align.AverageStructure(universe, reference, select=select).run()
-        assert_allclose(avg.results.universe.atoms.positions, ref, atol=4)
+        assert_allclose(avg.results.universe.atoms.positions, ref, rtol=1e-04)
         assert_allclose(avg.results.rmsd, rmsd)
 
     def test_average_structure_no_ref(self, universe):
         ref, rmsd = _get_aligned_average_positions(self.ref_files, universe)
         avg = align.AverageStructure(universe).run()
-        assert_allclose(avg.results.universe.atoms.positions, ref, atol=4)
+        assert_allclose(avg.results.universe.atoms.positions, ref, rtol=1e-04)
         assert_allclose(avg.results.rmsd, rmsd)
 
     def test_average_structure_no_msf(self, universe):
@@ -491,14 +491,14 @@ class TestAverageStructure(object):
         avg = align.AverageStructure(universe,
                                      ref_frame=ref_frame).run()
         assert_allclose(avg.results.universe.atoms.positions, ref,
-                        atol=4)
+                        rtol=1e-04)
         assert_allclose(avg.results.rmsd, rmsd)
 
     def test_average_structure_in_memory(self, universe):
         avg = align.AverageStructure(universe, in_memory=True).run()
         reference_coordinates = universe.trajectory.timeseries().mean(axis=1)
         assert_allclose(avg.results.universe.atoms.positions,
-                        reference_coordinates, atol=4)
+                        reference_coordinates, rtol=1e-04)
         assert avg.filename is None
 
 

--- a/testsuite/MDAnalysisTests/analysis/test_align.py
+++ b/testsuite/MDAnalysisTests/analysis/test_align.py
@@ -133,8 +133,7 @@ class TestGetMatchingAtoms(object):
         else:
             with pytest.warns(SelectionWarning):
                 with pytest.raises(SelectionError):
-                    groups = align.get_matching_atoms(ref, mobile,
-                                                      strict=strict)
+                    groups = align.get_matching_atoms(ref, mobile, strict=strict)
 
     def test_toggle_atom_mismatch_default_error(self, universe, reference):
         selection = ('resname ALA and name CA', 'resname ALA and name O')

--- a/testsuite/MDAnalysisTests/analysis/test_align.py
+++ b/testsuite/MDAnalysisTests/analysis/test_align.py
@@ -33,10 +33,8 @@ from MDAnalysisTests import executable_not_found
 from MDAnalysisTests.datafiles import (PSF, DCD, CRD, FASTA, ALIGN_BOUND,
                                        ALIGN_UNBOUND, PDB_helix)
 from numpy.testing import (
-    assert_almost_equal,
     assert_equal,
     assert_array_equal,
-    assert_array_almost_equal,
     assert_allclose,
 )
 
@@ -166,7 +164,7 @@ class TestGetMatchingAtoms(object):
 
         with expectation:
             rmsd = align.alignto(universe, reference, subselection=subselection)
-            assert_almost_equal(rmsd[1], 0.0, decimal=9)
+            assert_allclose(rmsd[1], 0.0, atol=9)
 
     def test_no_atom_masses(self, universe):
         #if no masses are present
@@ -198,16 +196,16 @@ class TestAlign(object):
         first_frame = bb.positions
         universe.trajectory[-1]
         last_frame = bb.positions
-        assert_almost_equal(rms.rmsd(first_frame, first_frame), 0.0, 5,
+        assert_allclose(rms.rmsd(first_frame, first_frame), 0.0, 5,
                             err_msg="error: rmsd(X,X) should be 0")
         # rmsd(A,B) = rmsd(B,A) should be exact but spurious failures in the
         # 9th decimal have been observed (see Issue 57 comment #1) so we relax
         # the test to 6 decimals.
         rmsd = rms.rmsd(first_frame, last_frame, superposition=True)
-        assert_almost_equal(
+        assert_allclose(
             rms.rmsd(last_frame, first_frame, superposition=True), rmsd, 6,
             err_msg="error: rmsd() is not symmetric")
-        assert_almost_equal(rmsd, 6.820321761927005, 5,
+        assert_allclose(rmsd, 6.820321761927005, 5,
                             err_msg="RMSD calculation between 1st and last AdK frame gave wrong answer")
         # test masses as weights
         last_atoms_weight = universe.atoms.masses
@@ -216,7 +214,7 @@ class TestAlign(object):
         rmsd = align.alignto(universe, reference, weights='mass')
         rmsd_sup_weight = rms.rmsd(A, B, weights=last_atoms_weight, center=True,
                                    superposition=True)
-        assert_almost_equal(rmsd[1], rmsd_sup_weight, 6)
+        assert_allclose(rmsd[1], rmsd_sup_weight, 6)
 
     def test_rmsd_custom_mass_weights(self, universe, reference):
         last_atoms_weight = universe.atoms.masses
@@ -226,7 +224,7 @@ class TestAlign(object):
                              weights=reference.atoms.masses)
         rmsd_sup_weight = rms.rmsd(A, B, weights=last_atoms_weight, center=True,
                                    superposition=True)
-        assert_almost_equal(rmsd[1], rmsd_sup_weight, 6)
+        assert_allclose(rmsd[1], rmsd_sup_weight, 6)
 
     def test_rmsd_custom_weights(self, universe, reference):
         weights = np.zeros(universe.atoms.n_atoms)
@@ -234,7 +232,7 @@ class TestAlign(object):
         weights[ca.indices] = 1
         rmsd = align.alignto(universe, reference, select='name CA')
         rmsd_weights = align.alignto(universe, reference, weights=weights)
-        assert_almost_equal(rmsd[1], rmsd_weights[1], 6)
+        assert_allclose(rmsd[1], rmsd_weights[1], 6)
 
     def test_AlignTraj_outfile_default(self, universe, reference, tmpdir):
         with tmpdir.as_cwd():
@@ -284,8 +282,8 @@ class TestAlign(object):
         x = align.AlignTraj(universe, reference, filename=outfile).run()
         fitted = mda.Universe(PSF, outfile)
 
-        assert_almost_equal(x.results.rmsd[0], 6.9290, decimal=3)
-        assert_almost_equal(x.results.rmsd[-1], 5.2797e-07, decimal=3)
+        assert_allclose(x.results.rmsd[0], 6.9290, atol=3)
+        assert_allclose(x.results.rmsd[-1], 5.2797e-07, atol=3)
 
         # RMSD against the reference frame
         # calculated on Mac OS X x86 with MDA 0.7.2 r689
@@ -298,8 +296,8 @@ class TestAlign(object):
         x = align.AlignTraj(universe, reference,
                             filename=outfile, weights='mass').run()
         fitted = mda.Universe(PSF, outfile)
-        assert_almost_equal(x.results.rmsd[0], 0, decimal=3)
-        assert_almost_equal(x.results.rmsd[-1], 6.9033, decimal=3)
+        assert_allclose(x.results.rmsd[0], 0, atol=3)
+        assert_allclose(x.results.rmsd[-1], 6.9033, atol=3)
 
         self._assert_rmsd(reference, fitted, 0, 0.0,
                           weights=universe.atoms.masses)
@@ -318,7 +316,7 @@ class TestAlign(object):
         x_weights = align.AlignTraj(universe, reference,
                                     filename=outfile, weights=weights).run()
 
-        assert_array_almost_equal(x.results.rmsd, x_weights.results.rmsd)
+        assert_allclose(x.results.rmsd, x_weights.results.rmsd)
 
     def test_AlignTraj_custom_mass_weights(self, universe, reference, tmpdir):
         outfile = str(tmpdir.join('align_test.dcd'))
@@ -326,8 +324,8 @@ class TestAlign(object):
                             filename=outfile,
                             weights=reference.atoms.masses).run()
         fitted = mda.Universe(PSF, outfile)
-        assert_almost_equal(x.results.rmsd[0], 0, decimal=3)
-        assert_almost_equal(x.results.rmsd[-1], 6.9033, decimal=3)
+        assert_allclose(x.results.rmsd[0], 0, atol=3)
+        assert_allclose(x.results.rmsd[-1], 6.9033, atol=3)
 
         self._assert_rmsd(reference, fitted, 0, 0.0,
                           weights=universe.atoms.masses)
@@ -347,8 +345,8 @@ class TestAlign(object):
         x = align.AlignTraj(universe, reference, filename=outfile,
                             in_memory=True).run()
         assert x.filename is None
-        assert_almost_equal(x.results.rmsd[0], 6.9290, decimal=3)
-        assert_almost_equal(x.results.rmsd[-1], 5.2797e-07, decimal=3)
+        assert_allclose(x.results.rmsd[0], 6.9290, atol=3)
+        assert_allclose(x.results.rmsd[-1], 5.2797e-07, atol=3)
 
         # check in memory trajectory
         self._assert_rmsd(reference, universe, 0, 6.929083044751061)
@@ -358,7 +356,7 @@ class TestAlign(object):
         fitted.trajectory[frame]
         rmsd = rms.rmsd(reference.atoms.positions, fitted.atoms.positions,
                         superposition=True)
-        assert_almost_equal(rmsd, desired, decimal=5,
+        assert_allclose(rmsd, desired, atol=5,
                             err_msg="frame {0:d} of fit does not have "
                                     "expected RMSD".format(frame))
 
@@ -393,8 +391,8 @@ class TestAlign(object):
         segB_free.translate(segB_bound.centroid() - segB_free.centroid())
 
         align.alignto(u_free, u_bound, select=selection)
-        assert_array_almost_equal(segB_bound.positions, segB_free.positions,
-                                  decimal=3)
+        assert_allclose(segB_bound.positions, segB_free.positions,
+                                  atol=3)
 
 
 def _get_aligned_average_positions(ref_files, ref, select="all", **kwargs):
@@ -437,31 +435,31 @@ class TestAverageStructure(object):
     def test_average_structure(self, universe, reference):
         ref, rmsd = _get_aligned_average_positions(self.ref_files, reference)
         avg = align.AverageStructure(universe, reference).run()
-        assert_almost_equal(avg.results.universe.atoms.positions, ref,
-                            decimal=4)
-        assert_almost_equal(avg.results.rmsd, rmsd)
+        assert_allclose(avg.results.universe.atoms.positions, ref,
+                            atol=4)
+        assert_allclose(avg.results.rmsd, rmsd)
 
     def test_average_structure_mass_weighted(self, universe, reference):
         ref, rmsd = _get_aligned_average_positions(self.ref_files, reference, weights='mass')
         avg = align.AverageStructure(universe, reference, weights='mass').run()
-        assert_almost_equal(avg.results.universe.atoms.positions, ref,
-                            decimal=4)
-        assert_almost_equal(avg.results.rmsd, rmsd)
+        assert_allclose(avg.results.universe.atoms.positions, ref,
+                            atol=4)
+        assert_allclose(avg.results.rmsd, rmsd)
 
     def test_average_structure_select(self, universe, reference):
         select = 'protein and name CA and resid 3-5'
         ref, rmsd = _get_aligned_average_positions(self.ref_files, reference, select=select)
         avg = align.AverageStructure(universe, reference, select=select).run()
-        assert_almost_equal(avg.results.universe.atoms.positions, ref,
-                            decimal=4)
-        assert_almost_equal(avg.results.rmsd, rmsd)
+        assert_allclose(avg.results.universe.atoms.positions, ref,
+                            atol=4)
+        assert_allclose(avg.results.rmsd, rmsd)
 
     def test_average_structure_no_ref(self, universe):
         ref, rmsd = _get_aligned_average_positions(self.ref_files, universe)
         avg = align.AverageStructure(universe).run()
-        assert_almost_equal(avg.results.universe.atoms.positions, ref,
-                            decimal=4)
-        assert_almost_equal(avg.results.rmsd, rmsd)
+        assert_allclose(avg.results.universe.atoms.positions, ref,
+                            atol=4)
+        assert_allclose(avg.results.rmsd, rmsd)
 
     def test_average_structure_no_msf(self, universe):
         avg = align.AverageStructure(universe).run()
@@ -484,15 +482,15 @@ class TestAverageStructure(object):
         universe.trajectory[0]
         ref, rmsd = _get_aligned_average_positions(self.ref_files, u)
         avg = align.AverageStructure(universe, ref_frame=ref_frame).run()
-        assert_almost_equal(avg.results.universe.atoms.positions, ref,
-                            decimal=4)
-        assert_almost_equal(avg.results.rmsd, rmsd)
+        assert_allclose(avg.results.universe.atoms.positions, ref,
+                            atol=4)
+        assert_allclose(avg.results.rmsd, rmsd)
 
     def test_average_structure_in_memory(self, universe):
         avg = align.AverageStructure(universe, in_memory=True).run()
         reference_coordinates = universe.trajectory.timeseries().mean(axis=1)
-        assert_almost_equal(avg.results.universe.atoms.positions,
-                            reference_coordinates, decimal=4)
+        assert_allclose(avg.results.universe.atoms.positions,
+                            reference_coordinates, atol=4)
         assert avg.filename is None
 
 

--- a/testsuite/MDAnalysisTests/analysis/test_align.py
+++ b/testsuite/MDAnalysisTests/analysis/test_align.py
@@ -164,7 +164,7 @@ class TestGetMatchingAtoms(object):
 
         with expectation:
             rmsd = align.alignto(universe, reference, subselection=subselection)
-            assert_allclose(rmsd[1], 0.0, atol=9)
+            assert_allclose(rmsd[1], 0.0, atol=1)
 
     def test_no_atom_masses(self, universe):
         #if no masses are present
@@ -197,7 +197,7 @@ class TestAlign(object):
         universe.trajectory[-1]
         last_frame = bb.positions
         assert_allclose(rms.rmsd(first_frame, first_frame), 0.0, 5,
-                            err_msg="error: rmsd(X,X) should be 0")
+                        err_msg="error: rmsd(X,X) should be 0")
         # rmsd(A,B) = rmsd(B,A) should be exact but spurious failures in the
         # 9th decimal have been observed (see Issue 57 comment #1) so we relax
         # the test to 6 decimals.
@@ -206,7 +206,7 @@ class TestAlign(object):
             rms.rmsd(last_frame, first_frame, superposition=True), rmsd, 6,
             err_msg="error: rmsd() is not symmetric")
         assert_allclose(rmsd, 6.820321761927005, 5,
-                            err_msg="RMSD calculation between 1st and last AdK frame gave wrong answer")
+                        err_msg="RMSD calculation between 1st and last AdK frame gave wrong answer")
         # test masses as weights
         last_atoms_weight = universe.atoms.masses
         A = universe.trajectory[0]
@@ -357,8 +357,8 @@ class TestAlign(object):
         rmsd = rms.rmsd(reference.atoms.positions, fitted.atoms.positions,
                         superposition=True)
         assert_allclose(rmsd, desired, atol=5,
-                            err_msg="frame {0:d} of fit does not have "
-                                    "expected RMSD".format(frame))
+                        err_msg="frame {0:d} of fit does not have "
+                                "expected RMSD".format(frame))
 
     def test_alignto_checks_selections(self, universe, reference):
         """Testing that alignto() fails if selections do not
@@ -392,7 +392,7 @@ class TestAlign(object):
 
         align.alignto(u_free, u_bound, select=selection)
         assert_allclose(segB_bound.positions, segB_free.positions,
-                                  atol=3)
+                        atol=3)
 
 
 def _get_aligned_average_positions(ref_files, ref, select="all", **kwargs):
@@ -436,14 +436,14 @@ class TestAverageStructure(object):
         ref, rmsd = _get_aligned_average_positions(self.ref_files, reference)
         avg = align.AverageStructure(universe, reference).run()
         assert_allclose(avg.results.universe.atoms.positions, ref,
-                            atol=4)
+                        atol=4)
         assert_allclose(avg.results.rmsd, rmsd)
 
     def test_average_structure_mass_weighted(self, universe, reference):
         ref, rmsd = _get_aligned_average_positions(self.ref_files, reference, weights='mass')
         avg = align.AverageStructure(universe, reference, weights='mass').run()
         assert_allclose(avg.results.universe.atoms.positions, ref,
-                            atol=4)
+                        atol=4)
         assert_allclose(avg.results.rmsd, rmsd)
 
     def test_average_structure_select(self, universe, reference):
@@ -451,14 +451,14 @@ class TestAverageStructure(object):
         ref, rmsd = _get_aligned_average_positions(self.ref_files, reference, select=select)
         avg = align.AverageStructure(universe, reference, select=select).run()
         assert_allclose(avg.results.universe.atoms.positions, ref,
-                            atol=4)
+                        atol=4)
         assert_allclose(avg.results.rmsd, rmsd)
 
     def test_average_structure_no_ref(self, universe):
         ref, rmsd = _get_aligned_average_positions(self.ref_files, universe)
         avg = align.AverageStructure(universe).run()
         assert_allclose(avg.results.universe.atoms.positions, ref,
-                            atol=4)
+                        atol=4)
         assert_allclose(avg.results.rmsd, rmsd)
 
     def test_average_structure_no_msf(self, universe):
@@ -483,14 +483,14 @@ class TestAverageStructure(object):
         ref, rmsd = _get_aligned_average_positions(self.ref_files, u)
         avg = align.AverageStructure(universe, ref_frame=ref_frame).run()
         assert_allclose(avg.results.universe.atoms.positions, ref,
-                            atol=4)
+                        atol=4)
         assert_allclose(avg.results.rmsd, rmsd)
 
     def test_average_structure_in_memory(self, universe):
         avg = align.AverageStructure(universe, in_memory=True).run()
         reference_coordinates = universe.trajectory.timeseries().mean(axis=1)
         assert_allclose(avg.results.universe.atoms.positions,
-                            reference_coordinates, atol=4)
+                        reference_coordinates, atol=4)
         assert avg.filename is None
 
 

--- a/testsuite/MDAnalysisTests/analysis/test_align.py
+++ b/testsuite/MDAnalysisTests/analysis/test_align.py
@@ -117,8 +117,7 @@ class TestGetMatchingAtoms(object):
         else:
             with pytest.warns(SelectionWarning):
                 with pytest.raises(SelectionError):
-                    groups = align.get_matching_atoms(ref, mobile,
-                                                      strict=strict)
+                    groups = align.get_matching_atoms(ref, mobile, strict=strict)
 
     @pytest.mark.parametrize("strict", (True, False))
     def test_nomatch_residues_raise_empty(self, universe, reference_small,

--- a/testsuite/MDAnalysisTests/analysis/test_align.py
+++ b/testsuite/MDAnalysisTests/analysis/test_align.py
@@ -133,7 +133,8 @@ class TestGetMatchingAtoms(object):
         else:
             with pytest.warns(SelectionWarning):
                 with pytest.raises(SelectionError):
-                    groups = align.get_matching_atoms(ref, mobile, strict=strict)
+                    groups = align.get_matching_atoms(ref, mobile,
+                                                      strict=strict)
 
     def test_toggle_atom_mismatch_default_error(self, universe, reference):
         selection = ('resname ALA and name CA', 'resname ALA and name O')

--- a/testsuite/MDAnalysisTests/analysis/test_align.py
+++ b/testsuite/MDAnalysisTests/analysis/test_align.py
@@ -164,7 +164,7 @@ class TestGetMatchingAtoms(object):
 
         with expectation:
             rmsd = align.alignto(universe, reference, subselection=subselection)
-            assert_allclose(rmsd[1], 0.0, atol = 1)
+            assert_allclose(rmsd[1], 0.0, atol=1)
 
     def test_no_atom_masses(self, universe):
         #if no masses are present
@@ -280,8 +280,8 @@ class TestAlign(object):
         x = align.AlignTraj(universe, reference, filename=outfile).run()
         fitted = mda.Universe(PSF, outfile)
 
-        assert_allclose(x.results.rmsd[0], 6.9290, atol = 3)
-        assert_allclose(x.results.rmsd[-1], 5.2797e-07, atol = 3)
+        assert_allclose(x.results.rmsd[0], 6.9290, atol=3)
+        assert_allclose(x.results.rmsd[-1], 5.2797e-07, atol=3)
 
         # RMSD against the reference frame
         # calculated on Mac OS X x86 with MDA 0.7.2 r689
@@ -294,8 +294,8 @@ class TestAlign(object):
         x = align.AlignTraj(universe, reference,
                             filename=outfile, weights='mass').run()
         fitted = mda.Universe(PSF, outfile)
-        assert_allclose(x.results.rmsd[0], 0, atol = 3)
-        assert_allclose(x.results.rmsd[-1], 6.9033, atol = 3)
+        assert_allclose(x.results.rmsd[0], 0, atol=3)
+        assert_allclose(x.results.rmsd[-1], 6.9033, atol=3)
 
         self._assert_rmsd(reference, fitted, 0, 0.0,
                           weights=universe.atoms.masses)
@@ -322,8 +322,8 @@ class TestAlign(object):
                             filename=outfile,
                             weights=reference.atoms.masses).run()
         fitted = mda.Universe(PSF, outfile)
-        assert_allclose(x.results.rmsd[0], 0, atol = 3)
-        assert_allclose(x.results.rmsd[-1], 6.9033, atol = 3)
+        assert_allclose(x.results.rmsd[0], 0, atol=3)
+        assert_allclose(x.results.rmsd[-1], 6.9033, atol=3)
 
         self._assert_rmsd(reference, fitted, 0, 0.0,
                           weights=universe.atoms.masses)
@@ -343,8 +343,8 @@ class TestAlign(object):
         x = align.AlignTraj(universe, reference, filename=outfile,
                             in_memory=True).run()
         assert x.filename is None
-        assert_allclose(x.results.rmsd[0], 6.9290, atol = 3)
-        assert_allclose(x.results.rmsd[-1], 5.2797e-07, atol = 3)
+        assert_allclose(x.results.rmsd[0], 6.9290, atol=3)
+        assert_allclose(x.results.rmsd[-1], 5.2797e-07, atol=3)
 
         # check in memory trajectory
         self._assert_rmsd(reference, universe, 0, 6.929083044751061)
@@ -390,7 +390,7 @@ class TestAlign(object):
 
         align.alignto(u_free, u_bound, select=selection)
         assert_allclose(segB_bound.positions, segB_free.positions,
-                        atol = 3)
+                        atol=3)
 
 
 def _get_aligned_average_positions(ref_files, ref, select="all", **kwargs):
@@ -433,26 +433,26 @@ class TestAverageStructure(object):
     def test_average_structure(self, universe, reference):
         ref, rmsd = _get_aligned_average_positions(self.ref_files, reference)
         avg = align.AverageStructure(universe, reference).run()
-        assert_allclose(avg.results.universe.atoms.positions, ref, atol = 4)
+        assert_allclose(avg.results.universe.atoms.positions, ref, atol=4)
         assert_allclose(avg.results.rmsd, rmsd)
 
     def test_average_structure_mass_weighted(self, universe, reference):
         ref, rmsd = _get_aligned_average_positions(self.ref_files, reference, weights='mass')
         avg = align.AverageStructure(universe, reference, weights='mass').run()
-        assert_allclose(avg.results.universe.atoms.positions, ref, atol = 4)
+        assert_allclose(avg.results.universe.atoms.positions, ref, atol=4)
         assert_allclose(avg.results.rmsd, rmsd)
 
     def test_average_structure_select(self, universe, reference):
         select = 'protein and name CA and resid 3-5'
         ref, rmsd = _get_aligned_average_positions(self.ref_files, reference, select=select)
         avg = align.AverageStructure(universe, reference, select=select).run()
-        assert_allclose(avg.results.universe.atoms.positions, ref, atol = 4)
+        assert_allclose(avg.results.universe.atoms.positions, ref, atol=4)
         assert_allclose(avg.results.rmsd, rmsd)
 
     def test_average_structure_no_ref(self, universe):
         ref, rmsd = _get_aligned_average_positions(self.ref_files, universe)
         avg = align.AverageStructure(universe).run()
-        assert_allclose(avg.results.universe.atoms.positions, ref, atol = 4)
+        assert_allclose(avg.results.universe.atoms.positions, ref, atol=4)
         assert_allclose(avg.results.rmsd, rmsd)
 
     def test_average_structure_no_msf(self, universe):
@@ -484,7 +484,7 @@ class TestAverageStructure(object):
         avg = align.AverageStructure(universe, in_memory=True).run()
         reference_coordinates = universe.trajectory.timeseries().mean(axis=1)
         assert_allclose(avg.results.universe.atoms.positions,
-                        reference_coordinates, atol = 4)
+                        reference_coordinates, atol=4)
         assert avg.filename is None
 
 

--- a/testsuite/MDAnalysisTests/analysis/test_align.py
+++ b/testsuite/MDAnalysisTests/analysis/test_align.py
@@ -219,7 +219,7 @@ class TestAlign(object):
         rmsd = align.alignto(universe, reference, weights='mass')
         rmsd_sup_weight = rms.rmsd(A, B, weights=last_atoms_weight, center=True,
                                    superposition=True)
-        assert_allclose(rmsd[1], rmsd_sup_weight, 1e-06)
+        assert_allclose(rmsd[1], rmsd_sup_weight, rtol=1e-06)
 
     def test_rmsd_custom_mass_weights(self, universe, reference):
         last_atoms_weight = universe.atoms.masses
@@ -237,7 +237,7 @@ class TestAlign(object):
         weights[ca.indices] = 1
         rmsd = align.alignto(universe, reference, select='name CA')
         rmsd_weights = align.alignto(universe, reference, weights=weights)
-        assert_allclose(rmsd[1], rmsd_weights[1], atol=1e-06)
+        assert_allclose(rmsd[1], rmsd_weights[1], rtol=0, atol=1.5 * 10**-6)
 
     def test_AlignTraj_outfile_default(self, universe, reference, tmpdir):
         with tmpdir.as_cwd():
@@ -288,7 +288,7 @@ class TestAlign(object):
         fitted = mda.Universe(PSF, outfile)
 
         assert_allclose(x.results.rmsd[0], 6.9290, rtol=1e-03)
-        assert_allclose(x.results.rmsd[-1], 5.2797e-07, atol=1e-03)
+        assert_allclose(x.results.rmsd[-1], 5.2797e-07, rtol=0, atol=1.5 * 10**-3)
 
         # RMSD against the reference frame
         # calculated on Mac OS X x86 with MDA 0.7.2 r689
@@ -301,7 +301,7 @@ class TestAlign(object):
         x = align.AlignTraj(universe, reference,
                             filename=outfile, weights='mass').run()
         fitted = mda.Universe(PSF, outfile)
-        assert_allclose(x.results.rmsd[0], 0, atol=1e-03)
+        assert_allclose(x.results.rmsd[0], 0, rtol=0, atol=1.5 * 10**-3)
         assert_allclose(x.results.rmsd[-1], 6.9033, rtol=1e-03)
 
         self._assert_rmsd(reference, fitted, 0, 0.0,
@@ -329,7 +329,7 @@ class TestAlign(object):
                             filename=outfile,
                             weights=reference.atoms.masses).run()
         fitted = mda.Universe(PSF, outfile)
-        assert_allclose(x.results.rmsd[0], 0, atol=1e-03)
+        assert_allclose(x.results.rmsd[0], 0, rtol=0, atol=1.5 * 10**-3)
         assert_allclose(x.results.rmsd[-1], 6.9033, rtol=1e-03)
 
         self._assert_rmsd(reference, fitted, 0, 0.0,
@@ -351,7 +351,7 @@ class TestAlign(object):
                             in_memory=True).run()
         assert x.filename is None
         assert_allclose(x.results.rmsd[0], 6.9290, rtol=1e-03)
-        assert_allclose(x.results.rmsd[-1], 5.2797e-07, atol=1e-03)
+        assert_allclose(x.results.rmsd[-1], 5.2797e-07,rtol=0, atol=1.5 * 10**-3)
 
         # check in memory trajectory
         self._assert_rmsd(reference, universe, 0, 6.929083044751061)
@@ -361,7 +361,7 @@ class TestAlign(object):
         fitted.trajectory[frame]
         rmsd = rms.rmsd(reference.atoms.positions, fitted.atoms.positions,
                         superposition=True)
-        assert_allclose(rmsd, desired, rtol=1e-05, atol=1e-05,
+        assert_allclose(rmsd, desired, rtol=0, atol=1.5 * 10**-5,
                         err_msg="frame {0:d} of fit does not have "
                                 "expected RMSD".format(frame))
 
@@ -449,7 +449,7 @@ class TestAverageStructure(object):
         ref, rmsd = _get_aligned_average_positions(self.ref_files, reference,
                                                    weights='mass')
         avg = align.AverageStructure(universe, reference, weights='mass').run()
-        assert_allclose(avg.results.universe.atoms.positions, ref, atol=1e-04)
+        assert_allclose(avg.results.universe.atoms.positions, ref, rtol=0, atol=1.5 * 10**-4)
         assert_allclose(avg.results.rmsd, rmsd)
 
     def test_average_structure_select(self, universe, reference):

--- a/testsuite/MDAnalysisTests/analysis/test_align.py
+++ b/testsuite/MDAnalysisTests/analysis/test_align.py
@@ -164,7 +164,7 @@ class TestGetMatchingAtoms(object):
 
         with expectation:
             rmsd = align.alignto(universe, reference, subselection=subselection)
-            assert_allclose(rmsd[1], 0.0, atol=1)
+            assert_allclose(rmsd[1], 0.0, atol = 1)
 
     def test_no_atom_masses(self, universe):
         #if no masses are present
@@ -202,13 +202,9 @@ class TestAlign(object):
         # 9th decimal have been observed (see Issue 57 comment #1) so we relax
         # the test to 6 decimals.
         rmsd = rms.rmsd(first_frame, last_frame, superposition=True)
-        assert_allclose(
-                        rms.rmsd(last_frame, first_frame, superposition=True), rmsd, 6,
-                        err_msg="error: rmsd() is not symmetric")
-        err_msg="RMSD calculation between 1st and last AdK frame gave wrong answer"
-        assert_allclose(rmsd, 6.820321761927005, 5,
-                        err_msg=err_msg 
-                        )
+        assert_allclose(rms.rmsd(last_frame, first_frame, superposition=True), rmsd, 6,
+                        err_msg = "error: rmsd() is not symmetric")
+        assert_allclose(rmsd, 6.820321761927005, 5, err_msg="RMSD calculation between 1st and last AdK frame gave wrong answer")
         # test masses as weights
         last_atoms_weight = universe.atoms.masses
         A = universe.trajectory[0]
@@ -284,8 +280,8 @@ class TestAlign(object):
         x = align.AlignTraj(universe, reference, filename=outfile).run()
         fitted = mda.Universe(PSF, outfile)
 
-        assert_allclose(x.results.rmsd[0], 6.9290, atol=3)
-        assert_allclose(x.results.rmsd[-1], 5.2797e-07, atol=3)
+        assert_allclose(x.results.rmsd[0], 6.9290, atol = 3)
+        assert_allclose(x.results.rmsd[-1], 5.2797e-07, atol = 3)
 
         # RMSD against the reference frame
         # calculated on Mac OS X x86 with MDA 0.7.2 r689
@@ -298,8 +294,8 @@ class TestAlign(object):
         x = align.AlignTraj(universe, reference,
                             filename=outfile, weights='mass').run()
         fitted = mda.Universe(PSF, outfile)
-        assert_allclose(x.results.rmsd[0], 0, atol=3)
-        assert_allclose(x.results.rmsd[-1], 6.9033, atol=3)
+        assert_allclose(x.results.rmsd[0], 0, atol = 3)
+        assert_allclose(x.results.rmsd[-1], 6.9033, atol = 3)
 
         self._assert_rmsd(reference, fitted, 0, 0.0,
                           weights=universe.atoms.masses)
@@ -326,8 +322,8 @@ class TestAlign(object):
                             filename=outfile,
                             weights=reference.atoms.masses).run()
         fitted = mda.Universe(PSF, outfile)
-        assert_allclose(x.results.rmsd[0], 0, atol=3)
-        assert_allclose(x.results.rmsd[-1], 6.9033, atol=3)
+        assert_allclose(x.results.rmsd[0], 0, atol = 3)
+        assert_allclose(x.results.rmsd[-1], 6.9033, atol = 3)
 
         self._assert_rmsd(reference, fitted, 0, 0.0,
                           weights=universe.atoms.masses)
@@ -347,8 +343,8 @@ class TestAlign(object):
         x = align.AlignTraj(universe, reference, filename=outfile,
                             in_memory=True).run()
         assert x.filename is None
-        assert_allclose(x.results.rmsd[0], 6.9290, atol=3)
-        assert_allclose(x.results.rmsd[-1], 5.2797e-07, atol=3)
+        assert_allclose(x.results.rmsd[0], 6.9290, atol = 3)
+        assert_allclose(x.results.rmsd[-1], 5.2797e-07, atol = 3)
 
         # check in memory trajectory
         self._assert_rmsd(reference, universe, 0, 6.929083044751061)
@@ -394,7 +390,7 @@ class TestAlign(object):
 
         align.alignto(u_free, u_bound, select=selection)
         assert_allclose(segB_bound.positions, segB_free.positions,
-                        atol=3)
+                        atol = 3)
 
 
 def _get_aligned_average_positions(ref_files, ref, select="all", **kwargs):
@@ -437,29 +433,26 @@ class TestAverageStructure(object):
     def test_average_structure(self, universe, reference):
         ref, rmsd = _get_aligned_average_positions(self.ref_files, reference)
         avg = align.AverageStructure(universe, reference).run()
-        assert_allclose(avg.results.universe.atoms.positions, ref, atol=4)
+        assert_allclose(avg.results.universe.atoms.positions, ref, atol = 4)
         assert_allclose(avg.results.rmsd, rmsd)
 
     def test_average_structure_mass_weighted(self, universe, reference):
         ref, rmsd = _get_aligned_average_positions(self.ref_files, reference, weights='mass')
         avg = align.AverageStructure(universe, reference, weights='mass').run()
-        assert_allclose(avg.results.universe.atoms.positions, ref,
-                        atol=4)
+        assert_allclose(avg.results.universe.atoms.positions, ref, atol = 4)
         assert_allclose(avg.results.rmsd, rmsd)
 
     def test_average_structure_select(self, universe, reference):
         select = 'protein and name CA and resid 3-5'
         ref, rmsd = _get_aligned_average_positions(self.ref_files, reference, select=select)
         avg = align.AverageStructure(universe, reference, select=select).run()
-        assert_allclose(avg.results.universe.atoms.positions, ref,
-                        atol=4)
+        assert_allclose(avg.results.universe.atoms.positions, ref, atol = 4)
         assert_allclose(avg.results.rmsd, rmsd)
 
     def test_average_structure_no_ref(self, universe):
         ref, rmsd = _get_aligned_average_positions(self.ref_files, universe)
         avg = align.AverageStructure(universe).run()
-        assert_allclose(avg.results.universe.atoms.positions, ref,
-                        atol=4)
+        assert_allclose(avg.results.universe.atoms.positions, ref, atol = 4)
         assert_allclose(avg.results.rmsd, rmsd)
 
     def test_average_structure_no_msf(self, universe):
@@ -491,7 +484,7 @@ class TestAverageStructure(object):
         avg = align.AverageStructure(universe, in_memory=True).run()
         reference_coordinates = universe.trajectory.timeseries().mean(axis=1)
         assert_allclose(avg.results.universe.atoms.positions,
-                        reference_coordinates, atol=4)
+                        reference_coordinates, atol = 4)
         assert avg.filename is None
 
 

--- a/testsuite/MDAnalysisTests/analysis/test_align.py
+++ b/testsuite/MDAnalysisTests/analysis/test_align.py
@@ -204,7 +204,8 @@ class TestAlign(object):
         rmsd = rms.rmsd(first_frame, last_frame, superposition=True)
         assert_allclose(rms.rmsd(last_frame, first_frame, superposition=True), rmsd, 6,
                         err_msg = "error: rmsd() is not symmetric")
-        assert_allclose(rmsd, 6.820321761927005, 5, err_msg="RMSD calculation between 1st and last AdK frame gave wrong answer")
+        assert_allclose(rmsd, 6.820321761927005, 5, err_msg='RMSD calculation between 1st' 
+                        'and last AdK frame gave wrong answer')
         # test masses as weights
         last_atoms_weight = universe.atoms.masses
         A = universe.trajectory[0]

--- a/testsuite/MDAnalysisTests/analysis/test_align.py
+++ b/testsuite/MDAnalysisTests/analysis/test_align.py
@@ -205,9 +205,10 @@ class TestAlign(object):
         assert_allclose(
                         rms.rmsd(last_frame, first_frame, superposition=True), rmsd, 6,
                         err_msg="error: rmsd() is not symmetric")
+        err_msg="RMSD calculation between 1st and last AdK frame gave wrong answer"
         assert_allclose(rmsd, 6.820321761927005, 5,
-                        err_msg="RMSD calculation " +
-                        "between 1st and last AdK frame gave wrong answer")
+                        err_msg=err_msg 
+                        )
         # test masses as weights
         last_atoms_weight = universe.atoms.masses
         A = universe.trajectory[0]

--- a/testsuite/MDAnalysisTests/analysis/test_align.py
+++ b/testsuite/MDAnalysisTests/analysis/test_align.py
@@ -237,7 +237,7 @@ class TestAlign(object):
         weights[ca.indices] = 1
         rmsd = align.alignto(universe, reference, select='name CA')
         rmsd_weights = align.alignto(universe, reference, weights=weights)
-        assert_allclose(rmsd[1], rmsd_weights[1], rtol=0, atol=1.5 * 10**-6)
+        assert_allclose(rmsd[1], rmsd_weights[1], rtol=0, atol=1.5 * 1e-06)
 
     def test_AlignTraj_outfile_default(self, universe, reference, tmpdir):
         with tmpdir.as_cwd():
@@ -288,7 +288,7 @@ class TestAlign(object):
         fitted = mda.Universe(PSF, outfile)
 
         assert_allclose(x.results.rmsd[0], 6.9290, rtol=1e-03)
-        assert_allclose(x.results.rmsd[-1], 5.2797e-07, rtol=0, atol=1.5 * 10**-3)
+        assert_allclose(x.results.rmsd[-1], 5.2797e-07, rtol=0, atol=1.5 * 1e-03)
 
         # RMSD against the reference frame
         # calculated on Mac OS X x86 with MDA 0.7.2 r689
@@ -301,7 +301,7 @@ class TestAlign(object):
         x = align.AlignTraj(universe, reference,
                             filename=outfile, weights='mass').run()
         fitted = mda.Universe(PSF, outfile)
-        assert_allclose(x.results.rmsd[0], 0, rtol=0, atol=1.5 * 10**-3)
+        assert_allclose(x.results.rmsd[0], 0, rtol=0, atol=1.5 * 1e-03)
         assert_allclose(x.results.rmsd[-1], 6.9033, rtol=1e-03)
 
         self._assert_rmsd(reference, fitted, 0, 0.0,
@@ -329,7 +329,7 @@ class TestAlign(object):
                             filename=outfile,
                             weights=reference.atoms.masses).run()
         fitted = mda.Universe(PSF, outfile)
-        assert_allclose(x.results.rmsd[0], 0, rtol=0, atol=1.5 * 10**-3)
+        assert_allclose(x.results.rmsd[0], 0, rtol=0, atol=1.5 * 1e-03)
         assert_allclose(x.results.rmsd[-1], 6.9033, rtol=1e-03)
 
         self._assert_rmsd(reference, fitted, 0, 0.0,
@@ -351,7 +351,7 @@ class TestAlign(object):
                             in_memory=True).run()
         assert x.filename is None
         assert_allclose(x.results.rmsd[0], 6.9290, rtol=1e-03)
-        assert_allclose(x.results.rmsd[-1], 5.2797e-07,rtol=0, atol=1.5 * 10**-3)
+        assert_allclose(x.results.rmsd[-1], 5.2797e-07,rtol=0, atol=1.5 * 1e-03)
 
         # check in memory trajectory
         self._assert_rmsd(reference, universe, 0, 6.929083044751061)
@@ -361,7 +361,7 @@ class TestAlign(object):
         fitted.trajectory[frame]
         rmsd = rms.rmsd(reference.atoms.positions, fitted.atoms.positions,
                         superposition=True)
-        assert_allclose(rmsd, desired, rtol=0, atol=1.5 * 10**-5,
+        assert_allclose(rmsd, desired, rtol=0, atol=1.5 * 1e-05,
                         err_msg="frame {0:d} of fit does not have "
                                 "expected RMSD".format(frame))
 
@@ -449,7 +449,7 @@ class TestAverageStructure(object):
         ref, rmsd = _get_aligned_average_positions(self.ref_files, reference,
                                                    weights='mass')
         avg = align.AverageStructure(universe, reference, weights='mass').run()
-        assert_allclose(avg.results.universe.atoms.positions, ref, rtol=0, atol=1.5 * 10**-4)
+        assert_allclose(avg.results.universe.atoms.positions, ref, rtol=0, atol=1.5 * 1e-04)
         assert_allclose(avg.results.rmsd, rmsd)
 
     def test_average_structure_select(self, universe, reference):

--- a/testsuite/MDAnalysisTests/analysis/test_align.py
+++ b/testsuite/MDAnalysisTests/analysis/test_align.py
@@ -209,7 +209,7 @@ class TestAlign(object):
         # 9th decimal have been observed (see Issue 57 comment #1) so we relax
         # the test to 6 decimals.
         rmsd = rms.rmsd(first_frame, last_frame, superposition=True)
-        assert_allclose(rms.rmsd(last_frame, first_frame, superposition=True), rmsd, 
+        assert_allclose(rms.rmsd(last_frame, first_frame, superposition=True), rmsd,
                         rtol=1e-06, err_msg="error: rmsd() is not symmetric")
         assert_allclose(rmsd, 6.820321761927005, rtol=1e-05, err_msg='RMSD calculation'
                         'between 1st'
@@ -451,7 +451,7 @@ class TestAverageStructure(object):
         ref, rmsd = _get_aligned_average_positions(self.ref_files, reference,
                                                    weights='mass')
         avg = align.AverageStructure(universe, reference, weights='mass').run()
-        assert_allclose(avg.results.universe.atoms.positions, ref, rtol=1e-04)
+        assert_allclose(avg.results.universe.atoms.positions, ref, atol=1e-04)
         assert_allclose(avg.results.rmsd, rmsd)
 
     def test_average_structure_select(self, universe, reference):

--- a/testsuite/MDAnalysisTests/analysis/test_align.py
+++ b/testsuite/MDAnalysisTests/analysis/test_align.py
@@ -470,15 +470,15 @@ class TestAverageStructure(object):
         u = mda.Merge(universe.atoms)
 
         # change to ref_frame
-        universe.trajectory[ref_frame]
+        #universe.trajectory[ref_frame]
         u.load_new(universe.atoms.positions)
 
         # back to start
-        universe.trajectory[0]
-        ref, rmsd = _get_aligned_average_positions(self.ref_files, u)
+        #universe.trajectory[0]
+        ref, rmsd = _get_aligned_average_positions(self.ref_files, 
+                                                   u)
         avg = align.AverageStructure(universe, ref_frame=ref_frame).run()
-        assert_allclose(avg.results.universe.atoms.positions, ref,
-                        atol=4)
+        assert_allclose(avg.results.universe.atoms.positions, ref, atol=4)
         assert_allclose(avg.results.rmsd, rmsd)
 
     def test_average_structure_in_memory(self, universe):

--- a/testsuite/MDAnalysisTests/analysis/test_align.py
+++ b/testsuite/MDAnalysisTests/analysis/test_align.py
@@ -239,7 +239,7 @@ class TestAlign(object):
         weights[ca.indices] = 1
         rmsd = align.alignto(universe, reference, select='name CA')
         rmsd_weights = align.alignto(universe, reference, weights=weights)
-        assert_allclose(rmsd[1], rmsd_weights[1], rtol=1e-06)
+        assert_allclose(rmsd[1], rmsd_weights[1], atol=1e-06)
 
     def test_AlignTraj_outfile_default(self, universe, reference, tmpdir):
         with tmpdir.as_cwd():
@@ -290,7 +290,7 @@ class TestAlign(object):
         fitted = mda.Universe(PSF, outfile)
 
         assert_allclose(x.results.rmsd[0], 6.9290, rtol=1e-03)
-        assert_allclose(x.results.rmsd[-1], 5.2797e-07, rtol=1e-03)
+        assert_allclose(x.results.rmsd[-1], 5.2797e-07, atol=1e-03)
 
         # RMSD against the reference frame
         # calculated on Mac OS X x86 with MDA 0.7.2 r689
@@ -303,7 +303,7 @@ class TestAlign(object):
         x = align.AlignTraj(universe, reference,
                             filename=outfile, weights='mass').run()
         fitted = mda.Universe(PSF, outfile)
-        assert_allclose(x.results.rmsd[0], 0, rtol=1e-03)
+        assert_allclose(x.results.rmsd[0], 0, atol=1e-03)
         assert_allclose(x.results.rmsd[-1], 6.9033, rtol=1e-03)
 
         self._assert_rmsd(reference, fitted, 0, 0.0,
@@ -331,7 +331,7 @@ class TestAlign(object):
                             filename=outfile,
                             weights=reference.atoms.masses).run()
         fitted = mda.Universe(PSF, outfile)
-        assert_allclose(x.results.rmsd[0], 0, rtol=1e-03)
+        assert_allclose(x.results.rmsd[0], 0, atol=1e-03)
         assert_allclose(x.results.rmsd[-1], 6.9033, rtol=1e-03)
 
         self._assert_rmsd(reference, fitted, 0, 0.0,
@@ -353,7 +353,7 @@ class TestAlign(object):
                             in_memory=True).run()
         assert x.filename is None
         assert_allclose(x.results.rmsd[0], 6.9290, rtol=1e-03)
-        assert_allclose(x.results.rmsd[-1], 5.2797e-07, rtol=1e-03)
+        assert_allclose(x.results.rmsd[-1], 5.2797e-07, atol=1e-03)
 
         # check in memory trajectory
         self._assert_rmsd(reference, universe, 0, 6.929083044751061)
@@ -363,7 +363,7 @@ class TestAlign(object):
         fitted.trajectory[frame]
         rmsd = rms.rmsd(reference.atoms.positions, fitted.atoms.positions,
                         superposition=True)
-        assert_allclose(rmsd, desired, rtol=1e-05,
+        assert_allclose(rmsd, desired, rtol=1e-05, atol=1e-05,
                         err_msg="frame {0:d} of fit does not have "
                                 "expected RMSD".format(frame))
 

--- a/testsuite/MDAnalysisTests/analysis/test_base.py
+++ b/testsuite/MDAnalysisTests/analysis/test_base.py
@@ -194,7 +194,7 @@ def test_start_stop_step(u, run_kwargs, frames):
     assert an.n_frames == len(frames)
     assert_equal(an.found_frames, frames)
     assert_equal(an.frames, frames, err_msg=FRAMES_ERR)
-    assert_allclose(an.times, frames+1, atol=4, err_msg=TIMES_ERR)
+    assert_allclose(an.times, frames+1, rtol=4, err_msg=TIMES_ERR)
 
 
 @pytest.mark.parametrize('run_kwargs, frames', [
@@ -251,7 +251,7 @@ def test_frames_times():
     assert an.n_frames == len(frames)
     assert_equal(an.found_frames, frames)
     assert_equal(an.frames, frames, err_msg=FRAMES_ERR)
-    assert_allclose(an.times, frames*100, atol=4, err_msg=TIMES_ERR)
+    assert_allclose(an.times, frames*100, rtol=4, err_msg=TIMES_ERR)
 
 
 def test_verbose(u):
@@ -366,7 +366,7 @@ def test_AnalysisFromFunction_args_content(u):
     ans = base.AnalysisFromFunction(mass_xyz, protein, another, masses)
     assert len(ans.args) == 3
     result = np.sum(ans.run().results.timeseries)
-    assert_allclose(result, -317054.67757345125, atol=6)
+    assert_allclose(result, -317054.67757345125, rtol=6)
     assert (ans.args[0] is protein) and (ans.args[1] is another)
     assert ans._trajectory is protein.universe.trajectory
 

--- a/testsuite/MDAnalysisTests/analysis/test_base.py
+++ b/testsuite/MDAnalysisTests/analysis/test_base.py
@@ -194,7 +194,7 @@ def test_start_stop_step(u, run_kwargs, frames):
     assert an.n_frames == len(frames)
     assert_equal(an.found_frames, frames)
     assert_equal(an.frames, frames, err_msg=FRAMES_ERR)
-    assert_allclose(an.times, frames+1, rtol=4, err_msg=TIMES_ERR)
+    assert_allclose(an.times, frames+1, rtol=1e-04, err_msg=TIMES_ERR)
 
 
 @pytest.mark.parametrize('run_kwargs, frames', [
@@ -251,7 +251,7 @@ def test_frames_times():
     assert an.n_frames == len(frames)
     assert_equal(an.found_frames, frames)
     assert_equal(an.frames, frames, err_msg=FRAMES_ERR)
-    assert_allclose(an.times, frames*100, rtol=4, err_msg=TIMES_ERR)
+    assert_allclose(an.times, frames*100, rtol=1e-04, err_msg=TIMES_ERR)
 
 
 def test_verbose(u):
@@ -366,7 +366,7 @@ def test_AnalysisFromFunction_args_content(u):
     ans = base.AnalysisFromFunction(mass_xyz, protein, another, masses)
     assert len(ans.args) == 3
     result = np.sum(ans.run().results.timeseries)
-    assert_allclose(result, -317054.67757345125, rtol=6)
+    assert_allclose(result, -317054.67757345125, rtol=1e-06)
     assert (ans.args[0] is protein) and (ans.args[1] is another)
     assert ans._trajectory is protein.universe.trajectory
 

--- a/testsuite/MDAnalysisTests/analysis/test_base.py
+++ b/testsuite/MDAnalysisTests/analysis/test_base.py
@@ -27,7 +27,7 @@ import pytest
 
 import numpy as np
 
-from numpy.testing import assert_equal, assert_almost_equal
+from numpy.testing import assert_equal, assert_allclose
 
 import MDAnalysis as mda
 from MDAnalysis.analysis import base
@@ -194,7 +194,7 @@ def test_start_stop_step(u, run_kwargs, frames):
     assert an.n_frames == len(frames)
     assert_equal(an.found_frames, frames)
     assert_equal(an.frames, frames, err_msg=FRAMES_ERR)
-    assert_almost_equal(an.times, frames+1, decimal=4, err_msg=TIMES_ERR)
+    assert_allclose(an.times, frames+1, atol=4, err_msg=TIMES_ERR)
 
 
 @pytest.mark.parametrize('run_kwargs, frames', [
@@ -251,7 +251,7 @@ def test_frames_times():
     assert an.n_frames == len(frames)
     assert_equal(an.found_frames, frames)
     assert_equal(an.frames, frames, err_msg=FRAMES_ERR)
-    assert_almost_equal(an.times, frames*100, decimal=4, err_msg=TIMES_ERR)
+    assert_allclose(an.times, frames*100, atol=4, err_msg=TIMES_ERR)
 
 
 def test_verbose(u):
@@ -366,7 +366,7 @@ def test_AnalysisFromFunction_args_content(u):
     ans = base.AnalysisFromFunction(mass_xyz, protein, another, masses)
     assert len(ans.args) == 3
     result = np.sum(ans.run().results.timeseries)
-    assert_almost_equal(result, -317054.67757345125, decimal=6)
+    assert_allclose(result, -317054.67757345125, atol=6)
     assert (ans.args[0] is protein) and (ans.args[1] is another)
     assert ans._trajectory is protein.universe.trajectory
 


### PR DESCRIPTION
changed assert_almost_equal and assert_array_almost_equal to assert_allclose llclose in test_align.py and test_base.py

Fixes #

Changes made in this Pull Request:
 - 


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
