### PR TITLE
Add cron trigger to cirrus.star

### DIFF
--- a/.cirrus.star
+++ b/.cirrus.star
@@ -23,6 +23,10 @@ def main(ctx):
     if ((env.get("CIRRUS_BASE_BRANCH") == "develop") and (env.get("CIRRUS_PR") != None)):
         return fs.read("maintainer/ci/cirrus-ci.yml")
 
+    # If it's a CRON job named twiceweekly
+    if ((env.get("CIRRUS_CRON") == "twiceweekly") and (env.get("CIRRUS_BRANCH") == "develop")):
+        return fs.read("maintainer/ci/cirrus-ci.yml")
+
     # If you've tagged a package or released something, deploy
     if ((env.get("CIRRUS_TAG") != None) or (env.get("CIRRUS_RELEASE") != None)):
         return fs.read("maintainer/ci/cirrus-deploy.yml")


### PR DESCRIPTION
Towards #4216 

Changes made in this Pull Request:
 - Just add an extra CRON trigger to the cirrus star. I made the necessary changes on the provider.
 - If it works, once end of August comes we just remove the PR trigger and we're done. 


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?


<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--4217.org.readthedocs.build/en/4217/

<!-- readthedocs-preview mdanalysis end -->