### PR TITLE
changing np to cnp

### DIFF
--- a/package/MDAnalysis/analysis/encore/cutils.pyx
+++ b/package/MDAnalysis/analysis/encore/cutils.pyx
@@ -32,19 +32,19 @@ Mixed Cython utils for ENCORE
 
 
 import numpy as np
-cimport numpy as np
+cimport numpy as cnp
 import cython
 from libc.math cimport sqrt
 
-np.import_array()
+cnp.import_array()
 
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def PureRMSD(np.ndarray[np.float64_t, ndim=2] coordsi,
-             np.ndarray[np.float64_t, ndim=2] coordsj,
+def PureRMSD(cnp.ndarray[cnp.float64_t, ndim=2] coordsi,
+             cnp.ndarray[cnp.float64_t, ndim=2] coordsj,
              int atomsn,
-             np.ndarray[np.float64_t, ndim=1] masses,
+             cnp.ndarray[cnp.float64_t, ndim=1] masses,
              double summasses):
 
     cdef  int k

--- a/package/MDAnalysis/lib/_augment.pyx
+++ b/package/MDAnalysis/lib/_augment.pyx
@@ -25,13 +25,13 @@
 import cython
 import numpy as np
 from .mdamath import triclinic_vectors
-cimport numpy as np
+cimport numpy as cnp
 cimport MDAnalysis.lib._cutil
 from MDAnalysis.lib._cutil cimport _dot, _norm, _cross
 
 from libcpp.vector cimport vector
 
-np.import_array()
+cnp.import_array()
 
 
 __all__ = ['augment_coordinates', 'undo_augment']
@@ -296,12 +296,12 @@ def augment_coordinates(float[:, ::1] coordinates, float[:] box, float r):
                 output.push_back(coord[j] - shiftZ[j])
             indices.push_back(i)
     n = indices.size()
-    return np.asarray(output, dtype=np.float32).reshape(n, 3), np.asarray(indices, dtype=np.intp)
+    return cnp.asarray(output, dtype=cnp.float32).reshape(n, 3), cnp.asarray(indices, dtype=cnp.intp)
 
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def undo_augment(np.intp_t[:] results, np.intp_t[:] translation, int nreal):
+def undo_augment(cnp.intp_t[:] results, cnp.intp_t[:] translation, int nreal):
     """Translate augmented indices back to original indices.
 
     Parameters
@@ -341,4 +341,4 @@ def undo_augment(np.intp_t[:] results, np.intp_t[:] translation, int nreal):
     for i in range(N):
         if results[i] >= nreal:
             results[i] = translation[results[i] - nreal]
-    return np.asarray(results, dtype=np.intp)
+    return cnp.asarray(results, dtype=cnp.intp)

--- a/package/MDAnalysis/lib/_augment.pyx
+++ b/package/MDAnalysis/lib/_augment.pyx
@@ -296,7 +296,7 @@ def augment_coordinates(float[:, ::1] coordinates, float[:] box, float r):
                 output.push_back(coord[j] - shiftZ[j])
             indices.push_back(i)
     n = indices.size()
-    return cnp.asarray(output, dtype=cnp.float32).reshape(n, 3), cnp.asarray(indices, dtype=cnp.intp)
+    return np.asarray(output, dtype=cnp.float32).reshape(n, 3), np.asarray(indices, dtype=cnp.intp)
 
 
 @cython.boundscheck(False)
@@ -341,4 +341,4 @@ def undo_augment(cnp.intp_t[:] results, cnp.intp_t[:] translation, int nreal):
     for i in range(N):
         if results[i] >= nreal:
             results[i] = translation[results[i] - nreal]
-    return cnp.asarray(results, dtype=cnp.intp)
+    return np.asarray(results, dtype=cnp.intp)

--- a/package/MDAnalysis/lib/_augment.pyx
+++ b/package/MDAnalysis/lib/_augment.pyx
@@ -296,7 +296,7 @@ def augment_coordinates(float[:, ::1] coordinates, float[:] box, float r):
                 output.push_back(coord[j] - shiftZ[j])
             indices.push_back(i)
     n = indices.size()
-    return np.asarray(output, dtype=cnp.float32).reshape(n, 3), np.asarray(indices, dtype=cnp.intp)
+    return np.asarray(output, dtype=np.float32).reshape(n, 3), np.asarray(indices, dtype=np.intp)
 
 
 @cython.boundscheck(False)
@@ -341,4 +341,4 @@ def undo_augment(cnp.intp_t[:] results, cnp.intp_t[:] translation, int nreal):
     for i in range(N):
         if results[i] >= nreal:
             results[i] = translation[results[i] - nreal]
-    return np.asarray(results, dtype=cnp.intp)
+    return np.asarray(results, dtype=np.intp)

--- a/package/MDAnalysis/lib/_cutil.pyx
+++ b/package/MDAnalysis/lib/_cutil.pyx
@@ -24,7 +24,7 @@
 
 import cython
 import numpy as np
-cimport numpy as np
+cimport numpy as cnp
 from libc.math cimport sqrt, fabs
 
 from MDAnalysis import NoDataError
@@ -35,7 +35,7 @@ from libcpp.vector cimport vector
 from libcpp.utility cimport pair
 from cython.operator cimport dereference as deref
 
-np.import_array()
+cnp.import_array()
 
 __all__ = ['unique_int_1d', 'make_whole', 'find_fragments',
            '_sarrus_det_single', '_sarrus_det_multiple']
@@ -51,7 +51,7 @@ ctypedef cmap[int, intset] intmap
 
 @cython.boundscheck(False)  # turn off bounds-checking for entire function
 @cython.wraparound(False)  # turn off negative index wrapping for entire function
-def unique_int_1d(np.intp_t[:] values):
+def unique_int_1d(cnp.intp_t[:] values):
     """Find the unique elements of a 1D array of integers.
 
     This function is optimal on sorted arrays.
@@ -73,10 +73,10 @@ def unique_int_1d(np.intp_t[:] values):
     cdef int i = 0
     cdef int j = 0
     cdef int n_values = values.shape[0]
-    cdef np.intp_t[:] result = np.empty(n_values, dtype=np.intp)
+    cdef cnp.intp_t[:] result = cnp.empty(n_values, dtype=np.intp)
 
     if n_values == 0:
-        return np.array(result)
+        return cnp.array(result)
 
     result[0] = values[0]
     for i in range(1, n_values):
@@ -87,14 +87,14 @@ def unique_int_1d(np.intp_t[:] values):
             is_monotonic = False
     result = result[:j + 1]
     if not is_monotonic:
-        result = unique_int_1d(np.sort(result))
+        result = unique_int_1d(cnp.sort(result))
 
-    return np.array(result)
+    return cnp.array(result)
 
 
 @cython.boundscheck(False)
-def _in2d(np.intp_t[:, :] arr1, np.intp_t[:, :] arr2):
-    """Similar to np.in1d except works on 2d arrays
+def _in2d(cnp.intp_t[:, :] arr1, cnp.intp_t[:, :] arr2):
+    """Similar to cnp.in1d except works on 2d arrays
 
     Parameters
     ----------
@@ -110,8 +110,8 @@ def _in2d(np.intp_t[:, :] arr1, np.intp_t[:, :] arr2):
     """
     cdef object out
     cdef ssize_t i
-    cdef cset[pair[np.intp_t, np.intp_t]] hits
-    cdef pair[np.intp_t, np.intp_t] p
+    cdef cset[pair[cnp.intp_t, cnp.intp_t]] hits
+    cdef pair[cnp.intp_t, cnp.intp_t] p
 
     """
     Construct a set from arr2 called hits
@@ -120,7 +120,7 @@ def _in2d(np.intp_t[:, :] arr1, np.intp_t[:, :] arr2):
     python would look like:
 
     hits = {(i, j) for (i, j) in arr2}
-    results = np.empty(arr1.shape[0])
+    results = cnp.empty(arr1.shape[0])
     for i, (x, y) in enumerate(arr1):
         results[i] = (x, y) in hits
 
@@ -130,13 +130,13 @@ def _in2d(np.intp_t[:, :] arr1, np.intp_t[:, :] arr2):
         raise ValueError("Both arrays must be (n, 2) arrays")
 
     for i in range(arr2.shape[0]):
-        p = pair[np.intp_t, np.intp_t](arr2[i, 0], arr2[i, 1])
+        p = pair[cnp.intp_t, cnp.intp_t](arr2[i, 0], arr2[i, 1])
         hits.insert(p)
 
-    out = np.empty(arr1.shape[0], dtype=np.uint8)
+    out = cnp.empty(arr1.shape[0], dtype=cnp.uint8)
     cdef unsigned char[::1] results = out
     for i in range(arr1.shape[0]):
-        p = pair[np.intp_t, np.intp_t](arr1[i, 0], arr1[i, 1])
+        p = pair[cnp.intp_t, cnp.intp_t](arr1[i, 0], arr1[i, 1])
 
         if hits.count(p):
             results[i] = True
@@ -243,7 +243,7 @@ def make_whole(atomgroup, reference_atom=None, inplace=True):
         are returned as a numpy array.
     """
     cdef intset refpoints, todo, done
-    cdef np.intp_t i, j, nloops, ref, atom, other, natoms
+    cdef cnp.intp_t i, j, nloops, ref, atom, other, natoms
     cdef cmap[int, int] ix_to_rel
     cdef intmap bonding
     cdef int[:, :] bonds
@@ -265,7 +265,7 @@ def make_whole(atomgroup, reference_atom=None, inplace=True):
 
     # Nothing to do for less than 2 atoms
     if natoms < 2:
-        return np.array(oldpos)
+        return cnp.array(oldpos)
 
     for i in range(natoms):
         ix_to_rel[ix_view[i]] = i
@@ -301,7 +301,7 @@ def make_whole(atomgroup, reference_atom=None, inplace=True):
             if not is_unwrapped:
                 break
         if is_unwrapped:
-            return np.array(oldpos)
+            return cnp.array(oldpos)
         for i in range(3):
             inverse_box[i] = 1.0 / box[i]
     else:
@@ -324,7 +324,7 @@ def make_whole(atomgroup, reference_atom=None, inplace=True):
             bonding[atom].insert(other)
             bonding[other].insert(atom)
 
-    newpos = np.zeros((oldpos.shape[0], 3), dtype=np.float32)
+    newpos = cnp.zeros((oldpos.shape[0], 3), dtype=cnp.float32)
 
     refpoints = intset()  # Who is safe to use as reference point?
     done = intset()  # Who have I already searched around?
@@ -334,7 +334,7 @@ def make_whole(atomgroup, reference_atom=None, inplace=True):
         newpos[ref, i] = oldpos[ref, i]
 
     nloops = 0
-    while <np.intp_t> refpoints.size() < natoms and nloops < natoms:
+    while <cnp.intp_t> refpoints.size() < natoms and nloops < natoms:
         # count iterations to prevent infinite loop here
         nloops += 1
 
@@ -362,11 +362,11 @@ def make_whole(atomgroup, reference_atom=None, inplace=True):
                 refpoints.insert(other)
             done.insert(atom)
 
-    if <np.intp_t> refpoints.size() < natoms:
+    if <cnp.intp_t> refpoints.size() < natoms:
         raise ValueError("AtomGroup was not contiguous from bonds, process failed")
     if inplace:
         atomgroup.positions = newpos
-    return np.array(newpos)
+    return cnp.array(newpos)
 
 
 @cython.boundscheck(False)
@@ -411,9 +411,9 @@ cdef float _norm(float * a):
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cpdef np.float64_t _sarrus_det_single(np.float64_t[:, ::1] m):
+cpdef cnp.float64_t _sarrus_det_single(cnp.float64_t[:, ::1] m):
     """Computes the determinant of a 3x3 matrix."""
-    cdef np.float64_t det
+    cdef cnp.float64_t det
     det = m[0, 0] * m[1, 1] * m[2, 2]
     det -= m[0, 0] * m[1, 2] * m[2, 1]
     det += m[0, 1] * m[1, 2] * m[2, 0]
@@ -425,13 +425,13 @@ cpdef np.float64_t _sarrus_det_single(np.float64_t[:, ::1] m):
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cpdef np.ndarray _sarrus_det_multiple(np.float64_t[:, :, ::1] m):
+cpdef cnp.ndarray _sarrus_det_multiple(cnp.float64_t[:, :, ::1] m):
     """Computes all determinants of an array of 3x3 matrices."""
-    cdef np.intp_t n
-    cdef np.intp_t i
-    cdef np.float64_t[:] det
+    cdef cnp.intp_t n
+    cdef cnp.intp_t i
+    cdef cnp.float64_t[:] det
     n = m.shape[0]
-    det = np.empty(n, dtype=np.float64)
+    det = cnp.empty(n, dtype=cnp.float64)
     for i in range(n):
         det[i] = m[i, 0, 0] * m[i, 1, 1] * m[i, 2, 2]
         det[i] -= m[i, 0, 0] * m[i, 1, 2] * m[i, 2, 1]
@@ -439,7 +439,7 @@ cpdef np.ndarray _sarrus_det_multiple(np.float64_t[:, :, ::1] m):
         det[i] -= m[i, 0, 1] * m[i, 1, 0] * m[i, 2, 2]
         det[i] += m[i, 0, 2] * m[i, 1, 0] * m[i, 2, 1]
         det[i] -= m[i, 0, 2] * m[i, 1, 1] * m[i, 2, 0]
-    return np.array(det)
+    return cnp.array(det)
 
 
 @cython.boundscheck(False)
@@ -470,11 +470,11 @@ def find_fragments(atoms, bondlist):
     cdef intset todo, frag_todo, frag_done
     cdef vector[int] this_frag
     cdef int i, a, b
-    cdef np.int64_t[:] atoms_view
-    cdef np.int32_t[:, :] bonds_view
+    cdef cnp.int64_t[:] atoms_view
+    cdef cnp.int32_t[:, :] bonds_view
 
-    atoms_view = np.asarray(atoms, dtype=np.int64)
-    bonds_view = np.asarray(bondlist, dtype=np.int32)
+    atoms_view = cnp.asarray(atoms, dtype=cnp.int64)
+    bonds_view = cnp.asarray(bondlist, dtype=cnp.int32)
 
     # grab record of which atoms I have to process
     # ie set of all nodes
@@ -513,6 +513,6 @@ def find_fragments(atoms, bondlist):
                         frag_todo.insert(b)
 
         # Add fragment to output
-        frags.append(np.asarray(this_frag))
+        frags.append(cnp.asarray(this_frag))
 
     return frags

--- a/package/MDAnalysis/lib/_cutil.pyx
+++ b/package/MDAnalysis/lib/_cutil.pyx
@@ -473,8 +473,8 @@ def find_fragments(atoms, bondlist):
     cdef cnp.int64_t[:] atoms_view
     cdef cnp.int32_t[:, :] bonds_view
 
-    atoms_view = cnp.asarray(atoms, dtype=cnp.int64)
-    bonds_view = cnp.asarray(bondlist, dtype=cnp.int32)
+    atoms_view = np.asarray(atoms, dtype=cnp.int64)
+    bonds_view = np.asarray(bondlist, dtype=cnp.int32)
 
     # grab record of which atoms I have to process
     # ie set of all nodes
@@ -513,6 +513,6 @@ def find_fragments(atoms, bondlist):
                         frag_todo.insert(b)
 
         # Add fragment to output
-        frags.append(cnp.asarray(this_frag))
+        frags.append(np.asarray(this_frag))
 
     return frags

--- a/package/MDAnalysis/lib/_cutil.pyx
+++ b/package/MDAnalysis/lib/_cutil.pyx
@@ -73,10 +73,10 @@ def unique_int_1d(cnp.intp_t[:] values):
     cdef int i = 0
     cdef int j = 0
     cdef int n_values = values.shape[0]
-    cdef cnp.intp_t[:] result = cnp.empty(n_values, dtype=np.intp)
+    cdef cnp.intp_t[:] result = np.empty(n_values, dtype=np.intp)
 
     if n_values == 0:
-        return cnp.array(result)
+        return np.array(result)
 
     result[0] = values[0]
     for i in range(1, n_values):
@@ -87,14 +87,14 @@ def unique_int_1d(cnp.intp_t[:] values):
             is_monotonic = False
     result = result[:j + 1]
     if not is_monotonic:
-        result = unique_int_1d(cnp.sort(result))
+        result = unique_int_1d(np.sort(result))
 
-    return cnp.array(result)
+    return np.array(result)
 
 
 @cython.boundscheck(False)
 def _in2d(cnp.intp_t[:, :] arr1, cnp.intp_t[:, :] arr2):
-    """Similar to cnp.in1d except works on 2d arrays
+    """Similar to np.in1d except works on 2d arrays
 
     Parameters
     ----------
@@ -120,7 +120,7 @@ def _in2d(cnp.intp_t[:, :] arr1, cnp.intp_t[:, :] arr2):
     python would look like:
 
     hits = {(i, j) for (i, j) in arr2}
-    results = cnp.empty(arr1.shape[0])
+    results = np.empty(arr1.shape[0])
     for i, (x, y) in enumerate(arr1):
         results[i] = (x, y) in hits
 
@@ -133,7 +133,7 @@ def _in2d(cnp.intp_t[:, :] arr1, cnp.intp_t[:, :] arr2):
         p = pair[cnp.intp_t, cnp.intp_t](arr2[i, 0], arr2[i, 1])
         hits.insert(p)
 
-    out = cnp.empty(arr1.shape[0], dtype=cnp.uint8)
+    out = np.empty(arr1.shape[0], dtype=np.uint8)
     cdef unsigned char[::1] results = out
     for i in range(arr1.shape[0]):
         p = pair[cnp.intp_t, cnp.intp_t](arr1[i, 0], arr1[i, 1])
@@ -265,7 +265,7 @@ def make_whole(atomgroup, reference_atom=None, inplace=True):
 
     # Nothing to do for less than 2 atoms
     if natoms < 2:
-        return cnp.array(oldpos)
+        return np.array(oldpos)
 
     for i in range(natoms):
         ix_to_rel[ix_view[i]] = i
@@ -301,7 +301,7 @@ def make_whole(atomgroup, reference_atom=None, inplace=True):
             if not is_unwrapped:
                 break
         if is_unwrapped:
-            return cnp.array(oldpos)
+            return np.array(oldpos)
         for i in range(3):
             inverse_box[i] = 1.0 / box[i]
     else:
@@ -324,7 +324,7 @@ def make_whole(atomgroup, reference_atom=None, inplace=True):
             bonding[atom].insert(other)
             bonding[other].insert(atom)
 
-    newpos = cnp.zeros((oldpos.shape[0], 3), dtype=cnp.float32)
+    newpos = np.zeros((oldpos.shape[0], 3), dtype=np.float32)
 
     refpoints = intset()  # Who is safe to use as reference point?
     done = intset()  # Who have I already searched around?
@@ -366,7 +366,7 @@ def make_whole(atomgroup, reference_atom=None, inplace=True):
         raise ValueError("AtomGroup was not contiguous from bonds, process failed")
     if inplace:
         atomgroup.positions = newpos
-    return cnp.array(newpos)
+    return np.array(newpos)
 
 
 @cython.boundscheck(False)
@@ -431,7 +431,7 @@ cpdef cnp.ndarray _sarrus_det_multiple(cnp.float64_t[:, :, ::1] m):
     cdef cnp.intp_t i
     cdef cnp.float64_t[:] det
     n = m.shape[0]
-    det = cnp.empty(n, dtype=cnp.float64)
+    det = np.empty(n, dtype=np.float64)
     for i in range(n):
         det[i] = m[i, 0, 0] * m[i, 1, 1] * m[i, 2, 2]
         det[i] -= m[i, 0, 0] * m[i, 1, 2] * m[i, 2, 1]
@@ -439,7 +439,7 @@ cpdef cnp.ndarray _sarrus_det_multiple(cnp.float64_t[:, :, ::1] m):
         det[i] -= m[i, 0, 1] * m[i, 1, 0] * m[i, 2, 2]
         det[i] += m[i, 0, 2] * m[i, 1, 0] * m[i, 2, 1]
         det[i] -= m[i, 0, 2] * m[i, 1, 1] * m[i, 2, 0]
-    return cnp.array(det)
+    return np.array(det)
 
 
 @cython.boundscheck(False)
@@ -473,8 +473,8 @@ def find_fragments(atoms, bondlist):
     cdef cnp.int64_t[:] atoms_view
     cdef cnp.int32_t[:, :] bonds_view
 
-    atoms_view = np.asarray(atoms, dtype=cnp.int64)
-    bonds_view = np.asarray(bondlist, dtype=cnp.int32)
+    atoms_view = np.asarray(atoms, dtype=np.int64)
+    bonds_view = np.asarray(bondlist, dtype=np.int32)
 
     # grab record of which atoms I have to process
     # ie set of all nodes

--- a/package/MDAnalysis/lib/formats/cython_util.pxd
+++ b/package/MDAnalysis/lib/formats/cython_util.pxd
@@ -20,6 +20,6 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
-cimport numpy as np
-np.import_array()
-cdef np.ndarray ptr_to_ndarray(void* data_ptr, np.int64_t[:] dim, int data_type)
+cimport numpy as cnp
+cnp.import_array()
+cdef cnp.ndarray ptr_to_ndarray(void* data_ptr, cnp.int64_t[:] dim, int data_type)

--- a/package/MDAnalysis/lib/formats/cython_util.pyx
+++ b/package/MDAnalysis/lib/formats/cython_util.pyx
@@ -110,7 +110,7 @@ cdef cnp.ndarray ptr_to_ndarray(void* data_ptr, cnp.int64_t[:] dim, int data_typ
     array_wrapper = ArrayWrapper()
     array_wrapper.set_data(<void*> data_ptr, <int*> &dim[0], dim.size, data_type)
 
-    cdef cnp.ndarray ndarray = cnp.array(array_wrapper, copy=False)
+    cdef cnp.ndarray ndarray = np.array(array_wrapper, copy=False)
     # Assign our object to the 'base' of the ndarray object
     ndarray.base = <PyObject*> array_wrapper
     # Increment the reference count, as the above assignement was done in

--- a/package/MDAnalysis/lib/formats/cython_util.pyx
+++ b/package/MDAnalysis/lib/formats/cython_util.pyx
@@ -21,12 +21,12 @@
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
 import numpy as np
-cimport numpy as np
+cimport numpy as cnp
 
 from libc.stdlib cimport free
 from cpython cimport PyObject, Py_INCREF
 
-np.import_array()
+cnp.import_array()
 
 
 cdef class ArrayWrapper:
@@ -74,8 +74,8 @@ cdef class ArrayWrapper:
     def __array__(self):
         """ Here we use the __array__ method, that is called when numpy
             tries to get an array from the object."""
-        ndarray = np.PyArray_SimpleNewFromData(self.ndim,
-                                               <np.npy_intp*> self.dim,
+        ndarray = cnp.PyArray_SimpleNewFromData(self.ndim,
+                                               <cnp.npy_intp*> self.dim,
                                                self.data_type,
                                                self.data_ptr)
         return ndarray
@@ -87,7 +87,7 @@ cdef class ArrayWrapper:
         # free(<int*>self.dim)
 
 
-cdef np.ndarray ptr_to_ndarray(void* data_ptr, np.int64_t[:] dim, int data_type):
+cdef cnp.ndarray ptr_to_ndarray(void* data_ptr, cnp.int64_t[:] dim, int data_type):
     """convert a pointer to an arbitrary C-pointer to a ndarray. The ndarray is
     constructed so that the array it's holding will be freed when the array is
     destroyed.
@@ -110,7 +110,7 @@ cdef np.ndarray ptr_to_ndarray(void* data_ptr, np.int64_t[:] dim, int data_type)
     array_wrapper = ArrayWrapper()
     array_wrapper.set_data(<void*> data_ptr, <int*> &dim[0], dim.size, data_type)
 
-    cdef np.ndarray ndarray = np.array(array_wrapper, copy=False)
+    cdef cnp.ndarray ndarray = cnp.array(array_wrapper, copy=False)
     # Assign our object to the 'base' of the ndarray object
     ndarray.base = <PyObject*> array_wrapper
     # Increment the reference count, as the above assignement was done in

--- a/package/MDAnalysis/lib/formats/libdcd.pxd
+++ b/package/MDAnalysis/lib/formats/libdcd.pxd
@@ -27,9 +27,9 @@ from libc.stdint cimport uintptr_t
 from libc.stdio cimport SEEK_SET, SEEK_CUR, SEEK_END
 import cython
 
-cimport numpy as np
+cimport numpy as cnp
 
-np.import_array()
+cnp.import_array()
 
 
 # Tell cython about the off_t type. It doesn't need to match exactly what is
@@ -131,9 +131,9 @@ cdef class DCDFile:
 
 
     # buffer for reading coordinates
-    cdef np.ndarray _coordinate_buffer
+    cdef cnp.ndarray _coordinate_buffer
     # buffer for reading unitcell     
-    cdef np.ndarray _unitcell_buffer
+    cdef cnp.ndarray _unitcell_buffer
 
     # fortran contiguious memoryviews of the buffers to pass to the C code
     cdef float[::1] xview

--- a/package/MDAnalysis/lib/formats/libdcd.pyx
+++ b/package/MDAnalysis/lib/formats/libdcd.pyx
@@ -513,11 +513,11 @@ cdef class DCDFile:
 
         if not self.wrote_header:
             raise IOError("write header first before frames can be written")
-        cdef cnp.ndarray xyz_ = cnp.asarray(xyz, order='F', dtype=FLOAT)
+        cdef cnp.ndarray xyz_ = np.asarray(xyz, order='F', dtype=FLOAT)
         cdef cnp.npy_intp[2] shape = cnp.PyArray_DIMS(xyz_)
         if (shape[0] != self.natoms) or (shape[1] != 3):
             raise ValueError("xyz shape is wrong should be (natoms, 3), got:".format(xyz.shape))
-        cdef double[::1] c_box = cnp.asarray(box, order='C', dtype=DOUBLE)
+        cdef double[::1] c_box = np.asarray(box, order='C', dtype=DOUBLE)
         # fortran contiguity
         cdef float[::1] x = xyz_[:, 0]
         cdef float[::1] y = xyz_[:, 1]
@@ -642,7 +642,7 @@ cdef class DCDFile:
             natoms = self.natoms
         else:
             natoms = len(indices)
-            c_indices = cnp.asarray(indices, dtype=cnp.int64)
+            c_indices = np.asarray(indices, dtype=cnp.int64)
         
         cdef cnp.npy_intp[3] dims
         cdef int hash_order = -1

--- a/package/MDAnalysis/lib/formats/libdcd.pyx
+++ b/package/MDAnalysis/lib/formats/libdcd.pyx
@@ -109,8 +109,8 @@ DCD_ERRORS = {
     -8: 'malloc failed'
 }
 
-FLOAT = cnp.float32
-DOUBLE = cnp.float64
+FLOAT = np.float32
+DOUBLE = np.float64
 
 DCDFrame = namedtuple('DCDFrame', 'xyz unitcell')
 
@@ -346,10 +346,10 @@ cdef class DCDFile:
         dims[0] = self.natoms
         dims[1] = self.ndims
         # note use of fortran flag (1)
-        self._coordinate_buffer = cnp.PyArray_EMPTY(2, dims, cnp.NPY_FLOAT32, 1)
+        self._coordinate_buffer = np.PyArray_EMPTY(2, dims, np.NPY_FLOAT32, 1)
         cdef cnp.npy_intp[1] unitcell_dims
         unitcell_dims[0] = 6
-        self._unitcell_buffer = cnp.PyArray_EMPTY(1, unitcell_dims, cnp.NPY_FLOAT64, 0)
+        self._unitcell_buffer = np.PyArray_EMPTY(1, unitcell_dims, np.NPY_FLOAT64, 0)
 
         # fortran contiguity
         self.xview = self._coordinate_buffer[:, 0]
@@ -509,12 +509,12 @@ cdef class DCDFile:
                 raise ValueError("box size is wrong should be 6, got: {}".format(box.size))
         else:
             # use a dummy box. It won't be written anyway in readdcd.
-            box = cnp.zeros(6)
+            box = np.zeros(6)
 
         if not self.wrote_header:
             raise IOError("write header first before frames can be written")
         cdef cnp.ndarray xyz_ = np.asarray(xyz, order='F', dtype=FLOAT)
-        cdef cnp.npy_intp[2] shape = cnp.PyArray_DIMS(xyz_)
+        cdef cnp.npy_intp[2] shape = np.PyArray_DIMS(xyz_)
         if (shape[0] != self.natoms) or (shape[1] != 3):
             raise ValueError("xyz shape is wrong should be (natoms, 3), got:".format(xyz.shape))
         cdef double[::1] c_box = np.asarray(box, order='C', dtype=DOUBLE)
@@ -638,11 +638,11 @@ cdef class DCDFile:
         cdef int natoms
         cdef cnp.ndarray[cnp.int64_t, ndim=1] c_indices
         if indices is None:
-            c_indices = cnp.PyArray_Arange(0, self.natoms, 1, cnp.NPY_INT64)
+            c_indices = np.PyArray_Arange(0, self.natoms, 1, np.NPY_INT64)
             natoms = self.natoms
         else:
             natoms = len(indices)
-            c_indices = np.asarray(indices, dtype=cnp.int64)
+            c_indices = np.asarray(indices, dtype=np.int64)
         
         cdef cnp.npy_intp[3] dims
         cdef int hash_order = -1
@@ -679,17 +679,17 @@ cdef class DCDFile:
         else:
             raise ValueError("unkown order '{}'".format(order))
 
-        cdef cnp.ndarray[float, ndim=3] xyz = cnp.PyArray_EMPTY(3, dims, cnp.NPY_FLOAT32, 0)
+        cdef cnp.ndarray[float, ndim=3] xyz = np.PyArray_EMPTY(3, dims, np.NPY_FLOAT32, 0)
         cdef cnp.npy_intp[2] unitcell_dims
         unitcell_dims[0] = n
         unitcell_dims[1] = 6
-        cdef cnp.ndarray[double, ndim=2] box = cnp.PyArray_EMPTY(2, unitcell_dims, cnp.NPY_FLOAT64, 0)
+        cdef cnp.ndarray[double, ndim=2] box = np.PyArray_EMPTY(2, unitcell_dims, np.NPY_FLOAT64, 0)
 
         cdef cnp.npy_intp[2] xyz_tmp_dims
         xyz_tmp_dims[0] = self.natoms
         xyz_tmp_dims[1] = self.ndims
         # note fortran flag (1)
-        cdef cnp.ndarray[float, ndim=2] xyz_tmp = cnp.PyArray_EMPTY(2, xyz_tmp_dims, cnp.NPY_FLOAT32, 1)
+        cdef cnp.ndarray[float, ndim=2] xyz_tmp = np.PyArray_EMPTY(2, xyz_tmp_dims, np.NPY_FLOAT32, 1)
 
         # memoryviews for slices into xyz_temp, note fortran contiguous
         cdef float[::1] x = xyz_tmp[:, 0]

--- a/package/MDAnalysis/lib/formats/libdcd.pyx
+++ b/package/MDAnalysis/lib/formats/libdcd.pyx
@@ -71,12 +71,12 @@ import string
 import sys
 import cython 
 
-cimport numpy as np
+cimport numpy as cnp
 from libc.stdio cimport SEEK_SET, SEEK_CUR, SEEK_END
 from libc.stdint cimport uintptr_t
 from libc.stdlib cimport free
 
-np.import_array()
+cnp.import_array()
 
 _whence_vals = {"FIO_SEEK_SET": SEEK_SET,
                 "FIO_SEEK_CUR": SEEK_CUR,
@@ -109,8 +109,8 @@ DCD_ERRORS = {
     -8: 'malloc failed'
 }
 
-FLOAT = np.float32
-DOUBLE = np.float64
+FLOAT = cnp.float32
+DOUBLE = cnp.float64
 
 DCDFrame = namedtuple('DCDFrame', 'xyz unitcell')
 
@@ -342,14 +342,14 @@ cdef class DCDFile:
         self.remarks = py_remarks
 
     cdef void _setup_buffers(self):
-        cdef np.npy_intp[2] dims 
+        cdef cnp.npy_intp[2] dims 
         dims[0] = self.natoms
         dims[1] = self.ndims
         # note use of fortran flag (1)
-        self._coordinate_buffer = np.PyArray_EMPTY(2, dims, np.NPY_FLOAT32, 1)
-        cdef np.npy_intp[1] unitcell_dims
+        self._coordinate_buffer = cnp.PyArray_EMPTY(2, dims, cnp.NPY_FLOAT32, 1)
+        cdef cnp.npy_intp[1] unitcell_dims
         unitcell_dims[0] = 6
-        self._unitcell_buffer = np.PyArray_EMPTY(1, unitcell_dims, np.NPY_FLOAT64, 0)
+        self._unitcell_buffer = cnp.PyArray_EMPTY(1, unitcell_dims, cnp.NPY_FLOAT64, 0)
 
         # fortran contiguity
         self.xview = self._coordinate_buffer[:, 0]
@@ -509,15 +509,15 @@ cdef class DCDFile:
                 raise ValueError("box size is wrong should be 6, got: {}".format(box.size))
         else:
             # use a dummy box. It won't be written anyway in readdcd.
-            box = np.zeros(6)
+            box = cnp.zeros(6)
 
         if not self.wrote_header:
             raise IOError("write header first before frames can be written")
-        cdef np.ndarray xyz_ = np.asarray(xyz, order='F', dtype=FLOAT)
-        cdef np.npy_intp[2] shape = np.PyArray_DIMS(xyz_)
+        cdef cnp.ndarray xyz_ = cnp.asarray(xyz, order='F', dtype=FLOAT)
+        cdef cnp.npy_intp[2] shape = cnp.PyArray_DIMS(xyz_)
         if (shape[0] != self.natoms) or (shape[1] != 3):
             raise ValueError("xyz shape is wrong should be (natoms, 3), got:".format(xyz.shape))
-        cdef double[::1] c_box = np.asarray(box, order='C', dtype=DOUBLE)
+        cdef double[::1] c_box = cnp.asarray(box, order='C', dtype=DOUBLE)
         # fortran contiguity
         cdef float[::1] x = xyz_[:, 0]
         cdef float[::1] y = xyz_[:, 1]
@@ -636,15 +636,15 @@ cdef class DCDFile:
         cdef int n
         n = len(range(start, stop, step))
         cdef int natoms
-        cdef np.ndarray[np.int64_t, ndim=1] c_indices
+        cdef cnp.ndarray[cnp.int64_t, ndim=1] c_indices
         if indices is None:
-            c_indices = np.PyArray_Arange(0, self.natoms, 1, np.NPY_INT64)
+            c_indices = cnp.PyArray_Arange(0, self.natoms, 1, cnp.NPY_INT64)
             natoms = self.natoms
         else:
             natoms = len(indices)
-            c_indices = np.asarray(indices, dtype=np.int64)
+            c_indices = cnp.asarray(indices, dtype=cnp.int64)
         
-        cdef np.npy_intp[3] dims
+        cdef cnp.npy_intp[3] dims
         cdef int hash_order = -1
         if order == 'fac':
             dims[0] = n
@@ -679,17 +679,17 @@ cdef class DCDFile:
         else:
             raise ValueError("unkown order '{}'".format(order))
 
-        cdef np.ndarray[float, ndim=3] xyz = np.PyArray_EMPTY(3, dims, np.NPY_FLOAT32, 0)
-        cdef np.npy_intp[2] unitcell_dims
+        cdef cnp.ndarray[float, ndim=3] xyz = cnp.PyArray_EMPTY(3, dims, cnp.NPY_FLOAT32, 0)
+        cdef cnp.npy_intp[2] unitcell_dims
         unitcell_dims[0] = n
         unitcell_dims[1] = 6
-        cdef np.ndarray[double, ndim=2] box = np.PyArray_EMPTY(2, unitcell_dims, np.NPY_FLOAT64, 0)
+        cdef cnp.ndarray[double, ndim=2] box = cnp.PyArray_EMPTY(2, unitcell_dims, cnp.NPY_FLOAT64, 0)
 
-        cdef np.npy_intp[2] xyz_tmp_dims
+        cdef cnp.npy_intp[2] xyz_tmp_dims
         xyz_tmp_dims[0] = self.natoms
         xyz_tmp_dims[1] = self.ndims
         # note fortran flag (1)
-        cdef np.ndarray[float, ndim=2] xyz_tmp = np.PyArray_EMPTY(2, xyz_tmp_dims, np.NPY_FLOAT32, 1)
+        cdef cnp.ndarray[float, ndim=2] xyz_tmp = cnp.PyArray_EMPTY(2, xyz_tmp_dims, cnp.NPY_FLOAT32, 1)
 
         # memoryviews for slices into xyz_temp, note fortran contiguous
         cdef float[::1] x = xyz_tmp[:, 0]

--- a/package/MDAnalysis/lib/formats/libmdaxdr.pxd
+++ b/package/MDAnalysis/lib/formats/libmdaxdr.pxd
@@ -22,9 +22,9 @@
 #
 
 import numpy as np
-cimport numpy as np
+cimport numpy as cnp
 
-np.import_array()
+cnp.import_array()
 from libc.stdint cimport int64_t
 
 from libc.stdio cimport SEEK_SET, SEEK_CUR, SEEK_END
@@ -92,9 +92,9 @@ cdef class _XDRFile:
     # the file mode
     cdef str mode
     # the simulation box
-    cdef np.ndarray box
+    cdef cnp.ndarray box
     # numpy array of offsets into the fle 
-    cdef np.ndarray _offsets
+    cdef cnp.ndarray _offsets
     # whether we have the offsets
     cdef readonly int _has_offsets
 

--- a/package/MDAnalysis/lib/formats/libmdaxdr.pyx
+++ b/package/MDAnalysis/lib/formats/libmdaxdr.pyx
@@ -99,7 +99,7 @@ from collections import namedtuple
 cnp.import_array()
 
 ctypedef float DTYPE_T
-DTYPE = cnp.float32
+DTYPE = np.float32
 cdef int DIMS = 3
 cdef int HASX = 1
 cdef int HASV = 2
@@ -424,7 +424,7 @@ cdef class TRRFile(_XDRFile):
     def calc_offsets(self):
         """read byte offsets from TRR file directly"""
         if not self.is_open:
-            return cnp.array([])
+            return np.array([])
         cdef int n_frames = 0
         cdef int est_nframes = 0
         cdef int64_t* offsets = NULL
@@ -438,10 +438,10 @@ cdef class TRRFile(_XDRFile):
         # memory leaks.
         cdef cnp.npy_intp[1] dim
         dim[0] = 1
-        cdef cnp.ndarray[cnp.int64_t, ndim=1] dims = cnp.PyArray_EMPTY(1, dim, cnp.NPY_INT64, 0)
+        cdef cnp.ndarray[cnp.int64_t, ndim=1] dims = np.PyArray_EMPTY(1, dim, np.NPY_INT64, 0)
         dims[0] = est_nframes
         # this handles freeing the allocated memory correctly.
-        cdef cnp.ndarray nd_offsets = ptr_to_ndarray(<void*> offsets, dims, cnp.NPY_INT64)
+        cdef cnp.ndarray nd_offsets = ptr_to_ndarray(<void*> offsets, dims, np.NPY_INT64)
         return nd_offsets[:n_frames]
 
     def read(self):
@@ -483,10 +483,10 @@ cdef class TRRFile(_XDRFile):
         unitcell_dim[0] = DIMS
         unitcell_dim[1] = DIMS
 
-        cdef cnp.ndarray[cnp.float32_t, ndim=2] xyz = cnp.PyArray_EMPTY(2, dim, cnp.NPY_FLOAT32, 0)
-        cdef cnp.ndarray[cnp.float32_t, ndim=2] velocity = cnp.PyArray_EMPTY(2, dim, cnp.NPY_FLOAT32, 0)
-        cdef cnp.ndarray[cnp.float32_t, ndim=2] forces = cnp.PyArray_EMPTY(2, dim, cnp.NPY_FLOAT32, 0)
-        cdef cnp.ndarray[cnp.float32_t, ndim=2] box = cnp.PyArray_EMPTY(2, unitcell_dim, cnp.NPY_FLOAT32, 0)
+        cdef cnp.ndarray[cnp.float32_t, ndim=2] xyz = np.PyArray_EMPTY(2, dim, np.NPY_FLOAT32, 0)
+        cdef cnp.ndarray[cnp.float32_t, ndim=2] velocity = np.PyArray_EMPTY(2, dim, np.NPY_FLOAT32, 0)
+        cdef cnp.ndarray[cnp.float32_t, ndim=2] forces = np.PyArray_EMPTY(2, dim, np.NPY_FLOAT32, 0)
+        cdef cnp.ndarray[cnp.float32_t, ndim=2] box = np.PyArray_EMPTY(2, unitcell_dim, np.NPY_FLOAT32, 0)
 
         return_code = read_trr(self.xfp, self.n_atoms, <int*> &step,
                                       &time, &lmbda, <matrix>box.data,
@@ -525,7 +525,7 @@ cdef class TRRFile(_XDRFile):
 
         Parameters
         ----------
-        positions : cnp.ndarray
+        positions : np.ndarray
             positions array to read positions into
 
         Returns
@@ -564,7 +564,7 @@ cdef class TRRFile(_XDRFile):
         unitcell_dim[1] = DIMS
 
 
-        cdef cnp.ndarray[cnp.float32_t, ndim=2] box = cnp.PyArray_EMPTY(2, unitcell_dim, cnp.NPY_FLOAT32, 0)
+        cdef cnp.ndarray[cnp.float32_t, ndim=2] box = np.PyArray_EMPTY(2, unitcell_dim, np.NPY_FLOAT32, 0)
 
         return_code = read_trr(self.xfp, self.n_atoms, <int*> &step,
                                       &time, &lmbda, <matrix>box.data,
@@ -650,7 +650,7 @@ cdef class TRRFile(_XDRFile):
             forces_ptr = <float*>forces_helper.data
 
         box = np.asarray(box)
-        cdef cnp.ndarray box_helper = cnp.ascontiguousarray(box, dtype=DTYPE)
+        cdef cnp.ndarray box_helper = np.ascontiguousarray(box, dtype=DTYPE)
         cdef float* box_ptr = <float*>box_helper.data
 
         if self.current_frame == 0:
@@ -727,7 +727,7 @@ cdef class XTCFile(_XDRFile):
     def calc_offsets(self):
         """Calculate offsets from XTC file directly"""
         if not self.is_open:
-            return cnp.array([])
+            return np.array([])
         cdef int n_frames = 0
         cdef int est_nframes = 0
         cdef int64_t* offsets = NULL
@@ -741,10 +741,10 @@ cdef class XTCFile(_XDRFile):
         # memory leaks.
         cdef cnp.npy_intp[1] dim
         dim[0] = 1
-        cdef cnp.ndarray[cnp.int64_t, ndim=1] dims = cnp.PyArray_EMPTY(1, dim, cnp.NPY_INT64, 0)
+        cdef cnp.ndarray[cnp.int64_t, ndim=1] dims = np.PyArray_EMPTY(1, dim, np.NPY_INT64, 0)
         dims[0] = est_nframes
         # this handles freeing the allocated memory correctly.
-        cdef cnp.ndarray nd_offsets = ptr_to_ndarray(<void*> offsets, dims, cnp.NPY_INT64)
+        cdef cnp.ndarray nd_offsets = ptr_to_ndarray(<void*> offsets, dims, np.NPY_INT64)
         return nd_offsets[:n_frames]
 
     def read(self):
@@ -784,8 +784,8 @@ cdef class XTCFile(_XDRFile):
         unitcell_dim[0] = DIMS
         unitcell_dim[1] = DIMS
 
-        cdef cnp.ndarray[cnp.float32_t, ndim=2] xyz = cnp.PyArray_EMPTY(2, dim, cnp.NPY_FLOAT32, 0)
-        cdef cnp.ndarray[cnp.float32_t, ndim=2] box = cnp.PyArray_EMPTY(2, unitcell_dim, cnp.NPY_FLOAT32, 0)
+        cdef cnp.ndarray[cnp.float32_t, ndim=2] xyz = np.PyArray_EMPTY(2, dim, np.NPY_FLOAT32, 0)
+        cdef cnp.ndarray[cnp.float32_t, ndim=2] box = np.PyArray_EMPTY(2, unitcell_dim, np.NPY_FLOAT32, 0)
 
         return_code = read_xtc(self.xfp, self.n_atoms, <int*> &step,
                                       &time, <matrix>box.data,
@@ -808,7 +808,7 @@ cdef class XTCFile(_XDRFile):
 
         Parameters
         ----------
-        positions : cnp.ndarray
+        positions : np.ndarray
            positions array to read positions into
 
         Returns
@@ -843,7 +843,7 @@ cdef class XTCFile(_XDRFile):
         unitcell_dim[0] = DIMS
         unitcell_dim[1] = DIMS
 
-        cdef cnp.ndarray[cnp.float32_t, ndim=2] box = cnp.PyArray_EMPTY(2, unitcell_dim, cnp.NPY_FLOAT32, 0)
+        cdef cnp.ndarray[cnp.float32_t, ndim=2] box = np.PyArray_EMPTY(2, unitcell_dim, np.NPY_FLOAT32, 0)
 
 
         return_code = read_xtc(self.xfp, self.n_atoms, <int*> &step,
@@ -896,8 +896,8 @@ cdef class XTCFile(_XDRFile):
         xyz = np.asarray(xyz, dtype=np.float32)
         box = np.asarray(box, dtype=np.float32)
 
-        cdef DTYPE_T[:, ::1] xyz_view = cnp.PyArray_GETCONTIGUOUS(xyz)
-        cdef DTYPE_T[:, ::1] box_view = cnp.PyArray_GETCONTIGUOUS(box)
+        cdef DTYPE_T[:, ::1] xyz_view = np.PyArray_GETCONTIGUOUS(xyz)
+        cdef DTYPE_T[:, ::1] box_view = np.PyArray_GETCONTIGUOUS(box)
 
         if self.current_frame == 0:
             self.n_atoms = xyz.shape[0]

--- a/package/MDAnalysis/lib/formats/libmdaxdr.pyx
+++ b/package/MDAnalysis/lib/formats/libmdaxdr.pyx
@@ -637,19 +637,19 @@ cdef class TRRFile(_XDRFile):
         cdef cnp.ndarray forces_helper
 
         if xyz is not None:
-            xyz = cnp.asarray(xyz)
-            xyz_helper = cnp.ascontiguousarray(xyz, dtype=DTYPE)
+            xyz = np.asarray(xyz)
+            xyz_helper = np.ascontiguousarray(xyz, dtype=DTYPE)
             xyz_ptr = <float*>xyz_helper.data
         if velocity is not None:
-            velocity = cnp.asarray(velocity)
-            velocity_helper = cnp.ascontiguousarray(velocity, dtype=DTYPE)
+            velocity = np.asarray(velocity)
+            velocity_helper = np.ascontiguousarray(velocity, dtype=DTYPE)
             velocity_ptr = <float*>velocity_helper.data
         if forces is not None:
-            forces = cnp.asarray(forces)
-            forces_helper = cnp.ascontiguousarray(forces, dtype=DTYPE)
+            forces = np.asarray(forces)
+            forces_helper = np.ascontiguousarray(forces, dtype=DTYPE)
             forces_ptr = <float*>forces_helper.data
 
-        box = cnp.asarray(box)
+        box = np.asarray(box)
         cdef cnp.ndarray box_helper = cnp.ascontiguousarray(box, dtype=DTYPE)
         cdef float* box_ptr = <float*>box_helper.data
 
@@ -893,8 +893,8 @@ cdef class XTCFile(_XDRFile):
             raise IOError('File opened in mode: {}. Writing only allow '
                           'in mode "w"'.format('self.mode'))
 
-        xyz = cnp.asarray(xyz, dtype=np.float32)
-        box = cnp.asarray(box, dtype=np.float32)
+        xyz = np.asarray(xyz, dtype=np.float32)
+        box = np.asarray(box, dtype=np.float32)
 
         cdef DTYPE_T[:, ::1] xyz_view = cnp.PyArray_GETCONTIGUOUS(xyz)
         cdef DTYPE_T[:, ::1] box_view = cnp.PyArray_GETCONTIGUOUS(box)

--- a/package/MDAnalysis/lib/qcprot.pyx
+++ b/package/MDAnalysis/lib/qcprot.pyx
@@ -137,8 +137,8 @@ Users will typically use the :func:`CalcRMSDRotationalMatrix` function.
 """
 
 import numpy as np
-cimport numpy as np
-np.import_array()
+cimport numpy as cnp
+cnp.import_array()
 
 from ..due import due, BibTeX, Doi
 
@@ -174,24 +174,24 @@ cdef extern from "math.h":
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def InnerProduct(np.ndarray[np.float64_t, ndim=1] A,
-                 np.ndarray[np.float64_t, ndim=2] coords1,
-                 np.ndarray[np.float64_t, ndim=2] coords2,
+def InnerProduct(cnp.ndarray[cnp.float64_t, ndim=1] A,
+                 cnp.ndarray[cnp.float64_t, ndim=2] coords1,
+                 cnp.ndarray[cnp.float64_t, ndim=2] coords2,
                  int N,
-                 np.ndarray[np.float64_t, ndim=1] weight):
+                 cnp.ndarray[cnp.float64_t, ndim=1] weight):
     """Calculate the inner product of two structures.
 
     Parameters
     ----------
-    A : ndarray np.float64_t
+    A : ndarray cnp.float64_t
         result inner product array, modified in place
-    coords1 : ndarray np.float64_t
+    coords1 : ndarray cnp.float64_t
         reference structure
-    coord2 : ndarray np.float64_t
+    coord2 : ndarray cnp.float64_t
         candidate structure
     N : int
         size of system
-    weights : ndarray np.float64_t (optional)
+    weights : ndarray cnp.float64_t (optional)
         use to calculate weighted inner product
 
 
@@ -278,25 +278,25 @@ def InnerProduct(np.ndarray[np.float64_t, ndim=1] A,
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def CalcRMSDRotationalMatrix(np.ndarray[np.float64_t, ndim=2] ref,
-                             np.ndarray[np.float64_t, ndim=2] conf,
+def CalcRMSDRotationalMatrix(cnp.ndarray[cnp.float64_t, ndim=2] ref,
+                             cnp.ndarray[cnp.float64_t, ndim=2] conf,
                              int N,
-                             np.ndarray[np.float64_t, ndim=1] rot,
-                             np.ndarray[np.float64_t, ndim=1] weights):
+                             cnp.ndarray[cnp.float64_t, ndim=1] rot,
+                             cnp.ndarray[cnp.float64_t, ndim=1] weights):
     """
     Calculate the RMSD & rotational matrix.
 
     Parameters
     ----------
-    ref : ndarray, np.float64_t
+    ref : ndarray, cnp.float64_t
         reference structure coordinates
-    conf : ndarray, np.float64_t
+    conf : ndarray, cnp.float64_t
         condidate structure coordinates
     N : int
         size of the system
-    rot : ndarray, np.float64_t
+    rot : ndarray, cnp.float64_t
         array to store rotation matrix. Must be flat
-    weights : ndarray, npfloat64_t (optional)
+    weights : ndarray, cnpfloat64_t (optional)
         weights for each component
 
     Returns

--- a/package/MDAnalysis/lib/qcprot.pyx
+++ b/package/MDAnalysis/lib/qcprot.pyx
@@ -183,15 +183,15 @@ def InnerProduct(cnp.ndarray[cnp.float64_t, ndim=1] A,
 
     Parameters
     ----------
-    A : ndarray cnp.float64_t
+    A : ndarray np.float64_t
         result inner product array, modified in place
-    coords1 : ndarray cnp.float64_t
+    coords1 : ndarray np.float64_t
         reference structure
-    coord2 : ndarray cnp.float64_t
+    coord2 : ndarray np.float64_t
         candidate structure
     N : int
         size of system
-    weights : ndarray cnp.float64_t (optional)
+    weights : ndarray np.float64_t (optional)
         use to calculate weighted inner product
 
 
@@ -288,15 +288,15 @@ def CalcRMSDRotationalMatrix(cnp.ndarray[cnp.float64_t, ndim=2] ref,
 
     Parameters
     ----------
-    ref : ndarray, cnp.float64_t
+    ref : ndarray, np.float64_t
         reference structure coordinates
-    conf : ndarray, cnp.float64_t
+    conf : ndarray, np.float64_t
         condidate structure coordinates
     N : int
         size of the system
-    rot : ndarray, cnp.float64_t
+    rot : ndarray, np.float64_t
         array to store rotation matrix. Must be flat
-    weights : ndarray, cnpfloat64_t (optional)
+    weights : ndarray, npfloat64_t (optional)
         weights for each component
 
     Returns
@@ -308,14 +308,14 @@ def CalcRMSDRotationalMatrix(cnp.ndarray[cnp.float64_t, ndim=2] ref,
        Array size changed from 3xN to Nx3.
     """
     cdef double E0
-    cdef np.ndarray[np.float64_t, ndim=1] A = np.zeros(9, dtype=np.float64)
+    cdef cnp.ndarray[cnp.float64_t, ndim=1] A = np.zeros(9, dtype=np.float64)
 
     E0 = InnerProduct(A, conf, ref, N, weights)
     return FastCalcRMSDAndRotation(rot, A, E0, N)
 
 
-def FastCalcRMSDAndRotation(np.ndarray[np.float64_t, ndim=1] rot,
-                            np.ndarray[np.float64_t, ndim=1] A,
+def FastCalcRMSDAndRotation(cnp.ndarray[cnp.float64_t, ndim=1] rot,
+                            cnp.ndarray[cnp.float64_t, ndim=1] A,
                             double E0, int N):
     """
     Calculate the RMSD, and/or the optimal rotation matrix.
@@ -346,7 +346,7 @@ def FastCalcRMSDAndRotation(np.ndarray[np.float64_t, ndim=1] rot,
     cdef double SxzpSzx, SyzpSzy, SxypSyx, SyzmSzy,
     cdef double SxzmSzx, SxymSyx, SxxpSyy, SxxmSyy
 
-    cdef np.ndarray[np.float64_t, ndim=1] C = np.zeros(4,)
+    cdef cnp.ndarray[np.float64_t, ndim=1] C = np.zeros(4,)
     cdef unsigned int i
     cdef double mxEigenV
     cdef double oldg = 0.0


### PR DESCRIPTION
Fixes #3908 

Changes made in this Pull Request:
 - changed `cimport numpy as np` to `cimport numpy as cnp` and it's related uses of `np` to `cnp`


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?


<!-- readthedocs-preview readthedocs-preview start -->
----
:books: Documentation preview :books:: https://readthedocs-preview--4101.org.readthedocs.build/en/4101/

<!-- readthedocs-preview readthedocs-preview end -->