### PR TITLE
Deprecate `ts` argument to _read_next_timestep

### DIFF
--- a/package/MDAnalysis/coordinates/DCD.py
+++ b/package/MDAnalysis/coordinates/DCD.py
@@ -200,6 +200,9 @@ class DCDReader(base.ReaderBase):
 
     def _read_next_timestep(self, ts=None):
         """copy next frame into timestep"""
+        if ts:
+            warnings.warn("ts argument to _read_next_timestep is deprecated as of 2.7.0 and will be removed in 3.0.0, see #3928")
+
         if self._frame == self.n_frames - 1:
             raise IOError('trying to go over trajectory limit')
         if ts is None:

--- a/package/MDAnalysis/coordinates/DLPoly.py
+++ b/package/MDAnalysis/coordinates/DLPoly.py
@@ -29,6 +29,7 @@ Read DL Poly_ format coordinate files
 .. _Poly: http://www.stfc.ac.uk/SCD/research/app/ccg/software/DL_POLY/44516.aspx
 """
 import numpy as np
+import warnings
 
 from . import base
 from . import core
@@ -164,6 +165,9 @@ class HistoryReader(base.ReaderBase):
         self._read_next_timestep()
 
     def _read_next_timestep(self, ts=None):
+        if ts:
+            warnings.warn("ts argument to _read_next_timestep is deprecated  as of 2.7.0 and will be removed in 3.0.0, see #3928")
+        
         if ts is None:
             ts = self.ts
 

--- a/package/MDAnalysis/coordinates/GMS.py
+++ b/package/MDAnalysis/coordinates/GMS.py
@@ -182,6 +182,9 @@ class GMSReader(base.ReaderBase):
         return self._read_next_timestep()
 
     def _read_next_timestep(self, ts=None):
+        if ts:
+            warnings.warn("ts argument to _read_next_timestep is deprecated as of 2.7.0 and will be removed in 3.0.0, see #3928")
+
         # check that the timestep object exists
         if ts is None:
             ts = self.ts

--- a/package/MDAnalysis/coordinates/MOL2.py
+++ b/package/MDAnalysis/coordinates/MOL2.py
@@ -217,6 +217,9 @@ class MOL2Reader(base.ReaderBase):
         return sections, coords
 
     def _read_next_timestep(self, ts=None):
+        if ts:
+            warnings.warn("ts argument to _read_next_timestep is deprecated as of 2.7.0 and will be removed in 3.0.0, see #3928")
+
         if ts is None:
             ts = self.ts
         else:

--- a/package/MDAnalysis/coordinates/PDB.py
+++ b/package/MDAnalysis/coordinates/PDB.py
@@ -372,6 +372,9 @@ class PDBReader(base.ReaderBase):
         self.ts.frame = -1
 
     def _read_next_timestep(self, ts=None):
+        if ts:
+            warnings.warn("ts argument to _read_next_timestep is deprecated as of 2.7.0 and will be removed in 3.0.0, see #3928")
+
         if ts is None:
             ts = self.ts
         else:

--- a/package/MDAnalysis/coordinates/TRJ.py
+++ b/package/MDAnalysis/coordinates/TRJ.py
@@ -681,6 +681,9 @@ class NCDFReader(base.ReaderBase):
         self._current_frame = -1
 
     def _read_next_timestep(self, ts=None):
+        if ts:
+            warnings.warn("ts argument to _read_next_timestep is deprecated as of 2.7.0 and will be removed in 3.0.0, see #3928") 
+
         if ts is None:
             ts = self.ts
         try:

--- a/package/MDAnalysis/coordinates/TRR.py
+++ b/package/MDAnalysis/coordinates/TRR.py
@@ -160,6 +160,9 @@ class TRRReader(XDRBaseReader):
             read_direct_xvf to read the data directly into the timestep
             rather than copying it from a temporary array.
         """
+        if ts:
+            warnings.warn("ts argument to _read_next_timestep is deprecated as of 2.7.0 and will be removed in 3.0.0, see #3928") 
+
         if self._frame == self.n_frames - 1:
             raise IOError(errno.EIO, 'trying to go over trajectory limit')
         if ts is None:

