### PR TITLE
switch out xdrlib to mda_xdrlib

### DIFF
--- a/.github/actions/setup-deps/action.yaml
+++ b/.github/actions/setup-deps/action.yaml
@@ -33,6 +33,8 @@ inputs:
     default: 'hypothesis'
   matplotlib:
     default: 'matplotlib-base'
+  mda_xdrlib:
+    default: 'mda_xdrlib'
   mmtf-python:
     default: 'mmtf-python'
   networkx:
@@ -111,6 +113,7 @@ runs:
           ${{ inputs.griddataformats }}
           ${{ inputs.hypothesis }}
           ${{ inputs.matplotlib }}
+          ${{ inputs.mda_xdrlib }}
           ${{ inputs.mmtf-python }}
           ${{ inputs.networkx }}
           ${{ inputs.numpy }}

--- a/.github/actions/setup-deps/action.yaml
+++ b/.github/actions/setup-deps/action.yaml
@@ -34,7 +34,7 @@ inputs:
   matplotlib:
     default: 'matplotlib-base'
   mda_xdrlib:
-    default: 'mda_xdrlib'
+    default: 'mda-xdrlib'
   mmtf-python:
     default: 'mmtf-python'
   networkx:

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -22,6 +22,9 @@ Fixes
 Enhancements
 
 Changes
+  * The `mda-xdrlib` module is now a core dependency of MDAnalysis
+    replacing the now deprecated `xdrlib` core Python library
+    (PR #4271)
 
 Deprecations
 

--- a/package/MDAnalysis/topology/TPRParser.py
+++ b/package/MDAnalysis/topology/TPRParser.py
@@ -158,7 +158,6 @@ Versions prior to Gromacs 4.0.x are not supported.
 __author__ = "Zhuyi Xue"
 __copyright__ = "GNU Public Licence, v2"
 
-import xdrlib
 
 from . import guessers
 from ..lib.util import openany

--- a/package/MDAnalysis/topology/tpr/utils.py
+++ b/package/MDAnalysis/topology/tpr/utils.py
@@ -48,7 +48,7 @@ The module also contains the :func:`do_inputrec` to read the TPR header with.
 """
 
 import numpy as np
-import xdrlib
+import mda_xdrlib
 import struct
 
 from . import obj
@@ -74,7 +74,7 @@ from ...core.topologyattrs import (
 )
 
 
-class TPXUnpacker(xdrlib.Unpacker):
+class TPXUnpacker(mda_xdrlib.Unpacker):
     """
     Extend the standard XDR unpacker for the specificity of TPX files.
     """

--- a/package/MDAnalysis/topology/tpr/utils.py
+++ b/package/MDAnalysis/topology/tpr/utils.py
@@ -48,7 +48,7 @@ The module also contains the :func:`do_inputrec` to read the TPR header with.
 """
 
 import numpy as np
-import mda_xdrlib import xdrlib
+from mda_xdrlib import xdrlib
 import struct
 
 from . import obj

--- a/package/MDAnalysis/topology/tpr/utils.py
+++ b/package/MDAnalysis/topology/tpr/utils.py
@@ -48,7 +48,7 @@ The module also contains the :func:`do_inputrec` to read the TPR header with.
 """
 
 import numpy as np
-import mda_xdrlib
+import mda_xdrlib import xdrlib
 import struct
 
 from . import obj
@@ -74,7 +74,7 @@ from ...core.topologyattrs import (
 )
 
 
-class TPXUnpacker(mda_xdrlib.Unpacker):
+class TPXUnpacker(xdrlib.Unpacker):
     """
     Extend the standard XDR unpacker for the specificity of TPX files.
     """

--- a/package/pyproject.toml
+++ b/package/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
     'threadpoolctl',
     'packaging',
     'fasteners',
+    'mda_xdrlib',
 ]
 keywords = [
     "python", "science", "chemistry", "biophysics", "molecular-dynamics",

--- a/package/pyproject.toml
+++ b/package/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     'threadpoolctl',
     'packaging',
     'fasteners',
-    'mda_xdrlib',
+    'mda-xdrlib',
 ]
 keywords = [
     "python", "science", "chemistry", "biophysics", "molecular-dynamics",

--- a/package/setup.py
+++ b/package/setup.py
@@ -604,6 +604,7 @@ if __name__ == '__main__':
           'threadpoolctl',
           'packaging',
           'fasteners',
+          'mda_xdrlib',
     ]
 
     setup(name='MDAnalysis',

--- a/package/setup.py
+++ b/package/setup.py
@@ -604,7 +604,7 @@ if __name__ == '__main__':
           'threadpoolctl',
           'packaging',
           'fasteners',
-          'mda_xdrlib',
+          'mda-xdrlib',
     ]
 
     setup(name='MDAnalysis',


### PR DESCRIPTION
Fixes #3934 

Changes made in this Pull Request:
 - switch out the one xdrlib usage to mda_xdrlib
 - remove unused import


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--4271.org.readthedocs.build/en/4271/

<!-- readthedocs-preview mdanalysis end -->