### PR TITLE
Add writing u.trajectory.ts.data['molecule_tag'] as molecule_tag atom attribute to LAMMPS datafile

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -37,6 +37,7 @@ Fixes
     (Issue #3336)
 
 Enhancements
+  * Add writing u.trajectory.ts.data['molecule_tag'] as molecule tags to LAMMPS data file (Issue #3548)
   * Add `progressbar_kwargs` parameter to `AnalysisBase.run` method, allowing to modify description, position etc of tqdm progressbars.
   * Add a nojump transformation, which unwraps trajectories so that particle
     paths are continuous. (Issue #3703, PR #4031)

--- a/package/MDAnalysis/coordinates/LAMMPS.py
+++ b/package/MDAnalysis/coordinates/LAMMPS.py
@@ -288,11 +288,7 @@ class DATAWriter(base.WriterBase):
         indices = atoms.indices + 1
         types = atoms.types.astype(np.int32)
 
-        try:
-            moltags = data['molecule_tag']
-        except KeyError:
-            moltags = [0] * len(atoms)
-
+        moltags = data.get("molecule_tag", np.zeros(len(atoms), dtype=int))
 
         if self.convert_units:
             coordinates = self.convert_pos_to_native(atoms.positions, inplace=False)

--- a/package/MDAnalysis/coordinates/LAMMPS.py
+++ b/package/MDAnalysis/coordinates/LAMMPS.py
@@ -296,15 +296,15 @@ class DATAWriter(base.WriterBase):
         if has_charges:
             for index, moltag, atype, charge, coords in zip(indices, moltags,
                     types, charges, coordinates):
-                self.f.write('{i:d} {m:d} {t:d} {c:f} {x:f} {y:f} {z:f}\n'.format(
-                             i=index, m=moltag, t=atype, c=charge, x=coords[0],
-                             y=coords[1], z=coords[2]))
+                x, y, z = coords
+                self.f.write(f"{index:d} {moltag:d} {atype:d} {charge:f}"
+                             f" {x:f} {y:f} {z:f}\n")
         else:
             for index, moltag, atype, coords in zip(indices, moltags, types,
                     coordinates):
-                self.f.write('{i:d} {m:d} {t:d} {x:f} {y:f} {z:f}\n'.format(
-                             i=index, m=moltag, t=atype, x=coords[0],
-                             y=coords[1], z=coords[2]))
+                x, y, z = coords
+                self.f.write(f"{index:d} {moltag:d} {atype:d}"
+                             f" {x:f} {y:f} {z:f}\n")
 
     def _write_velocities(self, atoms):
         self.f.write('\n')
@@ -400,8 +400,6 @@ class DATAWriter(base.WriterBase):
         else:
             frame = u.trajectory.ts.frame
 
-        data = u.trajectory.ts.data
-
         # make sure to use atoms (Issue 46)
         atoms = selection.atoms
 
@@ -446,7 +444,7 @@ class DATAWriter(base.WriterBase):
             self._write_dimensions(atoms.dimensions)
 
             self._write_masses(atoms)
-            self._write_atoms(atoms, data)
+            self._write_atoms(atoms, u.trajectory.ts.data)
             for attr in features.values():
                 if attr is None or len(attr) == 0:
                     continue

--- a/testsuite/MDAnalysisTests/coordinates/test_lammps.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_lammps.py
@@ -125,7 +125,7 @@ def LAMMPSDATAWriter(request, tmpdir_factory):
 def LAMMPSDATAWriter_molecule_tag(request, tmpdir_factory):
     filename, charges = request.param
     u = mda.Universe(filename)
-    if charges == False:
+    if not charges:
         u.del_TopologyAttr('charges')
 
     u.trajectory.ts.data['molecule_tag'] = u.atoms.resids

--- a/testsuite/MDAnalysisTests/coordinates/test_lammps.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_lammps.py
@@ -116,14 +116,17 @@ def LAMMPSDATAWriter(request, tmpdir_factory):
 
 
 @pytest.fixture(params=[
-    LAMMPSdata,
-    LAMMPSdata_mini,
-    LAMMPScnt,
-    LAMMPShyd,
+    [LAMMPSdata, True],
+    [LAMMPSdata_mini, True],
+    [LAMMPScnt, True],
+    [LAMMPShyd, True],
+    [LAMMPSdata, False]
 ], scope='module')
 def LAMMPSDATAWriter_molecule_tag(request, tmpdir_factory):
-    filename = request.param
+    filename, charges = request.param
     u = mda.Universe(filename)
+    if charges == False:
+        u.del_TopologyAttr('charges')
 
     u.trajectory.ts.data['molecule_tag'] = u.atoms.resids
 


### PR DESCRIPTION
Fixes #3548

Being able to write the molecule id in a LAMMPS data file is crucial for using the MDAnalysis as a generator of LAMMPS initial configurations, for example, in machine learning workflows.
Currently, the molecule_tag field reads as atoms.resids, but when writing a data file, zero values are hardcoded.
Following the discussion in #3548, I've implemented writing ts.data['molecule_tag'] into this field. 

Changes made in this Pull Request:
 
Added data as input parameter for DATAWriter._write_atoms
If data['molecule_tag'] is present, _write_atoms will write its values as the molecule_tag attribute of the Atoms section of the data file. Otherwise, it will fill molecule_tag with zeroes, consistent with the previous behavior.

Added special read-write-read function to the tests, which sets data['molecule_tag'] values from atoms.resids after reading the data file. Added the class to check the resids after using the aforementioned function.

PR Checklist
------------
 - [V] Tests?
 - [X] Docs?
 - [V] CHANGELOG updated?
 - [V] Issue raised/referenced?


<!-- readthedocs-preview readthedocs-preview start -->
----
:books: Documentation preview :books:: https://readthedocs-preview--4114.org.readthedocs.build/en/4114/

<!-- readthedocs-preview readthedocs-preview end -->