### PR TITLE
Fix Boltzmann typo in `units.py`

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,7 +13,7 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-??/??/?? IAlibay, jaclark5, MohitKumar020291, orionarcher
+??/??/?? IAlibay, jaclark5, MohitKumar020291, orionarcher, xhgchen
 
  * 2.6.0
 

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -18,6 +18,7 @@ The rules for this file:
  * 2.6.0
 
 Fixes
+  * Fix Boltzmann typo in `units.py` (PR #4214, Issue #4213)
   * Fix deletion of bond/angle/dihedral types (PR #4003, Issue #4001)
   * CRD, PQR, and PDBQT writers now write BZ2 and GZ files if requested
     (PR #4163, Issue #4159)

--- a/package/MDAnalysis/analysis/dielectric.py
+++ b/package/MDAnalysis/analysis/dielectric.py
@@ -159,7 +159,7 @@ class DielectricConstant(AnalysisBase):
         self.results.fluct = self.results.M2 - self.results.M * self.results.M
 
         self.results.eps = self.results.fluct / (
-              convert(constants["Boltzman_constant"], "kJ/mol", "eV") *
+              convert(constants["Boltzmann_constant"], "kJ/mol", "eV") *
               self.temperature * self.volume * constants["electric_constant"])
 
         self.results.eps_mean = self.results.eps.mean()

--- a/package/MDAnalysis/units.py
+++ b/package/MDAnalysis/units.py
@@ -193,7 +193,7 @@ constants = {
     'N_Avogadro': 6.02214129e+23,          # mol**-1
     'elementary_charge': 1.602176565e-19,  # As
     'calorie': 4.184,                      # J
-    'Boltzman_constant': 8.314462159e-3,   # KJ (mol K)**-1
+    'Boltzmann_constant': 8.314462159e-3,   # KJ (mol K)**-1
     'electric_constant': 5.526350e-3,      # As (Angstroms Volts)**-1
 }
 

--- a/testsuite/MDAnalysisTests/utils/test_units.py
+++ b/testsuite/MDAnalysisTests/utils/test_units.py
@@ -51,7 +51,7 @@ class TestConstants(object):
         ('N_Avogadro', 6.02214129e+23),  # mol**-1
         ('elementary_charge', 1.602176565e-19),  # As
         ('calorie', 4.184),  # J
-        ('Boltzman_constant', 8.314462159e-3),  # KJ (mol K)**-1
+        ('Boltzmann_constant', 8.314462159e-3),  # KJ (mol K)**-1
         ('electric_constant', 5.526350e-3),  # As (Angstroms Volts)**-1
     )
 


### PR DESCRIPTION
Fixes #4213 

Changes made in this Pull Request:
 - Update `package/MDAnalysis/analysis/dielectric.py`, `package/MDAnalysis/units.py`, and
`testsuite/MDAnalysisTests/utils/test_units.py`
to reflect correct spelling


<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--4214.org.readthedocs.build/en/4214/

<!-- readthedocs-preview mdanalysis end -->