### PR TITLE
Add Py3.12 for Azure pipelines CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,7 +35,7 @@ jobs:
           PYTHON_VERSION: '3.12'
           PYTHON_ARCH: 'x64'
           BUILD_TYPE: 'wheel'
-          NUMPY_MIN: '1.23.2'
+          NUMPY_MIN: '1.26.0'
           imageName: 'windows-2019'
         Win-Python39-64bit-full-wheel:
           PYTHON_VERSION: '3.9'
@@ -47,7 +47,7 @@ jobs:
           PYTHON_VERSION: '3.12'
           PYTHON_ARCH: 'x64'
           BUILD_TYPE: 'wheel'
-          NUMPY_MIN: '1.23.2'
+          NUMPY_MIN: '1.26.0'
           imageName: 'ubuntu-latest'
         Linux-Python39-64bit-full-wheel:
           PYTHON_VERSION: '3.9'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,13 +26,13 @@ jobs:
           PYTHON_ARCH: 'x64'
           BUILD_TYPE: 'normal'
           imageName: 'windows-2019'
-        Win-Python311-64bit-full:
-          PYTHON_VERSION: '3.11'
+        Win-Python312-64bit-full:
+          PYTHON_VERSION: '3.12'
           PYTHON_ARCH: 'x64'
           BUILD_TYPE: 'normal'
           imageName: 'windows-2019'
-        Win-Python311-64bit-full-wheel:
-          PYTHON_VERSION: '3.11'
+        Win-Python312-64bit-full-wheel:
+          PYTHON_VERSION: '3.12'
           PYTHON_ARCH: 'x64'
           BUILD_TYPE: 'wheel'
           NUMPY_MIN: '1.23.2'
@@ -43,8 +43,8 @@ jobs:
           BUILD_TYPE: 'wheel'
           NUMPY_MIN: '1.22.3'
           imageName: 'windows-2019'
-        Linux-Python311-64bit-full-wheel:
-          PYTHON_VERSION: '3.11'
+        Linux-Python312-64bit-full-wheel:
+          PYTHON_VERSION: '3.12'
           PYTHON_ARCH: 'x64'
           BUILD_TYPE: 'wheel'
           NUMPY_MIN: '1.23.2'


### PR DESCRIPTION
Probably going to fail, but let's at least try.

Changes made in this Pull Request:
 - Bump up max Azure pipelines CI tests to py3.12 (from 3.11) 

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--4327.org.readthedocs.build/en/4327/

<!-- readthedocs-preview mdanalysis end -->