### PR TITLE
Move darker information to a PR comment instead

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -67,8 +67,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ github.token }}
       run: |
-        python maintainer/ci/darker-outcomes.py  --main_stat ${{ steps.darker-main-code.outcome }} \
-                                                 --test_stat ${{ steps.darker-test-code.outcome }}
+        python maintainer/ci/darker-outcomes.py  --main_stat ${{ steps.darker-main-code.conclusion }} \
+                                                 --test_stat ${{ steps.darker-test-code.conclusion }}
 
 
   pylint_check:

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -65,8 +65,8 @@ jobs:
 
     - name: write-errors
       run: |
-        echo "run_id: ${{ vars.GITHUB_RUN_ID }}"
-        echo "job_id: ${{ vars.GITHUB_JOB }}"
+        echo "run_id: ${{ GITHUB_RUN_ID }}"
+        echo "job_id: ${{ GITHUB_JOB }}"
         echo "main_stat: ${{ steps.darker-main-code.outcome }}"
         echo "test_stat: ${{ steps.darker-test-code.outcome }}"
         #python maintainer/ci/darker-outcomes.py --run_id ${{ GITHUB_RUN_ID }} \

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -64,6 +64,8 @@ jobs:
         lint: "flake8"
 
     - name: write-errors
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
       run: |
         python maintainer/ci/darker-outcomes.py  --main_stat ${{ steps.darker-main-code.outcome }} \
                                                  --test_stat ${{ steps.darker-test-code.outcome }}

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -72,8 +72,8 @@ jobs:
         echo "job_id: ${JOBID}"
         echo "main_stat: ${{ steps.darker-main-code.outcome }}"
         echo "test_stat: ${{ steps.darker-test-code.outcome }}"
-        #python maintainer/ci/darker-outcomes.py --run_id ${{ GITHUB_RUN_ID }} \
-        #                                        --job_id ${{ GITHUB_JOB }} \
+        #python maintainer/ci/darker-outcomes.py --run_id ${RUNID} \
+        #                                        --job_id ${JOBID} \
         #                                        --main_stat ${{ steps.darker-main-code.outcome }} \
         #                                       --test_stat ${{ steps.darker-test-code.outcome }}
 

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -64,9 +64,12 @@ jobs:
         lint: "flake8"
 
     - name: write-errors
+      env:
+        RUNID: ${{ env.GITHUB_RUN_ID }}
+        JOBID: ${{ env.GITHUB_JOB }}
       run: |
-        echo "run_id: $GITHUB_RUN_ID"
-        echo "job_id: $GITHUB_JOB"
+        echo "run_id: ${RUNID}"
+        echo "job_id: ${JOBID}"
         echo "main_stat: ${{ steps.darker-main-code.outcome }}"
         echo "test_stat: ${{ steps.darker-test-code.outcome }}"
         #python maintainer/ci/darker-outcomes.py --run_id ${{ GITHUB_RUN_ID }} \

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -65,10 +65,14 @@ jobs:
 
     - name: write-errors
       run: |
-        python maintainer/ci/darker-outcomes.py --run_id ${{ vars.GITHUB_RUN_ID }} \
-                                                --job_id ${{ vars.GITHUB_JOB }} \
-                                                --main_stat ${{ steps.darker-main-code.outcome }} \
-                                                --test_stat ${{ steps.darker-test-code.outcome }}
+        echo "run_id: ${{ vars.GITHUB_RUN_ID }}"
+        echo "job_id: ${{ vars.GITHUB_JOB }}"
+        echo "main_stat: ${{ steps.darker-main-code.outcome }}"
+        echo "test_stat: ${{ steps.darker-test-code.outcome }}"
+        #python maintainer/ci/darker-outcomes.py --run_id ${{ vars.GITHUB_RUN_ID }} \
+        #                                        --job_id ${{ vars.GITHUB_JOB }} \
+        #                                        --main_stat ${{ steps.darker-main-code.outcome }} \
+        #                                       --test_stat ${{ steps.darker-test-code.outcome }}
 
 
   pylint_check:

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -65,8 +65,8 @@ jobs:
 
     - name: write-errors
       run: |
-        echo "run_id: ${{ env.GITHUB_RUN_ID }}"
-        echo "job_id: ${{ env.GITHUB_JOB }}"
+        echo "run_id: $GITHUB_RUN_ID"
+        echo "job_id: $GITHUB_JOB"
         echo "main_stat: ${{ steps.darker-main-code.outcome }}"
         echo "test_stat: ${{ steps.darker-test-code.outcome }}"
         #python maintainer/ci/darker-outcomes.py --run_id ${{ GITHUB_RUN_ID }} \

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -65,8 +65,8 @@ jobs:
 
     - name: write-errors
       run: |
