### PR TITLE
WIP, ENH: faster TPR topology building for large systems

### DIFF
--- a/package/MDAnalysis/topology/tpr/obj.py
+++ b/package/MDAnalysis/topology/tpr/obj.py
@@ -32,6 +32,7 @@ Class definitions for the TPRParser
 
 """
 from collections import namedtuple
+import functools
 from ..tables import Z2SYMB
 
 TpxHeader = namedtuple(
@@ -69,9 +70,11 @@ class MoleculeKind(object):
             f"#residues: {self.number_of_residues():<10d}"
         )
 
+    @functools.lru_cache
     def number_of_atoms(self):
         return len(self.atomkinds)
 
+    @functools.lru_cache
     def number_of_residues(self):
         return len({a.resid for a in self.atomkinds})
 

--- a/package/MDAnalysis/topology/tpr/obj.py
+++ b/package/MDAnalysis/topology/tpr/obj.py
@@ -111,10 +111,10 @@ class AtomKind(object):
             self, id, name, type, resid, resname, mass, charge, atomic_number):
         # id is only within the scope of a single molecule, not the whole system
         self.id = id
-        self.name = name
-        self.type = type
+        self.name = name.decode()
+        self.type = type.decode()
         self.resid = resid
-        self.resname = resname
+        self.resname = resname.decode()
         self.mass = mass
         self.charge = charge
         self.atomic_number = atomic_number


### PR DESCRIPTION
Related to gh-4058
 
- for the same scenario reported there, this drops the read-in time from 76 seconds to 54 seconds; there are some pretty serious caveats though:
  - I'm not convinced the testsuite, which passes locally, is actually sufficient to catch mistakes here--consider for example that I don't add atom indices to `impropers`, `dihedrals`, and `angles` since the testsuite only caught me not doing it for `bonds` (if this is a real issue, this should be useful information for the team re: test coverage)
  - some data types may have changed, and in general I wasn't particularly sympathetic to preservation of types or data structures if the test suite didn't catch me
  - I didn't check if any of the standard `asv` benchmarks are sensitive to these changes, nor did I investigate whether the large system-tailored changes here add a large constant overhead for smaller systems, or systems with different distrubutions of topological entities (i.e., larger num molecules to total atom ratio, etc.)

Still a lot of work to do before we're IO-bound though:
![image](https://user-images.githubusercontent.com/7903078/228388090-809fb848-a50a-486f-af29-1171c7cd066e.png)



<!-- readthedocs-preview readthedocs-preview start -->
----
:books: Documentation preview :books:: https://readthedocs-preview--4098.org.readthedocs.build/en/4098/

<!-- readthedocs-preview readthedocs-preview end -->