### PR TITLE
Docs warning for charge in DielectricConstant

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -13,7 +13,7 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" http://semver.org
 
 ------------------------------------------------------------------------------
-??/??/?? IAlibay, hmacdope, pillose, jaclark5, tylerjereddy
+??/??/?? IAlibay, hmacdope, pillose, jaclark5, tylerjereddy, PicoCentauri
 
  * 2.7.0
 
@@ -21,6 +21,8 @@ Fixes
   * Fix Atom type guessing error (PR #4168, Issue #4167)
 
 Enhancements
+  * Added a warning about charge neutrality to the documentation of
+    ``DielectricConstant`` (Issue #4262, PR #4263)
 
 Changes
   * NumPy `in1d` replaced with `isin` in preparation for NumPy

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -22,7 +22,7 @@ Fixes
 
 Enhancements
   * Added a warning about charge neutrality to the documentation of
-    ``DielectricConstant`` (Issue #4262, PR #4263)
+    `DielectricConstant` (Issue #4262, PR #4263)
 
 Changes
   * NumPy `in1d` replaced with `isin` in preparation for NumPy

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -22,6 +22,8 @@ Fixes
     their original type value (np.float64 and np.nan) (PR #4272)
 
 Enhancements
+  * Added a warning about charge neutrality to the documentation of
+    `DielectricConstant` (Issue #4262, PR #4263)
 
 Changes
   * The `mda-xdrlib` module is now a core dependency of MDAnalysis
@@ -42,8 +44,6 @@ Fixes
   * Fix Atom type guessing error (PR #4168, Issue #4167)
 
 Enhancements
-  * Added a warning about charge neutrality to the documentation of
-    `DielectricConstant` (Issue #4262, PR #4263)
 
 Changes
   * Reverts PR #4108, builds are now again made using the oldest

--- a/package/MDAnalysis/analysis/dielectric.py
+++ b/package/MDAnalysis/analysis/dielectric.py
@@ -65,6 +65,10 @@ class DielectricConstant(AnalysisBase):
     the usual case if electrostatics are handled with a Ewald summation
     technique. See [Neumann1983]_ for details on the derivation.
 
+    .. warning::
+      Applying this class requires that no free charges, such as ions or
+      charged fragments, are present in the simulation.
+
     Parameters
     ----------
     atomgroup : MDAnalysis.core.groups.AtomGroup


### PR DESCRIPTION
Fixes #4262

Add a warning box to the documentation that only charge neutral systems can be handled by the current implementation.
See also #4249 for details on why this is important.


PR Checklist
------------
 - [x] Tests (we have a test for the error raise already.)?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--4263.org.readthedocs.build/en/4263/

<!-- readthedocs-preview mdanalysis end -->