### PR TITLE
Remove extra pkg_resource use

### DIFF
--- a/package/MDAnalysis/analysis/data/filenames.py
+++ b/package/MDAnalysis/analysis/data/filenames.py
@@ -107,10 +107,12 @@ __all__ = [
     # reference plots for Ramachandran and Janin classes
 ]
 
-from pkg_resources import resource_filename
 
-Rama_ref = resource_filename(__name__, 'rama_ref_data.npy')
-Janin_ref = resource_filename(__name__, 'janin_ref_data.npy')
+from importlib import resources
+
+_base_ref = resources.files('MDAnalysis.analysis.data')
+Rama_ref = (_base_ref / 'rama_ref_data.npy').as_posix()
+Janin_ref = (_base_ref / 'janin_ref_data.npy').as_posix()
 
 # This should be the last line: clean up namespace
-del resource_filename
+del resources


### PR DESCRIPTION
Towards Python 3.12

Changes made in this Pull Request:
 - Remove an extra `pkg_resource` use that we hadn't previously noticed.


PR Checklist
------------
 - [x] Tests?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--4294.org.readthedocs.build/en/4294/

<!-- readthedocs-preview mdanalysis end -->