### PR TITLE
3925

### DIFF
--- a/package/doc/sphinx/source/conf.py
+++ b/package/doc/sphinx/source/conf.py
@@ -101,7 +101,6 @@ master_doc = 'index'
 # (take the list from AUTHORS)
 # Ordering: (1) Naveen (2) Elizabeth, then all contributors in alphabetical order
 #           (last) Oliver
-mda.__authors__ = ['Naveen Michaud-Agrawal', 'Elizabeth J. Denning', 'MDAnalysis contributors', 'Oliver Beckstein']
 author_list = mda.__authors__
 authors = u', '.join(author_list[:-1]) + u', and ' + author_list[-1]
 project = u'MDAnalysis'

--- a/package/doc/sphinx/source/conf.py
+++ b/package/doc/sphinx/source/conf.py
@@ -101,6 +101,7 @@ master_doc = 'index'
 # (take the list from AUTHORS)
 # Ordering: (1) Naveen (2) Elizabeth, then all contributors in alphabetical order
 #           (last) Oliver
+mda.__authors__ = ['Naveen Michaud-Agrawal', 'Elizabeth J. Denning', 'MDAnalysis contributors', 'Oliver Beckstein']
 author_list = mda.__authors__
 authors = u', '.join(author_list[:-1]) + u', and ' + author_list[-1]
 project = u'MDAnalysis'

--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -21,5 +21,6 @@ seaborn>=0.7.0,<=0.9
 sphinx==1.8.5
 sphinx_rtd_theme
 sphinx_sitemap
+sphinxcontrib.bibtex
 threadpoolctl
 tqdm

--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -21,6 +21,6 @@ seaborn>=0.7.0,<=0.9
 sphinx==1.8.5
 sphinx_rtd_theme
 sphinx_sitemap
-sphinxcontrib.bibtex
+sphinxcontrib-bibtex
 threadpoolctl
 tqdm


### PR DESCRIPTION
Resolves doctest run problem.

Changes made in this Pull Request: This PR solves the problem of failure of run in doctest as `sphinxcontrib-bibtex` module is not built in `sphinx`  which is required for doctest.
 - 


PR Checklist
------------
 - [ ] Tests?
 - [x] Docs?
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?


<!-- readthedocs-preview readthedocs-preview start -->
----
:books: Documentation preview :books:: https://readthedocs-preview--4079.org.readthedocs.build/en/4079/

<!-- readthedocs-preview readthedocs-preview end -->