### PR TITLE
Revert "Temporarily pin chemfiles to <0.10.4"

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -114,7 +114,7 @@ jobs:
   - script: >-
       python -m pip install
       biopython
-      "chemfiles>=0.10,<0.10.4"
+      chemfiles>=0.10
       duecredit
       gsd
       joblib


### PR DESCRIPTION
This reverts commit fab74fa326f9bcdfb36108f9f889f3b8013d739e from #4143, a new build have been uploaded to PyPI which should fix the issue. Let's see what CI says!

Ping @IAlibay

<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--4147.org.readthedocs.build/en/4147/

<!-- readthedocs-preview mdanalysis end -->