### PR TITLE
Update numpy in pyproject.toml

### DIFF
--- a/package/pyproject.toml
+++ b/package/pyproject.toml
@@ -34,7 +34,7 @@ maintainers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    'numpy>=1.21.0',
+    'numpy>=1.22.3',
     'biopython>=1.80',
     'networkx>=2.0',
     'GridDataFormats>=0.4.0',


### PR DESCRIPTION
Looks like we forgot to bump up the numpy version in the pyproject.toml? setup.py is fine.

PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--4227.org.readthedocs.build/en/4227/

<!-- readthedocs-preview mdanalysis end -->