### PR TITLE
Remove strtobool use

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -40,6 +40,9 @@ Enhancements
     PR #4284)
 
 Changes
+  * High memory tests (enabled through the environment variable
+    `ENABLE_HIGH_MEM_UNIT_TESTS` are now only enabled if the environment variable
+    is set to "true") (PR #4295)
   * The `mda-xdrlib` module is now a core dependency of MDAnalysis
     replacing the now deprecated `xdrlib` core Python library
     (PR #4271)

--- a/testsuite/MDAnalysisTests/lib/test_nsgrid.py
+++ b/testsuite/MDAnalysisTests/lib/test_nsgrid.py
@@ -21,7 +21,6 @@
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
 
-from distutils.util import strtobool
 import os
 
 import pytest
@@ -380,11 +379,10 @@ def test_issue_2670():
 
 def high_mem_tests_enabled():
     """ Returns true if ENABLE_HIGH_MEM_UNIT_TESTS is set to true."""
-    env = os.getenv("ENABLE_HIGH_MEM_UNIT_TESTS", default="0")
-    try:
-        return strtobool(env)
-    except ValueError:
-        return False
+    env = os.getenv("ENABLE_HIGH_MEM_UNIT_TESTS", default="false").lower()
+    if env == 'true':
+        return True
+    return False
 
 
 reason = ("Turned off by default. The test can be enabled by setting "


### PR DESCRIPTION
Simple enough one but it was tripping the Py3.12 tests.

Changes made in this Pull Request:
 - Switch from strtobool to a simple check on "true" for the high memory tests.


PR Checklist
------------
 - [x] Tests?
 - [x] CHANGELOG updated?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--4295.org.readthedocs.build/en/4295/

<!-- readthedocs-preview mdanalysis end -->