### PR TITLE
Expose C distance backend in libmdanalysis.pxd

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -15,7 +15,7 @@ The rules for this file:
 
 -------------------------------------------------------------------------------
 ??/??/?? IAlibay, ianmkenney, PicoCentauri, pgbarletta, p-j-smith, 
-         richardjgowers, lilyminium, ALescoulie
+         richardjgowers, lilyminium, ALescoulie, hmacdope
 
  * 2.7.0
 
@@ -30,6 +30,8 @@ Fixes
   * Fix atom charge reading in PDBQT parser (Issue #4282, PR #4283)
 
 Enhancements
+  * Refactor c_distances backend to have a cython .pxd header and expose in
+    libmdanalysis (Issue #4315, PR #4324)
   * Add faster nucleic acid Major and Minor pair distance calculators using
     AnalysisBase for updated nucleicacids module (Issue #3720, PR #3735)
   * Adds external sidebar links (Issue #4296)

--- a/package/MDAnalysis/lib/c_distances.pxd
+++ b/package/MDAnalysis/lib/c_distances.pxd
@@ -1,0 +1,29 @@
+from libc.stdint cimport uint64_t, UINT64_MAX
+
+
+cdef extern from "string.h":
+    void* memcpy(void* dst, void* src, int len)
+
+cdef extern from "calc_distances.h":
+    ctypedef float coordinate[3]
+    cdef bint USED_OPENMP
+    void _calc_distance_array(coordinate* ref, uint64_t numref, coordinate* conf, uint64_t numconf, double* distances)
+    void _calc_distance_array_ortho(coordinate* ref, uint64_t numref, coordinate* conf, uint64_t numconf, float* box, double* distances)
+    void _calc_distance_array_triclinic(coordinate* ref, uint64_t numref, coordinate* conf, uint64_t numconf, float* box, double* distances)
+    void _calc_self_distance_array(coordinate* ref, uint64_t numref, double* distances)
+    void _calc_self_distance_array_ortho(coordinate* ref, uint64_t numref, float* box, double* distances)
+    void _calc_self_distance_array_triclinic(coordinate* ref, uint64_t numref, float* box, double* distances)
+    void _coord_transform(coordinate* coords, uint64_t numCoords, double* box)
+    void _calc_bond_distance(coordinate* atom1, coordinate* atom2, uint64_t numatom, double* distances)
+    void _calc_bond_distance_ortho(coordinate* atom1, coordinate* atom2, uint64_t numatom, float* box, double* distances)
+    void _calc_bond_distance_triclinic(coordinate* atom1, coordinate* atom2, uint64_t numatom, float* box, double* distances)
+    void _calc_angle(coordinate* atom1, coordinate* atom2, coordinate* atom3, uint64_t numatom, double* angles)
+    void _calc_angle_ortho(coordinate* atom1, coordinate* atom2, coordinate* atom3, uint64_t numatom, float* box, double* angles)
+    void _calc_angle_triclinic(coordinate* atom1, coordinate* atom2, coordinate* atom3, uint64_t numatom, float* box, double* angles)
+    void _calc_dihedral(coordinate* atom1, coordinate* atom2, coordinate* atom3, coordinate* atom4, uint64_t numatom, double* angles)
+    void _calc_dihedral_ortho(coordinate* atom1, coordinate* atom2, coordinate* atom3, coordinate* atom4, uint64_t numatom, float* box, double* angles)
+    void _calc_dihedral_triclinic(coordinate* atom1, coordinate* atom2, coordinate* atom3, coordinate* atom4, uint64_t numatom, float* box, double* angles)
+    void _ortho_pbc(coordinate* coords, uint64_t numcoords, float* box)
+    void _triclinic_pbc(coordinate* coords, uint64_t numcoords, float* box)
+    void minimum_image(double* x, float* box, float* inverse_box)
+    void minimum_image_triclinic(float* x, float* box, float* inverse_box)

--- a/package/MDAnalysis/lib/c_distances.pyx
+++ b/package/MDAnalysis/lib/c_distances.pyx
@@ -41,32 +41,6 @@ from libc.float cimport FLT_MAX, DBL_MAX
 # make UINT64_MAX visible at the python layer
 _UINT64_MAX = UINT64_MAX
 
-cdef extern from "string.h":
-    void* memcpy(void* dst, void* src, int len)
-
-cdef extern from "calc_distances.h":
-    ctypedef float coordinate[3]
-    cdef bint USED_OPENMP
-    void _calc_distance_array(coordinate* ref, uint64_t numref, coordinate* conf, uint64_t numconf, double* distances)
-    void _calc_distance_array_ortho(coordinate* ref, uint64_t numref, coordinate* conf, uint64_t numconf, float* box, double* distances)
-    void _calc_distance_array_triclinic(coordinate* ref, uint64_t numref, coordinate* conf, uint64_t numconf, float* box, double* distances)
-    void _calc_self_distance_array(coordinate* ref, uint64_t numref, double* distances)
-    void _calc_self_distance_array_ortho(coordinate* ref, uint64_t numref, float* box, double* distances)
-    void _calc_self_distance_array_triclinic(coordinate* ref, uint64_t numref, float* box, double* distances)
-    void _coord_transform(coordinate* coords, uint64_t numCoords, double* box)
-    void _calc_bond_distance(coordinate* atom1, coordinate* atom2, uint64_t numatom, double* distances)
-    void _calc_bond_distance_ortho(coordinate* atom1, coordinate* atom2, uint64_t numatom, float* box, double* distances)
-    void _calc_bond_distance_triclinic(coordinate* atom1, coordinate* atom2, uint64_t numatom, float* box, double* distances)
-    void _calc_angle(coordinate* atom1, coordinate* atom2, coordinate* atom3, uint64_t numatom, double* angles)
-    void _calc_angle_ortho(coordinate* atom1, coordinate* atom2, coordinate* atom3, uint64_t numatom, float* box, double* angles)
-    void _calc_angle_triclinic(coordinate* atom1, coordinate* atom2, coordinate* atom3, uint64_t numatom, float* box, double* angles)
-    void _calc_dihedral(coordinate* atom1, coordinate* atom2, coordinate* atom3, coordinate* atom4, uint64_t numatom, double* angles)
-    void _calc_dihedral_ortho(coordinate* atom1, coordinate* atom2, coordinate* atom3, coordinate* atom4, uint64_t numatom, float* box, double* angles)
-    void _calc_dihedral_triclinic(coordinate* atom1, coordinate* atom2, coordinate* atom3, coordinate* atom4, uint64_t numatom, float* box, double* angles)
-    void _ortho_pbc(coordinate* coords, uint64_t numcoords, float* box)
-    void _triclinic_pbc(coordinate* coords, uint64_t numcoords, float* box)
-    void minimum_image(double* x, float* box, float* inverse_box)
-    void minimum_image_triclinic(float* x, float* box, float* inverse_box)
 
 OPENMP_ENABLED = True if USED_OPENMP else False
 

--- a/package/MDAnalysis/lib/libmdanalysis/__init__.pxd
+++ b/package/MDAnalysis/lib/libmdanalysis/__init__.pxd
@@ -4,3 +4,4 @@
 from ..coordinates cimport timestep
 from .formats cimport libmdaxdr
 from .formats cimport libdcd
+from . cimport c_distances

--- a/package/doc/sphinx/source/documentation_pages/lib_modules.rst
+++ b/package/doc/sphinx/source/documentation_pages/lib_modules.rst
@@ -103,5 +103,8 @@ For example, imagine we are writing a Cython extension module in
 Currently modules that are exposed as public Cython headers are:
 
 - :mod:`MDAnalysis.coordinates.timestep`
+- :mod:`MDAnalysis.lib.formats.libmdaxdr`
+- :mod:`MDAnalysis.lib.formats.libdcd`
+- :mod:`MDAnalysis.lib.c_distances`
 
 For more details consult the source :mod:`MDAnalysis.lib.libmdanalysis.__init__.pxd`


### PR DESCRIPTION
Fixes #4315 

Changes made in this Pull Request:
 - Refactors C distances to use a PXD
 - Expose in libmdanalysis.pxd


PR Checklist
------------
 - [X] CHANGELOG updated?
 - [X] Issue raised/referenced?

## Developers certificate of origin
- [X] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--4342.org.readthedocs.build/en/4342/

<!-- readthedocs-preview mdanalysis end -->