### PR TITLE
update CoC with option to report to NumFOCUS

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -126,6 +126,10 @@ The online form gives you the option to keep your report anonymous or request
 that we follow up with you directly. While we cannot follow up on an anonymous
 report, we will take appropriate action.
 
+You may also follow [NumFOCUS’s Code of Conduct violation reporting][NF-conduct] 
+guidelines if you would like to contact a third-party outside of the MDAnalysis 
+community.
+
 ## Enforcement
 
 When a report is sent to us we will reply as soon as possible to confirm receipt;
@@ -162,3 +166,6 @@ Attribution*](http://creativecommons.org/licenses/by/3.0/) license.
 
 [conduct-mail]: mailto:mdnalysis-conduct@googlegroups.com
 [conduct-form]: https://goo.gl/forms/w2IwBKkY3oT0aVEB3
+
+[NF-conduct]: https://numfocus.org/code-of-conduct
+


### PR DESCRIPTION
Changes made in this Pull Request:
- add option to report to NF conduct
- makes CoC consistent with https://github.com/MDAnalysis/mdanalysis/wiki/GSoC-Onboarding-Guide-2023

Note that I am also opening a PR for the website to make the same changes. However, _this_ document is the original source and needs to be changed first.

PR Checklist
------------
 - n/a Tests?
 - n/a Docs?
 - n/a CHANGELOG updated?
 - n/a Issue raised/referenced?


<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--4135.org.readthedocs.build/en/4135/

<!-- readthedocs-preview mdanalysis end -->