### PR TITLE
Add production tarball pypi builds to cron & ensure use of correct compiler [Issue #4223]

### DIFF
--- a/.github/workflows/gh-ci-cron.yaml
+++ b/.github/workflows/gh-ci-cron.yaml
@@ -285,7 +285,7 @@ jobs:
       shell: bash
       run: |
           if [ "${{ matrix.wheels }}" == "false" ]; then
-            INSTALL_FLAGS="--no-binary -vvv"
+            INSTALL_FLAGS="-vvv --no-binary"
           fi
           pip install ${INSTALL_FLAGS} mdanalysis mdanalysistests pytest-xdist pytest-timeout "gsd<3.0"
 

--- a/.github/workflows/gh-ci-cron.yaml
+++ b/.github/workflows/gh-ci-cron.yaml
@@ -3,9 +3,6 @@ on:
   schedule:
     # 3 am Tuesdays and Fridays
     - cron: "0 3 * * 2,5"
-  pull_request:
-    branches:
-      - develop
 
 concurrency:
   # Probably overly cautious group naming.

--- a/.github/workflows/gh-ci-cron.yaml
+++ b/.github/workflows/gh-ci-cron.yaml
@@ -288,7 +288,7 @@ jobs:
           if [ "${{ matrix.wheels }}" == "false" ]; then
             INSTALL_FLAGS="-vvv --no-binary"
           fi
-          pip install ${INSTALL_FLAGS} mdanalysis mdanalysistests pytest-xdist pytest-timeout "gsd<3.0"
+          pip install ${INSTALL_FLAGS} mdanalysis mdanalysistests pytest-xdist pytest-timeout
 
     - name: run_tests
       shell: bash

--- a/.github/workflows/gh-ci-cron.yaml
+++ b/.github/workflows/gh-ci-cron.yaml
@@ -285,7 +285,7 @@ jobs:
       shell: bash
       run: |
           if [ "${{ matrix.wheels }}" == "false" ]; then
-            INSTALL_FLAGS="--no-binary -v"
+            INSTALL_FLAGS="--no-binary -vvv"
           fi
           pip install ${INSTALL_FLAGS} mdanalysis mdanalysistests pytest-xdist pytest-timeout "gsd<3.0"
 

--- a/.github/workflows/gh-ci-cron.yaml
+++ b/.github/workflows/gh-ci-cron.yaml
@@ -270,8 +270,10 @@ jobs:
           python-version: ["3.9", "3.10", "3.11"]
           wheels: ['true', 'false']
     steps:
+      # Checkout to have access to local actions (i.e. setup-os)
     - uses: actions/checkout@v3
 
+      # We need this here in order to make sure we assign the correct compiler (i.e. clang for macos)
     - name: setup_os
       uses: ./.github/actions/setup-os
       with:
@@ -284,6 +286,8 @@ jobs:
     - name: install_mdanalysis
       shell: bash
       run: |
+          # If wheels is False we build directly from source so we use the --no-binary flag
+          # to avoid pulling down wheels for MDAnalysis (which are already precompiled)
           if [ "${{ matrix.wheels }}" == "false" ]; then
             INSTALL_FLAGS="-vvv --no-binary"
           fi

--- a/.github/workflows/gh-ci-cron.yaml
+++ b/.github/workflows/gh-ci-cron.yaml
@@ -3,6 +3,9 @@ on:
   schedule:
     # 3 am Tuesdays and Fridays
     - cron: "0 3 * * 2,5"
+  pull_request:
+    branches:
+      - develop
 
 concurrency:
   # Probably overly cautious group naming.
@@ -211,15 +214,20 @@ jobs:
   conda-latest-release:
     # A set of runner to check that the latest conda release works as expected
     if: "github.repository == 'MDAnalysis/mdanalysis'"
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}-latest
     timeout-minutes: 60
     strategy:
         fail-fast: false
         matrix:
-          os: [ubuntu-latest, macos-latest]
+          os: [ubuntu, macos]
           python-version: ["3.9", "3.10", "3.11"]
     steps:
     - uses: actions/checkout@v3
+
+    - name: setup_os
+      uses: ./.github/actions/setup-os
+      with:
+        os-type: ${{ matrix.os }}
 
     - name: setup_micromamba
       uses: mamba-org/setup-micromamba@v1
@@ -253,14 +261,22 @@ jobs:
   pypi-latest-release:
     # A set of runner to check that the latest conda release works as expected
     if: "github.repository == 'MDAnalysis/mdanalysis'"
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}-latest
     timeout-minutes: 60
     strategy:
         fail-fast: false
         matrix:
-          os: [ubuntu-latest, macos-latest, windows-latest]
+          os: [ubuntu, macos, windows]
           python-version: ["3.9", "3.10", "3.11"]
+          wheels: ['true', 'false']
     steps:
+    - uses: actions/checkout@v3
+
+    - name: setup_os
+      uses: ./.github/actions/setup-os
+      with:
+        os-type: ${{ matrix.os }}
+
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
@@ -268,7 +284,10 @@ jobs:
     - name: install_mdanalysis
       shell: bash
       run: |
-          pip install mdanalysis mdanalysistests pytest-xdist pytest-timeout "gsd<3.0"
+          if [ "${{ matrix.wheels }}" == "false" ]; then
+            INSTALL_FLAGS="--no-binary -v"
+          fi
+          pip install ${INSTALL_FLAGS} mdanalysis mdanalysistests pytest-xdist pytest-timeout "gsd<3.0"
 
     - name: run_tests
       shell: bash


### PR DESCRIPTION
Fixes #4223 

Changes made in this Pull Request:
 - Add production tarball install tests
 - Make sure we use clang for macos runners


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--4240.org.readthedocs.build/en/4240/

<!-- readthedocs-preview mdanalysis end -->