### PR TITLE
changed comparisons of scalars to use pytest.approx function

### DIFF
--- a/testsuite/MDAnalysisTests/analysis/test_align.py
+++ b/testsuite/MDAnalysisTests/analysis/test_align.py
@@ -369,7 +369,7 @@ class TestAlign(object):
         fitted.trajectory[frame]
         rmsd = rms.rmsd(reference.atoms.positions, fitted.atoms.positions,
                         superposition=True)
-        assert_allclose(rmsd, desired, rtol=1e-5,
+        assert_allclose(rmsd, desired, atol=1e-5,
                             err_msg="frame {0:d} of fit does not have "
                                     "expected RMSD".format(frame))
 
@@ -450,14 +450,14 @@ class TestAverageStructure(object):
         ref, rmsd = _get_aligned_average_positions(self.ref_files, reference)
         avg = align.AverageStructure(universe, reference).run()
         assert_allclose(avg.results.universe.atoms.positions, ref,
-                            rtol=1e-04)
+                            atol=1e-04)
         assert avg.results.rmsd == pytest.approx(rmsd)
 
     def test_average_structure_mass_weighted(self, universe, reference):
         ref, rmsd = _get_aligned_average_positions(self.ref_files, reference, weights='mass')
         avg = align.AverageStructure(universe, reference, weights='mass').run()
         assert_allclose(avg.results.universe.atoms.positions, ref,
-                            rtol=1e-04)
+                            atol=1e-04)
         assert avg.results.rmsd == pytest.approx(rmsd) 
 
     def test_average_structure_select(self, universe, reference):
@@ -465,14 +465,14 @@ class TestAverageStructure(object):
         ref, rmsd = _get_aligned_average_positions(self.ref_files, reference, select=select)
         avg = align.AverageStructure(universe, reference, select=select).run()
         assert_allclose(avg.results.universe.atoms.positions, ref,
-                            rtol=1e-04)
+                            atol=1e-04)
         assert avg.results.rmsd == pytest.approx(rmsd) 
 
     def test_average_structure_no_ref(self, universe):
         ref, rmsd = _get_aligned_average_positions(self.ref_files, universe)
         avg = align.AverageStructure(universe).run()
         assert_allclose(avg.results.universe.atoms.positions, ref,
-                            rtol=1e-04)
+                            atol=1e-04)
         assert avg.results.rmsd == pytest.approx(rmsd) 
 
     def test_average_structure_no_msf(self, universe):
@@ -498,7 +498,7 @@ class TestAverageStructure(object):
         avg = align.AverageStructure(universe, ref_frame=ref_frame).run()
 
         assert_allclose(avg.results.universe.atoms.positions, ref,
-                            rtol=1e-04)
+                            atol=1e-04)
         assert avg.results.rmsd == pytest.approx(rmsd) 
 
     def test_average_structure_in_memory(self, universe):

--- a/testsuite/MDAnalysisTests/analysis/test_align.py
+++ b/testsuite/MDAnalysisTests/analysis/test_align.py
@@ -230,7 +230,7 @@ class TestAlign(object):
                              weights=reference.atoms.masses)
         rmsd_sup_weight = rms.rmsd(A, B, weights=last_atoms_weight, center=True,
                                    superposition=True)
-        assert rmsd[1] == pytest.approx(rmsd_sup_weight), "Not equal to tolerance rel=1e-06"
+        assert rmsd[1] == pytest.approx(rmsd_sup_weight, abs=1e-06), "Not equal to tolerance rel=1e-06"
 
     def test_rmsd_custom_weights(self, universe, reference):
         weights = np.zeros(universe.atoms.n_atoms)
@@ -238,7 +238,7 @@ class TestAlign(object):
         weights[ca.indices] = 1
         rmsd = align.alignto(universe, reference, select='name CA')
         rmsd_weights = align.alignto(universe, reference, weights=weights)
-        assert rmsd[1] == pytest.approx(rmsd_weights[1]), "Not equal to tolerance rel=1e-06"
+        assert rmsd[1] == pytest.approx(rmsd_weights[1], abs=1e-06), "Not equal to tolerance rel=1e-06"
 
     def test_AlignTraj_outfile_default(self, universe, reference, tmpdir):
         with tmpdir.as_cwd():
