### PR TITLE
Start 2.7.0-dev0

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,10 +13,21 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
+??/??/?? IAlibay
+
+ * 2.7.0
+
+Fixes
+
+Enhancements
+
+Changes
+
+Deprecations
+
 
 08/15/23 IAlibay, jaclark5, MohitKumar020291, orionarcher, xhgchen,
          ztimol, orbeckst
-
 
  * 2.6.0
 

--- a/package/MDAnalysis/version.py
+++ b/package/MDAnalysis/version.py
@@ -67,4 +67,4 @@ Data
 # e.g. with lib.log
 
 #: Release of MDAnalysis as a string, using `semantic versioning`_.
-__version__ = "2.6.0"  # NOTE: keep in sync with RELEASE in setup.py
+__version__ = "2.7.0-dev0"  # NOTE: keep in sync with RELEASE in setup.py

--- a/package/pyproject.toml
+++ b/package/pyproject.toml
@@ -25,7 +25,7 @@ maintainers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    'numpy>=1.22.3,<2.0',
+    'numpy>=1.22.3',
     'biopython>=1.80',
     'networkx>=2.0',
     'GridDataFormats>=0.4.0',

--- a/package/setup.py
+++ b/package/setup.py
@@ -592,7 +592,7 @@ if __name__ == '__main__':
     exts, cythonfiles = extensions(config)
 
     install_requires = [
-          'numpy>=1.22.3,<2.0',
+          'numpy>=1.22.3',
           'biopython>=1.80',
           'networkx>=2.0',
           'GridDataFormats>=0.4.0',

--- a/package/setup.py
+++ b/package/setup.py
@@ -67,7 +67,7 @@ import configparser
 from subprocess import getoutput
 
 # NOTE: keep in sync with MDAnalysis.__version__ in version.py
-RELEASE = "2.6.0"
+RELEASE = "2.7.0-dev0"
 
 is_release = 'dev' not in RELEASE
 

--- a/testsuite/MDAnalysisTests/__init__.py
+++ b/testsuite/MDAnalysisTests/__init__.py
@@ -97,7 +97,7 @@ import pytest
 logger = logging.getLogger("MDAnalysisTests.__init__")
 
 # keep in sync with RELEASE in setup.py
-__version__ = "2.6.0"
+__version__ = "2.7.0-dev0"
 
 
 # Do NOT import MDAnalysis at this level. Tests should do it themselves.

--- a/testsuite/setup.py
+++ b/testsuite/setup.py
@@ -87,7 +87,7 @@ if sys.version_info[:2] < (3, 9):
 
 if __name__ == '__main__':
     # this must be in-sync with MDAnalysis
-    RELEASE = "2.6.0"
+    RELEASE = "2.7.0-dev0"
     with open("README") as summary:
         LONG_DESCRIPTION = summary.read()
 


### PR DESCRIPTION
Things haven't made it to conda-forge yet, but right now if things are broken we'll have to do a 2.6.1 release anyways.

Changes made in this Pull Request:
 - Start 2.7.0-dev0
 - Remove upper numpy pin to allow us to test against nightly builds of NumPy.

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--4245.org.readthedocs.build/en/4245/

<!-- readthedocs-preview mdanalysis end -->