### PR TITLE
fix error message for XDR readers

### DIFF
--- a/package/MDAnalysis/coordinates/XDR.py
+++ b/package/MDAnalysis/coordinates/XDR.py
@@ -63,8 +63,7 @@ def offsets_filename(filename, ending='npz'):
 
     """
     head, tail = split(filename)
-    return join(head, '.{tail}_offsets.{ending}'.format(tail=tail,
-                                                        ending=ending))
+    return join(head, f'.{tail}_offsets.{ending}')
 
 
 def read_numpy_offsets(filename):
@@ -88,7 +87,7 @@ def read_numpy_offsets(filename):
 
     #  `ValueError` is encountered when the offset file is corrupted.
     except (ValueError, IOError):
-        warnings.warn("Failed to load offsets file {}\n".format(filename))
+        warnings.warn(f"Failed to load offsets file {filename}\n")
         return False
 
 class XDRBaseReader(base.ReaderBase):
@@ -201,7 +200,7 @@ class XDRBaseReader(base.ReaderBase):
         except OSError as e:
             if isinstance(e, PermissionError) or e.errno == errno.EROFS:
                 warnings.warn(f"Cannot write lock/offset file in same location as "
-                               "{self.filename}. Using slow offset calculation.")
+                              f"{self.filename}. Using slow offset calculation.")
                 self._read_offsets(store=True)
                 return
             else:
@@ -220,10 +219,10 @@ class XDRBaseReader(base.ReaderBase):
             # refer to Issue #1893
             data = read_numpy_offsets(fname)
             if not data:
-                warnings.warn("Reading offsets from {} failed, "
-                              "reading offsets from trajectory instead.\n"
-                              "Consider setting 'refresh_offsets=True' "
-                              "when loading your Universe.".format(fname))
+                warnings.warn(f"Reading offsets from {fname} failed, "
+                              f"reading offsets from trajectory instead.\n"
+                              f"Consider setting 'refresh_offsets=True' "
+                              f"when loading your Universe.")
                 self._read_offsets(store=True)
                 return
 
@@ -256,7 +255,7 @@ class XDRBaseReader(base.ReaderBase):
                          offsets=offsets, size=size, ctime=ctime,
                          n_atoms=self._xdr.n_atoms)
             except Exception as e:
-                warnings.warn("Couldn't save offsets because: {}".format(e))
+                warnings.warn(f"Couldn't save offsets because: {e}")
 
     @property
     def n_frames(self):

--- a/package/MDAnalysis/coordinates/XDR.py
+++ b/package/MDAnalysis/coordinates/XDR.py
@@ -220,9 +220,9 @@ class XDRBaseReader(base.ReaderBase):
             data = read_numpy_offsets(fname)
             if not data:
                 warnings.warn(f"Reading offsets from {fname} failed, "
-                              f"reading offsets from trajectory instead.\n"
-                              f"Consider setting 'refresh_offsets=True' "
-                              f"when loading your Universe.")
+                              "reading offsets from trajectory instead.\n"
+                              "Consider setting 'refresh_offsets=True' "
+                              "when loading your Universe.")
                 self._read_offsets(store=True)
                 return
 

--- a/testsuite/MDAnalysisTests/coordinates/base.py
+++ b/testsuite/MDAnalysisTests/coordinates/base.py
@@ -443,13 +443,13 @@ class BaseReaderTest(object):
         assert_equal(len(reader), len(reader_p))
         assert_equal(reader.ts, reader_p.ts,
                      "Timestep is changed after pickling")
-    
+
     def test_frame_collect_all_same(self, reader):
-        # check that the timestep resets so that the base reference is the same 
+        # check that the timestep resets so that the base reference is the same
         # for all timesteps in a collection with the exception of memoryreader
         # and DCDReader
         if isinstance(reader, mda.coordinates.memory.MemoryReader):
-            pytest.xfail("memoryreader allows independent coordinates") 
+            pytest.xfail("memoryreader allows independent coordinates")
         if isinstance(reader, mda.coordinates.DCD.DCDReader):
             pytest.xfail("DCDReader allows independent coordinates."
                           "This behaviour is deprecated and will be changed"
@@ -493,9 +493,11 @@ class BaseReaderTest(object):
         assert(timeseries.shape[0] == len(reader))
         assert(timeseries.shape[1] == len(atoms))
         assert(timeseries.shape[2] == 3)
-    
+
     def test_timeseries_empty_asel(self, reader):
-        atoms = mda.Universe(reader.filename).select_atoms(None)
+        with pytest.warns(UserWarning,
+                          match="Empty string to select atoms, empty group returned."):
+            atoms = mda.Universe(reader.filename).select_atoms(None)
         with pytest.raises(ValueError, match="Timeseries requires at least"):
             reader.timeseries(atoms)
 

--- a/testsuite/MDAnalysisTests/coordinates/test_xdr.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_xdr.py
@@ -553,11 +553,9 @@ class _GromacsWriterIssue117(object):
 
     @pytest.fixture()
     def universe(self):
-        with pytest.warns(UserWarning,
-                          match="ATOMIC_NUMBER record not found"):
-            u = mda.Universe(PRMncdf, NCDF)
-        return u
+        return mda.Universe(PRMncdf, NCDF)
 
+    @pytest.mark.filterwarnings("ignore: ATOMIC_NUMBER record not found")
     def test_write_trajectory(self, universe, tmpdir):
         """Test writing Gromacs trajectories from AMBER NCDF (Issue 117)"""
         outfile = str(tmpdir.join('xdr-writer-issue117' + self.ext))
@@ -565,9 +563,7 @@ class _GromacsWriterIssue117(object):
             for ts in universe.trajectory:
                 W.write(universe)
 
-        with pytest.warns(UserWarning,
-                          match="ATOMIC_NUMBER record not found"):
-            uw = mda.Universe(PRMncdf, outfile)
+        uw = mda.Universe(PRMncdf, outfile)
 
         # check that the coordinates are identical for each time step
         for orig_ts, written_ts in zip(universe.trajectory, uw.trajectory):

--- a/testsuite/MDAnalysisTests/coordinates/test_xdr.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_xdr.py
@@ -575,7 +575,7 @@ class _GromacsWriterIssue117(object):
                 written_ts._pos,
                 orig_ts._pos,
                 self.prec,
-                err_msg=(f"coordinate mismatch between original and written "
+                err_msg=("coordinate mismatch between original and written "
                          f"trajectory at frame {orig_ts.frame:d} (orig) vs "
                          f"{orig_ts.frame:d} (written)"))
 

--- a/testsuite/MDAnalysisTests/coordinates/test_xdr.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_xdr.py
@@ -47,6 +47,7 @@ from MDAnalysis.coordinates.base import Timestep
 from MDAnalysis.coordinates import XDR
 from MDAnalysisTests.util import get_userid
 
+
 @pytest.mark.parametrize("filename,kwargs,reference", [
     ("foo.xtc", {}, ".foo.xtc_offsets.npz"),
     ("foo.xtc", {"ending": "npz"}, ".foo.xtc_offsets.npz"),
@@ -55,6 +56,7 @@ from MDAnalysisTests.util import get_userid
 def test_offsets_filename(filename, kwargs, reference):
     fn = XDR.offsets_filename(filename, **kwargs)
     assert fn == reference
+
 
 class _XDRReader_Sub(object):
     @pytest.fixture()

--- a/testsuite/MDAnalysisTests/coordinates/test_xdr.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_xdr.py
@@ -553,7 +553,10 @@ class _GromacsWriterIssue117(object):
 
     @pytest.fixture()
     def universe(self):
-        return mda.Universe(PRMncdf, NCDF)
+        with pytest.warns(UserWarning,
+                          match="ATOMIC_NUMBER record not found"):
+            u = mda.Universe(PRMncdf, NCDF)
+        return u
 
     def test_write_trajectory(self, universe, tmpdir):
         """Test writing Gromacs trajectories from AMBER NCDF (Issue 117)"""
@@ -562,7 +565,9 @@ class _GromacsWriterIssue117(object):
             for ts in universe.trajectory:
                 W.write(universe)
 
-        uw = mda.Universe(PRMncdf, outfile)
+        with pytest.warns(UserWarning,
+                          match="ATOMIC_NUMBER record not found"):
+            uw = mda.Universe(PRMncdf, outfile)
 
         # check that the coordinates are identical for each time step
         for orig_ts, written_ts in zip(universe.trajectory, uw.trajectory):
@@ -570,10 +575,9 @@ class _GromacsWriterIssue117(object):
                 written_ts._pos,
                 orig_ts._pos,
                 self.prec,
-                err_msg="coordinate mismatch "
-                "between original and written "
-                "trajectory at frame %d (orig) vs %d "
-                "(written)" % (orig_ts.frame, written_ts.frame))
+                err_msg=(f"coordinate mismatch between original and written "
+                         f"trajectory at frame {orig_ts.frame:d} (orig) vs "
+                         f"{orig_ts.frame:d} (written)"))
 
 
 class TestXTCWriterIssue117(_GromacsWriterIssue117):


### PR DESCRIPTION
Fixes #

Changes made in this Pull Request:
- error message for not being able to write lockfile did not insert the filename into message: fixed by using proper f string
- changed all .format to modern f string in XDR.py
- add explicit test for offsets_filename()
- add additional pytest.warns() to tests to catch warnings (reduces warnings output and checks that all expected warnings are raised with proper messages)



PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--4231.org.readthedocs.build/en/4231/

<!-- readthedocs-preview mdanalysis end -->