### PR TITLE
Renamed variable `asel` 

### DIFF
--- a/package/MDAnalysis/analysis/rms.py
+++ b/package/MDAnalysis/analysis/rms.py
@@ -810,7 +810,7 @@ class RMSF(AnalysisBase):
                                         in_memory=True).run()
 
            # 3) reference = average structure
-           ref_coordinates = u.trajectory.timeseries(asel=protein).mean(axis=1)
+           ref_coordinates = u.trajectory.timeseries(ag_select=protein).mean(axis=1)
            # make a reference structure (need to reshape into a 1-frame
            # "trajectory")
            reference = mda.Merge(protein).load_new(ref_coordinates[:, None, :],

--- a/package/MDAnalysis/coordinates/DCD.py
+++ b/package/MDAnalysis/coordinates/DCD.py
@@ -277,7 +277,7 @@ class DCDReader(base.ReaderBase):
         return self.ts.dt
 
     def timeseries(self,
-                   asel=None,
+                   ag_select=None,
                    start=None,
                    stop=None,
                    step=None,
@@ -286,7 +286,7 @@ class DCDReader(base.ReaderBase):
 
         Parameters
         ----------
-        asel : :class:`~MDAnalysis.core.groups.AtomGroup`
+        ag_select : :class:`~MDAnalysis.core.groups.AtomGroup`
             The :class:`~MDAnalysis.core.groups.AtomGroup` to read the
             coordinates from. Defaults to None, in which case the full set of
             coordinate data is returned.
@@ -318,11 +318,11 @@ class DCDReader(base.ReaderBase):
 
         start, stop, step = self.check_slice_indices(start, stop, step)
 
-        if asel is not None:
-            if len(asel) == 0:
+        if ag_select is not None:
+            if len(ag_select) == 0:
                 raise ValueError(
                     "Timeseries requires at least one atom to analyze")
-            atom_numbers = list(asel.indices)
+            atom_numbers = list(ag_select.indices)
         else:
             atom_numbers = list(range(self.n_atoms))
 

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -981,7 +981,7 @@ class ProtoReader(IOBase, metaclass=_Readermeta):
             natoms=self.n_atoms
         ))
     
