### PR TITLE
Fix PDBQT docs to accurately say that last letter of segid is used as chainID

### DIFF
--- a/package/MDAnalysis/coordinates/PDBQT.py
+++ b/package/MDAnalysis/coordinates/PDBQT.py
@@ -237,7 +237,7 @@ class PDBQTWriter(base.WriterBase):
 
         Note
         ----
-        The first letter of the
+        The last letter of the
         :attr:`~MDAnalysis.core.groups.Atom.segid` is used as the PDB
         chainID.
 


### PR DESCRIPTION
Fixes #4287 

Changes made in this Pull Request:
 - Updates last to say first


PR Checklist
------------
 - [ ] Tests?
 - [x] Docs?
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--4288.org.readthedocs.build/en/4288/

<!-- readthedocs-preview mdanalysis end -->