@@ -289,8 +289,8 @@ class TestAlign(object):
         fitted = mda.Universe(PSF, outfile)
 
         
-        assert x.results.rmsd[0] == pytest.approx(6.9290, rel=1e-03), "Not equal to tolerance rel=1e-03"
-        assert x.results.rmsd[-1] == pytest.approx(5.2797e-07, rel=1e-03), "Not equal to tolerance rel=1e-03"
+        assert x.results.rmsd[0] == pytest.approx(6.9290, abs=1e-03), "Not equal to tolerance rel=1e-03"
+        assert x.results.rmsd[-1] == pytest.approx(5.2797e-07, abs=1e-03), "Not equal to tolerance rel=1e-03"
 
         # RMSD against the reference frame
         # calculated on Mac OS X x86 with MDA 0.7.2 r689
@@ -304,8 +304,8 @@ class TestAlign(object):
                             filename=outfile, weights='mass').run()
         fitted = mda.Universe(PSF, outfile)
 
-        assert x.results.rmsd[0] == pytest.approx(0, rel=1e-03), "Not equal to tolerance rel=1e-03"
-        assert x.results.rmsd[-1] == pytest.approx(6.9033, rel=1e-03), "Not equal to tolerance rel=1e-03"
+        assert x.results.rmsd[0] == pytest.approx(0, abs=1e-03), "Not equal to tolerance rel=1e-03"
+        assert x.results.rmsd[-1] == pytest.approx(6.9033, abs=1e-03), "Not equal to tolerance rel=1e-03"
         
 
         self._assert_rmsd(reference, fitted, 0, 0.0,
@@ -335,8 +335,8 @@ class TestAlign(object):
                             weights=reference.atoms.masses).run()
         fitted = mda.Universe(PSF, outfile)
 
