### PR TITLE
Change DEFs to cdef int constants

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,7 +13,7 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-??/??/?? IAlibay
+??/??/?? IAlibay, hmacdope
 
  * 2.7.0
 
@@ -22,6 +22,8 @@ Fixes
 Enhancements
 
 Changes
+  * Cython DEF statments have been replaced with compile time integer constants
+    as DEF is deprecated as of Cython>=3.0 (Issue #4237, PR #4246)
 
 Deprecations
 

--- a/package/MDAnalysis/lib/nsgrid.pyx
+++ b/package/MDAnalysis/lib/nsgrid.pyx
@@ -83,18 +83,18 @@ import numpy as np
 from libcpp.vector cimport vector
 from libc cimport math
 
-DEF END = -1
+cdef int END = -1
 
-DEF XX = 0
-DEF XY = 3
-DEF YY = 4
-DEF XZ = 6
-DEF YZ = 7
-DEF ZZ = 8
+cdef int XX = 0
+cdef int XY = 3
+cdef int YY = 4
+cdef int XZ = 6
+cdef int YZ = 7
+cdef int ZZ = 8
 
 # Cube root of the maximum size of a 32 bit signed integer. If the system is divided into more
 # grids than this, integer overflow will occur.
-DEF MAX_GRID_DIM = 1290
+cdef int  MAX_GRID_DIM = 1290
 
 ctypedef float coordinate[3]
 


### PR DESCRIPTION
Fixes #4237 

Changes made in this Pull Request:
 - Changes cython DEFs to be integer constants due to deprecation of DEF in cython 3.0+


PR Checklist
------------
 - [X] CHANGELOG updated?
 - [X] Issue raised/referenced?

## Developers certificate of origin
- [X] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--4246.org.readthedocs.build/en/4246/

<!-- readthedocs-preview mdanalysis end -->