### PR TITLE
[HOLD end of August] Deal with loss of free continuous Cirrus CI

### DIFF
--- a/.cirrus.star
+++ b/.cirrus.star
@@ -19,10 +19,6 @@ def main(ctx):
     print(env.get("CIRRUS_PR") != None)
     print(env.get("CIRRUS_BASE_BRANCH") == "develop")
 
-    # If you're targetting develop and it's a PR, run a CI job
-    if ((env.get("CIRRUS_BASE_BRANCH") == "develop") and (env.get("CIRRUS_PR") != None)):
-        return fs.read("maintainer/ci/cirrus-ci.yml")
-
     # If it's a CRON job named twiceweekly
     if ((env.get("CIRRUS_CRON") == "twiceweekly") and (env.get("CIRRUS_BRANCH") == "develop")):
         return fs.read("maintainer/ci/cirrus-ci.yml")

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
   MDAnalysis Repository README
 ================================
 
-|numfocus| |build| |cron| |linters| |cov|
+|numfocus| |build| |cron| |cirruscron| |linters| |cov|
 
 |docs| |devdocs| |usergroup| |developergroup| |anaconda| |asv|
 
@@ -174,6 +174,10 @@ For citations of included algorithms and sub-modules please see the references_.
 .. |cron| image:: https://github.com/MDAnalysis/mdanalysis/actions/workflows/gh-ci-cron.yaml/badge.svg
    :alt: Github Actions Cron Job Status
    :target: https://github.com/MDAnalysis/mdanalysis/actions/workflows/gh-ci-cron.yaml
+
+.. |cirruscron| image:: https://img.shields.io/cirrus/github/MDAnalysis/mdanalysis/develop
+   :alt: Cirrus CI - Cron job status
+   :target: https://cirrus-ci.com/github/MDAnalysis/mdanalysis/develop
 
 .. |linters| image:: https://github.com/MDAnalysis/mdanalysis/actions/workflows/linters.yaml/badge.svg
    :alt: Github Actions Linters Status


### PR DESCRIPTION
Fixes #4216 

Changes made in this Pull Request:
 - Drop running Cirrus CI on PRs, now will only run on a twice weekly cron
 - Add badge so we know if things are breaking

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--4234.org.readthedocs.build/en/4234/

<!-- readthedocs-preview mdanalysis end -->