### PR TITLE
MAINT: NumPy recarray shim

### DIFF
--- a/package/MDAnalysis/analysis/hydrogenbonds/wbridge_analysis.py
+++ b/package/MDAnalysis/analysis/hydrogenbonds/wbridge_analysis.py
@@ -1771,7 +1771,7 @@ class WaterBridgeAnalysis(AnalysisBase):
 
         Returns
         -------
-        table : numpy.recarray
+        table : numpy.rec.recarray
             A "tidy" table with one hydrogen bond per row, labeled according to
             `output_format` and containing information of atom_1, atom_2,
             distance, and angle.
@@ -1832,7 +1832,7 @@ class WaterBridgeAnalysis(AnalysisBase):
                 cursor += 1
         assert cursor == num_records, \
             "Internal Error: Not all wb records stored"
-        table = out.view(np.recarray)
+        table = out.view(np.rec.recarray)
         logger.debug(
             "WBridge: Stored results as table with %(num_records)d entries.",
             vars())


### PR DESCRIPTION
* based on https://github.com/numpy/numpy/pull/24587:
  * replace the single usage of `np.recarray` I found in our codebase--there are references to third-party libraries providing us with `recarray` that I haven't touched
  * similar PRs have been merged to `pandas` and `scipy`

[skip cirrus]

<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--4275.org.readthedocs.build/en/4275/

<!-- readthedocs-preview mdanalysis end -->