### PR TITLE
MAINT: Cython 3.x compat fix read-only

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -17,11 +17,12 @@ The rules for this file:
 ??/??/?? IAlibay, pgbarletta, mglagolev, hmacdope, manuel.nuno.melo, chrispfae, 
          ooprathamm, MeetB7, BFedder, v-parmar, MoSchaeffler, jbarnoud, jandom,
          xhgchen, jaclark5, DrDomenicoMarson, AHMED-salah00, schlaicha,
-         SophiaRuan, g2707
+         SophiaRuan, g2707, tylerjereddy
 
  * 2.5.0
 
 Fixes
+  * Added support for Cython `3.0.0b2` (PR #4129)
   * Skip tests artificially checking for readonly or PermissionError cases
     when running at root user on linux systems (Issue #4112, PR #4120)
   * Fix chi1_selections() ignored atom names CG1 OG OG1 SG and incorrectly returned

--- a/package/MDAnalysis/lib/formats/cython_util.pyx
+++ b/package/MDAnalysis/lib/formats/cython_util.pyx
@@ -112,7 +112,7 @@ cdef np.ndarray ptr_to_ndarray(void* data_ptr, np.int64_t[:] dim, int data_type)
 
     cdef np.ndarray ndarray = np.array(array_wrapper, copy=False)
     # Assign our object to the 'base' of the ndarray object
-    ndarray.base = <PyObject*> array_wrapper
+    ndarray[:] = array_wrapper.__array__()
     # Increment the reference count, as the above assignement was done in
     # C, and Python does not know that there is this additional reference
     Py_INCREF(array_wrapper)


### PR DESCRIPTION
* fixes the following build error with the latest Cython beta pre-release and allows the full test suite to pass (at least for me, locally) with both Cython `0.29.34` and latest beta

```
  Error compiling Cython file:
  ------------------------------------------------------------
  ...
      array_wrapper = ArrayWrapper()
      array_wrapper.set_data(<void*> data_ptr, <int*> &dim[0], dim.size, data_type)

      cdef np.ndarray ndarray = np.array(array_wrapper, copy=False)
      # Assign our object to the 'base' of the ndarray object
      ndarray.base = <PyObject*> array_wrapper
             ^
  ------------------------------------------------------------

  MDAnalysis/lib/formats/cython_util.pyx:115:11: Assignment to a read-only property
```

* `DEF` statements are deprecated in Cython 3.x as well, but I've kept this focused on the more serious error

<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--4129.org.readthedocs.build/en/4129/

<!-- readthedocs-preview mdanalysis end -->