### PR TITLE
Add 3.12 to minimal deps CI run

### DIFF
--- a/.github/workflows/gh-ci-cron.yaml
+++ b/.github/workflows/gh-ci-cron.yaml
@@ -184,7 +184,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          python-version: ["3.10", "3.11"]
+          python-version: ["3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -48,6 +48,11 @@ jobs:
               full-deps: true
               codecov: false
               extra-pip-deps: asv
+            - name: python_312
+              os: ubuntu-latest
+              python-version: "3.12"
+              full-deps: false
+              codecov: true
     env:
       CYTHON_TRACE_NOGIL: 1
       MPLBACKEND: agg

--- a/package/pyproject.toml
+++ b/package/pyproject.toml
@@ -14,6 +14,7 @@ requires = [
     "numpy==1.22.3; python_version=='3.9' and platform_python_implementation != 'PyPy'",
     "numpy==1.22.3; python_version=='3.10' and platform_python_implementation != 'PyPy'",
     "numpy==1.23.2; python_version=='3.11' and platform_python_implementation != 'PyPy'",
+    "numpy==1.26.0; python_version=='3.12' and platform_python_implementation != 'PyPy'",
     # For unreleased versions of Python there is currently no known supported
     # NumPy version. In that case we just let it be a bare NumPy install
     "numpy<2.0; python_version>='3.12'",

--- a/package/pyproject.toml
+++ b/package/pyproject.toml
@@ -66,6 +66,7 @@ classifiers = [
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
     'Programming Language :: C',
     'Topic :: Scientific/Engineering',
     'Topic :: Scientific/Engineering :: Bio-Informatics',

--- a/package/setup.py
+++ b/package/setup.py
@@ -582,6 +582,7 @@ if __name__ == '__main__':
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Programming Language :: C',
         'Topic :: Scientific/Engineering',
         'Topic :: Scientific/Engineering :: Bio-Informatics',


### PR DESCRIPTION
Changes made in this Pull Request:
 - Add py3.12 to minimal deps CI run
 - Add py3.12 to pypi checks
 - Fix pyproject.toml


## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--4319.org.readthedocs.build/en/4319/

<!-- readthedocs-preview mdanalysis end -->