-        echo "run_id: ${{ GITHUB_RUN_ID }}"
-        echo "job_id: ${{ GITHUB_JOB }}"
+        echo "run_id: ${{ env.GITHUB_RUN_ID }}"
+        echo "job_id: ${{ env.GITHUB_JOB }}"
         echo "main_stat: ${{ steps.darker-main-code.outcome }}"
         echo "test_stat: ${{ steps.darker-test-code.outcome }}"
         #python maintainer/ci/darker-outcomes.py --run_id ${{ GITHUB_RUN_ID }} \

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -64,18 +64,9 @@ jobs:
         lint: "flake8"
 
     - name: write-errors
-      env:
-        RUNID: ${{ GITHUB_RUN_ID }}
-        JOBID: ${{ GITHUB_JOB }}
       run: |
-        echo "run_id: ${RUNID}"
-        echo "job_id: ${JOBID}"
-        echo "main_stat: ${{ steps.darker-main-code.outcome }}"
-        echo "test_stat: ${{ steps.darker-test-code.outcome }}"
-        #python maintainer/ci/darker-outcomes.py --run_id ${RUNID} \
-        #                                        --job_id ${JOBID} \
-        #                                        --main_stat ${{ steps.darker-main-code.outcome }} \
-        #                                       --test_stat ${{ steps.darker-test-code.outcome }}
+        python maintainer/ci/darker-outcomes.py  --main_stat ${{ steps.darker-main-code.outcome }} \
+                                                 --test_stat ${{ steps.darker-test-code.outcome }}
 
 
   pylint_check:

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -65,8 +65,8 @@ jobs:
 
     - name: write-errors
       env:
-        RUNID: ${{ env.GITHUB_RUN_ID }}
-        JOBID: ${{ env.GITHUB_JOB }}
+        RUNID: ${{ GITHUB_RUN_ID }}
+        JOBID: ${{ GITHUB_JOB }}
       run: |
         echo "run_id: ${RUNID}"
         echo "job_id: ${JOBID}"

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -65,8 +65,8 @@ jobs:
 
     - name: write-errors
       run: |
-        python maintainer/ci/darker-outcomes.py --run_id ${{ github.run_id }} \
-                                                --job_id ${{ github.job_id }} \
+        python maintainer/ci/darker-outcomes.py --run_id ${{ vars.GITHUB_RUN_ID }} \
+                                                --job_id ${{ vars.GITHUB_JOB }} \
                                                 --main_stat ${{ steps.darker-main-code.outcome }} \
                                                 --test_stat ${{ steps.darker-test-code.outcome }}
 

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -67,8 +67,10 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ github.token }}
       run: |
-        python maintainer/ci/darker-outcomes.py  --main_stat ${{ steps.darker-main-code.conclusion }} \
-                                                 --test_stat ${{ steps.darker-test-code.conclusion }}
+        echo ${{ steps.darker-main-code.outcome }}
+        echo ${{ steps.darker-test-code.outcome }}
+        python maintainer/ci/darker-outcomes.py  --main_stat ${{ steps.darker-main-code.outcome }} \
+                                                 --test_stat ${{ steps.darker-test-code.outcome }}
 
 
   pylint_check:

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -69,8 +69,8 @@ jobs:
         echo "job_id: ${{ vars.GITHUB_JOB }}"
         echo "main_stat: ${{ steps.darker-main-code.outcome }}"
         echo "test_stat: ${{ steps.darker-test-code.outcome }}"
-        #python maintainer/ci/darker-outcomes.py --run_id ${{ vars.GITHUB_RUN_ID }} \
-        #                                        --job_id ${{ vars.GITHUB_JOB }} \
+        #python maintainer/ci/darker-outcomes.py --run_id ${{ GITHUB_RUN_ID }} \
+        #                                        --job_id ${{ GITHUB_JOB }} \
         #                                        --main_stat ${{ steps.darker-main-code.outcome }} \
         #                                       --test_stat ${{ steps.darker-test-code.outcome }}
 

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -37,8 +37,14 @@ jobs:
       with:
         python-version: 3.8
 
-    - name: darker main code
+    - name: setup_dependencies
+      run: |
+        pip install PyGithub
+
+    - name: darker-main-code
+      id: darker-main-code
       uses: akaihola/darker@1.5.1
