### PR TITLE
Port over the get_cmap fix from mdakit-hole2

### DIFF
--- a/package/MDAnalysis/analysis/hole2/hole.py
+++ b/package/MDAnalysis/analysis/hole2/hole.py
@@ -871,7 +871,7 @@ class HoleAnalysis(AnalysisBase):
             frames = util.asiterable(frames)
 
         if color is None:
-            colormap = plt.cm.get_cmap(cmap)
+            colormap = matplotlib.colormaps.get_cmap(cmap)
             norm = matplotlib.colors.Normalize(vmin=min(frames),
                                                vmax=max(frames))
             colors = colormap(norm(frames))


### PR DESCRIPTION
See: https://github.com/MDAnalysis/hole2-mdakit/pull/39/files

We might need to consider if removing hole2 and just optionally importing hole2-mdakit might be a good idea eventually.

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--4338.org.readthedocs.build/en/4338/

<!-- readthedocs-preview mdanalysis end -->