### PR TITLE
Move ConverterBase out of coordinates/base.py

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,7 +13,7 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-??/??/?? IAlibay, hmacdope, pillose, jaclark5
+??/??/?? IAlibay, hmacdope, pillose, jaclark5, ianmkenney
 
  * 2.7.0
 
@@ -27,6 +27,7 @@ Changes
     (Issue #4247)
   * Cython DEF statments have been replaced with compile time integer constants
     as DEF is deprecated as of Cython>=3.0 (Issue #4237, PR #4246)
+  * ConverterBase class moved from coordinates/base.py to converters/base.py (Issue #3404)
 
 Deprecations
 

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -30,6 +30,8 @@ Changes
   * ConverterBase class moved from coordinates/base.py to converters/base.py (Issue #3404)
 
 Deprecations
+  * coordinates.base.ConverterBase has been deprecated and will be removed in 3.0.0;
+    use converters.base.ConvertBase instead (Issue #3404)
 
 
 08/15/23 IAlibay, jaclark5, MohitKumar020291, orionarcher, xhgchen,

--- a/package/MDAnalysis/converters/ParmEd.py
+++ b/package/MDAnalysis/converters/ParmEd.py
@@ -82,12 +82,13 @@ import itertools
 import warnings
 
 from . import base
+from ..coordinates.base import SingleFrameReaderBase
 from ..topology.tables import SYMB2Z
 from ..core.universe import Universe
 from ..exceptions import NoDataError
 
 
-class ParmEdReader(base.SingleFrameReaderBase):
+class ParmEdReader(SingleFrameReaderBase):
     """Coordinate reader for ParmEd."""
     format = 'PARMED'
 

--- a/package/MDAnalysis/converters/ParmEd.py
+++ b/package/MDAnalysis/converters/ParmEd.py
@@ -81,7 +81,7 @@ import functools
 import itertools
 import warnings
 
-from ..coordinates import base
+from . import base
 from ..topology.tables import SYMB2Z
 from ..core.universe import Universe
 from ..exceptions import NoDataError

--- a/package/MDAnalysis/converters/RDKit.py
+++ b/package/MDAnalysis/converters/RDKit.py
@@ -88,7 +88,8 @@ from io import StringIO
 
 import numpy as np
 
-from ..coordinates import base, memory
+from . import base
+from ..coordinates import memory
 from ..coordinates.PDB import PDBWriter
 from ..core.topologyattrs import _TOPOLOGY_ATTRS
 from ..exceptions import NoDataError

--- a/package/MDAnalysis/converters/base.py
+++ b/package/MDAnalysis/converters/base.py
@@ -1,0 +1,62 @@
+# -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
+#
+# MDAnalysis --- https://www.mdanalysis.org
+# Copyright (c) 2006-2017 The MDAnalysis Development Team and contributors
+# (see the file AUTHORS for the full list of names)
+#
+# Released under the GNU Public Licence, v2 or any higher version
+#
+# Please cite your use of MDAnalysis in published work:
+#
+# R. J. Gowers, M. Linke, J. Barnoud, T. J. E. Reddy, M. N. Melo, S. L. Seyler,
+# D. L. Dotson, J. Domanski, S. Buchoux, I. M. Kenney, and O. Beckstein.
+# MDAnalysis: A Python package for the rapid analysis of molecular dynamics
+# simulations. In S. Benthall and S. Rostrup editors, Proceedings of the 15th
+# Python in Science Conference, pages 102-109, Austin, TX, 2016. SciPy.
+# doi: 10.25080/majora-629e541a-00e
+#
+# N. Michaud-Agrawal, E. J. Denning, T. B. Woolf, and O. Beckstein.
+# MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
+# J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
+#
+
+"""\
+Converters
+----------
+
+Converters output information to other libraries.
+
+.. autoclass:: ConverterBase
+   :members:
+   :inherited-members:
+"""
+
+from .. import _CONVERTERS
+from ..coordinates.base import IOBase, SingleFrameReaderBase
+from ..lib.util import asiterable
+
+
+class _Convertermeta(type):
+    # Auto register upon class creation
+    def __init__(cls, name, bases, classdict):
+        type.__init__(type, name, bases, classdict)
+        try:
+            fmt = asiterable(classdict['lib'])
+        except KeyError:
+            pass
+        else:
+            for f in fmt:
+                f = f.upper()
+                _CONVERTERS[f] = cls
+
+
+class ConverterBase(IOBase, metaclass=_Convertermeta):
+    """Base class for converting to other libraries.
+    """
+
+    def __repr__(self):
+        return "<{cls}>".format(cls=self.__class__.__name__)
+
+    def convert(self, obj):
+        raise NotImplementedError

--- a/package/MDAnalysis/converters/base.py
+++ b/package/MDAnalysis/converters/base.py
@@ -33,7 +33,7 @@ Converters output information to other libraries.
 """
 
 from .. import _CONVERTERS
-from ..coordinates.base import IOBase, SingleFrameReaderBase
+from ..coordinates.base import IOBase
 from ..lib.util import asiterable
 
 

--- a/package/MDAnalysis/converters/base.py
+++ b/package/MDAnalysis/converters/base.py
@@ -21,9 +21,8 @@
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
 
-"""\
-Converters
-----------
+""" Base classes --- :mod:`MDAnalysis.converters.base`
+======================================================
 
 Converters output information to other libraries.
 

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -103,11 +103,11 @@ file.
 
 Converters
 ----------
-Converters output information to other libraries. 
+Converters output information to other libraries.
 
 .. deprecated:: 2.7.0
     All converter code has been moved to :mod:`MDAnalysis.converters` and will
-    be removed in 3.0.0.
+    be removed from the :mod:`MDAnalysis.coordinates.base` module in 3.0.0.
 
 .. autoclass:: ConverterBase
    :members:
@@ -1810,7 +1810,7 @@ class ConverterBase(IOBase, metaclass=_Convertermeta):
     """Base class for converting to other libraries.
 
     .. deprecated:: 2.7.0
-        This class has been moved to 
+        This class has been moved to
         :class:`MDAnalysis.converters.base.ConverterBase` and will be removed
         from :mod:`MDAnalysis.coordinates.base` in 3.0.0.
     """

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -101,17 +101,6 @@ file.
    :members:
    :inherited-members:
 
-
-Converters
-----------
-
-Converters output information to other libraries.
-
-.. autoclass:: ConverterBase
-   :members:
-   :inherited-members:
-
-
 Helper classes
 --------------
 
@@ -134,7 +123,6 @@ from .. import (
     _READERS, _READER_HINTS,
     _SINGLEFRAME_WRITERS,
     _MULTIFRAME_WRITERS,
-    _CONVERTERS
 )
 from .. import units
 from ..auxiliary.base import AuxReader
@@ -1782,31 +1770,3 @@ def range_length(start, stop, step):
     else:
         # The range is empty.
         return 0
-
-
-class _Convertermeta(type):
-    # Auto register upon class creation
-    def __init__(cls, name, bases, classdict):
-        type.__init__(type, name, bases, classdict)
-        try:
-            fmt = asiterable(classdict['lib'])
-        except KeyError:
-            pass
-        else:
-            for f in fmt:
-                f = f.upper()
-                _CONVERTERS[f] = cls
-
-class ConverterBase(IOBase, metaclass=_Convertermeta):
-    """Base class for converting to other libraries.
-
-    See Also
-    --------
-    :mod:`MDAnalysis.converters`
-    """
-
-    def __repr__(self):
-        return "<{cls}>".format(cls=self.__class__.__name__)
-
-    def convert(self, obj):
-        raise NotImplementedError

--- a/package/doc/sphinx/source/documentation_pages/converters.rst
+++ b/package/doc/sphinx/source/documentation_pages/converters.rst
@@ -52,3 +52,11 @@ Another syntax is also available for tab-completion support::
 
     core/accessors
 
+
+Developers may find the :mod:`MDAnaylsis.converters.base` module helpful for
+creating new converter classes.
+
+.. toctree::
+   :maxdepth: 1
+
+   converters/base

--- a/package/doc/sphinx/source/documentation_pages/converters/base.rst
+++ b/package/doc/sphinx/source/documentation_pages/converters/base.rst
@@ -1,0 +1,1 @@
+.. automodule:: MDAnalysis.converters.base

--- a/testsuite/MDAnalysisTests/converters/test_base.py
+++ b/testsuite/MDAnalysisTests/converters/test_base.py
@@ -1,4 +1,3 @@
-
 # -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 fileencoding=utf-8
 #

--- a/testsuite/MDAnalysisTests/converters/test_base.py
+++ b/testsuite/MDAnalysisTests/converters/test_base.py
@@ -35,7 +35,7 @@ def test_coordinate_converterbase_warning():
 
     with pytest.warns(DeprecationWarning, match=wmsg):
         class DerivedConverter(ConverterBase):
-            ...
+            pass
 
 
 def test_converters_converterbase_no_warning():
@@ -45,4 +45,4 @@ def test_converters_converterbase_no_warning():
         warnings.simplefilter("error")
 
         class DerivedConverter(ConverterBase):
-            ...
+            pass

--- a/testsuite/MDAnalysisTests/converters/test_base.py
+++ b/testsuite/MDAnalysisTests/converters/test_base.py
@@ -1,0 +1,48 @@
+
+# -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 fileencoding=utf-8
+#
+# MDAnalysis --- https://www.mdanalysis.org
+# Copyright (c) 2006-2017 The MDAnalysis Development Team and contributors
+# (see the file AUTHORS for the full list of names)
+#
+# Released under the GNU Public Licence, v2 or any higher version
+#
+# Please cite your use of MDAnalysis in published work:
+#
+# R. J. Gowers, M. Linke, J. Barnoud, T. J. E. Reddy, M. N. Melo, S. L. Seyler,
+# D. L. Dotson, J. Domanski, S. Buchoux, I. M. Kenney, and O. Beckstein.
+# MDAnalysis: A Python package for the rapid analysis of molecular dynamics
+# simulations. In S. Benthall and S. Rostrup editors, Proceedings of the 15th
+# Python in Science Conference, pages 102-109, Austin, TX, 2016. SciPy.
+# doi: 10.25080/majora-629e541a-00e
+#
+# N. Michaud-Agrawal, E. J. Denning, T. B. Woolf, and O. Beckstein.
+# MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
+# J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
+
+import pytest
+import warnings
+
+
+def test_coordinate_converterbase_warning():
+    from MDAnalysis.coordinates.base import ConverterBase
+
+    wmsg = ("ConverterBase moved from coordinates.base."
+            "ConverterBase to converters.base.ConverterBase "
+            "and will be removed from coordinates.base "
+            "in MDAnalysis release 3.0.0")
+
+    with pytest.warns(DeprecationWarning, match=wmsg):
+        class DerivedConverter(ConverterBase):
+            ...
+
+
+def test_converters_converterbase_no_warning():
+    from MDAnalysis.converters.base import ConverterBase
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+
+        class DerivedConverter(ConverterBase):
+            ...

--- a/testsuite/MDAnalysisTests/converters/test_base.py
+++ b/testsuite/MDAnalysisTests/converters/test_base.py
@@ -26,6 +26,7 @@ import warnings
 
 def test_coordinate_converterbase_warning():
     from MDAnalysis.coordinates.base import ConverterBase
+    import MDAnalysis.converters.base
 
     wmsg = ("ConverterBase moved from coordinates.base."
             "ConverterBase to converters.base.ConverterBase "
@@ -36,12 +37,20 @@ def test_coordinate_converterbase_warning():
         class DerivedConverter(ConverterBase):
             pass
 
+    assert issubclass(DerivedConverter, ConverterBase)
+    assert not issubclass(DerivedConverter,
+                          MDAnalysis.converters.base.ConverterBase)
+
 
 def test_converters_converterbase_no_warning():
     from MDAnalysis.converters.base import ConverterBase
 
+    # check that no warning is issued at all
+    # when subclassing converters.base.ConverterBase
     with warnings.catch_warnings():
         warnings.simplefilter("error")
 
         class DerivedConverter(ConverterBase):
             pass
+
+    assert issubclass(DerivedConverter, ConverterBase)


### PR DESCRIPTION
Fixes #3404 

Changes made in this Pull Request:
 - Moved ConverterBase into converters/base.py


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
