### PR TITLE
MAINT, TST: suppress np warns

### DIFF
--- a/package/MDAnalysis/lib/mdamath.py
+++ b/package/MDAnalysis/lib/mdamath.py
@@ -292,9 +292,10 @@ def triclinic_box(x: npt.ArrayLike, y: npt.ArrayLike, z: npt.ArrayLike) -> npt.N
     lx = norm(x)
     ly = norm(y)
     lz = norm(z)
-    alpha = np.rad2deg(np.arccos(np.dot(y, z) / (ly * lz)))
-    beta = np.rad2deg(np.arccos(np.dot(x, z) / (lx * lz)))
-    gamma = np.rad2deg(np.arccos(np.dot(x, y) / (lx * ly)))
+    with np.errstate(invalid="ignore"):
+        alpha = np.rad2deg(np.arccos(np.dot(y, z) / (ly * lz)))
+        beta = np.rad2deg(np.arccos(np.dot(x, z) / (lx * lz)))
+        gamma = np.rad2deg(np.arccos(np.dot(x, y) / (lx * ly)))
     box = np.array([lx, ly, lz, alpha, beta, gamma], dtype=np.float32)
     # Only positive edge lengths and angles in (0, 180) are allowed:
     if np.all(box > 0.0) and alpha < 180.0 and beta < 180.0 and gamma < 180.0:

--- a/testsuite/MDAnalysisTests/lib/test_util.py
+++ b/testsuite/MDAnalysisTests/lib/test_util.py
@@ -312,7 +312,8 @@ class TestMatrixOperations(object):
             ref[1, 1] = y * sin_c
             ref[2, 0] = z * cos_b
             ref[2, 1] = z * (cos_a - cos_b * cos_c) / sin_c
-            ref[2, 2] = np.sqrt(z * z - ref[2, 0] ** 2 - ref[2, 1] ** 2)
+            with np.errstate(invalid="ignore"):
+                ref[2, 2] = np.sqrt(z * z - ref[2, 0] ** 2 - ref[2, 1] ** 2)
             ref = ref.astype(np.float32)
         return ref
 


### PR DESCRIPTION
* while checking our compatibility with just-released NumPy `1.25.0` (seems "ok" on M2 mac), I went ahead and suppressed about 17 % of our test suite warnings (5384 / 32502) with a few NumPy floating point error handlers

* related to gh-2980

* I doubt there's any harm in doing this--if we have a real algorithm issue it should be enforced by our testsuite anyway, rather than relying on fp warnings

<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--4175.org.readthedocs.build/en/4175/

<!-- readthedocs-preview mdanalysis end -->