### PR TITLE
MAINT: mkdtemp 3.12 support

### DIFF
--- a/package/MDAnalysis/analysis/hole2/utils.py
+++ b/package/MDAnalysis/analysis/hole2/utils.py
@@ -125,7 +125,7 @@ def check_and_fix_long_filename(filename, tmpdir=os.path.curdir,
     if make_symlink:
         # shorten path by creating a symlink inside a safe temp dir
         _, ext = os.path.splitext(filename)
-        dirname = tempfile.mkdtemp(dir=tmpdir)
+        dirname = os.path.relpath(tempfile.mkdtemp(dir=tmpdir))
         newname = os.path.join(dirname, os.path.basename(filename))
         if len(newname) > max_length:
             fd, newname = tempfile.mkstemp(suffix=ext, dir=dirname)


### PR DESCRIPTION
* force the use of a relative path for `mkdtemp` in our source code because, from the Python `3.12` release notes:

> tempfile.mkdtemp() now always returns an absolute path, even if the
argument provided to the dir parameter is a relative path.

* with this patch, the full testsuite now passes on (x86_64 Linux) Python `3.12.0` (which is now out) when combined with gh-4301 and gh-4300 (though see my cautions about thread safety/concurrency for the latter)

* this fixes the 1 remaining failure with 3.12: `MDAnalysisTests/analysis/test_hole2.py::TestCheckAndFixLongFilename::test_symlink_dir`

[skip cirrus]

<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--4309.org.readthedocs.build/en/4309/

<!-- readthedocs-preview mdanalysis end -->