### PR TITLE
Fix permission errors w/ readonly tmpdirs and pytest 7.3

### DIFF
--- a/testsuite/MDAnalysisTests/coordinates/test_xdr.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_xdr.py
@@ -25,7 +25,6 @@ from unittest.mock import patch
 
 import os
 import shutil
-import stat
 import subprocess
 from pathlib import Path
 
@@ -890,7 +889,9 @@ class _GromacsReader_offsets(object):
                                                     ending='.lock')), False)
 
         # pre-teardown permission fix - leaving permission blocked dir
-        # is problematic on py3.9 + Windows it seems.
+        # is problematic on py3.9 + Windows it seems. See issue
+        # [4123](https://github.com/MDAnalysis/mdanalysis/issues/4123)
+        # for more details.
         if os.name == 'nt':
             subprocess.call(f"icacls {tmpdir} /grant Users:W", shell=True)
         else:

--- a/testsuite/MDAnalysisTests/coordinates/test_xdr.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_xdr.py
@@ -23,14 +23,13 @@
 import pytest
 from unittest.mock import patch
 
-import errno
-import numpy as np
 import os
-from os.path import split
 import shutil
+import stat
 import subprocess
 from pathlib import Path
 
+import numpy as np
 from numpy.testing import (assert_equal,
                            assert_almost_equal,
                            assert_allclose)
@@ -889,6 +888,15 @@ class _GromacsReader_offsets(object):
         # check the lock file is not created as well.
         assert_equal(os.path.exists(XDR.offsets_filename(filename,
                                                     ending='.lock')), False)
+
+        # pre-teardown permission fix - leaving permission blocked dir
+        # is problematic on py3.9 + Windows it seems.
+        if os.name == 'nt':
+            subprocess.call(f"icacls {tmpdir} /grant Users:W", shell=True)
+        else:
+            os.chmod(str(tmpdir), 0o777)
+
+        shutil.rmtree(tmpdir)
 
     def test_offset_lock_created(self):
         assert os.path.exists(XDR.offsets_filename(self.filename,

--- a/testsuite/MDAnalysisTests/core/test_universe.py
+++ b/testsuite/MDAnalysisTests/core/test_universe.py
@@ -171,15 +171,6 @@ class TestUniverseCreation(object):
             with pytest.raises(PermissionError, match=f"Errno {errno.EACCES}"):
                 mda.Universe('permission.denied.tpr')
 
-            # pre-teardown permission fix - leaving permission blocked dir
-            # is problematic on py3.9 + Windows it seems.
-            if os.name == 'nt':
-                subprocess.call(f"icacls {tmpdir} /grant Users:W", shell=True)
-            else:
-                os.chmod(str(tmpdir), 0o777)
-
-            shutil.rmtree(tmpdir)
-
     def test_load_new_VE(self):
         u = mda.Universe.empty(0)
 

--- a/testsuite/MDAnalysisTests/core/test_universe.py
+++ b/testsuite/MDAnalysisTests/core/test_universe.py
@@ -23,6 +23,7 @@
 import pickle
 
 import os
+import shutil
 import subprocess
 import errno
 from collections import defaultdict
@@ -169,6 +170,15 @@ class TestUniverseCreation(object):
             # Issue #3221 match by PermissionError and error number instead
             with pytest.raises(PermissionError, match=f"Errno {errno.EACCES}"):
                 mda.Universe('permission.denied.tpr')
+
+            # pre-teardown permission fix - leaving permission blocked dir
+            # is problematic on py3.9 + Windows it seems.
+            if os.name == 'nt':
+                subprocess.call(f"icacls {tmpdir} /grant Users:W", shell=True)
+            else:
+                os.chmod(str(tmpdir), 0o777)
+
+            shutil.rmtree(tmpdir)
 
     def test_load_new_VE(self):
         u = mda.Universe.empty(0)

--- a/testsuite/MDAnalysisTests/core/test_universe.py
+++ b/testsuite/MDAnalysisTests/core/test_universe.py
@@ -23,7 +23,6 @@
 import pickle
 
 import os
-import shutil
 import subprocess
 import errno
 from collections import defaultdict


### PR DESCRIPTION
Azure pipelines has been failing recently (see #4121 ), due to the latest pytest 7.3 release.

The source of the error seems to be a mixture of windows, python 3.9, pytest and pathlib incompatibilities when trying to clean up temporary directories that have been set to read-only.

To fix this, here we just conclude the one affected test by re-enabling write permissions to the directory and removing it ahead of the test completing.

PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?


<!-- readthedocs-preview readthedocs-preview start -->
----
:books: Documentation preview :books:: https://readthedocs-preview--4122.org.readthedocs.build/en/4122/

<!-- readthedocs-preview readthedocs-preview end -->