-        assert x.results.rmsd[0] == pytest.approx(0, rel=1e-03), "Not equal to tolerance rel=1e-03"
-        assert x.results.rmsd[-1] == pytest.approx(6.9033, rel=1e-03), "Not equal to tolerance rel=1e-03"
+        assert x.results.rmsd[0] == pytest.approx(0, abs=1e-03), "Not equal to tolerance rel=1e-03"
+        assert x.results.rmsd[-1] == pytest.approx(6.9033, abs=1e-03), "Not equal to tolerance rel=1e-03"
         
 
         self._assert_rmsd(reference, fitted, 0, 0.0,
@@ -357,8 +357,8 @@ class TestAlign(object):
         x = align.AlignTraj(universe, reference, filename=outfile,
                             in_memory=True).run()
         assert x.filename is None
-        assert x.results.rmsd[0] == pytest.approx(6.9290, rel=1e-03), "Not equal to tolerance rel=1e-03"
-        assert x.results.rmsd[-1] == pytest.approx(5.2797e-07, rel=1e-03), "Not equal to tolerance rel=1e-03"
+        assert x.results.rmsd[0] == pytest.approx(6.9290, abs=1e-03), "Not equal to tolerance rel=1e-03"
+        assert x.results.rmsd[-1] == pytest.approx(5.2797e-07, abs=1e-03), "Not equal to tolerance rel=1e-03"
 
 
         # check in memory trajectory
@@ -369,7 +369,7 @@ class TestAlign(object):
         fitted.trajectory[frame]
         rmsd = rms.rmsd(reference.atoms.positions, fitted.atoms.positions,
                         superposition=True)
-        assert_almost_equal(rmsd, desired, decimal=5,
+        assert_allclose(rmsd, desired, rtol=1e-5,
                             err_msg="frame {0:d} of fit does not have "
                                     "expected RMSD".format(frame))
 
@@ -449,9 +449,9 @@ class TestAverageStructure(object):
     def test_average_structure(self, universe, reference):
         ref, rmsd = _get_aligned_average_positions(self.ref_files, reference)
         avg = align.AverageStructure(universe, reference).run()
-        assert_almost_equal(avg.results.universe.atoms.positions, ref,
-                            decimal=4)
-        assert_almost_equal(avg.results.rmsd, rmsd)
+        assert_allclose(avg.results.universe.atoms.positions, ref,
+                            rtol=1e-04)
+        assert avg.results.rmsd == pytest.approx(rmsd)
 
     def test_average_structure_mass_weighted(self, universe, reference):
         ref, rmsd = _get_aligned_average_positions(self.ref_files, reference, weights='mass')
@@ -505,7 +505,7 @@ class TestAverageStructure(object):
         avg = align.AverageStructure(universe, in_memory=True).run()
         reference_coordinates = universe.trajectory.timeseries().mean(axis=1)
         assert_allclose(avg.results.universe.atoms.positions,
-                            reference_coordinates, rtol=1e-044)
+                            reference_coordinates, rtol=1e-04)
         assert avg.filename is None
 
 

--- a/testsuite/MDAnalysisTests/analysis/test_align.py
+++ b/testsuite/MDAnalysisTests/analysis/test_align.py
@@ -166,7 +166,7 @@ class TestGetMatchingAtoms(object):
 
         with expectation:
             rmsd = align.alignto(universe, reference, subselection=subselection)
-            assert_almost_equal(rmsd[1], 0.0, decimal=9)
+            assert rmsd[1] == pytest.approx(0.0, rel=1e-09)
 
     def test_no_atom_masses(self, universe):
         #if no masses are present
@@ -198,17 +198,21 @@ class TestAlign(object):
         first_frame = bb.positions
         universe.trajectory[-1]
         last_frame = bb.positions
-        assert_almost_equal(rms.rmsd(first_frame, first_frame), 0.0, 5,
-                            err_msg="error: rmsd(X,X) should be 0")
+
+        # pytest.approx function is used here because the output of rmsd() is a scalar
+        # all comparisons of scalars have been changed from using the function assert_almost_equal to pytest.approx function
+        assert rms.rmsd(first_frame, first_frame) == pytest.approx(0.0), "error: rmsd(X,X) should be 0"
+
         # rmsd(A,B) = rmsd(B,A) should be exact but spurious failures in the
         # 9th decimal have been observed (see Issue 57 comment #1) so we relax
         # the test to 6 decimals.
+        # by default pytest.approx has a relaive tolerance of 1e-06
         rmsd = rms.rmsd(first_frame, last_frame, superposition=True)
-        assert_almost_equal(
-            rms.rmsd(last_frame, first_frame, superposition=True), rmsd, 6,
-            err_msg="error: rmsd() is not symmetric")
-        assert_almost_equal(rmsd, 6.820321761927005, 5,
-                            err_msg="RMSD calculation between 1st and last AdK frame gave wrong answer")
+        
+        assert rms.rmsd(last_frame, first_frame, superposition=True) == pytest.approx(rmsd), "error: rmsd() is not symmetric"
+
+        assert rmsd == pytest.approx(6.820321761927005, rel=1e-05), "RMSD calculation between 1st and last AdK frame gave wrong answer"
+
         # test masses as weights
         last_atoms_weight = universe.atoms.masses
         A = universe.trajectory[0]
@@ -216,7 +220,7 @@ class TestAlign(object):
         rmsd = align.alignto(universe, reference, weights='mass')
         rmsd_sup_weight = rms.rmsd(A, B, weights=last_atoms_weight, center=True,
                                    superposition=True)
-        assert_almost_equal(rmsd[1], rmsd_sup_weight, 6)
+        assert rmsd[1] == pytest.approx(rmsd_sup_weight), "Not equal to tolerance rel=1e-06"
 
     def test_rmsd_custom_mass_weights(self, universe, reference):
         last_atoms_weight = universe.atoms.masses
@@ -226,7 +230,7 @@ class TestAlign(object):
                              weights=reference.atoms.masses)
         rmsd_sup_weight = rms.rmsd(A, B, weights=last_atoms_weight, center=True,
                                    superposition=True)
-        assert_almost_equal(rmsd[1], rmsd_sup_weight, 6)
+        assert rmsd[1] == pytest.approx(rmsd_sup_weight), "Not equal to tolerance rel=1e-06"
 
     def test_rmsd_custom_weights(self, universe, reference):
         weights = np.zeros(universe.atoms.n_atoms)