+      continue-on-error: true
       with:
         version: "@master"
         options: "--check --diff --color"
@@ -46,15 +52,23 @@ jobs:
         revision: "HEAD^"
         lint: "flake8"
 
-    - name: darker test code
+    - name: darker-test-code
+      id: darker-test-code
       uses: akaihola/darker@1.5.1
-      if: success() || failure()
+      continue-on-error: true
       with:
         version: "@master"
         options: "--check --diff --color"
         src: "./testsuite/MDAnalysisTests"
         revision: "HEAD^"
         lint: "flake8"
+
+    - name: write-errors
+      run: |
+        python maintainer/ci/darker-outcomes.py --run_id ${{ github.run_id }} \
+                                                --job_id ${{ github.job_id }} \
+                                                --main_stat ${{ steps.darker-main-code.outcome }} \
+                                                --test_stat ${{ steps.darker-test-code.outcome }}
 
 
   pylint_check:

--- a/maintainer/ci/darker-outcomes.py
+++ b/maintainer/ci/darker-outcomes.py
@@ -165,7 +165,7 @@ def gen_message(pr, main_stat, test_stat, action_url):
                 f'Have a look at linter action url for details: {action_url}\n'
                 '**Please note:** _The `black` linter is purely '
                 'informational, you can safely ignore these outcomes if '
-                'there are no flake8 failures!\n')
+                'there are no flake8 failures!_\n')
     return msg
 
 
@@ -186,7 +186,7 @@ def post_comment(pr, message, match_string):
       A matching string to recognise if the comment already exists.
     """
     # Extract a list of matching comments from PR
-    comments = [comm for comm in pr.get_comments() if match_string in comm.body]
+    comments = [comm for comm in pr.get_issue_comments() if match_string in comm.body]
 
     if len(comments) > 0:
         # Edit the comment in-place

--- a/maintainer/ci/darker-outcomes.py
+++ b/maintainer/ci/darker-outcomes.py
@@ -33,20 +33,6 @@ parser = argparse.ArgumentParser(
 
 
 parser.add_argument(
-    "--run_id",
-    type=str,
-    help="Github action run id",
-)
-
-
-parser.add_argument(
-    "--job_id",
-    type=str,
-    help="Github action job id",
-)
-
-
-parser.add_argument(
     "--main_stat",
     type=bool,
     help="Status of main code linting",
@@ -63,5 +49,8 @@ parser.add_argument(
 if __name__ == "__main__":
     args = parser.parse_args()
 
+    run_id = os.environ['GITHUB_RUN_ID']
+    job_id = os.environ['GITHUB_JOB']
+
     print(f"Linting - code: {args.main_stat}, tests: {args.test_stat}, "
-          f"action: https://www.github.com/MDAnalysis/mdanalysis/actions/runs/{args.run_id}/jobs/{args.job_id}")
+          f"action: https://www.github.com/MDAnalysis/mdanalysis/actions/runs/{run_id}/jobs/{job_id}")

--- a/maintainer/ci/darker-outcomes.py
+++ b/maintainer/ci/darker-outcomes.py
@@ -167,14 +167,16 @@ def gen_message(pr, main_stat, test_stat, action_url):
     if bool_outcome(main_stat) and bool_outcome(test_stat):
         msg += ('There are currently no issues detected! 🎉')
     else:
-        msg += ('_**Please note:** The `black` linter is purely '
-                'informational, you can safely ignore these outcomes if '
-                'there are no flake8 failures!_\n\n'
-                'Some issues were found with the formatting of your code.\n'
-                f'main package code:    {_format_outcome(main_stat)}\n'
-                f'testsuite code:       {_format_outcome(test_stat)}\n'
+        msg += ('Some issues were found with the formatting of your code.\n'
+                f'* Main package code: {_format_outcome(main_stat)}\n'
+                f'* Testsuite code: {_format_outcome(test_stat)}\n'
                 'Please have a look at the `darker-main-code` and '
-                f'`darker-test-code` steps here for more details: {action_url}')
+                f'`darker-test-code` steps here for more details: '
+                '{action_url}\n\n'
+                '---\n'
+                '_**Please note:** The `black` linter is purely '
+                'informational, you can safely ignore these outcomes if '
+                'there are no flake8 failures!_')
     return msg
 
 

--- a/maintainer/ci/darker-outcomes.py
+++ b/maintainer/ci/darker-outcomes.py
@@ -97,6 +97,8 @@ def get_action_url(repo, pr, run_id, workflow_name, job_name):
     linters = [wf for wf in repo.get_workflows()
                if wf.name == workflow_name][0]
 
+    print(linters)
+    print(run_id)
     # Extract the gh action run
     run = [r for r in linters.get_runs(branch=pr.head.ref)
            if r.id == run_id][0]

--- a/maintainer/ci/darker-outcomes.py
+++ b/maintainer/ci/darker-outcomes.py
@@ -186,7 +186,7 @@ def post_comment(pr, message, match_string):
       A matching string to recognise if the comment already exists.
     """
     # Extract a list of matching comments from PR
