### PR TITLE
Enable old Boltzmann key with `DeprecationWarning`

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -21,6 +21,9 @@ The rules for this file:
  * 2.6.0
 
 Fixes
+  * Fix Boltzmann constant API break by enabling access to old
+    'Boltzman_constant' key with a `DeprecationWarning` in `units.py`
+    (PR #4230, Issue #4229)
   * Fix AtomGroup.center_of_charge(..., unwrap=True) giving
     inconsistent (but scientifically correct) results on Intel macOS
     (Issue #4211)

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -57,8 +57,7 @@ Changes
     (PR #4174, Issue #3819)
 
 Deprecations
-  * Fix Boltzmann constant API break by enabling access to old
-    'Boltzman_constant' key with a `DeprecationWarning` in `units.py`
+  * Incorrectly spelt Boltzmann unit entry will be removed in version 2.8.0
     (PR #4230, Issue #4229)
   * The hole2 module is deprecated in favour of the the MDAKit:
     https://github.com/MDAnalysis/hole2-mdakit (Issue #4179, PR #4200)

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -21,9 +21,6 @@ The rules for this file:
  * 2.6.0
 
 Fixes
-  * Fix Boltzmann constant API break by enabling access to old
-    'Boltzman_constant' key with a `DeprecationWarning` in `units.py`
-    (PR #4230, Issue #4229)
   * Fix AtomGroup.center_of_charge(..., unwrap=True) giving
     inconsistent (but scientifically correct) results on Intel macOS
     (Issue #4211)
@@ -60,6 +57,9 @@ Changes
     (PR #4174, Issue #3819)
 
 Deprecations
+  * Fix Boltzmann constant API break by enabling access to old
+    'Boltzman_constant' key with a `DeprecationWarning` in `units.py`
+    (PR #4230, Issue #4229)
   * The hole2 module is deprecated in favour of the the MDAKit:
     https://github.com/MDAnalysis/hole2-mdakit (Issue #4179, PR #4200)
   * MDAnalysis no longer officially supports 32 bit installations (they are

--- a/package/MDAnalysis/units.py
+++ b/package/MDAnalysis/units.py
@@ -172,6 +172,23 @@ References and footnotes
 
 """
 
+import warnings
+
+
+# Remove in 2.8.0
+class DeprecatedKeyAccessDict(dict):
+    deprecated_kB = 'Boltzman_constant'
+
+    def __getitem__(self, key):
+        if key == self.deprecated_kB:
+            wmsg = ("Please use 'Boltzmann_constant' henceforth. The key "
+                    "'Boltzman_constant' was a typo and will be removed "
+                    "in MDAnalysis 2.8.0.")
+            warnings.warn(wmsg, DeprecationWarning)
+            key = 'Boltzmann_constant'
+        return super().__getitem__(key)
+
+
 #
 # NOTE: Whenever a constant is added to the constants dict, you also
 #       MUST add an appropriate entry to
@@ -189,13 +206,13 @@ References and footnotes
 #:    http://physics.nist.gov/Pubs/SP811/appenB8.html#C
 #:
 #: .. versionadded:: 0.9.0
-constants = {
+constants = DeprecatedKeyAccessDict({
     'N_Avogadro': 6.02214129e+23,          # mol**-1
     'elementary_charge': 1.602176565e-19,  # As
     'calorie': 4.184,                      # J
     'Boltzmann_constant': 8.314462159e-3,   # KJ (mol K)**-1
     'electric_constant': 5.526350e-3,      # As (Angstroms Volts)**-1
-}
+})
 
 #: The basic unit of *length* in MDAnalysis is the Angstrom.
 #: Conversion factors between the base unit and other lengthUnits *x* are stored.

--- a/testsuite/MDAnalysisTests/utils/test_units.py
+++ b/testsuite/MDAnalysisTests/utils/test_units.py
@@ -52,12 +52,20 @@ class TestConstants(object):
         ('elementary_charge', 1.602176565e-19),  # As
         ('calorie', 4.184),  # J
         ('Boltzmann_constant', 8.314462159e-3),  # KJ (mol K)**-1
+        ('Boltzman_constant', 8.314462159e-3),  # remove in 2.8.0
         ('electric_constant', 5.526350e-3),  # As (Angstroms Volts)**-1
     )
 
     @pytest.mark.parametrize('name, value', constants_reference)
     def test_constant(self, name, value):
         assert_almost_equal(units.constants[name], value)
+
+    def test_boltzmann_typo_deprecation(self):
+        wmsg = ("Please use 'Boltzmann_constant' henceforth. The key "
+                "'Boltzman_constant' was a typo and will be removed "
+                "in MDAnalysis 2.8.0.")
+        with pytest.warns(DeprecationWarning, match=wmsg):
+            units.constants['Boltzman_constant']
 
 
 class TestConversion(object):


### PR DESCRIPTION
Fixes #4229

Changes made in this Pull Request:
 - Provide old `'Boltzman_constant'` key in subclassed dict and wrap `__getitem__` with `DeprecationWarning`
 - Add test for old `'Boltzman_constant'` key
 - Add test for deprecation warning with old `'Boltzman_constant'` key


PR Checklist
------------
 - [x] Tests?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--4230.org.readthedocs.build/en/4230/

<!-- readthedocs-preview mdanalysis end -->