### PR TITLE
Add pytest-timeout to CI

### DIFF
--- a/.github/actions/setup-deps/action.yaml
+++ b/.github/actions/setup-deps/action.yaml
@@ -83,6 +83,8 @@ inputs:
     default: 'coverage'
   pytest-cov:
     default: 'pytest-cov'
+  pytest-timeout:
+    default: 'pytest-timeout'
   pytest-xdist:
     default: 'pytest-xdist'
   trove-classifiers:
@@ -157,6 +159,7 @@ runs:
         PIP_MIN_DEPS: |
           ${{ inputs.coverage }}
           ${{ inputs.pytest-cov }}
+          ${{ inputs.pytest-timeout }}
           ${{ inputs.pytest-xdist }}
           ${{ inputs.trove-classifiers }}
         PIP_OPT_DEPS: |

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -255,4 +255,4 @@ jobs:
 
       - name: run_tests
         run: |
-          pytest --timeout=100 -n auto --pyargs MDAnalysisTests
+          pytest --timeout=200 -n auto --pyargs MDAnalysisTests

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -244,7 +244,7 @@ jobs:
       - name: install_min_deps
         if: "matrix.type == 'MIN'"
         run: |
-          pip install pytest pytest-xdist
+          pip install pytest pytest-xdist pytest-timeout
 
       - name: pip_install_mda
         run: |
@@ -255,4 +255,4 @@ jobs:
 
       - name: run_tests
         run: |
-          pytest -n2 --pyargs MDAnalysisTests
+          pytest --timeout=100 -n auto --pyargs MDAnalysisTests

--- a/.github/workflows/gh-ci-cron.yaml
+++ b/.github/workflows/gh-ci-cron.yaml
@@ -3,9 +3,6 @@ on:
   schedule:
     # 3 am Tuesdays and Fridays
     - cron: "0 3 * * 2,5"
-  pull_request:
-    branches:
-      - develop
 
 concurrency:
   # Probably overly cautious group naming.

--- a/.github/workflows/gh-ci-cron.yaml
+++ b/.github/workflows/gh-ci-cron.yaml
@@ -72,7 +72,7 @@ jobs:
 
     - name: run_tests
       run: |
-        pytest --timeout=100 -n auto testsuite/MDAnalysisTests --durations=50 -W error::FutureWarning
+        pytest --timeout=200 -n auto testsuite/MDAnalysisTests --durations=50 -W error::FutureWarning
 
 
   # Issue #3442
@@ -120,7 +120,7 @@ jobs:
 
     - name: run_tests
       run: |
-        pytest --timeout=100 -n auto testsuite/MDAnalysisTests --disable-pytest-warnings --durations=50
+        pytest --timeout=200 -n auto testsuite/MDAnalysisTests --disable-pytest-warnings --durations=50
 
 
   old_ubuntu_macos:
@@ -167,7 +167,7 @@ jobs:
 
     - name: run_tests
       run: |
-        pytest --timeout=100 -n auto testsuite/MDAnalysisTests --disable-pytest-warnings --durations=50
+        pytest --timeout=200 -n auto testsuite/MDAnalysisTests --disable-pytest-warnings --durations=50
 
 
   # Issue 1727
@@ -205,7 +205,7 @@ jobs:
 
     - name: run_tests
       run: |
-        pytest --timeout=100 -n auto testsuite/MDAnalysisTests --disable-pytest-warnings --durations=50
+        pytest --timeout=200 -n auto testsuite/MDAnalysisTests --disable-pytest-warnings --durations=50
         
   # Issue 4208
   conda-latest-release:
@@ -248,7 +248,7 @@ jobs:
 
     - name: run_tests
       run: |
-          pytest --timeout=100 -n auto --pyargs MDAnalysisTests
+          pytest --timeout=200 -n auto --pyargs MDAnalysisTests
           
   pypi-latest-release:
     # A set of runner to check that the latest conda release works as expected
@@ -273,4 +273,4 @@ jobs:
     - name: run_tests
       shell: bash
       run: |
-          pytest --timeout=100 -n auto --pyargs MDAnalysisTests
+          pytest --timeout=200 -n auto --pyargs MDAnalysisTests