-    comments = [comm for comm in pr.get_comments if match_string in comm.body]
+    comments = [comm for comm in pr.get_comments() if match_string in comm.body]
 
     if len(comments) > 0:
         # Edit the comment in-place

--- a/maintainer/ci/darker-outcomes.py
+++ b/maintainer/ci/darker-outcomes.py
@@ -209,7 +209,7 @@ if __name__ == "__main__":
     # Get Pull Request
     gh_ref = os.environ['GITHUB_REF']
     ## gh_ref for a PR is pull/prNumber/merge
-    pr_num = int(gh_ref.split('/')[2]
+    pr_num = int(gh_ref.split('/')[2])
     pr = get_pull_request(repo, pr_num)
 
     # Get the url to the github action job being pointed to

--- a/maintainer/ci/darker-outcomes.py
+++ b/maintainer/ci/darker-outcomes.py
@@ -152,8 +152,8 @@ def gen_message(pr, main_stat, test_stat, action_url):
     str
       Message to be posted to PR author.
     """
-    msg = ('### Linter Bot:\n\n'
-           f'Hi {pr.user.login}! Thanks for making this PR. '
+    msg = ('### Linter Bot Results:\n\n'
+           f'Hi @{pr.user.login}! Thanks for making this PR. '
            'We linted your code and found the following: \n\n')
 
     # If everything is ok
@@ -221,4 +221,4 @@ if __name__ == "__main__":
     message = gen_message(pr, args.main_stat, args.test_stat, action_url)
 
     # Post your comment
-    post_comment(pr, message, match_string='### Linter Bot:')
+    post_comment(pr, message, match_string='### Linter Bot Results:')

--- a/maintainer/ci/darker-outcomes.py
+++ b/maintainer/ci/darker-outcomes.py
@@ -97,11 +97,9 @@ def get_action_url(repo, pr, run_id, workflow_name, job_name):
     linters = [wf for wf in repo.get_workflows()
                if wf.name == workflow_name][0]
 
-    print(linters)
-    print(run_id)
     # Extract the gh action run
     run = [r for r in linters.get_runs(branch=pr.head.ref)
-           if r.id == run_id][0]
+           if r.id == int(run_id)][0]
 
     # The exact job url can't be recovered via the Python API
     # Switch over to using the REST API instead

--- a/maintainer/ci/darker-outcomes.py
+++ b/maintainer/ci/darker-outcomes.py
@@ -210,6 +210,7 @@ if __name__ == "__main__":
     gh_ref = os.environ['GITHUB_REF']
     ## gh_ref for a PR is pull/:prNumber/merge
     pr_num = int(gh_ref.split('/')[2][1:])
+    print(pr_num)
     pr = get_pull_request(repo, pr_num)
 
     # Get the url to the github action job being pointed to

--- a/maintainer/ci/darker-outcomes.py
+++ b/maintainer/ci/darker-outcomes.py
@@ -152,7 +152,7 @@ def gen_message(pr, main_stat, test_stat, action_url):
     str
       Message to be posted to PR author.
     """
-    msg = ('### Linter Bot:\n\n',
+    msg = ('### Linter Bot:\n\n'
            f'Hi {pr.user.login}! Thanks for making this PR. '
            'We linted your code and found the following: \n\n')
 

--- a/maintainer/ci/darker-outcomes.py
+++ b/maintainer/ci/darker-outcomes.py
@@ -210,6 +210,7 @@ if __name__ == "__main__":
     gh_ref = os.environ['GITHUB_REF']
     ## gh_ref for a PR is pull/:prNumber/merge
     pr_num = int(gh_ref.split('/')[2][1:])
+    print(gh_ref)
     print(pr_num)
     pr = get_pull_request(repo, pr_num)
 

--- a/maintainer/ci/darker-outcomes.py
+++ b/maintainer/ci/darker-outcomes.py
@@ -221,4 +221,4 @@ if __name__ == "__main__":
     message = gen_message(pr, args.main_stat, args.test_stat, action_url)
 
     # Post your comment
-    post_comment(pr, message, match_string='### Linter Bot Results:')
+    post_comment(pr, message, match_string='Linter Bot Results:')

--- a/maintainer/ci/darker-outcomes.py
+++ b/maintainer/ci/darker-outcomes.py
@@ -160,9 +160,9 @@ def gen_message(pr, main_stat, test_stat, action_url):
     if bool_outcome(main_stat) and bool_outcome(test_stat):
         msg += ('There are currently no issues detected! 🎉')
     else:
-        msg += (f'main package code: {main_stat}\n'
-                f'testsuite code: {main_stat}\n\n'
-                f'Have a look at linter action url for details: {action_url}\n'
+        msg += (f'Some issues were found with the formatting of your code.\n'
+                'Please have a look at the `darker-main-code` and '
+                f'`darker-test-code` steps here for more details: {action_url}')
                 '**Please note:** _The `black` linter is purely '
                 'informational, you can safely ignore these outcomes if '
                 'there are no flake8 failures!_\n')

--- a/maintainer/ci/darker-outcomes.py
+++ b/maintainer/ci/darker-outcomes.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+
+# MIT License
+
+# Copyright (c) 2023 MDAnalysis Development Team
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import argparse
+import os
+from github import Github
+
+
+parser = argparse.ArgumentParser(
+    description="Write PR comment for failed darker linting",
+)
+
+
+parser.add_argument(
+    "--run_id",
+    type=str,
+    help="Github action run id",
+)
+
+
+parser.add_argument(
+    "--job_id",
+    type=str,
+    help="Github action job id",
+)
+
+
+parser.add_argument(
+    "--main_stat",
+    type=bool,
+    help="Status of main code linting",
+)
+
+
+parser.add_argument(
+    "--test_stat",
+    type=bool,
+    help="Status of test code linting",
+)
+
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+
+    print(f"Linting - code: {args.main_stat}, tests: {args.test_stat}, "
+          f"action: https://www.github.com/MDAnalysis/mdanalysis/actions/runs/{args.run_id}/jobs/{args.job_id}")

--- a/maintainer/ci/darker-outcomes.py
+++ b/maintainer/ci/darker-outcomes.py
@@ -168,11 +168,13 @@ def gen_message(pr, main_stat, test_stat, action_url):
         msg += ('There are currently no issues detected! 🎉')
     else:
         msg += ('Some issues were found with the formatting of your code.\n'
-                f'* Main package code: {_format_outcome(main_stat)}\n'
-                f'* Testsuite code: {_format_outcome(test_stat)}\n'
-                'Please have a look at the `darker-main-code` and '
-                f'`darker-test-code` steps here for more details: '
-                '{action_url}\n\n'
+                '| Code Location | Outcome |\n'
+                '| --- | --- |\n'
+                f'| main package | {_format_outcome(main_stat)}|\n'
+                f'| testsuite | {_format_outcome(test_stat)}|\n'
+                '\nPlease have a look at the `darker-main-code` and '
+                '`darker-test-code` steps here for more details: '
+                f'{action_url}\n\n'
                 '---\n'
                 '_**Please note:** The `black` linter is purely '
                 'informational, you can safely ignore these outcomes if '

--- a/maintainer/ci/darker-outcomes.py
+++ b/maintainer/ci/darker-outcomes.py
@@ -34,23 +34,30 @@ parser = argparse.ArgumentParser(
 
 parser.add_argument(
     "--main_stat",
-    type=bool,
+    type=str,
     help="Status of main code linting",
 )
 
 
 parser.add_argument(
     "--test_stat",
-    type=bool,
+    type=str,
     help="Status of test code linting",
 )
+
+
+def bool_outcome(outcome: str) -> bool:
+    return True if (outcome == 'passed') else False
 
 
 if __name__ == "__main__":
     args = parser.parse_args()
 
     run_id = os.environ['GITHUB_RUN_ID']
-    job_id = os.environ['GITHUB_JOB']
+    job_id = os.environ['GITHUB_RUN_NUMBER']
 
-    print(f"Linting - code: {args.main_stat}, tests: {args.test_stat}, "
+    def bool_outcome
+
+    print(f"Linting - code: {bool_outcome(args.main_stat)}, "
+          f"tests: {bool_outcome(args.test_stat)}, "
           f"action: https://www.github.com/MDAnalysis/mdanalysis/actions/runs/{run_id}/jobs/{job_id}")

--- a/maintainer/ci/darker-outcomes.py
+++ b/maintainer/ci/darker-outcomes.py
@@ -56,8 +56,6 @@ if __name__ == "__main__":
     run_id = os.environ['GITHUB_RUN_ID']
     job_id = os.environ['GITHUB_RUN_NUMBER']
 
-    def bool_outcome
-
     print(f"Linting - code: {bool_outcome(args.main_stat)}, "
           f"tests: {bool_outcome(args.test_stat)}, "
           f"action: https://www.github.com/MDAnalysis/mdanalysis/actions/runs/{run_id}/jobs/{job_id}")

--- a/maintainer/ci/darker-outcomes.py
+++ b/maintainer/ci/darker-outcomes.py
@@ -208,10 +208,8 @@ if __name__ == "__main__":
 
     # Get Pull Request
     gh_ref = os.environ['GITHUB_REF']
-    ## gh_ref for a PR is pull/:prNumber/merge
-    pr_num = int(gh_ref.split('/')[2][1:])
-    print(gh_ref)
-    print(pr_num)
+    ## gh_ref for a PR is pull/prNumber/merge
+    pr_num = int(gh_ref.split('/')[2]
     pr = get_pull_request(repo, pr_num)
 
     # Get the url to the github action job being pointed to

--- a/maintainer/ci/darker-outcomes.py
+++ b/maintainer/ci/darker-outcomes.py
@@ -152,6 +152,13 @@ def gen_message(pr, main_stat, test_stat, action_url):
     str
       Message to be posted to PR author.
     """
+
+    def _format_outcome(stat):
+        if bool_outcome(stat):
+            return "✅ Passed"
+        else:
+            return "⚠️  Possible failure"
+
     msg = ('### Linter Bot Results:\n\n'
            f'Hi @{pr.user.login}! Thanks for making this PR. '
            'We linted your code and found the following: \n\n')
@@ -160,12 +167,14 @@ def gen_message(pr, main_stat, test_stat, action_url):
     if bool_outcome(main_stat) and bool_outcome(test_stat):
         msg += ('There are currently no issues detected! 🎉')
     else:
-        msg += (f'Some issues were found with the formatting of your code.\n'
+        msg += ('_**Please note:** The `black` linter is purely '
+                'informational, you can safely ignore these outcomes if '
+                'there are no flake8 failures!_\n\n'
+                'Some issues were found with the formatting of your code.\n'
+                f'main package code:    {_format_outcome(main_stat)}\n'
+                f'testsuite code:       {_format_outcome(test_stat)}\n'
                 'Please have a look at the `darker-main-code` and '
                 f'`darker-test-code` steps here for more details: {action_url}')
-                '**Please note:** _The `black` linter is purely '
-                'informational, you can safely ignore these outcomes if '
-                'there are no flake8 failures!_\n')
     return msg
 
 

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -145,6 +145,15 @@ from ..auxiliary import _AUXREADERS
 from ..lib.util import asiterable, Namespace, store_init_arguments
 from ..lib.util import NamedStream
 
+class aweirdClass:
+    def __init__(self):
+        pass
+    def areallylongmethodthisprobablyshouldbelongerthaneightycharactersbutitsomehowIneedmorecharacters(self):
+        pass
+
+
+    def ashortclassbutsomanyemptylines(self):
+        pass
 
 class FrameIteratorBase(object):
     """

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -145,15 +145,6 @@ from ..auxiliary import _AUXREADERS
 from ..lib.util import asiterable, Namespace, store_init_arguments
 from ..lib.util import NamedStream
 
-class aweirdClass:
-    def __init__(self):
-        pass
-    def areallylongmethodthisprobablyshouldbelongerthaneightycharactersbutitsomehowIneedmorecharacters(self):
-        pass
-
-
-    def ashortclassbutsomanyemptylines(self):
-        pass
 
 class FrameIteratorBase(object):
     """


### PR DESCRIPTION
Hopefully this will at least temporarily clarify the way darker works and should prevent further misunderstandings.

## Changes made in this Pull Request:
 - Darker lint now always returns green.
 - Instead we use the github api (partly PyGithub, partly RESTful), so extract & post the outcomes as a comment.

## Unknowns
  - Right now I have no idea how well this will survive in the wild. It might need tweaking in a further iteration.
  - One of the things that I _think_ might be problematic is when branches come from forks. The best I can do for this is open a separate PR once this is fixed and see if everything behaves as expected.