### PR TITLE
[WIP] Modify charge neutrality verification in DielectricConstant

### DIFF
--- a/package/MDAnalysis/analysis/dielectric.py
+++ b/package/MDAnalysis/analysis/dielectric.py
@@ -74,6 +74,10 @@ class DielectricConstant(AnalysisBase):
     make_whole : bool
       Make molecules whole; If the input already contains whole molecules
       this can be disabled to gain speedup
+    check_neutrality_of: str
+        Modify the level at which charge neutrality is enforced. Options are
+        {'group', 'segments', 'residues', 'molecules', 'fragments'}. Default
+        is 'fragments' and the most permissive is 'group'.
     verbose : bool
       Show detailed progress of the calculation
 
@@ -117,18 +121,19 @@ class DielectricConstant(AnalysisBase):
 
     .. versionadded:: 2.1.0
     """
-    def __init__(self, atomgroup, temperature=300, make_whole=True, **kwargs):
+    def __init__(self, atomgroup, temperature=300, make_whole=True, check_neutrality_of="fragments",**kwargs):
         super(DielectricConstant, self).__init__(atomgroup.universe.trajectory,
                                                  **kwargs)
         self.atomgroup = atomgroup
         self.temperature = temperature
         self.make_whole = make_whole
+        self.check_neutrality_of = check_neutrality_of
 
     def _prepare(self):
         if not hasattr(self.atomgroup, "charges"):
             raise NoDataError("No charges defined given atomgroup.")
 
-        if not np.allclose(self.atomgroup.total_charge(compound='group'),
+        if not np.allclose(self.atomgroup.total_charge(compound=self.check_neutrality_of),
                            0.0, atol=1E-5):
             raise NotImplementedError("Analysis for non-neutral systems or"
                                       " systems with free charges are not"

--- a/package/MDAnalysis/analysis/dielectric.py
+++ b/package/MDAnalysis/analysis/dielectric.py
@@ -128,7 +128,7 @@ class DielectricConstant(AnalysisBase):
         if not hasattr(self.atomgroup, "charges"):
             raise NoDataError("No charges defined given atomgroup.")
 
-        if not np.allclose(self.atomgroup.total_charge(compound='fragments'),
+        if not np.allclose(self.atomgroup.total_charge(compound='group'),
                            0.0, atol=1E-5):
             raise NotImplementedError("Analysis for non-neutral systems or"
                                       " systems with free charges are not"


### PR DESCRIPTION
This PR allows DielectricConstant to check charge neutrality at a customizable granularity.

I work with electrolyte systems where `fragments` are molecules in the system. In the current scheme, DielectricConstant will fail on my systems because ions have non-zero charge. This adds a keyword to modify the level at which charge neutrality is enforced.

I think changing the hard-coded option to "group" to simplify the API would also be a good fix, it's unclear to me why "fragments" is desirable.

Fixes #

Changes made in this Pull Request:
 - add new `check_neutrality_of` kwarg to DielectricConstant


PR Checklist
------------
 - [ ] Tests?
 - [x] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--4249.org.readthedocs.build/en/4249/

<!-- readthedocs-preview mdanalysis end -->