### PR TITLE
Add xfail on randomly failing 32bit-windows h5md test

### DIFF
--- a/testsuite/MDAnalysisTests/coordinates/test_h5md.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_h5md.py
@@ -127,7 +127,7 @@ class TestH5MDWriterBaseAPI(BaseWriterTest):
                     w.write(universe.atoms)
             self._check_copy(outfile, ref, reader)
 
-    @pytest.mark.xfail((os.name =='nt' and sys.maxsize <= 2**32),
+    @pytest.mark.xfail((os.name == 'nt' and sys.maxsize <= 2**32),
                        reason="occasional fail on 32-bit windows")
     def test_write_trajectory_universe(self, ref, reader, universe, tmpdir):
         outfile = 'write-uni-test.' + ref.ext
@@ -252,13 +252,6 @@ class TestH5MDReaderWithRealTrajectory(object):
     def test_jump_last_frame(self, universe):
         universe.trajectory[-1]
         assert universe.trajectory.ts.frame == 2
-
-    @pytest.mark.parametrize("start, stop, step", ((0, 2, 1),
-                                                   (1, 2, 1)))
-    def test_slice(universe, start, stop, step):
-        frames = [universe.trajectory.ts.frame
-                  for ts in universe.trajectory[start:stop:step]]
-        assert_equal(frames, np.arange(start, stop, step))
 
     @pytest.mark.parametrize("start, stop, step", ((0, 2, 1),
                                                    (1, 2, 1)))

--- a/testsuite/MDAnalysisTests/coordinates/test_h5md.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_h5md.py
@@ -127,6 +127,8 @@ class TestH5MDWriterBaseAPI(BaseWriterTest):
                     w.write(universe.atoms)
             self._check_copy(outfile, ref, reader)
 
+    @pytest.mark.xfail((os.name =='nt' and sys.maxsize <= 2**32),
+                       reason="occasional fail on 32-bit windows")
     def test_write_trajectory_universe(self, ref, reader, universe, tmpdir):
         outfile = 'write-uni-test.' + ref.ext
         with tmpdir.as_cwd():


### PR DESCRIPTION
This is now happening too often. With 32bit support deprecated across the board, it's probably not worth trying to work out the right combination of pins that won't have the transient failure.

Changes
------------
- Add xfail on randomly failing test
- Remove duplicate test_slice definition (flake8 actually works)


PR Checklist
------------
 - [x] Tests?