@@ -234,7 +238,7 @@ class TestAlign(object):
         weights[ca.indices] = 1
         rmsd = align.alignto(universe, reference, select='name CA')
         rmsd_weights = align.alignto(universe, reference, weights=weights)
-        assert_almost_equal(rmsd[1], rmsd_weights[1], 6)
+        assert rmsd[1] == pytest.approx(rmsd_weights[1]), "Not equal to tolerance rel=1e-06"
 
     def test_AlignTraj_outfile_default(self, universe, reference, tmpdir):
         with tmpdir.as_cwd():
@@ -284,8 +288,9 @@ class TestAlign(object):
         x = align.AlignTraj(universe, reference, filename=outfile).run()
         fitted = mda.Universe(PSF, outfile)
 
-        assert_almost_equal(x.results.rmsd[0], 6.9290, decimal=3)
-        assert_almost_equal(x.results.rmsd[-1], 5.2797e-07, decimal=3)
+        
+        assert x.results.rmsd[0] == pytest.approx(6.9290, rel=1e-03), "Not equal to tolerance rel=1e-03"
+        assert x.results.rmsd[-1] == pytest.approx(5.2797e-07, rel=1e-03), "Not equal to tolerance rel=1e-03"
 
         # RMSD against the reference frame
         # calculated on Mac OS X x86 with MDA 0.7.2 r689
@@ -298,8 +303,10 @@ class TestAlign(object):
         x = align.AlignTraj(universe, reference,
                             filename=outfile, weights='mass').run()
         fitted = mda.Universe(PSF, outfile)
-        assert_almost_equal(x.results.rmsd[0], 0, decimal=3)
-        assert_almost_equal(x.results.rmsd[-1], 6.9033, decimal=3)
+
+        assert x.results.rmsd[0] == pytest.approx(0, rel=1e-03), "Not equal to tolerance rel=1e-03"
+        assert x.results.rmsd[-1] == pytest.approx(6.9033, rel=1e-03), "Not equal to tolerance rel=1e-03"
+        
 
         self._assert_rmsd(reference, fitted, 0, 0.0,
                           weights=universe.atoms.masses)
@@ -318,7 +325,8 @@ class TestAlign(object):
         x_weights = align.AlignTraj(universe, reference,
                                     filename=outfile, weights=weights).run()
 
-        assert_array_almost_equal(x.results.rmsd, x_weights.results.rmsd)
+        # changed fucnion from assert_array_almost_equal to assert_allclose
+        assert_allclose(x.results.rmsd, x_weights.results.rmsd)
 
     def test_AlignTraj_custom_mass_weights(self, universe, reference, tmpdir):
         outfile = str(tmpdir.join('align_test.dcd'))
@@ -326,8 +334,10 @@ class TestAlign(object):
                             filename=outfile,
                             weights=reference.atoms.masses).run()
         fitted = mda.Universe(PSF, outfile)
-        assert_almost_equal(x.results.rmsd[0], 0, decimal=3)
-        assert_almost_equal(x.results.rmsd[-1], 6.9033, decimal=3)
+
+        assert x.results.rmsd[0] == pytest.approx(0, rel=1e-03), "Not equal to tolerance rel=1e-03"
+        assert x.results.rmsd[-1] == pytest.approx(6.9033, rel=1e-03), "Not equal to tolerance rel=1e-03"
+        
 
         self._assert_rmsd(reference, fitted, 0, 0.0,
                           weights=universe.atoms.masses)
@@ -347,8 +357,9 @@ class TestAlign(object):
         x = align.AlignTraj(universe, reference, filename=outfile,
                             in_memory=True).run()
         assert x.filename is None
-        assert_almost_equal(x.results.rmsd[0], 6.9290, decimal=3)
-        assert_almost_equal(x.results.rmsd[-1], 5.2797e-07, decimal=3)
+        assert x.results.rmsd[0] == pytest.approx(6.9290, rel=1e-03), "Not equal to tolerance rel=1e-03"
+        assert x.results.rmsd[-1] == pytest.approx(5.2797e-07, rel=1e-03), "Not equal to tolerance rel=1e-03"
+
 
         # check in memory trajectory
         self._assert_rmsd(reference, universe, 0, 6.929083044751061)
