### PR TITLE
Switch to scientifc python nightly package location for cron tests against upstream nightly wheels

### DIFF
--- a/.github/workflows/gh-ci-cron.yaml
+++ b/.github/workflows/gh-ci-cron.yaml
@@ -3,9 +3,6 @@ on:
   schedule:
     # 3 am Tuesdays and Fridays
     - cron: "0 3 * * 2,5"
-  pull_request:
-    branches:
-      - develop
 
 concurrency:
   # Probably overly cautious group naming.

--- a/.github/workflows/gh-ci-cron.yaml
+++ b/.github/workflows/gh-ci-cron.yaml
@@ -52,7 +52,7 @@ jobs:
       # overwrite installs by picking up nightly wheels
     - name: nightly_wheels
       run: |
-        pip install --pre -U -i https://pypi.anaconda.org/scipy-wheels-nightly/simple scipy numpy h5py matplotlib
+        pip install --pre -U -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scipy numpy networkx matplotlib
 
     - name: list_deps
       run: |

--- a/.github/workflows/gh-ci-cron.yaml
+++ b/.github/workflows/gh-ci-cron.yaml
@@ -3,6 +3,9 @@ on:
   schedule:
     # 3 am Tuesdays and Fridays
     - cron: "0 3 * * 2,5"
+  pull_request:
+    branches:
+      - develop
 
 concurrency:
   # Probably overly cautious group naming.

--- a/package/MDAnalysis/lib/src/transformations/transformations.c
+++ b/package/MDAnalysis/lib/src/transformations/transformations.c
@@ -965,7 +965,7 @@ PyOutputConverter_AnyDoubleArrayOrNone(
         *address = NULL;
         return NPY_SUCCEED;
     }
-    if (PyArray_Check(object) && (obj->descr->type_num == PyArray_DOUBLE)) {
+    if (PyArray_Check(object) && (obj->descr->type_num == NPY_DOUBLE)) {
         Py_INCREF(object);
         *address = (PyArrayObject *)object;
         return NPY_SUCCEED;

--- a/package/MDAnalysis/lib/src/transformations/transformations.c
+++ b/package/MDAnalysis/lib/src/transformations/transformations.c
@@ -786,7 +786,7 @@ PyConverter_AnyDoubleArray(
     PyObject **address)
 {
     PyArrayObject *obj = (PyArrayObject *)object;
-    if (PyArray_Check(object) && obj->descr->type_num == PyArray_DOUBLE) {
+    if (PyArray_Check(object) && obj->descr->type_num == NPY_DOUBLE) {
         *address = object;
         Py_INCREF(object);
         return NPY_SUCCEED;


### PR DESCRIPTION
Fixes #4202 

Changes made in this Pull Request:
 - switch target for nightly wheel repo
 - remove h5py from list (hasn't been updated in a long while in nightly builds anyways)
 - Switch deprecated PyArray_DOUBLE to NPY_DOUBLE in transformations code

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?


<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--4203.org.readthedocs.build/en/4203/

<!-- readthedocs-preview mdanalysis end -->