### PR TITLE
Switch away from build_sphinx

### DIFF
--- a/.github/actions/build-src/action.yaml
+++ b/.github/actions/build-src/action.yaml
@@ -88,4 +88,6 @@ runs:
       if: ${{ inputs.build-docs == 'true' }}
       shell: bash -l {0}
       run: |
-        cd package/doc && python -m sphinx -T -E -b html -D language=en sphinx/source html
+        SOURCEDIR="sphinx/source"
+        BUILDDIR="html"
+        cd package/doc && python -m sphinx -T -E -b html -D language=en ${SOURCEDIR} ${BUILDDIR}

--- a/.github/actions/build-src/action.yaml
+++ b/.github/actions/build-src/action.yaml
@@ -90,4 +90,4 @@ runs:
       run: |
         SOURCEDIR="sphinx/source"
         BUILDDIR="html"
-        cd package/doc && python -m sphinx -T -E -b html -D language=en ${SOURCEDIR} ${BUILDDIR}
+        cd package/doc && python -m sphinx -T -E --keep-going -b html -D language=en ${SOURCEDIR} ${BUILDDIR}

--- a/.github/actions/build-src/action.yaml
+++ b/.github/actions/build-src/action.yaml
@@ -88,4 +88,4 @@ runs:
       if: ${{ inputs.build-docs == 'true' }}
       shell: bash -l {0}
       run: |
-        cd package && python setup.py build_sphinx -E --keep-going
+        cd package/doc && python -m sphinx -T -E -b html -D language=en sphinx/source html

--- a/.github/actions/build-src/action.yaml
+++ b/.github/actions/build-src/action.yaml
@@ -90,4 +90,4 @@ runs:
       run: |
         SOURCEDIR="sphinx/source"
         BUILDDIR="html"
-        cd package/doc && python -m sphinx -T -E --keep-going -b html -D language=en ${SOURCEDIR} ${BUILDDIR}
+        cd package/doc && sphinx-build -T -E --keep-going -b html -D language=en ${SOURCEDIR} ${BUILDDIR}


### PR DESCRIPTION
Fixes #4277 

Changes made in this Pull Request:
 - change `python setup.py build_sphinx` to just run sphinx straight. This is less elegant since we *have* to specify the source and output directories.


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--4278.org.readthedocs.build/en/4278/

<!-- readthedocs-preview mdanalysis end -->