--- a/package/MDAnalysis/coordinates/TRR.py
+++ b/package/MDAnalysis/coordinates/TRR.py
@@ -32,6 +32,7 @@ MDAnalysis.coordinates.XTC: Read and write GROMACS XTC trajectory files.
 MDAnalysis.coordinates.XDR: BaseReader/Writer for XDR based formats
 """
 import errno
+import warnings
 from . import base
 from .XDR import XDRBaseReader, XDRBaseWriter
 from ..lib.formats.libmdaxdr import TRRFile

--- a/package/MDAnalysis/coordinates/TRZ.py
+++ b/package/MDAnalysis/coordinates/TRZ.py
@@ -190,6 +190,9 @@ class TRZReader(base.ReaderBase):
             raise IOError
 
     def _read_next_timestep(self, ts=None):
+        if ts:
+            warnings.warn("ts argument to _read_next_timestep is deprecated as of 2.7.0 and will be removed in 3.0.0, see #3928")
+
         if ts is None:
             ts = self.ts
 

--- a/package/MDAnalysis/coordinates/TXYZ.py
+++ b/package/MDAnalysis/coordinates/TXYZ.py
@@ -133,6 +133,9 @@ class TXYZReader(base.ReaderBase):
         return self._read_next_timestep()
 
     def _read_next_timestep(self, ts=None):
+        if ts:
+            warnings.warn("ts argument to _read_next_timestep is deprecated as of 2.7.0 and will be removed in 3.0.0, see #3928")
+
         # check that the timestep object exists
         if ts is None:
             ts = self.ts

--- a/package/MDAnalysis/coordinates/XTC.py
+++ b/package/MDAnalysis/coordinates/XTC.py
@@ -149,6 +149,9 @@ class XTCReader(XDRBaseReader):
             read_direct_x method of XTCFile to read the data directly
             into the timestep rather than copying it from a temporary array.
         """
+        if ts:
+            warnings.warn("ts argument to _read_next_timestep is deprecated as of 2.7.0 and will be removed in 3.0.0, see #3928")
+
         if self._frame == self.n_frames - 1:
             raise IOError(errno.EIO, 'trying to go over trajectory limit')
         if ts is None:

--- a/package/MDAnalysis/coordinates/XTC.py
+++ b/package/MDAnalysis/coordinates/XTC.py
@@ -33,6 +33,7 @@ MDAnalysis.coordinates.XDR: BaseReader/Writer for XDR based formats
 """
 
 import errno
+import warnings
 from . import base
 from .XDR import XDRBaseReader, XDRBaseWriter
 from ..lib.formats.libmdaxdr import XTCFile

--- a/package/MDAnalysis/coordinates/XYZ.py
+++ b/package/MDAnalysis/coordinates/XYZ.py
@@ -400,6 +400,9 @@ class XYZReader(base.ReaderBase):
 
     def _read_next_timestep(self, ts=None):
         # check that the timestep object exists
+        if ts:
+            warnings.warn("ts argument to _read_next_timestep is deprecated as of 2.7.0 and will be removed in 3.0.0, see #3928")
+
         if ts is None:
             ts = self.ts
 

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -792,6 +792,7 @@ class ProtoReader(IOBase, metaclass=_Readermeta):
         #         ts = self.ts
         #     ts.frame = self._read_next_frame(etc)
         #     return ts
+        # NOTE: ts argument is deprecated as of 2.7.0 and will be removed in 3.0.0
         ...
 
     def __iter__(self):

--- a/package/MDAnalysis/coordinates/chain.py
+++ b/package/MDAnalysis/coordinates/chain.py
@@ -574,6 +574,9 @@ class ChainReader(base.ReaderBase):
         return self.ts
 
     def _read_next_timestep(self, ts=None):
+        if ts:
+            warnings.warn("ts argument to _read_next_timestep is deprecated as of 2.7.0 and will be removed in 3.0.0, see #3928")
+
         if ts is None:
             ts = self.ts
 

--- a/package/MDAnalysis/coordinates/chemfiles.py
+++ b/package/MDAnalysis/coordinates/chemfiles.py
@@ -214,6 +214,9 @@ class ChemfilesReader(base.ReaderBase):
 
     def _read_next_timestep(self, ts=None):
         """copy next frame into timestep"""
+        if ts:
+            warnings.warn("ts argument to _read_next_timestep is deprecated as of 2.7.0 and will be removed in 3.0.0, see #3928")
+
         if self._step >= self.n_frames:
             raise IOError("trying to go over trajectory limit")
         if ts is None:

--- a/package/MDAnalysis/coordinates/memory.py
+++ b/package/MDAnalysis/coordinates/memory.py
@@ -570,6 +570,8 @@ class MemoryReader(base.ProtoReader):
 
     def _read_next_timestep(self, ts=None):
         """copy next frame into timestep"""
+        if ts:
+            warnings.warn("ts argument to _read_next_timestep is deprecated as of 2.7.0 and will be removed in 3.0.0, see #3928")
 
         if self.ts.frame >= self.n_frames-1:
             raise IOError(errno.EIO, 'trying to go over trajectory limit')


### PR DESCRIPTION
Fixes #3928 

Changes made in this Pull Request:
 - Adds deprecation warning for `_read_next_timestep` use of optional `ts=None` arg (barely ever used) 
 
As this is an implementation detail I didn't add docs changes, as I couldn't see a record of it documented anywhere anyway. 

The warning is guarded by a conditional to avoid an immense amount of warnings.

PR Checklist
------------
 - [X] CHANGELOG updated?
 - [X] Issue raised/referenced?

## Developers certificate of origin
- [X] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--4334.org.readthedocs.build/en/4334/

<!-- readthedocs-preview mdanalysis end -->