### PR TITLE
Adding py3.12 to full dependency CI checks

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -27,7 +27,7 @@ jobs:
         fail-fast: false
         matrix:
           os: [ubuntu-latest, ]
-          python-version: ["3.9", "3.10", "3.11"]
+          python-version: ["3.9", "3.10", "3.11", "3.12"]
           full-deps: [true, ]
           codecov: [true, ]
           include:
@@ -48,11 +48,6 @@ jobs:
               full-deps: true
               codecov: false
               extra-pip-deps: asv
-            - name: python_312
-              os: ubuntu-latest
-              python-version: "3.12"
-              full-deps: false
-              codecov: true
     env:
       CYTHON_TRACE_NOGIL: 1
       MPLBACKEND: agg


### PR DESCRIPTION
Just testing things out to see which upstream dependency we're currently waiting on.

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--4329.org.readthedocs.build/en/4329/

<!-- readthedocs-preview mdanalysis end -->