### PR TITLE
scipy.integrate.simps deprecation

### DIFF
--- a/package/MDAnalysis/analysis/pca.py
+++ b/package/MDAnalysis/analysis/pca.py
@@ -747,8 +747,8 @@ def cosine_content(pca_space, i):
     t = np.arange(len(pca_space))
     T = len(pca_space)
     cos = np.cos(np.pi * t * (i + 1) / T)
-    return ((2.0 / T) * (scipy.integrate.simps(cos*pca_space[:, i])) ** 2 /
-            scipy.integrate.simps(pca_space[:, i] ** 2))
+    return ((2.0 / T) * (scipy.integrate.simpson(cos*pca_space[:, i])) ** 2 /
+            scipy.integrate.simpson(pca_space[:, i] ** 2))
 
 
 @due.dcite(


### PR DESCRIPTION
## Context

2023-11-03T03:16:21.1314426Z   /home/runner/work/mdanalysis/mdanalysis/package/MDAnalysis/analysis/pca.py:750: DeprecationWarning: 'scipy.integrate.simps' is deprecated in favour of 'scipy.integrate.simpson' and will be removed in SciPy 1.14.0

## In this PR

Switch to scipy.integrate.simpson - note that the `even` keyword now defaults to Simpson's rule compared to `avg` in scipy.integrate.simps.

As the `even` keyword is deprecated and soon to be removed, I think the aim would be to just use this new behaviour going forward.


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--4330.org.readthedocs.build/en/4330/

<!-- readthedocs-preview mdanalysis end -->