@@ -393,8 +404,9 @@ class TestAlign(object):
         segB_free.translate(segB_bound.centroid() - segB_free.centroid())
 
         align.alignto(u_free, u_bound, select=selection)
-        assert_array_almost_equal(segB_bound.positions, segB_free.positions,
-                                  decimal=3)
+        # changed function from assert_array_almost_equal to assert_allclose
+        assert_allclose(segB_bound.positions, segB_free.positions,
+                                  rtol=1e-03)
 
 
 def _get_aligned_average_positions(ref_files, ref, select="all", **kwargs):
@@ -444,24 +456,24 @@ class TestAverageStructure(object):
     def test_average_structure_mass_weighted(self, universe, reference):
         ref, rmsd = _get_aligned_average_positions(self.ref_files, reference, weights='mass')
         avg = align.AverageStructure(universe, reference, weights='mass').run()
-        assert_almost_equal(avg.results.universe.atoms.positions, ref,
-                            decimal=4)
-        assert_almost_equal(avg.results.rmsd, rmsd)
+        assert_allclose(avg.results.universe.atoms.positions, ref,
+                            rtol=1e-04)
+        assert avg.results.rmsd == pytest.approx(rmsd) 
 
     def test_average_structure_select(self, universe, reference):
         select = 'protein and name CA and resid 3-5'
         ref, rmsd = _get_aligned_average_positions(self.ref_files, reference, select=select)
         avg = align.AverageStructure(universe, reference, select=select).run()
-        assert_almost_equal(avg.results.universe.atoms.positions, ref,
-                            decimal=4)
-        assert_almost_equal(avg.results.rmsd, rmsd)
+        assert_allclose(avg.results.universe.atoms.positions, ref,
+                            rtol=1e-04)
+        assert avg.results.rmsd == pytest.approx(rmsd) 
 
     def test_average_structure_no_ref(self, universe):
         ref, rmsd = _get_aligned_average_positions(self.ref_files, universe)
         avg = align.AverageStructure(universe).run()
-        assert_almost_equal(avg.results.universe.atoms.positions, ref,
-                            decimal=4)
-        assert_almost_equal(avg.results.rmsd, rmsd)
+        assert_allclose(avg.results.universe.atoms.positions, ref,
+                            rtol=1e-04)
+        assert avg.results.rmsd == pytest.approx(rmsd) 
 
     def test_average_structure_no_msf(self, universe):
         avg = align.AverageStructure(universe).run()
@@ -484,15 +496,16 @@ class TestAverageStructure(object):
         universe.trajectory[0]
         ref, rmsd = _get_aligned_average_positions(self.ref_files, u)
         avg = align.AverageStructure(universe, ref_frame=ref_frame).run()
-        assert_almost_equal(avg.results.universe.atoms.positions, ref,
-                            decimal=4)
-        assert_almost_equal(avg.results.rmsd, rmsd)
+
+        assert_allclose(avg.results.universe.atoms.positions, ref,
+                            rtol=1e-04)
+        assert avg.results.rmsd == pytest.approx(rmsd) 
 
     def test_average_structure_in_memory(self, universe):
         avg = align.AverageStructure(universe, in_memory=True).run()
         reference_coordinates = universe.trajectory.timeseries().mean(axis=1)
-        assert_almost_equal(avg.results.universe.atoms.positions,
-                            reference_coordinates, decimal=4)
+        assert_allclose(avg.results.universe.atoms.positions,
+                            reference_coordinates, rtol=1e-044)
         assert avg.filename is None
 
 


### PR DESCRIPTION
…arison of arrays to use numpy.testing.assert_allclose function

Fixes #

Changes made in this Pull Request:
 - 


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?


<!-- readthedocs-preview readthedocs-preview start -->
----
:books: Documentation preview :books:: https://readthedocs-preview--4090.org.readthedocs.build/en/4090/

<!-- readthedocs-preview readthedocs-preview end -->