### PR TITLE
Fix rtd link in PR comments

### DIFF
--- a/.github/workflows/rtd.yaml
+++ b/.github/workflows/rtd.yaml
@@ -15,4 +15,4 @@ jobs:
     steps:
     - uses: readthedocs/actions/preview@v1
       with:
-        project-slug: "readthedocs-preview"
+        project-slug: "mdanalysis"


### PR DESCRIPTION
Given that we didn't notice it was failing, I do wonder how useful it actually is... :/

Changes made in this Pull Request:
 - Fix project_slug entry to point to mdanalysis


PR Checklist
------------
 - Tests?
 - Docs?
 - CHANGELOG updated?
 - Issue raised/referenced?


<!-- readthedocs-preview readthedocs-preview start -->
----
:books: Documentation preview :books:: https://readthedocs-preview--4126.org.readthedocs.build/en/4126/

<!-- readthedocs-preview readthedocs-preview end -->