### PR TITLE
Read chainID from PDBQT

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -33,6 +33,7 @@ Enhancements
   * Added a warning about charge neutrality to the documentation of
     `DielectricConstant` (Issue #4262, PR #4263)
   * Add support for reading chainID info from prmtop amber topologies (PR #4007)
+  * Add support for reading chainID info from Autodock PDBQT files (PR #4284)
 
 Changes
   * The `mda-xdrlib` module is now a core dependency of MDAnalysis

--- a/package/MDAnalysis/topology/PDBQTParser.py
+++ b/package/MDAnalysis/topology/PDBQTParser.py
@@ -75,6 +75,7 @@ from ..core.topologyattrs import (
     Resnums,
     Resnames,
     Segids,
+    ChainIDs,
     Tempfactors,
 )
 
@@ -88,7 +89,7 @@ class PDBQTParser(TopologyReaderBase):
      - atom names
      - altLocs
      - resnames
-     - chainIDs (becomes segid)
+     - chainIDs (assigned to segid as well)
      - resids
      - record_types (ATOM/HETATM)
      - icodes
@@ -165,6 +166,8 @@ class PDBQTParser(TopologyReaderBase):
         icodes = np.array(icodes, dtype=object)
         resnames = np.array(resnames, dtype=object)
         chainids = np.array(chainids, dtype=object)
+
+        attrs.append(ChainIDs(chainids))
 
         residx, (resids, icodes, resnames, chainids) = change_squash(
             (resids, icodes), (resids, icodes, resnames, chainids))

--- a/testsuite/MDAnalysisTests/coordinates/test_pdbqt.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_pdbqt.py
@@ -44,6 +44,12 @@ class TestPDBQT(object):
         sel = universe.select_atoms('segid B')
         assert_equal(sel.n_atoms, 896, "failed to select segment B")
 
+    def test_chainID(self, universe):
+        sel = universe.select_atoms('chainID A')
+        assert_equal(sel.n_atoms, 909, "failed to chainID segment A")
+        sel = universe.select_atoms('chainID B')
+        assert_equal(sel.n_atoms, 896, "failed to chainID segment B")
+
     def test_protein(self, universe):
         sel = universe.select_atoms('protein')
         assert_equal(sel.n_atoms, 1805, "failed to select protein")

--- a/testsuite/MDAnalysisTests/coordinates/test_pdbqt.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_pdbqt.py
@@ -39,15 +39,15 @@ class TestPDBQT(object):
         return mda.Universe(PDBQT_input)
 
     def test_segid(self, universe):
-        sel = universe.select_atoms('segid A')
+        sel = universe.select_atoms("segid A")
         assert_equal(sel.n_atoms, 909, "failed to select segment A")
-        sel = universe.select_atoms('segid B')
+        sel = universe.select_atoms("segid B")
         assert_equal(sel.n_atoms, 896, "failed to select segment B")
 
     def test_chainID(self, universe):
-        sel = universe.select_atoms('chainID A')
+        sel = universe.select_atoms("chainID A")
         assert_equal(sel.n_atoms, 909, "failed to chainID segment A")
-        sel = universe.select_atoms('chainID B')
+        sel = universe.select_atoms("chainID B")
         assert_equal(sel.n_atoms, 896, "failed to chainID segment B")
 
     def test_protein(self, universe):

--- a/testsuite/MDAnalysisTests/topology/test_pdbqt.py
+++ b/testsuite/MDAnalysisTests/topology/test_pdbqt.py
@@ -32,8 +32,19 @@ class TestPDBQT(ParserBase):
     parser = mda.topology.PDBQTParser.PDBQTParser
     ref_filename = PDBQT_input
     expected_attrs = [
-        'ids', 'names', 'charges', 'types', 'altLocs', 'resids', 'resnames',
-        'segids', 'record_types', 'icodes', 'occupancies', 'tempfactors'
+        "ids",
+        "names",
+        "charges",
+        "types",
+        "altLocs",
+        "resids",
+        "resnames",
+        "segids",
+        "chainIDs",
+        "record_types",
+        "icodes",
+        "occupancies",
+        "tempfactors",
     ]
     guessed_attrs = ['masses']
     expected_n_atoms = 1805


### PR DESCRIPTION
Fixes #4207

The user also complained about lacking elements, but given that the PDBQT format replaced the `element` field from the PDB `ATOM` record, I guess is fair that we don't try to create the from the `atomtype`. In any case, the solution given to the user could be made a FAQ (if it's indeed a FAQ).

Changes made in this Pull Request:
 - Use the chain ID read from the atoms to create the proper `chainIDs` attribute instead of just discarding them.


PR Checklist
------------
 - [x] Tests?
 - [X] Docs?
 - [X] CHANGELOG updated?
 - [X] Issue raised/referenced?

## Developers certificate of origin
- [X] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--4284.org.readthedocs.build/en/4284/

<!-- readthedocs-preview mdanalysis end -->