### PR TITLE
Fix deploy to use the right environment & token permissions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -117,12 +117,16 @@ jobs:
           path: testsuite/dist/*.tar.gz
           retention-days: 7
 
-  upload_testpypi:
+  upload_testpypi_mdanalysis:
     if: |
       github.repository == 'MDAnalysis/mdanalysis' &&
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/package'))
-    name: testpypi upload
-    environment: deploy
+    name: testpypi_upload_mdanalysis
+    environment:
+      name: deploy
+      url: https://test.pypi.org/p/mdanalysis
+    permissions:
+      id-token: write
     runs-on: ubuntu-latest
     needs: [build_wheels, build_sdist, build_sdist_tests]
     steps:
@@ -142,6 +146,29 @@ jobs:
           skip_existing: true
           repository_url: https://test.pypi.org/legacy/
 
+  upload_testpypi_mdanalysistests:
+    if: |
+      github.repository == 'MDAnalysis/mdanalysis' &&
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/package'))
+    name: testpypi_upload_mdanalysistests
+    environment:
+      name: deploy
+      url: https://test.pypi.org/p/mdanalysis
+    permissions:
+      id-token: write
+    runs-on: ubuntu-latest
+    needs: [build_wheels, build_sdist, build_sdist_tests]
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact
+          path: dist
+
+      - name: move_test_dist
+        run: |
+          mkdir -p testsuite/dist
+          mv dist/MDAnalysisTests-* testsuite/dist
+
       - name: upload_tests
         uses: pypa/gh-action-pypi-publish@v1.8.10
         with:
@@ -149,12 +176,16 @@ jobs:
           skip_existing: true
           repository_url: https://test.pypi.org/legacy/
  
-  upload_pypi:
+  upload_pypi_mdanalysis:
     if: |
       github.repository == 'MDAnalysis/mdanalysis' &&
       github.event_name == 'release' && github.event.action == 'published'
-    name: pypi upload
-    environment: deploy
+    name: pypi_upload_mdanalysis
+    environment:
+      name: deploy
+      url: https://pypi.org/p/mdanalysis
+    permissions:
+      id-token: write
     runs-on: ubuntu-latest
     needs: [build_wheels, build_sdist, build_sdist_tests]
     steps:
@@ -170,6 +201,29 @@ jobs:
 
       - name: upload_source_and_wheels
         uses: pypa/gh-action-pypi-publish@v1.18.10
+
+  upload_pypi_mdanalysistests:
+    if: |
+      github.repository == 'MDAnalysis/mdanalysis' &&
+      github.event_name == 'release' && github.event.action == 'published'
+    name: pypi_upload_mdanalysistests
+    environment:
+      name: deploy
+      url: https://pypi.org/p/mdanalysistests
+    permissions:
+      id-token: write
+    runs-on: ubuntu-latest
+    needs: [build_wheels, build_sdist, build_sdist_tests]
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact
+          path: dist
+
+      - name: move_test_dist
+        run: |
+          mkdir -p testsuite/dist
+          mv dist/MDAnalysisTests-* testsuite/dist
 
       - name: upload_tests
         uses: pypa/gh-action-pypi-publish@v1.18.10
@@ -183,7 +237,7 @@ jobs:
     name: testpypi check
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
-    needs: upload_testpypi
+    needs: [upload_testpypi_mdanalysis, upload_testpypi_mdanalysistests]
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Follows up from #4325 

I didn't see what we needed to set the environment url & token permissions, so doing so now.

This does load to some annoying proliferation of action steps, I'll probably create a reusable action at some point, but for now this will do.

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--4328.org.readthedocs.build/en/4328/

<!-- readthedocs-preview mdanalysis end -->