### PR TITLE
fixed incorrect duecredit environment variable in documentation

### DIFF
--- a/package/doc/sphinx/source/documentation_pages/references.rst
+++ b/package/doc/sphinx/source/documentation_pages/references.rst
@@ -258,7 +258,7 @@ or set the environment variable :envvar:`DUECREDIT_ENABLE`
 
 .. code-block:: bash
 
-   DUECREDIT-ENABLE=yes python yourscript.py
+   DUECREDIT_ENABLE=yes python yourscript.py
 
 Once the citations have been extracted (to a hidden file in the
 current directory), you can use the :program:`duecredit` program to


### PR DESCRIPTION
Changes made in this Pull Request:
 - Changed example duecredit environment variable from
   `DUECREDIT-ENABLE` (invalid) to `DUECREDIT_ENABLE`


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--4226.org.readthedocs.build/en/4226/

<!-- readthedocs-preview mdanalysis end -->