### PR TITLE
NEP29, raise Python to 3.9

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -189,16 +189,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
         type: ["FULL", "MIN"]
         exclude:
           # Py311 doesn't support all optional deps yet
           - python-version: "3.11"
             type: "FULL"
           # Multiple deps don't like windows
-          - os: windows-latest
-            python-version: "3.8"
-            type: "FULL"
           - os: windows-latest
             python-version: "3.9"
             type: "FULL"

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -26,39 +26,39 @@ jobs:
         fail-fast: false
         matrix:
           os: [ubuntu-latest, ]
-          python-version: ["3.8", "3.9", "3.10", "3.11"]
+          python-version: ["3.9", "3.10", "3.11"]
           full-deps: [true, ]
           install_hole: [true, ]
           codecov: [true, ]
           include:
-            - name: macOS_monterey_py39
+            - name: macOS_monterey_py311
               os: macOS-12
-              python-version: 3.9
+              python-version: "3.11"
               full-deps: true
               install_hole: true
               codecov: true
-            - name: macOS_bigsur_py38
+            - name: macOS_bigsur_py39
               os: macOS-11
-              python-version: 3.8
+              python-version: 3.9
               full-deps: true
               install_hole: true
               codecov: false
             - name: minimal-ubuntu
               os: ubuntu-latest
-              python-version: 3.8
+              python-version: 3.9
               full-deps: false
               install_hole: false
               codecov: true
             - name: numpy_min
               os: ubuntu-latest
-              python-version: 3.8
+              python-version: 3.9
               full-deps: false
               install_hole: false
               codecov: false
               numpy: numpy=1.21.0
             - name: asv_check
               os: ubuntu-latest
-              python-version: 3.8
+              python-version: 3.9
               full-deps: true
               install_hole: false
               codecov: false
@@ -142,7 +142,7 @@ jobs:
     - name: setup_miniconda
       uses: conda-incubator/setup-miniconda@v2
       with:
-        python-version: 3.8
+        python-version: 3.9
         auto-update-conda: true
         channel-priority: flexible
         channels: conda-forge, bioconda
@@ -238,7 +238,7 @@ jobs:
 
     - uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: 3.9
 
     - name: install_deps
       run: |

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -104,7 +104,7 @@ jobs:
 
     - uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: 3.9
 
     - name: install
       run: |
@@ -126,7 +126,7 @@ jobs:
       - name: setup_miniconda
         uses: conda-incubator/setup-miniconda@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
           auto-update-conda: true
           channel-priority: flexible
           channels: conda-forge, bioconda

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,7 +82,7 @@ jobs:
   - script: python -m pip install --upgrade pip setuptools wheel
     displayName: 'Install tools'
   - script: >-
-      python -m pip install --only-binary=h5py,scipy
+      python -m pip install --only-binary=scipy
       cython
       hypothesis
       matplotlib
@@ -92,11 +92,17 @@ jobs:
       pytest-cov
       pytest-xdist
       scikit-learn
-      h5py>=2.10
       tqdm
       threadpoolctl
       fasteners
     displayName: 'Install dependencies'
+  # H5PY wheels are problematic on 32bit py3.9, so we don't install
+  # it in that specific case. Note: prefer binary because building
+  # h5py is difficult on azure.
+  - script: >-
+      pip install --prefer-binary h5py>=2.10
+    displayName: 'Install non 32bit dependencies'
+    condition: and(succeeded(), ne(variables['PYTHON_ARCH'], 'x86'))
   # for wheel install testing, we pin to an
   # older NumPy, the oldest version we support and that
   # supports the Python version in use

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,14 +21,14 @@ jobs:
     MPLBACKEND: agg
   strategy:
     matrix:
-        Win-Python38-32bit-full:
-          PYTHON_VERSION: '3.8'
+        Win-Python39-32bit-full:
+          PYTHON_VERSION: '3.9'
           PYTHON_ARCH: 'x86'
           BUILD_TYPE: 'normal'
           NUMPY_MIN: '1.21.0'
           imageName: 'windows-2019'
-        Win-Python38-64bit-full:
-          PYTHON_VERSION: '3.8'
+        Win-Python39-64bit-full:
+          PYTHON_VERSION: '3.9'
           PYTHON_ARCH: 'x64'
           BUILD_TYPE: 'normal'
           imageName: 'windows-2019'
@@ -43,8 +43,8 @@ jobs:
           BUILD_TYPE: 'wheel'
           NUMPY_MIN: '1.23.2'
           imageName: 'windows-2019'
