### PR TITLE
Cirrus deploy wheels

### DIFF
--- a/.cirrus.star
+++ b/.cirrus.star
@@ -17,6 +17,7 @@ def main(ctx):
     print(env.get("CIRRUS_TAG") == None)
     print(env.get("CIRRUS_RELEASE") == None)
     print(env.get("CIRRUS_PR") != None)
+    print(env.get("CIRRUS_BASE_BRANCH") == "develop")
 
     # If you're targetting develop and it's a PR, run a CI job
     if ((env.get("CIRRUS_BASE_BRANCH") == "develop") and (env.get("CIRRUS_PR") != None)):

--- a/.cirrus.star
+++ b/.cirrus.star
@@ -21,10 +21,10 @@ def main(ctx):
 
     # If you're targetting develop and it's a PR, run a CI job
     if ((env.get("CIRRUS_BASE_BRANCH") == "develop") and (env.get("CIRRUS_PR") != None)):
-        fs.read("maintainer/ci/cirrus-ci.yml")
+        return fs.read("maintainer/ci/cirrus-ci.yml")
 
     # If you've tagged a package or released something, deploy
     if ((env.get("CIRRUS_TAG") != None) or (env.get("CIRRUS_RELEASE") != None)):
-        fs.read("maintainer/ci/cirrus-deploy.yml")
+        return fs.read("maintainer/ci/cirrus-deploy.yml")
 
     return []

--- a/.cirrus.star
+++ b/.cirrus.star
@@ -13,15 +13,17 @@ def main(ctx):
     if env.get("CIRRUS_REPO_FULL_NAME") != "MDAnalysis/mdanalysis":
         return []
 
+    # Some debugging to know what state you are in, by default everything is None but PR
     print(env.get("CIRRUS_TAG") == None)
     print(env.get("CIRRUS_RELEASE") == None)
     print(env.get("CIRRUS_PR") != None)
 
