### PR TITLE
Update benchmarks default python in asv.conf.json

### DIFF
--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -21,7 +21,7 @@
 
     // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.
-    "pythons": ["3.8"],
+    "pythons": ["3.10"],
     // The matrix of dependencies to test.  Each key is the name of a
     // package (in PyPI) and the values are version numbers.  An empty
     // list indicates to just test against the default (latest)


### PR DESCRIPTION
Fixes #4351

Changes made in this Pull Request:
 - changes default python  version in benchmarks to be 3.10


PR Checklist
------------
 - [ ] CHANGELOG updated?
 - [X] Issue raised/referenced?

## Developers certificate of origin
- [X] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--4352.org.readthedocs.build/en/4352/

<!-- readthedocs-preview mdanalysis end -->