-        Win-Python38-64bit-full-wheel:
-          PYTHON_VERSION: '3.8'
+        Win-Python39-64bit-full-wheel:
+          PYTHON_VERSION: '3.9'
           PYTHON_ARCH: 'x64'
           BUILD_TYPE: 'wheel'
           NUMPY_MIN: '1.21.0'
@@ -55,8 +55,8 @@ jobs:
           BUILD_TYPE: 'wheel'
           NUMPY_MIN: '1.23.2'
           imageName: 'ubuntu-latest'
-        Linux-Python38-64bit-full-wheel:
-          PYTHON_VERSION: '3.8'
+        Linux-Python39-64bit-full-wheel:
+          PYTHON_VERSION: '3.9'
           PYTHON_ARCH: 'x64'
           BUILD_TYPE: 'wheel'
           NUMPY_MIN: '1.21.0'

--- a/maintainer/conda/environment.yml
+++ b/maintainer/conda/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - h5py>=2.10
   - hypothesis
   - joblib>=0.12
-  - matplotlib==3.2.2
+  - matplotlib>=3.2.2
   - mmtf-python
   - mock
   - networkx

--- a/maintainer/conda/environment.yml
+++ b/maintainer/conda/environment.yml
@@ -18,7 +18,7 @@ dependencies:
   - networkx
   - numpy>=1.21
   - pytest
-  - python==3.8
+  - python==3.9
   - pytng>=0.2.3
   - scikit-learn
   - scipy

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -16,8 +16,8 @@ The rules for this file:
   
 ??/??/?? IAlibay, pgbarletta, mglagolev, hmacdope, manuel.nuno.melo, chrispfae, 
          ooprathamm, MeetB7, BFedder, v-parmar, MoSchaeffler, jbarnoud, jandom,
-         xhgchen, jaclark5, DrDomenicoMarson, AHMED-salah00, schlaicha, SophiaRuan,
-	 g2707
+         xhgchen, jaclark5, DrDomenicoMarson, AHMED-salah00, schlaicha,
+         SophiaRuan, g2707
 
  * 2.5.0
 

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -18,6 +18,7 @@ The rules for this file:
          ooprathamm, MeetB7, BFedder, v-parmar, MoSchaeffler, jbarnoud, jandom,
          xhgchen, jaclark5, DrDomenicoMarson, AHMED-salah00, schlaicha, SophiaRuan,
 	 g2707
+
  * 2.5.0
 
 Fixes
