### PR TITLE
remove -ffast-math compiler flag

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -21,9 +21,9 @@ The rules for this file:
  * 2.6.0
 
 Fixes
-  * Fix AtomGroup.center_of_charge(..., unwrap=True) giving wrong
-    results on Intel macOS by removing `-ffast-math` compiler flag
-    (Issues #3821, #4211)    
+  * Fix AtomGroup.center_of_charge(..., unwrap=True) giving
+    inconsistent (but scientifically correct) results on Intel macOS
+    (Issue #4211)
   * Fix Boltzmann typo in `units.py` (PR #4214, Issue #4213)
   * Fix deletion of bond/angle/dihedral types (PR #4003, Issue #4001)
   * CRD, PQR, and PDBQT writers now write BZ2 and GZ files if requested
@@ -35,6 +35,11 @@ Enhancements
     (Issue #3546)
 
 Changes
+  * Removed `-ffast-math` compiler flag to avoid potentially incorrect
+    floating point results in MDAnalysis *and* other codes when
+    MDAnalysis shared libraries are loaded --- see 
+    https://moyix.blogspot.com/2022/09/someones-been-messing-with-my-subnormals.html
+    (Issues #3821, #4211)
   * Atom ID representation order updated to match that of associated
     AtomGroup indices.
     (PR #4191, Issue #4181)

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -14,11 +14,16 @@ The rules for this file:
 
 ------------------------------------------------------------------------------
 
-??/??/?? IAlibay, jaclark5, MohitKumar020291, orionarcher, xhgchen, ztimol
+??/??/?? IAlibay, jaclark5, MohitKumar020291, orionarcher, xhgchen,
+         ztimol, orbeckst
+
 
  * 2.6.0
 
 Fixes
+  * Fix AtomGroup.center_of_charge(..., unwrap=True) giving wrong
+    results on Intel macOS by removing `-ffast-math` compiler flag
+    (Issues #3821, #4211)    
   * Fix Boltzmann typo in `units.py` (PR #4214, Issue #4213)
   * Fix deletion of bond/angle/dihedral types (PR #4003, Issue #4001)
   * CRD, PQR, and PDBQT writers now write BZ2 and GZ files if requested

--- a/package/setup.py
+++ b/package/setup.py
@@ -268,7 +268,7 @@ def extensions(config):
     use_openmp = config.get('use_openmp', default=True)
     annotate_cython = config.get('annotate_cython', default=False)
 
-    extra_compile_args = ['-std=c99', '-ffast-math', '-O3', '-funroll-loops',
+    extra_compile_args = ['-std=c99', '-O3', '-funroll-loops',
                           '-fsigned-zeros'] # see #2722
     define_macros = []
     if config.get('debug_cflags', default=False):


### PR DESCRIPTION
Fixes #4211 and #3821

Changes made in this Pull Request:
- removed `-ffast-math` from the compiler flags in `setup.py`
- Without -ffast-math, the AtomGroup.center_of_charge(..., unwrap=True) pass again on Intel x86_64 macOS.


PR Checklist
------------
 - [x] Tests? (existing, checked locally on Intel mac 15.2)
 - n/a Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--4220.org.readthedocs.build/en/4220/

<!-- readthedocs-preview mdanalysis end -->