-    def timeseries(self, asel: Optional['AtomGroup']=None,
+    def timeseries(self, ag_select: Optional['AtomGroup']=None,
                    start: Optional[int]=None, stop: Optional[int]=None,
                    step: Optional[int]=None,
                    order: Optional[str]='fac') -> np.ndarray:
@@ -989,7 +989,7 @@ class ProtoReader(IOBase, metaclass=_Readermeta):
 
         Parameters
         ----------
-        asel : AtomGroup (optional)
+        ag_select : AtomGroup (optional)
             The :class:`~MDAnalysis.core.groups.AtomGroup` to read the
             coordinates from. Defaults to ``None``, in which case the full set
             of coordinate data is returned.
@@ -1021,11 +1021,11 @@ class ProtoReader(IOBase, metaclass=_Readermeta):
         start, stop, step = self.check_slice_indices(start, stop, step)
         nframes = len(range(start, stop, step))
 
-        if asel is not None:
-            if len(asel) == 0:
+        if ag_select is not None:
+            if len(ag_select) == 0:
                 raise ValueError(
                     "Timeseries requires at least one atom to analyze")
-            atom_numbers = asel.indices
+            atom_numbers = ag_select.indices
             natoms = len(atom_numbers)
         else:
             natoms = self.n_atoms

--- a/package/MDAnalysis/coordinates/memory.py
+++ b/package/MDAnalysis/coordinates/memory.py
@@ -488,18 +488,18 @@ class MemoryReader(base.ProtoReader):
         self.ts.frame = -1
         self.ts.time = -1
 
-    def timeseries(self, asel=None, start=0, stop=-1, step=1, order='afc'):
+    def timeseries(self, ag_select=None, start=0, stop=-1, step=1, order='afc'):
         """Return a subset of coordinate data for an AtomGroup in desired
         column order. If no selection is given, it will return a view of the
         underlying array, while a copy is returned otherwise.
 
         Parameters
         ---------
-        asel : AtomGroup (optional)
+        ag_select : AtomGroup (optional)
             Atom selection. Defaults to ``None``, in which case the full set of
             coordinate data is returned. Note that in this case, a view
             of the underlying numpy array is returned, while a copy of the
-            data is returned whenever `asel` is different from ``None``.
+            data is returned whenever `ag_select` is different from ``None``.
         start : int (optional)
             the start trajectory frame
         stop : int (optional)
@@ -556,17 +556,17 @@ class MemoryReader(base.ProtoReader):
                        [slice(None)] * (2-f_index))
 
         # Return a view if either:
-        #   1) asel is None
-        #   2) asel corresponds to the selection of all atoms.
+        #   1) ag_select is None
+        #   2) ag_select corresponds to the selection of all atoms.
         array = array[tuple(basic_slice)]
-        if (asel is None or asel is asel.universe.atoms):
+        if (ag_select is None or ag_select is ag_select.universe.atoms):
             return array
         else:
-            if len(asel) == 0:
+            if len(ag_select) == 0:
                 raise ValueError("Timeseries requires at least one atom "
                                   "to analyze")
             # If selection is specified, return a copy
-            return array.take(asel.indices, a_index)
+            return array.take(ag_select.indices, a_index)
 
     def _read_next_timestep(self, ts=None):
         """copy next frame into timestep"""

--- a/testsuite/MDAnalysisTests/analysis/test_align.py
+++ b/testsuite/MDAnalysisTests/analysis/test_align.py
@@ -401,7 +401,7 @@ def _get_aligned_average_positions(ref_files, ref, select="all", **kwargs):
     u = mda.Universe(*ref_files, in_memory=True)
     prealigner = align.AlignTraj(u, ref, select=select, **kwargs).run()
     ag = u.select_atoms(select)
-    reference_coordinates = u.trajectory.timeseries(asel=ag).mean(axis=1)
+    reference_coordinates = u.trajectory.timeseries(ag_select=ag).mean(axis=1)
     rmsd = sum(prealigner.results.rmsd/len(u.trajectory))
     return reference_coordinates, rmsd
 

--- a/testsuite/MDAnalysisTests/coordinates/base.py
+++ b/testsuite/MDAnalysisTests/coordinates/base.py
@@ -486,15 +486,15 @@ class BaseReaderTest(object):
                                        step=slice[2], order='fac')
         assert_allclose(timeseries, positions)
 
-    @pytest.mark.parametrize('asel', ("index 1", "index 2", "index 1 to 3"))
-    def test_timeseries_asel_shape(self, reader, asel):
-        atoms = mda.Universe(reader.filename).select_atoms(asel)
+    @pytest.mark.parametrize('ag_select', ("index 1", "index 2", "index 1 to 3"))
+    def test_timeseries_ag_select_shape(self, reader, ag_select):
+        atoms = mda.Universe(reader.filename).select_atoms(ag_select)
         timeseries = reader.timeseries(atoms, order='fac')
         assert(timeseries.shape[0] == len(reader))
         assert(timeseries.shape[1] == len(atoms))
         assert(timeseries.shape[2] == 3)
     
-    def test_timeseries_empty_asel(self, reader):
+    def test_timeseries_empty_ag_select(self, reader):
         atoms = mda.Universe(reader.filename).select_atoms(None)
         with pytest.raises(ValueError, match="Timeseries requires at least"):
             reader.timeseries(atoms)

--- a/testsuite/MDAnalysisTests/coordinates/test_dcd.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_dcd.py
@@ -224,16 +224,16 @@ def test_timeseries_order(order, shape, universe_dcd):
                                      [9, 4, 2, 0, 50]])
 def test_timeseries_atomindices(indices, universe_dcd):
         allframes = universe_dcd.trajectory.timeseries(order='afc')
-        asel = universe_dcd.atoms[indices]
-        xyz = universe_dcd.trajectory.timeseries(asel=asel, order='afc')
+        ag_select = universe_dcd.atoms[indices]
+        xyz = universe_dcd.trajectory.timeseries(ag_select=ag_select, order='afc')
         assert len(xyz) == len(indices)
         assert_array_almost_equal(xyz, allframes[indices])
 
 
 def test_timeseries_empty_selection(universe_dcd):
     with pytest.raises(ValueError):
-        asel = universe_dcd.select_atoms('name FOO')
-        universe_dcd.trajectory.timeseries(asel=asel)
+        ag_select = universe_dcd.select_atoms('name FOO')
+        universe_dcd.trajectory.timeseries(ag_select=ag_select)
 
 
 def test_reader_set_dt():

--- a/testsuite/MDAnalysisTests/coordinates/test_memory.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_memory.py
@@ -155,23 +155,23 @@ class TestMemoryReader(MultiframeReaderTest):
 
     def test_timeseries_view_from_universe_atoms(self, ref, reader):
         # timeseries() is expected to provide a view of the underlying array
-        # also in the special case when asel=universe.atoms.
+        # also in the special case when ag_select=universe.atoms.
         selection = ref.universe.atoms
-        assert reader.timeseries(asel=selection).base is reader.get_array()
+        assert reader.timeseries(ag_select=selection).base is reader.get_array()
 
     def test_timeseries_view_from_select_all(self, ref, reader):
         # timeseries() is expected to provide a view of the underlying array
         # also in the special case when using "all" in selections.
         selection = ref.universe.select_atoms("all")
         assert_equal(reader.timeseries(
-            asel=selection).base is reader.get_array(),
+            ag_select=selection).base is reader.get_array(),
             True)
 
     def test_timeseries_noview(self, ref, reader):
         # timeseries() is expected NOT to provide a view of the underlying array
         # for any other selection than "all".
         selection = ref.universe.select_atoms("name CA")
-        assert reader.timeseries(asel=selection).base is not reader.get_array()
+        assert reader.timeseries(ag_select=selection).base is not reader.get_array()
 
     def test_repr(self, reader):
         str_rep = str(reader)

--- a/testsuite/MDAnalysisTests/core/test_atom.py
+++ b/testsuite/MDAnalysisTests/core/test_atom.py
@@ -81,8 +81,8 @@ class TestAtom(object):
         assert_almost_equal(a.position, pos)
 
     def test_atom_selection(self, universe, atom):
-        asel = universe.select_atoms('atom 4AKE 67 CG').atoms[0]
-        assert atom == asel
+        ag_select = universe.select_atoms('atom 4AKE 67 CG').atoms[0]
+        assert atom == ag_select
 
     def test_hierarchy(self, universe, atom):
         u = universe


### PR DESCRIPTION
Fixes #3911 

Changes made in this Pull Request:
 - renamed variable `asel` to `ag_select`


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?


<!-- readthedocs-preview readthedocs-preview start -->
----
:books: Documentation preview :books:: https://readthedocs-preview--4077.org.readthedocs.build/en/4077/

<!-- readthedocs-preview readthedocs-preview end -->