### PR TITLE
Point to new reporting form link (owned by conduct@mdanalysis.org)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -36,8 +36,8 @@ a misunderstanding and de-escalate things.
 However, sometimes these informal processes may be inadequate: they fail to
 work, there is urgency or risk to someone, nobody is intervening publicly and
 you don't feel comfortable speaking in public, etc. For these or other reasons,
-structured follow-up may be necessary and here we provide the means for that: we
-welcome reports by filling out [*this form*][conduct-form].
+structured follow-up may be necessary and here we provide the means for that: [we
+welcome reports](#reporting) by filling out [*this form*][conduct-form].
 
 This code applies equally to founders, developers, mentors and new
 community members, in all spaces managed by MDAnalysis. This
@@ -133,7 +133,7 @@ guidelines if you would like to contact a third-party outside of the MDAnalysis
 community.
 
 ### Reporting at MDAnalysis Events and Meetups
-If you are attending an MDAnalysis event or meetup and wish to make a report, you may contact the ombudspersons (who will identify themselves at the event) or other event staff/meetup organizers so that they can take any appropriate immediate response. If you would prefer not to do that, please [submit a report][conduct-form] to MDAnalysis. 
+If you are attending an MDAnalysis event or meetup and wish to [make a report](#reporting), you may contact the ombudspersons (who will identify themselves at the event) or other event staff/meetup organizers so that they can take any appropriate immediate response. If you would prefer not to do that, please [submit a report][conduct-form] to MDAnalysis. 
 
 Ombudspeople and event staff/meetup organizers will be happy to help participants contact venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the event/meetup.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -4,6 +4,7 @@ experience a welcoming, supportive, and productive environment that is
 free from harassment.
 
 **Table of Contents**
+
 - [MDAnalysis Code of Conduct and Community Guidelines](#mdanalysis-code-of-conduct-and-community-guidelines)
 - [Diversity, Equity, and Inclusion Statement](#diversity-equity-and-inclusion-statement)
 - [Reporting](#reporting)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -37,9 +37,7 @@ However, sometimes these informal processes may be inadequate: they fail to
 work, there is urgency or risk to someone, nobody is intervening publicly and
 you don't feel comfortable speaking in public, etc. For these or other reasons,
 structured follow-up may be necessary and here we provide the means for that: we
-welcome reports by
-emailing [*Conduct-email*][conduct-mail] or
-in anonymous by filling out [*this form*][conduct-form].
+welcome reports by filling out [*this form*][conduct-form].
 
 This code applies equally to founders, developers, mentors and new
 community members, in all spaces managed by MDAnalysis. This
@@ -109,6 +107,12 @@ at our [*user-mailing-list*](mailto:mdnalysis-discussions@googlegroups.com).
    and telling someone that you are sorry is act of empathy that doesn’t
    automatically imply an admission of guilt.
 
+## Diversity, Equity, and Inclusion Statement
+
+MDAnalysis strives to ensure a welcoming, inclusive space for all. As a [*NumFOCUS*](https://numfocus.org/) sponsored project, we fully support their [*Diversity & Inclusion in Scientific Computing*](https://numfocus.org/programs/diversity-inclusion) (DISC) mission and abide by their Diversity Statement:
+
+> *"NumFOCUS welcomes and encourages participation in our community by people of all backgrounds and identities. We are committed to promoting and sustaining a culture that values mutual respect, tolerance, and learning, and we work together as a community to help each other live out these values."*
+
 ## Reporting
 
 If someone makes you or any other contributor feel unsafe or unwelcome, please
@@ -172,8 +176,7 @@ materials under open licensing terms for us to easily reuse.
 All content on this page is licensed under a [*Creative Commons
 Attribution*](http://creativecommons.org/licenses/by/3.0/) license. 
 
-[conduct-mail]: mailto:mdnalysis-conduct@googlegroups.com
-[conduct-form]: https://goo.gl/forms/w2IwBKkY3oT0aVEB3
+[conduct-form]: https://forms.gle/r2SMU4XcwM814CpJ9
 
 [NF-conduct]: https://numfocus.org/code-of-conduct
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -3,16 +3,14 @@ every member in the MDAnalysis community so that everyone can
 experience a welcoming, supportive, and productive environment that is
 free from harassment.
 
-<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-generate-toc again -->
 **Table of Contents**
-
 - [MDAnalysis Code of Conduct and Community Guidelines](#mdanalysis-code-of-conduct-and-community-guidelines)
 - [Diversity, Equity, and Inclusion Statement](#diversity-equity-and-inclusion-statement)
 - [Reporting](#reporting)
+   * [Reporting at MDAnalysis Events and Meetups](#reporting-at-mdanalysis-events-and-meetups)
 - [Enforcement](#enforcement)
 - [Acknowledgment](#acknowledgment)
 
-<!-- markdown-toc end -->
 ## MDAnalysis Code of Conduct and Community Guidelines
 
 MDAnalysis is an engaged and respectful community made up of people from all

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -7,6 +7,7 @@ free from harassment.
 **Table of Contents**
 
 - [MDAnalysis Code of Conduct and Community Guidelines](#mdanalysis-code-of-conduct-and-community-guidelines)
+- [Diversity, Equity, and Inclusion Statement](#diversity-equity-and-inclusion-statement)
 - [Reporting](#reporting)
 - [Enforcement](#enforcement)
 - [Acknowledgment](#acknowledgment)


### PR DESCRIPTION
The CoC Committee has changed the ownership of the reporting form to conduct@mdanalysis.org. This PR points all relevant links to the updated form.

Changes made in this Pull Request:
 - Remove conduct-mail from CoC and community guidelines section
 - Point links to new reporting form, which is owned by conduct@mdanalysis.org
 - Add DEI statement, which was previously only on the website CoC page (*I am not sure how to update the TOC. Would someone be able to please do this before merging this PR, or walk me through the appropriate steps?*)

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--4298.org.readthedocs.build/en/4298/

<!-- readthedocs-preview mdanalysis end -->