### PR TITLE
[WIP] Changed resid to read from res number in tpr file and added res index

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,12 +13,14 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-??/??/?? IAlibay, hmacdope, pillose
+??/??/?? IAlibay, hmacdope, pillose, ztimol
 
  * 2.7.0
 
 Fixes
   * Fix Atom type guessing error (PR #4168, Issue #4167)
+  * Fix AtomGroup resids to match resnumbers of tpr file
+    (PR #4251, Issue #4224)
 
 Enhancements
 

--- a/package/MDAnalysis/topology/tpr/obj.py
+++ b/package/MDAnalysis/topology/tpr/obj.py
@@ -43,7 +43,7 @@ Box = namedtuple("Box", "size rel v")
 Mtop = namedtuple("Mtop", "nmoltype moltypes nmolblock")
 Params = namedtuple("Params", "atnr ntypes functype reppow fudgeQQ")
 Atom = namedtuple("Atom", ["m", "q", "mB", "qB", "tp", "typeB", "ptype", "resind", "atomnumber"])
-Atoms = namedtuple("Atoms", "atoms nr nres type typeB atomnames resnames")
+Atoms = namedtuple("Atoms", "atoms nr nres type typeB atomnames resnames resids")
 Ilist = namedtuple("Ilist", "nr ik, iatoms")
 Molblock = namedtuple("Molblock", [
     "molb_type", "molb_nmol", "molb_natoms_mol",
@@ -105,11 +105,12 @@ class MoleculeKind(object):
 
 class AtomKind(object):
     def __init__(
-            self, id, name, type, resid, resname, mass, charge, atomic_number):
+            self, id, name, type, resind, resid, resname, mass, charge, atomic_number):
         # id is only within the scope of a single molecule, not the whole system
         self.id = id
         self.name = name
         self.type = type
+        self.resind = resind
         self.resid = resid
         self.resname = resname
         self.mass = mass

--- a/package/MDAnalysis/topology/tpr/utils.py
+++ b/package/MDAnalysis/topology/tpr/utils.py
@@ -792,8 +792,10 @@ def do_atoms(data, symtab, fver):
 
 
 def do_resinfo(data, symtab, fver, nres):
+
     if fver < 63:
         resnames = [symtab[i] for i in ndo_int(data, nres)]
+        resids = [i+1 for i in range(nres)]
     else:
         resnames = []
         resids = []


### PR DESCRIPTION
Fixes #4224

Changes made in this Pull Request:
 - Read in res number from tpr file and set it to resid
 - Change current resid to res index
 - Topology resids as well as resids from a written gro file should now match resids in tpr file.

Additional Info:
- Current implementation: resid reads the residue index from the tpr file. This is the cause of issue 4224.
- Updated implementation: A res number is also provided in the tpr file and resid is assigned to this value. The res index is also read but is no longer assigned as the resid.

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [ ] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--4251.org.readthedocs.build/en/4251/

<!-- readthedocs-preview mdanalysis end -->