--- a/.github/workflows/gh-ci-cron.yaml
+++ b/.github/workflows/gh-ci-cron.yaml
@@ -3,6 +3,9 @@ on:
   schedule:
     # 3 am Tuesdays and Fridays
     - cron: "0 3 * * 2,5"
+  pull_request:
+    branches:
+      - develop
 
 concurrency:
   # Probably overly cautious group naming.

--- a/.github/workflows/gh-ci-cron.yaml
+++ b/.github/workflows/gh-ci-cron.yaml
@@ -72,7 +72,7 @@ jobs:
 
     - name: run_tests
       run: |
-        pytest -n auto testsuite/MDAnalysisTests --durations=50 -W error::FutureWarning
+        pytest --timeout=100 -n auto testsuite/MDAnalysisTests --durations=50 -W error::FutureWarning
 
 
   # Issue #3442
@@ -120,7 +120,7 @@ jobs:
 
     - name: run_tests
       run: |
-        pytest -n auto testsuite/MDAnalysisTests --disable-pytest-warnings --durations=50
+        pytest --timeout=100 -n auto testsuite/MDAnalysisTests --disable-pytest-warnings --durations=50
 
 
   old_ubuntu_macos:
@@ -167,7 +167,7 @@ jobs:
 
     - name: run_tests
       run: |
-        pytest -n auto testsuite/MDAnalysisTests --disable-pytest-warnings --durations=50
+        pytest --timeout=100 -n auto testsuite/MDAnalysisTests --disable-pytest-warnings --durations=50
 
 
   # Issue 1727
@@ -201,11 +201,11 @@ jobs:
 
     - name: install_pip_extras
       run: |
-        pip install pytest-xdist
+        pip install pytest-xdist pytest-timeout
 
     - name: run_tests
       run: |
-        pytest -n auto testsuite/MDAnalysisTests --disable-pytest-warnings --durations=50
+        pytest --timeout=100 -n auto testsuite/MDAnalysisTests --disable-pytest-warnings --durations=50
         
   # Issue 4208
   conda-latest-release:
@@ -248,7 +248,7 @@ jobs:
 
     - name: run_tests
       run: |
-          pytest -n auto --pyargs MDAnalysisTests
+          pytest --timeout=100 -n auto --pyargs MDAnalysisTests
           
   pypi-latest-release:
     # A set of runner to check that the latest conda release works as expected
@@ -268,9 +268,9 @@ jobs:
     - name: install_mdanalysis
       shell: bash
       run: |
-          pip install mdanalysis mdanalysistests pytest-xdist "gsd<3.0"
+          pip install mdanalysis mdanalysistests pytest-xdist pytest-timeout "gsd<3.0"
 
     - name: run_tests
       shell: bash
       run: |
-          pytest -n auto --pyargs MDAnalysisTests
+          pytest --timeout=100 -n auto --pyargs MDAnalysisTests

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -97,7 +97,7 @@ jobs:
           PYTEST_FLAGS="${PYTEST_FLAGS} --cov-config=.coveragerc --cov=MDAnalysis --cov-report=xml"
         fi
         echo $PYTEST_FLAGS
-        pytest -n auto testsuite/MDAnalysisTests $PYTEST_FLAGS
+        pytest -n auto --timeout=100 testsuite/MDAnalysisTests $PYTEST_FLAGS
 
     - name: run_asv
       if: contains(matrix.name, 'asv_check')
@@ -229,7 +229,7 @@ jobs:
     - name: install_deps
       run: |
         python -m pip install -U pip pipx wheel build
-        python -m pip install twine "readme-renderer>=34.0" pytest-xdist
+        python -m pip install twine "readme-renderer>=34.0" pytest-xdist pytest-timeout
 
     - name: build_package_sdist
       run: |
@@ -260,4 +260,4 @@ jobs:
 
     - name: run tests
       working-directory: ./dist
-      run: python -m pytest -n auto --pyargs MDAnalysisTests
+      run: python -m pytest --timeout=100 -n auto --pyargs MDAnalysisTests

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -22,7 +22,7 @@ jobs:
   main_tests:
     if: "github.repository == 'MDAnalysis/mdanalysis'"
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 120
+    timeout-minutes: 60
     strategy:
         fail-fast: false
         matrix:

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -97,7 +97,7 @@ jobs:
           PYTEST_FLAGS="${PYTEST_FLAGS} --cov-config=.coveragerc --cov=MDAnalysis --cov-report=xml"
         fi
         echo $PYTEST_FLAGS
