### PR TITLE
[DEPEND #4150] Prerelease 2.5.0

### DIFF
--- a/maintainer/conda/MDAnalysis/meta.yaml
+++ b/maintainer/conda/MDAnalysis/meta.yaml
@@ -1,7 +1,7 @@
 package:
   name: mdanalysis
   # This has to be changed after a release
-  version: "2.5.0-dev0"
+  version: "2.5.0"
 
 source:
    git_url: https://github.com/MDAnalysis/mdanalysis

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,7 +13,7 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-??/??/?? IAlibay, pgbarletta, mglagolev, hmacdope, manuel.nuno.melo, chrispfae, 
+05/28/23 IAlibay, pgbarletta, mglagolev, hmacdope, manuel.nuno.melo, chrispfae, 
          ooprathamm, MeetB7, BFedder, v-parmar, MoSchaeffler, jbarnoud, jandom,
          xhgchen, jaclark5, DrDomenicoMarson, AHMED-salah00, schlaicha,
          SophiaRuan, g2707, p-j-smith, tylerjereddy, xiki-tempula, richardjgowers,

--- a/package/MDAnalysis/version.py
+++ b/package/MDAnalysis/version.py
@@ -67,4 +67,4 @@ Data
 # e.g. with lib.log
 
 #: Release of MDAnalysis as a string, using `semantic versioning`_.
-__version__ = "2.5.0-dev0"  # NOTE: keep in sync with RELEASE in setup.py
+__version__ = "2.5.0"  # NOTE: keep in sync with RELEASE in setup.py

--- a/package/setup.py
+++ b/package/setup.py
@@ -67,7 +67,7 @@ import configparser
 from subprocess import getoutput
 
 # NOTE: keep in sync with MDAnalysis.__version__ in version.py
-RELEASE = "2.5.0-dev0"
+RELEASE = "2.5.0"
 
 is_release = 'dev' not in RELEASE
 

--- a/testsuite/MDAnalysisTests/__init__.py
+++ b/testsuite/MDAnalysisTests/__init__.py
@@ -97,7 +97,7 @@ import pytest
 logger = logging.getLogger("MDAnalysisTests.__init__")
 
 # keep in sync with RELEASE in setup.py
-__version__ = "2.5.0-dev0"
+__version__ = "2.5.0"
 
 
 # Do NOT import MDAnalysis at this level. Tests should do it themselves.

--- a/testsuite/setup.py
+++ b/testsuite/setup.py
@@ -87,7 +87,7 @@ if sys.version_info[:2] < (3, 9):
 
 if __name__ == '__main__':
     # this must be in-sync with MDAnalysis
-    RELEASE = "2.5.0-dev0"
+    RELEASE = "2.5.0"
     with open("README") as summary:
         LONG_DESCRIPTION = summary.read()
 


### PR DESCRIPTION
Once this is merged we are in a code freeze for a while until 2.5.0 is fully out (I expect this one to be quite problematic).

Changes made in this Pull Request:
 - Update all version tags to 2.5.0


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?


<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--4154.org.readthedocs.build/en/4154/

<!-- readthedocs-preview mdanalysis end -->