-    #if (env.get("CIRRUS_BASE_BRANCH" == "develop") and (env.get("CIRRUS_PR") != ""):
-    #    fs.read("maintainer/ci/cirrus-ci.yml")
+    # If you're targetting develop and it's a PR, run a CI job
+    if (env.get("CIRRUS_BASE_BRANCH" == "develop") and (env.get("CIRRUS_PR") != None):
+        fs.read("maintainer/ci/cirrus-ci.yml")
 
-    #if (env.get("CIRRUS_TAG" != "") or (env.get("CIRRUS_RELEASE") != ""):
-    #    fs.read("maintainer/ci/cirrus-deploy.yml")
+    # If you've tagged a package or released something, deploy
+    if (env.get("CIRRUS_TAG" != None) or (env.get("CIRRUS_RELEASE") != None):
+        fs.read("maintainer/ci/cirrus-deploy.yml")
 
-    #return []
-    return fs.read("maintainer/ci/cirrus-deploy.yml")
+    return []

--- a/.cirrus.star
+++ b/.cirrus.star
@@ -19,11 +19,11 @@ def main(ctx):
     print(env.get("CIRRUS_PR") != None)
 
     # If you're targetting develop and it's a PR, run a CI job
-    if (env.get("CIRRUS_BASE_BRANCH" == "develop") and (env.get("CIRRUS_PR") != None):
+    if ((env.get("CIRRUS_BASE_BRANCH") == "develop") and (env.get("CIRRUS_PR") != None)):
         fs.read("maintainer/ci/cirrus-ci.yml")
 
     # If you've tagged a package or released something, deploy
-    if (env.get("CIRRUS_TAG" != None) or (env.get("CIRRUS_RELEASE") != None):
+    if ((env.get("CIRRUS_TAG") != None) or (env.get("CIRRUS_RELEASE") != None)):
         fs.read("maintainer/ci/cirrus-deploy.yml")
 
     return []

--- a/.cirrus.star
+++ b/.cirrus.star
@@ -15,4 +15,5 @@ def main(ctx):
         or (env.get("CIRRUS_BASE_BRANCH") != "develop")):
         return []
 
-    return fs.read("maintainer/ci/cirrus-ci.yml") + fs.read("maintainer/ci/cirrus-deploy.yml")
+    return fs.read("maintainer/ci/cirrus-deploy.yml")
+    #return fs.read("maintainer/ci/cirrus-ci.yml") + fs.read("maintainer/ci/cirrus-deploy.yml")

--- a/.cirrus.star
+++ b/.cirrus.star
@@ -13,9 +13,9 @@ def main(ctx):
     if env.get("CIRRUS_REPO_FULL_NAME") != "MDAnalysis/mdanalysis":
         return []
 
-    print(env.get("CIRRUS_TAG"))
-    print(env.get("CIRRUS_RELEASE"))
-    print(env.get("CIRRUS_PR"))
+    print(env.get("CIRRUS_TAG") == None)
+    print(env.get("CIRRUS_RELEASE") == None)
+    print(env.get("CIRRUS_PR") != None)
 
     #if (env.get("CIRRUS_BASE_BRANCH" == "develop") and (env.get("CIRRUS_PR") != ""):
     #    fs.read("maintainer/ci/cirrus-ci.yml")

--- a/.cirrus.star
+++ b/.cirrus.star
@@ -10,10 +10,18 @@ load("cirrus", "env", "fs")
 
 def main(ctx):
     # Default case: don't do anything if not in the core repo
-    # or if you're not targetting the develop branch
-    if ((env.get("CIRRUS_REPO_FULL_NAME") != "MDAnalysis/mdanalysis")
-        or (env.get("CIRRUS_BASE_BRANCH") != "develop")):
+    if env.get("CIRRUS_REPO_FULL_NAME") != "MDAnalysis/mdanalysis":
         return []
 
+    print(env.get("CIRRUS_TAG"))
+    print(env.get("CIRRUS_RELEASE"))
+    print(env.get("CIRRUS_PR"))
+
+    #if (env.get("CIRRUS_BASE_BRANCH" == "develop") and (env.get("CIRRUS_PR") != ""):
+    #    fs.read("maintainer/ci/cirrus-ci.yml")
+
+    #if (env.get("CIRRUS_TAG" != "") or (env.get("CIRRUS_RELEASE") != ""):
+    #    fs.read("maintainer/ci/cirrus-deploy.yml")
+
+    #return []
     return fs.read("maintainer/ci/cirrus-deploy.yml")
-    #return fs.read("maintainer/ci/cirrus-ci.yml") + fs.read("maintainer/ci/cirrus-deploy.yml")

--- a/.cirrus.star
+++ b/.cirrus.star
@@ -15,4 +15,4 @@ def main(ctx):
         or (env.get("CIRRUS_BASE_BRANCH") != "develop")):
         return []
 
-    return fs.read("maintainer/ci/cirrus-ci.yml")
+    return fs.read("maintainer/ci/cirrus-ci.yml") + fs.read("maintainer/ci/cirrus-deploy.yml")

--- a/maintainer/ci/cirrus-deploy.yml
+++ b/maintainer/ci/cirrus-deploy.yml
@@ -54,6 +54,7 @@ wheel_upload_task:
     unzip wheels.zip
     ls *
     ls wheelhouse
+    apt install -y python3-venv python-is-python3
     python --version
     python3 --version
     python -m pip install pipx
@@ -63,7 +64,7 @@ wheel_upload_task:
     if [ -z "$CIRRUS_RELEASE"]; then
         export TWINE_PASSWORD=$PYPI
         twine upload -r pypi wheelhouse/* --non-interactive
-    elif [[ $CIRRUS_TAG == "release-"* ]]; then
+    elif [[ $CIRRUS_TAG == "package-"* ]]; then
         export TWINE_PASSWORD=$TESTPYPI
         twine upload -r testpypi wheelhouse/* --non-interactive
     else

--- a/maintainer/ci/cirrus-deploy.yml
+++ b/maintainer/ci/cirrus-deploy.yml
@@ -7,22 +7,22 @@ build_and_store_wheels: &BUILD_AND_STORE_WHEELS
     path: "wheelhouse/*"
 
 
-linux_aarch64_wheel_task:
-  compute_engine_instance:
-    image_project: cirrus-images
-    image: family/docker-builder-arm64
-    architecture: arm64
-    platform: linux
-    cpu: 4
-    memory: 4G
-  env:
-    CIBW_BUILD: cp39-manylinux* cp310-manylinux* cp311-manylinux*
-
-  build_script: |
-    apt install -y python3-venv python-is-python3
-    python3 --version
-    python --version
-  <<: *BUILD_AND_STORE_WHEELS
+#linux_aarch64_wheel_task:
+#  compute_engine_instance:
+#    image_project: cirrus-images
+#    image: family/docker-builder-arm64
+#    architecture: arm64
+#    platform: linux
+#    cpu: 4
+#    memory: 4G
+#  env:
+#    CIBW_BUILD: cp39-manylinux* cp310-manylinux* cp311-manylinux*
+#
+#  build_script: |
+#    apt install -y python3-venv python-is-python3
+#    python3 --version
+#    python --version
+#  <<: *BUILD_AND_STORE_WHEELS
 
 
 macos_arm64_wheel_task:
@@ -43,9 +43,11 @@ macos_arm64_wheel_task:
 wheel_upload_task:
   depends_on:
     - macos_arm64_wheel
-    - linux_aarch64_wheel
-  container:
-    image: python:latest
+    #- linux_aarch64_wheel
+  compute_engine_instance:
+    image_project: cirrus-images
+    image: family/docker-builder
+    platform: linux
   env:
     TESTPYPI: ENCRYPTED[!adb082e719dbf71b700796a3f6969d1ca8ba69879cbf8ce4e969285b2ccd0212a54afea897c8d55174bd18388b22fd7a!]
     PYPI: ENCRYPTED[!35e6711ac1b0f6ff790a2743db2e02c9efc07a49865252c53f9482c71609946746eb7d05fa75a13c094c9692f4d869d4!]

--- a/maintainer/ci/cirrus-deploy.yml
+++ b/maintainer/ci/cirrus-deploy.yml
@@ -2,7 +2,7 @@ build_and_store_wheels: &BUILD_AND_STORE_WHEELS
   install_cibuildwheel_script:
     - python -m pip install cibuildwheel==2.12.3
   run_cibuildwheel_script:
-    - cibuildwheel
+    - cibuildwheel ./package
   #wheels_artifacts:
   #  path: "wheelhouse/*"
 

--- a/maintainer/ci/cirrus-deploy.yml
+++ b/maintainer/ci/cirrus-deploy.yml
@@ -43,7 +43,7 @@ macos_arm64_wheel_task:
 wheel_upload_task:
   depends_on:
     - macos_arm64_wheel
-    #- linux_aarch64_wheel
+    - linux_aarch64_wheel
   compute_engine_instance:
     image_project: cirrus-images
     image: family/docker-builder

--- a/maintainer/ci/cirrus-deploy.yml
+++ b/maintainer/ci/cirrus-deploy.yml
@@ -42,8 +42,8 @@ macos_arm64_wheel_task:
 
 wheel_upload_task:
   depends_on:
-    - macos_arm64_wheel_task
-    - linux_aarch64_wheel_task
+    - macos_arm64_wheel
+    - linux_aarch64_wheel
   container:
     image: python:latest
   env:

--- a/maintainer/ci/cirrus-deploy.yml
+++ b/maintainer/ci/cirrus-deploy.yml
@@ -66,7 +66,7 @@ wheel_upload_task:
     echo $CIRRUS_RELEASE
     echo $CIRRUS_TAG
 
-    if [ -z "$CIRRUS_RELEASE"]; then
+    if [ ! -z "$CIRRUS_RELEASE" ]; then
         echo "RELEASE THE KRAKEN!"
         #export TWINE_PASSWORD=$PYPI
         #pipx run twine upload -r pypi wheelhouse/* --non-interactive

--- a/maintainer/ci/cirrus-deploy.yml
+++ b/maintainer/ci/cirrus-deploy.yml
@@ -58,7 +58,7 @@ wheel_upload_task:
     python3 --version
     python -m pip install pipx
 
-    export TWINE_USERNAME = "__token__"
+    export TWINE_USERNAME="__token__"
 
     if [ -z "$CIRRUS_RELEASE"]; then
         export TWINE_PASSWORD=$PYPI

--- a/maintainer/ci/cirrus-deploy.yml
+++ b/maintainer/ci/cirrus-deploy.yml
@@ -7,22 +7,22 @@ build_and_store_wheels: &BUILD_AND_STORE_WHEELS
     path: "wheelhouse/*"
 
 
-#linux_aarch64_wheel_task:
-#  compute_engine_instance:
-#    image_project: cirrus-images
-#    image: family/docker-builder-arm64
-#    architecture: arm64
-#    platform: linux
-#    cpu: 4
-#    memory: 4G
-#  env:
-#    CIBW_BUILD: cp39-manylinux* cp310-manylinux* cp311-manylinux*
-#
-#  build_script: |
-#    apt install -y python3-venv python-is-python3
-#    python3 --version
-#    python --version
-#  <<: *BUILD_AND_STORE_WHEELS
+linux_aarch64_wheel_task:
+  compute_engine_instance:
+    image_project: cirrus-images
+    image: family/docker-builder-arm64
+    architecture: arm64
+    platform: linux
+    cpu: 4
+    memory: 4G
+  env:
+    CIBW_BUILD: cp39-manylinux* cp310-manylinux* cp311-manylinux*
+
+  build_script: |
+    apt install -y python3-venv python-is-python3
+    python3 --version
+    python --version
+  <<: *BUILD_AND_STORE_WHEELS
 
 
 macos_arm64_wheel_task:
@@ -67,15 +67,13 @@ wheel_upload_task:
     echo $CIRRUS_TAG
 
     if [ ! -z "$CIRRUS_RELEASE" ]; then
-        echo "RELEASE THE KRAKEN!"
-        #export TWINE_PASSWORD=$PYPI
-        #pipx run twine upload -r pypi wheelhouse/* --non-interactive
+        echo "RELEASE INCOMING!"
+        export TWINE_PASSWORD=$PYPI
+        pipx run twine upload -r pypi wheelhouse/* --non-interactive
     elif [[ $CIRRUS_TAG == "package-"* ]]; then
-        echo "it's a package!"
-        #export TWINE_PASSWORD=$TESTPYPI
-        #pipx run twine upload -r testpypi wheelhouse/* --non-interactive
+        echo "Let's get this tested!"
+        export TWINE_PASSWORD=$TESTPYPI
+        pipx run twine upload -r testpypi wheelhouse/* --non-interactive
     else
-        echo "sure whatever"
-        #export TWINE_PASSWORD="FOOBAR"
-        #pipx run twine upload -r testpypi wheelhouse/* --non-interactive
+        echo "Nothing to see here I'm afraid"
     fi

--- a/maintainer/ci/cirrus-deploy.yml
+++ b/maintainer/ci/cirrus-deploy.yml
@@ -40,7 +40,7 @@ macos_arm64_wheel_task:
   <<: *BUILD_AND_STORE_WHEELS
 
 
-wheel_upload:
+wheel_upload_task:
   depends_on:
     - macos_arm64_wheel_task
     - linux_aarch64_wheel_task

--- a/maintainer/ci/cirrus-deploy.yml
+++ b/maintainer/ci/cirrus-deploy.yml
@@ -65,11 +65,11 @@ wheel_upload_task:
 
     if [ -z "$CIRRUS_RELEASE"]; then
         export TWINE_PASSWORD=$PYPI
-        twine upload -r pypi wheelhouse/* --non-interactive
+        pipx run twine upload -r pypi wheelhouse/* --non-interactive
     elif [[ $CIRRUS_TAG == "package-"* ]]; then
         export TWINE_PASSWORD=$TESTPYPI
-        twine upload -r testpypi wheelhouse/* --non-interactive
+        pipx run twine upload -r testpypi wheelhouse/* --non-interactive
     else
         export TWINE_PASSWORD="FOOBAR"
-        twine upload -r testpypi wheelhouse/* --non-interactive
+        pipx run twine upload -r testpypi wheelhouse/* --non-interactive
     fi

--- a/maintainer/ci/cirrus-deploy.yml
+++ b/maintainer/ci/cirrus-deploy.yml
@@ -1,0 +1,40 @@
+build_and_store_wheels: &BUILD_AND_STORE_WHEELS
+  install_cibuildwheel_script:
+    - python -m pip install cibuildwheel==2.12.3
+  run_cibuildwheel_script:
+    - cibuildwheel
+  wheels_artifacts:
+    path: "wheelhouse/*"
+
+
+linux_aarch64_task:
+  arm_container:
+    image: python:latest
+    cpu: 8
+    memory: 8G
+
+  ci_script: |
+    python3 --version
+    python3 -m venv mda-dev
+    source mda-dev/bin/activate
+    python3 -m pip install ./package
+    python3 -m pip install ./testsuite
+    python3 -m pip install pytest-xdist
+    python3 -m pytest -n 8 ./testsuite/MDAnalysisTests
+
+
+macos_arm64_task:
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-ventura-base:latest
+
+  ci_script: |
+    brew update
+    brew install python@3.11
+    /opt/homebrew/bin/python3 -m venv ~/py_311
+    source ~/py_311/bin/activate
+    cd package
+    python -m pip install .
+    cd ../testsuite
+    python -m pip install .
+    python -m pip install pytest pytest-xdist
+    python -m pytest -n auto MDAnalysisTests

--- a/maintainer/ci/cirrus-deploy.yml
+++ b/maintainer/ci/cirrus-deploy.yml
@@ -3,8 +3,8 @@ build_and_store_wheels: &BUILD_AND_STORE_WHEELS
     - python -m pip install cibuildwheel==2.12.3
   run_cibuildwheel_script:
     - cibuildwheel
-  wheels_artifacts:
-    path: "wheelhouse/*"
+  #wheels_artifacts:
+  #  path: "wheelhouse/*"
 
 
 linux_aarch64_task:
@@ -12,29 +12,25 @@ linux_aarch64_task:
     image: python:latest
     cpu: 8
     memory: 8G
+  env:
+    CIBW_BUILD: cp39-manylinux* cp310-manylinux* cp311-manylinux*
 
-  ci_script: |
+  build_script: |
     python3 --version
-    python3 -m venv mda-dev
-    source mda-dev/bin/activate
-    python3 -m pip install ./package
-    python3 -m pip install ./testsuite
-    python3 -m pip install pytest-xdist
-    python3 -m pytest -n 8 ./testsuite/MDAnalysisTests
+    python --version
+  <<: *BUILD_AND_STORE_WHEELS
 
 
 macos_arm64_task:
   macos_instance:
-    image: ghcr.io/cirruslabs/macos-ventura-base:latest
+    image: ghcr.io/cirruslabs/macos-monterey-xcode:14
+  env:
+    CIBW_BUILD: cp39-* cp310-* cp311-*
+    PATH: /opt/homebrew/opt/python@3.10/bin:$PATH
 
-  ci_script: |
-    brew update
-    brew install python@3.11
-    /opt/homebrew/bin/python3 -m venv ~/py_311
-    source ~/py_311/bin/activate
-    cd package
-    python -m pip install .
-    cd ../testsuite
-    python -m pip install .
-    python -m pip install pytest pytest-xdist
-    python -m pytest -n auto MDAnalysisTests
+  build_script: |
+    brew install python@3.10
+    ln -s python3 /opt/homebrew/opt/python@3.10/bin/python
+    python --version
+    python3 --version
+  <<: *BUILD_AND_STORE_WHEELS

--- a/maintainer/ci/cirrus-deploy.yml
+++ b/maintainer/ci/cirrus-deploy.yml
@@ -8,14 +8,18 @@ build_and_store_wheels: &BUILD_AND_STORE_WHEELS
 
 
 linux_aarch64_wheel_task:
-  arm_container:
-    image: python:latest
-    cpu: 8
-    memory: 8G
+  compute_engine_instance:
+    image_project: cirrus-images
+    image: family/docker-builder-arm64
+    architecture: arm64
+    platform: linux
+    cpu: 4
+    memory: 4G
   env:
     CIBW_BUILD: cp39-manylinux* cp310-manylinux* cp311-manylinux*
 
   build_script: |
+    apt install -y python3-venv python-is-python3
     python3 --version
     python --version
   <<: *BUILD_AND_STORE_WHEELS

--- a/maintainer/ci/cirrus-deploy.yml
+++ b/maintainer/ci/cirrus-deploy.yml
@@ -43,8 +43,8 @@ wheel_upload:
   container:
     image: python:latest
   env:
-    TESTPYPI: ENCRYPTED[LOOKATMEIMATOKEN]
-    PYPI: ENCRYPTED[NEVERGONNAGIVEYOUUPNEVERGONNALETYOUDOWNNEVERGONNAEATPARSNIPS]
+    TESTPYPI: ENCRYPTED[!adb082e719dbf71b700796a3f6969d1ca8ba69879cbf8ce4e969285b2ccd0212a54afea897c8d55174bd18388b22fd7a!]
+    PYPI: ENCRYPTED[!35e6711ac1b0f6ff790a2743db2e02c9efc07a49865252c53f9482c71609946746eb7d05fa75a13c094c9692f4d869d4!]
   uploady_script:
     curl https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/wheels.zip --output wheels.zip
     unzip wheels.zip

--- a/maintainer/ci/cirrus-deploy.yml
+++ b/maintainer/ci/cirrus-deploy.yml
@@ -72,3 +72,4 @@ wheel_upload_task:
     else
         export TWINE_PASSWORD="FOOBAR"
         twine upload -r testpypi wheelhouse/* --non-interactive
+    fi

--- a/maintainer/ci/cirrus-deploy.yml
+++ b/maintainer/ci/cirrus-deploy.yml
@@ -49,11 +49,23 @@ wheel_upload_task:
   env:
     TESTPYPI: ENCRYPTED[!adb082e719dbf71b700796a3f6969d1ca8ba69879cbf8ce4e969285b2ccd0212a54afea897c8d55174bd18388b22fd7a!]
     PYPI: ENCRYPTED[!35e6711ac1b0f6ff790a2743db2e02c9efc07a49865252c53f9482c71609946746eb7d05fa75a13c094c9692f4d869d4!]
-  uploady_script:
+  uploady_script: |
     curl https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/wheels.zip --output wheels.zip
     unzip wheels.zip
     ls *
     ls wheels
     python --version
     python3 --version
-    echo "Hey Nate, how's life?"
+    python -m pip install pipx
+
+    export TWINE_USERNAME = "__token__"
+
+    if [ -z "$CIRRUS_RELEASE"]; then
+        export TWINE_PASSWORD=$PYPI
+        twine upload -r pypi wheels/* --non-interactive
+    elif [[ $CIRRUS_TAG == "release-"* ]]; then
+        export TWINE_PASSWORD=$TESTPYPI
+        twine upload -r testpypi wheels/* --non-interactive
+    else
+        export TWINE_PASSWORD="FOOBAR"
+        twine upload -r pypi wheels/* --non-interactive

--- a/maintainer/ci/cirrus-deploy.yml
+++ b/maintainer/ci/cirrus-deploy.yml
@@ -53,7 +53,7 @@ wheel_upload_task:
     curl https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/wheels.zip --output wheels.zip
     unzip wheels.zip
     ls *
-    ls wheels
+    ls wheelhouse
     python --version
     python3 --version
     python -m pip install pipx
@@ -62,10 +62,10 @@ wheel_upload_task:
 
     if [ -z "$CIRRUS_RELEASE"]; then
         export TWINE_PASSWORD=$PYPI
-        twine upload -r pypi wheels/* --non-interactive
+        twine upload -r pypi wheelhouse/* --non-interactive
     elif [[ $CIRRUS_TAG == "release-"* ]]; then
         export TWINE_PASSWORD=$TESTPYPI
-        twine upload -r testpypi wheels/* --non-interactive
+        twine upload -r testpypi wheelhouse/* --non-interactive
     else
         export TWINE_PASSWORD="FOOBAR"
-        twine upload -r pypi wheels/* --non-interactive
+        twine upload -r testpypi wheelhouse/* --non-interactive

--- a/maintainer/ci/cirrus-deploy.yml
+++ b/maintainer/ci/cirrus-deploy.yml
@@ -3,11 +3,11 @@ build_and_store_wheels: &BUILD_AND_STORE_WHEELS
     - python -m pip install cibuildwheel==2.12.3
   run_cibuildwheel_script:
     - cibuildwheel ./package
-  #wheels_artifacts:
-  #  path: "wheelhouse/*"
+  wheels_artifacts:
+    path: "wheelhouse/*"
 
 
-linux_aarch64_task:
+linux_aarch64_wheel_task:
   arm_container:
     image: python:latest
     cpu: 8
@@ -21,7 +21,7 @@ linux_aarch64_task:
   <<: *BUILD_AND_STORE_WHEELS
 
 
-macos_arm64_task:
+macos_arm64_wheel_task:
   macos_instance:
     image: ghcr.io/cirruslabs/macos-monterey-xcode:14
   env:
@@ -34,3 +34,22 @@ macos_arm64_task:
     python --version
     python3 --version
   <<: *BUILD_AND_STORE_WHEELS
+
+
+wheel_upload:
+  depends_on:
+    - macos_arm64_wheel_task
+    - linux_aarch64_wheel_task
+  container:
+    image: python:latest
+  env:
+    TESTPYPI: ENCRYPTED[LOOKATMEIMATOKEN]
+    PYPI: ENCRYPTED[NEVERGONNAGIVEYOUUPNEVERGONNALETYOUDOWNNEVERGONNAEATPARSNIPS]
+  uploady_script:
+    curl https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/wheels.zip --output wheels.zip
+    unzip wheels.zip
+    ls *
+    ls wheels
+    python --version
+    python3 --version
+    echo "Hey Nate, how's life?"

--- a/maintainer/ci/cirrus-deploy.yml
+++ b/maintainer/ci/cirrus-deploy.yml
@@ -63,13 +63,19 @@ wheel_upload_task:
 
     export TWINE_USERNAME="__token__"
 
+    echo $CIRRUS_RELEASE
+    echo $CIRRUS_TAG
+
     if [ -z "$CIRRUS_RELEASE"]; then
-        export TWINE_PASSWORD=$PYPI
-        pipx run twine upload -r pypi wheelhouse/* --non-interactive
+        echo "RELEASE THE KRAKEN!"
+        #export TWINE_PASSWORD=$PYPI
+        #pipx run twine upload -r pypi wheelhouse/* --non-interactive
     elif [[ $CIRRUS_TAG == "package-"* ]]; then
-        export TWINE_PASSWORD=$TESTPYPI
-        pipx run twine upload -r testpypi wheelhouse/* --non-interactive
+        echo "it's a package!"
+        #export TWINE_PASSWORD=$TESTPYPI
+        #pipx run twine upload -r testpypi wheelhouse/* --non-interactive
     else
-        export TWINE_PASSWORD="FOOBAR"
-        pipx run twine upload -r testpypi wheelhouse/* --non-interactive
+        echo "sure whatever"
+        #export TWINE_PASSWORD="FOOBAR"
+        #pipx run twine upload -r testpypi wheelhouse/* --non-interactive
     fi

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -51,6 +51,7 @@ Fixes
     (Issue #3336)
 
 Enhancements
+  * ARM64 (osx and linux) wheels now uploaded on release (Issue #4054)
   * Add writing u.trajectory.ts.data['molecule_tag'] as molecule tags to LAMMPS data file (Issue #3548)
   * Improved speed of chi1_selection (PR #4109)
   * Add `progressbar_kwargs` parameter to `AnalysisBase.run` method, allowing


### PR DESCRIPTION
Fixes #4054 

Changes made in this Pull Request:
 - The wheels on the bus go round and round... and now build for arm64
   - See https://cibuildwheel.readthedocs.io/en/stable/setup/#cirrus-ci for the base template

TODO:
 - [x] Add in the machinery for uploading to test / real pypi
 - [x] Add in the trigger machinery
 - [x] Buy hummus, bread, and tomatoes


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?


<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--4150.org.readthedocs.build/en/4150/

<!-- readthedocs-preview mdanalysis end -->