### PR TITLE
Revert numpy build pinning changes

### DIFF
--- a/.github/actions/build-src/action.yaml
+++ b/.github/actions/build-src/action.yaml
@@ -42,7 +42,7 @@ inputs:
     #   example, when we use nightly wheels of NumPy.
     descriptions: 'Use build isolation for pip installs, if false `--no-build-isolation` is used. '
     required: true
-    default: false
+    default: true
 
 
 runs:

--- a/.github/workflows/gh-ci-cron.yaml
+++ b/.github/workflows/gh-ci-cron.yaml
@@ -69,6 +69,8 @@ jobs:
       with:
         build-tests: true
         build-docs: false
+        # We don't use build isolation because we want to ensure that we
+        # test building with brand new versions of NumPy here.
         isolation: false
 
     - name: run_tests
@@ -119,7 +121,7 @@ jobs:
       with:
         build-tests: true
         build-docs: false
-        isolation: false
+        isolation: true
 
     - name: run_tests
       run: |
@@ -167,7 +169,7 @@ jobs:
       with:
         build-tests: true
         build-docs: false
-        isolation: false
+        isolation: true
 
     - name: run_tests
       run: |

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -88,10 +88,11 @@ jobs:
       with:
         build-tests: true
         build-docs: false
-        # If we specifically define an old NumPy version then we isolate the
-        # the build, i.e. make sure that we build with NumPy 1.25+ but we keep
-        # the old version of NumPy as what we use for runtime testing
-        isolation: ${{ matrix.numpy != '' }}
+        # The standard mdanalysis deployment is to build with the
+        # oldest supported numpy version and then use whatever new
+        # numpy version we want at runtime. To do this we ensure
+        # that we use build isolation
+        isolation: true
 
     - name: check_deps
       run: |
@@ -161,7 +162,7 @@ jobs:
       with:
         build-tests: true
         build-docs: true
-        isolation: false
+        isolation: true
 
     - name: doctests
       if: github.event_name == 'pull_request'

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -23,6 +23,8 @@ Fixes
 Enhancements
 
 Changes
+  * Reverts PR #4108, builds are now again made using the oldest
+    supported Python version.
   * NumPy `in1d` replaced with `isin` in preparation for NumPy
     `2.0` (PR #4255)
   * Update documentation for SurvivalProbabilty to be more clear

--- a/package/pyproject.toml
+++ b/package/pyproject.toml
@@ -3,11 +3,20 @@
 requires = [
     "Cython>=0.28",
     "packaging",
-    # NumPy 1.25+ offers backwards compatibility that tracks with greater
-    # than NEP29 (see: https://numpy.org/doc/stable/dev/depending_on_numpy.html#adding-a-dependency-on-numpy)
-    # We pin our wheel installation to that and a maximum of numpy 2.0 since
-    # this will likely involve several breaking changes
-    "numpy>=1.25,<2.0; python_version>='3.9'",
+    # lowest NumPy we can use for a given Python,
+    # In part adapted from: https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg
+    # except for more exotic platform (Mac Arm flavors)
+    # aarch64, AIX, s390x, and arm64 all support 1.21 so we can safely pin to this
+    # Note: MDA does not build with PyPy so we do not support it in the build system
+    # Scipy: On windows avoid 1.21.6, 1.22.0, and 1.22.1 because they were built on vc142
+    # Let's set everything to this version to make things clean, also avoids other issues
+    # on other archs
+    "numpy==1.22.3; python_version=='3.9' and platform_python_implementation != 'PyPy'",
+    "numpy==1.22.3; python_version=='3.10' and platform_python_implementation != 'PyPy'",
+    "numpy==1.23.2; python_version=='3.11' and platform_python_implementation != 'PyPy'",
+    # For unreleased versions of Python there is currently no known supported
+    # NumPy version. In that case we just let it be a bare NumPy install
+    "numpy<2.0; python_version>='3.12'",
     "setuptools",
     "wheel",
 ]


### PR DESCRIPTION
Fixes #4260 

This reverts the numpy build pinning and would allow us to move forward with a 2.6.1 release.

Changes made in this Pull Request:
 - Reverts numpy build pinning in pyproject.toml
 - Switches build isolation back on for everything but nightly wheel checks


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--4261.org.readthedocs.build/en/4261/

<!-- readthedocs-preview mdanalysis end -->