### PR TITLE
Add readthedocs preview action

### DIFF
--- a/.github/workflows/rtd.yaml
+++ b/.github/workflows/rtd.yaml
@@ -1,0 +1,18 @@
+name: readthedocs/preview
+
+on:
+  pull_request_target:
+    types: [opened]
+    branches:
+      - develop
+
+jobs:
+  rtdpreview:
+    if: "github.repository == 'MDAnalysis/mdanalysis'"
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+    - uses: readthedocs/actions/preview@v1
+      with:
+        project-slug: "readthedocs-preview"


### PR DESCRIPTION
This should fix the problem mentioned on discord whereby it becomes difficult to know the right link to where docs are being built through the rtd action.

Because this is a `pull_request_target` action, I don't think it'll work properly until after it gets merged.