### PR TITLE
Added atom ID sort to topopology object representation

### DIFF
--- a/package/MDAnalysis/core/topologyobjects.py
+++ b/package/MDAnalysis/core/topologyobjects.py
@@ -116,7 +116,7 @@ class TopologyObject(object):
         return hash((self._u, tuple(self.indices)))
 
     def __repr__(self):
-        indices = (self.indices if self.indices[0] < self.indices[-1]
+        indices = np.sort(self.indices if self.indices[0] < self.indices[-1]
                    else self.indices[::-1])
         return "<{cname} between: {conts}>".format(
             cname=self.__class__.__name__,

--- a/testsuite/MDAnalysisTests/core/test_topologyobjects.py
+++ b/testsuite/MDAnalysisTests/core/test_topologyobjects.py
@@ -157,7 +157,7 @@ class TestTopologyObjects(object):
     def test_angle_repr(self, PSFDCD):
         angle = PSFDCD.atoms[[30, 10, 20]].angle
 
-        assert_equal(repr(angle), '<Angle between: Atom 20, Atom 10, Atom 30>')
+        assert_equal(repr(angle), '<Angle between: Atom 10, Atom 20, Atom 30>')
 
     def test_angle_180(self):
         # we edit the coordinates, so make our own universe
@@ -183,7 +183,7 @@ class TestTopologyObjects(object):
         dihedral = PSFDCD.atoms[[4, 7, 8, 1]].dihedral
 
         assert_equal(repr(dihedral),
-                     '<Dihedral between: Atom 1, Atom 8, Atom 7, Atom 4>')
+                     '<Dihedral between: Atom 1, Atom 4, Atom 7, Atom 8>')
 
     # Improper_Dihedral class check
     def test_improper(self, PSFDCD):
@@ -197,7 +197,7 @@ class TestTopologyObjects(object):
 
         assert_equal(
             repr(imp),
-            '<ImproperDihedral between: Atom 1, Atom 8, Atom 7, Atom 4>')
+            '<ImproperDihedral between: Atom 1, Atom 4, Atom 7, Atom 8>')
 
     def test_ureybradley_repr(self, PSFDCD):
         ub = PSFDCD.atoms[[30, 10]].ureybradley
@@ -221,7 +221,7 @@ class TestTopologyObjects(object):
 
         assert_equal(
             repr(cmap),
-            '<CMap between: Atom 2, Atom 1, Atom 8, Atom 7, Atom 4>')
+            '<CMap between: Atom 1, Atom 2, Atom 4, Atom 7, Atom 8>')
     
     def test_cmap_repr_VE(self, PSFDCD):
         with pytest.raises(ValueError):


### PR DESCRIPTION
Fixes #4181

Entirely possible I missed something but the change seems pretty straightforward. Atom ID topology representations for bonds, angles, dihedrals and other associated objects are now sorted. Happy to update docs/changelogs if necessary.

Changes made in this Pull Request:
 - Added np sort of atoms IDs to topology representation.
 - Tests updated - representation checks for topology representation matches new sorted representation.


PR Checklist
------------
 - [ ] Tests? - All tests appear to pass. Can't seem to identify the 1 check that's flagged in the GH Actions pipeline.
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?


<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--4190.org.readthedocs.build/en/4190/

<!-- readthedocs-preview mdanalysis end -->