-        pytest -n auto --timeout=100 testsuite/MDAnalysisTests $PYTEST_FLAGS
+        pytest -n auto --timeout=200 testsuite/MDAnalysisTests $PYTEST_FLAGS
 
     - name: run_asv
       if: contains(matrix.name, 'asv_check')
@@ -260,4 +260,4 @@ jobs:
 
     - name: run tests
       working-directory: ./dist
-      run: python -m pytest --timeout=100 -n auto --pyargs MDAnalysisTests
+      run: python -m pytest --timeout=200 -n auto --pyargs MDAnalysisTests

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -130,7 +130,7 @@ jobs:
     condition: and(succeeded(), eq(variables['BUILD_TYPE'], 'normal'))
   - powershell: |
       cd testsuite
-      pytest MDAnalysisTests --disable-pytest-warnings -n auto --timeout=100 -rsx --cov=MDAnalysis
+      pytest MDAnalysisTests --disable-pytest-warnings -n auto --timeout=200 -rsx --cov=MDAnalysis
     displayName: 'Run MDAnalysis Test Suite'
   - script: |
       curl -s https://codecov.io/bash | bash

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -85,6 +85,7 @@ jobs:
       packaging
       pytest
       pytest-cov
+      pytest-timeout
       pytest-xdist
       scikit-learn
       tqdm
@@ -129,7 +130,7 @@ jobs:
     condition: and(succeeded(), eq(variables['BUILD_TYPE'], 'normal'))
   - powershell: |
       cd testsuite
-      pytest MDAnalysisTests --disable-pytest-warnings -n 2 -rsx --cov=MDAnalysis
+      pytest MDAnalysisTests --disable-pytest-warnings -n auto --timeout=100 -rsx --cov=MDAnalysis
     displayName: 'Run MDAnalysis Test Suite'
   - script: |
       curl -s https://codecov.io/bash | bash

--- a/maintainer/ci/cirrus-ci.yml
+++ b/maintainer/ci/cirrus-ci.yml
@@ -11,7 +11,7 @@ linux_aarch64_task:
     python3 -m pip install ./package
     python3 -m pip install ./testsuite
     python3 -m pip install pytest-xdist pytest-timeout
-    python3 -m pytest --timeout=100 -n 8 ./testsuite/MDAnalysisTests
+    python3 -m pytest --timeout=200 -n 8 ./testsuite/MDAnalysisTests
 
 
 macos_arm64_task:
@@ -28,4 +28,4 @@ macos_arm64_task:
     cd ../testsuite
     python -m pip install .
     python -m pip install pytest pytest-xdist pytest-timeout
-    python -m pytest --timeout=100 -n auto MDAnalysisTests
+    python -m pytest --timeout=200 -n auto MDAnalysisTests

--- a/maintainer/ci/cirrus-ci.yml
+++ b/maintainer/ci/cirrus-ci.yml
@@ -10,8 +10,8 @@ linux_aarch64_task:
     source mda-dev/bin/activate
     python3 -m pip install ./package
     python3 -m pip install ./testsuite
-    python3 -m pip install pytest-xdist
-    python3 -m pytest -n 8 ./testsuite/MDAnalysisTests
+    python3 -m pip install pytest-xdist pytest-timeout
+    python3 -m pytest --timeout=100 -n 8 ./testsuite/MDAnalysisTests
 
 
 macos_arm64_task:
@@ -27,5 +27,5 @@ macos_arm64_task:
     python -m pip install .
     cd ../testsuite
     python -m pip install .
-    python -m pip install pytest pytest-xdist
-    python -m pytest -n auto MDAnalysisTests
+    python -m pip install pytest pytest-xdist pytest-timeout
+    python -m pytest --timeout=100 -n auto MDAnalysisTests


### PR DESCRIPTION
Temporary patch for #4209 

Changes made in this Pull Request:
 - Add pytest-timeout to gh actions, azure and Cirrus 


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?


<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--4215.org.readthedocs.build/en/4215/

<!-- readthedocs-preview mdanalysis end -->