### PR TITLE
Switch to hole2 install via conda-forge

### DIFF
--- a/.github/actions/build-src/action.yaml
+++ b/.github/actions/build-src/action.yaml
@@ -47,4 +47,4 @@ runs:
       if: ${{ inputs.build-docs == 'true' }}
       shell: bash -l {0}
       run: |
-        cd package && python setup.py build_sphinx -E --keep-going
+        cd package && python setup.py build_sphinx -E # --keep-going

--- a/.github/actions/build-src/action.yaml
+++ b/.github/actions/build-src/action.yaml
@@ -47,4 +47,4 @@ runs:
       if: ${{ inputs.build-docs == 'true' }}
       shell: bash -l {0}
       run: |
-        cd package && python setup.py build_sphinx -E # --keep-going
+        cd package && python setup.py build_sphinx -E --keep-going

--- a/.github/actions/build-src/action.yaml
+++ b/.github/actions/build-src/action.yaml
@@ -1,10 +1,6 @@
 name: 'build-src'
 description: 'make source builds for CI'
 inputs:
-  build-hole:
-    description: 'build HOLE2'
-    required: true
-    default: true
   build-tests:
     description: 'build MDA tests'
     required: true
@@ -21,7 +17,6 @@ runs:
     - name: echo_inputs
       shell: bash -l {0}
       run: |
-        echo ${{ inputs.build-hole }}
         echo ${{ inputs.build-tests }}
         echo ${{ inputs.build-docs }}
 
@@ -35,19 +30,6 @@ runs:
         pip list
         conda info
         conda list
-
-    - name: build_hole
-      if: ${{ inputs.build-hole == 'true' }}
-      shell: bash -l {0}
-      run: |
-        # We manually build hole2 to avoid OS incompatibilities
-        git clone https://github.com/MDAnalysis/hole2.git
-        cd hole2/src
-        source ../source.apache
-        (make FC=${FC}) && (make PREFIX=${HOME}/hole2 FC=${FC} install)
-        source ../source.unset
-        echo "HOLE_BINDIR=${HOME}/hole2/bin" >> $GITHUB_ENV
-        echo "${HOME}/hole2/bin" >> $GITHUB_PATH
 
     - name: build_mda_main
       shell: bash -l {0}

--- a/.github/actions/setup-deps/action.yaml
+++ b/.github/actions/setup-deps/action.yaml
@@ -60,6 +60,8 @@ inputs:
     default: 'distopia>=0.2.0'
   h5py:
     default: 'h5py>=2.10'
+  hole2:
+    default: 'hole2'
   joblib:
     default: 'joblib>=0.12'
   netcdf4:
@@ -122,6 +124,7 @@ runs:
           ${{ inputs.clustalw }}
           ${{ inputs.distopia }}
           ${{ inputs.h5py }}
+          ${{ inputs.hole2 }}
           ${{ inputs.joblib }}
           ${{ inputs.netcdf4 }}
           ${{ inputs.openmm }}

--- a/.github/workflows/gh-ci-cron.yaml
+++ b/.github/workflows/gh-ci-cron.yaml
@@ -62,7 +62,6 @@ jobs:
     - name: build_srcs
       uses: ./.github/actions/build-src
       with:
-        build-hole: true
         build-tests: true
         build-docs: false
 
@@ -107,7 +106,6 @@ jobs:
     - name: build_srcs
       uses: ./.github/actions/build-src
       with:
-        build-hole: true
         build-tests: true
         build-docs: false
 
@@ -151,7 +149,6 @@ jobs:
     - name: build_srcs
       uses: ./.github/actions/build-src
       with:
-        build-hole: true
         build-tests: true
         build-docs: false
 

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -28,27 +28,23 @@ jobs:
           os: [ubuntu-latest, ]
           python-version: ["3.9", "3.10", "3.11"]
           full-deps: [true, ]
-          install_hole: [true, ]
           codecov: [true, ]
           include:
             - name: macOS_monterey_py311
               os: macOS-12
               python-version: "3.11"
               full-deps: true
-              install_hole: true
               codecov: true
             - name: numpy_min
               os: ubuntu-latest
               python-version: 3.9
               full-deps: false
-              install_hole: false
               codecov: true
               numpy: numpy=1.21.0
             - name: asv_check
               os: ubuntu-latest
               python-version: 3.9
               full-deps: true
-              install_hole: false
               codecov: false
               extra-pip-deps: asv
     env:
@@ -85,7 +81,6 @@ jobs:
     - name: build_srcs
       uses: ./.github/actions/build-src
       with:
-        build-hole: ${{ matrix.install_hole }}
         build-tests: true
         build-docs: false
 
@@ -145,7 +140,6 @@ jobs:
     - name: build_srcs
       uses: ./.github/actions/build-src
       with:
-        build-hole: false
         build-tests: true
         build-docs: true
 

--- a/package/doc/sphinx/source/conf.py
+++ b/package/doc/sphinx/source/conf.py
@@ -373,15 +373,15 @@ epub_copyright = u'2015, '+authors
 
 # Configuration for intersphinx: refer to the Python standard library
 # and other packages used by MDAnalysis
-intersphinx_mapping = {'https://docs.h5py.org/en/stable': None,
-                       'https://docs.python.org/3/': None,
-                       'https://docs.scipy.org/doc/scipy/': None,
-                       'https://gsd.readthedocs.io/en/stable/': None,
-                       'https://matplotlib.org/stable/': None,
-                       'https://mdanalysis.org/GridDataFormats/': None,
-                       'https://mdanalysis.org/pmda/': None,
-                       'https://networkx.org/documentation/stable/': None,
-                       'https://numpy.org/doc/stable/': None,
-                       'https://parmed.github.io/ParmEd/html/': None,
-                       'https://rdkit.org/docs/': None,
+intersphinx_mapping = {'h5py': ('https://docs.h5py.org/en/stable', None),
+                       'python': ('https://docs.python.org/3/', None),
+                       'scipy': ('https://docs.scipy.org/doc/scipy/', None),
+                       'gsd': ('https://gsd.readthedocs.io/en/stable/', None),
+                       'maplotlib': ('https://matplotlib.org/stable/', None),
+                       'griddataformats': ('https://mdanalysis.org/GridDataFormats/', None),
+                       'pmda': ('https://mdanalysis.org/pmda/', None),
+                       'networkx': ('https://networkx.org/documentation/stable/', None),
+                       'numpy': ('https://numpy.org/doc/stable/', None),
+                       'parmed': ('https://parmed.github.io/ParmEd/html/', None),
+                       'rdkit': ('https://rdkit.org/docs/', None),
                        }


### PR DESCRIPTION
Fixes #4012 #4132

Changes made in this Pull Request:
 - Switches hole2 building to just be an optional conda-forge install
 - Only test that changes is asv that will not fetch hole2 (before it didn't build it to save time).


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?


<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--4131.org.readthedocs.build/en/4131/

<!-- readthedocs-preview mdanalysis end -->