@@ -28,7 +29,8 @@ Fixes
   * Allows shape_parameter and asphericity to yield per residue quantities
     (Issue #3002, PR #3905)
   * Add tests for "No path data" exception raise in test_psa.py (Issue #4036)
-  * Fix uninitialized `format` variable issue when calling `selections.get_writer` directly (PR #4043)
+  * Fix uninitialized `format` variable issue when calling
+    `selections.get_writer` directly (PR #4043)
   * Fix tests should use results.rmsf to avoid DeprecationWarning (Issue #3695)
   * Fix EDRReader failing when parsing single-frame EDR files (Issue #3999)
   * Fix test clobbering in lib/test_util.py (PR #4000)
@@ -37,7 +39,8 @@ Fixes
     (Issue #3336)
 
 Enhancements
-  * Add `progressbar_kwargs` parameter to `AnalysisBase.run` method, allowing to modify description, position etc of tqdm progressbars.
+  * Add `progressbar_kwargs` parameter to `AnalysisBase.run` method, allowing
+    to modify description, position etc of tqdm progressbars.
   * Add a nojump transformation, which unwraps trajectories so that particle
     paths are continuous. (Issue #3703, PR #4031)
   * Added AtomGroup TopologyAttr to calculate gyration moments (Issue #3904,
@@ -50,6 +53,7 @@ Enhancements
     and SegmentGroup. (PR #3953)
 
 Changes
+  * As per NEP29 the minimum supported Python version has been raised to 3.9.
   * einsum method for Einstein summation convention introduced to increase 
     performance (Issue #2063, PR #4089)
   * Add progress bars to track the progress of _conclude() functions

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -53,7 +53,8 @@ Enhancements
     and SegmentGroup. (PR #3953)
 
 Changes
-  * As per NEP29 the minimum supported Python version has been raised to 3.9.
+  * As per NEP29 the minimum supported Python version has been raised to 3.9
+    (PR #4115).
   * einsum method for Einstein summation convention introduced to increase 
     performance (Issue #2063, PR #4089)
   * Add progress bars to track the progress of _conclude() functions

--- a/package/pyproject.toml
+++ b/package/pyproject.toml
@@ -6,13 +6,9 @@ requires = [
     # lowest NumPy we can use for a given Python,
     # In part adapted from: https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg
     # except for more exotic platform (Mac Arm flavors)
-    # aarch64, AIX, s390x all support < 1.21 so we can safely pin to this
+    # aarch64, AIX, s390x, and arm64 all support 1.21 so we can safely pin to this
     # Note: MDA does not build with PyPy so we do not support it in the build system
-    "numpy==1.21.0; python_version=='3.8' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_python_implementation != 'PyPy'",
-    "numpy==1.21.0; python_version=='3.9' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_python_implementation != 'PyPy'",
-    # arm64 on darwin for py3.8+ requires numpy >=1.21.0
-    "numpy==1.21.0; python_version=='3.8' and platform_machine=='arm64' and platform_system=='Darwin' and platform_python_implementation != 'PyPy'",
-    "numpy==1.21.0; python_version=='3.9' and platform_machine=='arm64' and platform_system=='Darwin' and platform_python_implementation != 'PyPy'",
+    "numpy==1.21.0; python_version=='3.9' and platform_python_implementation != 'PyPy'",
     # Scipy: On windows avoid 1.21.6, 1.22.0, and 1.22.1 because they were built on vc142
     "numpy==1.22.3; python_version=='3.10' and platform_system=='Windows' and platform_python_implementation != 'PyPy'",
     # As per https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg
@@ -37,7 +33,7 @@ authors = [
 maintainers = [
     {name = 'MDAnalysis Core Developers', email = 'mdanalysis@numfocus.org'}
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     'numpy>=1.21.0',
     'biopython>=1.80',
@@ -67,7 +63,6 @@ classifiers = [
     'Operating System :: MacOS :: MacOS X',
     'Operating System :: Microsoft :: Windows',
     'Programming Language :: Python',
-    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',

--- a/package/setup.py
+++ b/package/setup.py
@@ -58,7 +58,7 @@ import platform
 
 # Make sure I have the right Python version.
 if sys.version_info[:2] < (3, 9):
-    print('MDAnalysis requires Python 3.9 or better. Python {0:d}.{1:d} detected'.format(*
+    print('MDAnalysis requires Python 3.9+. Python {0:d}.{1:d} detected'.format(*
           sys.version_info[:2]))
     print('Please upgrade your version of Python.')
     sys.exit(-1)

--- a/package/setup.py
+++ b/package/setup.py
@@ -57,8 +57,8 @@ import warnings
 import platform
 
 # Make sure I have the right Python version.
-if sys.version_info[:2] < (3, 8):
-    print('MDAnalysis requires Python 3.8 or better. Python {0:d}.{1:d} detected'.format(*
+if sys.version_info[:2] < (3, 9):
+    print('MDAnalysis requires Python 3.9 or better. Python {0:d}.{1:d} detected'.format(*
           sys.version_info[:2]))
     print('Please upgrade your version of Python.')
     sys.exit(-1)
@@ -579,7 +579,6 @@ if __name__ == '__main__':
         'Operating System :: Microsoft :: Windows ',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
@@ -637,7 +636,7 @@ if __name__ == '__main__':
                         ],
           },
           ext_modules=exts,
-          python_requires='>=3.8',
+          python_requires='>=3.9',
           # all standard requirements are available through PyPi and
           # typically can be installed without difficulties through setuptools
           setup_requires=[

--- a/testsuite/setup.py
+++ b/testsuite/setup.py
@@ -78,8 +78,8 @@ class MDA_SDist(sdist.sdist):
 
 
 # Make sure I have the right Python version.
-if sys.version_info[:2] < (3, 8):
-    print("MDAnalysis requires Python 3.8 or better. "
+if sys.version_info[:2] < (3, 9):
+    print("MDAnalysis requires Python 3.9 or better. "
           "Python {0:d}.{1:d} detected".format(*sys.version_info[:2]))
     print("Please upgrade your version of Python.")
     sys.exit(-1)
@@ -101,7 +101,6 @@ if __name__ == '__main__':
         'Operating System :: Microsoft :: Windows ',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
@@ -185,7 +184,7 @@ if __name__ == '__main__':
                          'data/*.txt',
                         ],
           },
-          python_requires='>=3.8',
+          python_requires='>=3.9',
           install_requires=[
               'MDAnalysis=={0!s}'.format(RELEASE),  # same as this release!
               'pytest>=3.3.0', # Raised to 3.3.0 due to Issue 2329


### PR DESCRIPTION
Towards 2.5.0 release

We won't release until the 14th (at least I'm not planning to do a release over Easter holidays), so I think we can safely say we'll bump things up to Python 3.9 in line with NEP29.


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?


<!-- readthedocs-preview readthedocs-preview start -->
----
:books: Documentation preview :books:: https://readthedocs-preview--4115.org.readthedocs.build/en/4115/

<!-- readthedocs-preview readthedocs-preview end -->