### PR TITLE
Document the usage of ```NoDataError``` in it's docstring

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -222,6 +222,7 @@ Chronological list of authors
   - Shubham Kumar
   - Zaheer Timol
   - Geongi Moon
+  - Heet Vekariya
 
 External code
 -------------

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -30,7 +30,7 @@ Fixes
   * Fix atom charge reading in PDBQT parser (Issue #4282, PR #4283)
 
 Enhancements
-  * Document the usage of NoDataError in it's docstring (Issue #3901, PR #4359)
+  * Document the usage of NoDataError in its docstring (Issue #3901, PR #4359)
   * Refactor c_distances backend to have a cython .pxd header and expose in
     libmdanalysis (Issue #4315, PR #4324)
   * Add faster nucleic acid Major and Minor pair distance calculators using

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -15,7 +15,7 @@ The rules for this file:
 
 -------------------------------------------------------------------------------
 ??/??/?? IAlibay, ianmkenney, PicoCentauri, pgbarletta, p-j-smith, 
-         richardjgowers, lilyminium, ALescoulie, hmacdope
+         richardjgowers, lilyminium, ALescoulie, hmacdope, HeetVekariya
 
  * 2.7.0
 
@@ -30,6 +30,7 @@ Fixes
   * Fix atom charge reading in PDBQT parser (Issue #4282, PR #4283)
 
 Enhancements
+  * Document the usage of NoDataError in it's docstring (Issue #3901, PR #4359)
   * Refactor c_distances backend to have a cython .pxd header and expose in
     libmdanalysis (Issue #4315, PR #4324)
   * Add faster nucleic acid Major and Minor pair distance calculators using

--- a/package/MDAnalysis/exceptions.py
+++ b/package/MDAnalysis/exceptions.py
@@ -36,19 +36,20 @@ class NoDataError(ValueError, AttributeError):
     """Raised when empty input is not allowed or required data are missing.
 
     This exception is raised in the following scenarios:
+
     * Raised when a :class:`~MDAnalysis.core.topologyattrs.TopologyAttr`
-    (e.g., bonds, charges) is not present in the data.
+      (e.g., bonds, charges) is not present in the data.
 
     * Raised when data is missing in an analysis class because the `run()`
-    method has not been called. Examples include polymer analysis, PSA
-    (Path Similarity Analysis), dielectric analysis, and hydrogen bond
-    analysis.
+      method has not been called. Examples include polymer analysis, PSA
+      (Path Similarity Analysis), dielectric analysis, and hydrogen bond
+      analysis.
 
     * Raised when timestep data is missing, such as positions, velocities,
-    or forces.
+      or forces.
 
     * Raised in the `nojump` transformation if there is no box information
-    in the universe.
+      in the universe.
 
     This exception should not be raised in cases where arrays have zero width,
     or AtomGroups are empty.

--- a/package/MDAnalysis/exceptions.py
+++ b/package/MDAnalysis/exceptions.py
@@ -41,9 +41,8 @@ class NoDataError(ValueError, AttributeError):
       (e.g., bonds, charges) is not present in the data.
 
     * Raised when data is missing in an analysis class because the `run()`
-      method has not been called. Examples include polymer analysis, PSA
-      (Path Similarity Analysis), dielectric analysis, and hydrogen bond
-      analysis.
+      method has not been called, e.g.
+      :class:`~MDAnalysis.analysis.polymer.PersistenceLength`.
 
     * Raised when timestep data is missing, such as positions, velocities,
       or forces.

--- a/package/MDAnalysis/exceptions.py
+++ b/package/MDAnalysis/exceptions.py
@@ -35,6 +35,26 @@ class SelectionError(Exception):
 class NoDataError(ValueError, AttributeError):
     """Raised when empty input is not allowed or required data are missing.
 
+    This exception is used in various scenarios:
+    -   Raised when a Topology Attribute (e.g., bonds, charges) is not
+        present in the data.
+
+    -   Raised when data is missing in an analysis class because the `run()`
+        method has not been called. Examples include polymer analysis, PSA
+        (Potential Surface Analysis), dielectric analysis, and hydrogen bond
+        analysis.
+
+    -   Raised when timestep data is missing, such as positions, velocities,
+        or forces.
+
+    -   Raised in the `nojump` transformation if there is no box information
+        in the universe.
+
+    Additionally, this exception may be raised in cases where:
+
+    -   Arrays have zero width.
+    -   AtomGroups are empty.
+
     .. versionchanged:: 1.0.0
         Now a subclass of AttributeError as well as ValueError
     """

--- a/package/MDAnalysis/exceptions.py
+++ b/package/MDAnalysis/exceptions.py
@@ -35,25 +35,23 @@ class SelectionError(Exception):
 class NoDataError(ValueError, AttributeError):
     """Raised when empty input is not allowed or required data are missing.
 
-    This exception is used in various scenarios:
-    -   Raised when a Topology Attribute (e.g., bonds, charges) is not
-        present in the data.
+    This exception is raised in the following scenarios:
+    * Raised when a :class:`~MDAnalysis.core.topologyattrs.TopologyAttr`
+    (e.g., bonds, charges) is not present in the data.
 
-    -   Raised when data is missing in an analysis class because the `run()`
-        method has not been called. Examples include polymer analysis, PSA
-        (Potential Surface Analysis), dielectric analysis, and hydrogen bond
-        analysis.
+    * Raised when data is missing in an analysis class because the `run()`
+    method has not been called. Examples include polymer analysis, PSA
+    (Path Similarity Analysis), dielectric analysis, and hydrogen bond
+    analysis.
 
-    -   Raised when timestep data is missing, such as positions, velocities,
-        or forces.
+    * Raised when timestep data is missing, such as positions, velocities,
+    or forces.
 
-    -   Raised in the `nojump` transformation if there is no box information
-        in the universe.
+    * Raised in the `nojump` transformation if there is no box information
+    in the universe.
 
-    Additionally, this exception may be raised in cases where:
-
-    -   Arrays have zero width.
-    -   AtomGroups are empty.
+    This exception should not be raised in cases where arrays have zero width,
+    or AtomGroups are empty.
 
     .. versionchanged:: 1.0.0
         Now a subclass of AttributeError as well as ValueError


### PR DESCRIPTION
Fixes #3901 

Changes made in this Pull Request:
 - Adds the usage of ```NoDataError``` in it's docstring.

![image](https://github.com/MDAnalysis/mdanalysis/assets/91054457/402e367c-7c38-42d4-9596-1d8350ca9ed8)


PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--4359.org.readthedocs.build/en/4359/

<!-- readthedocs-preview mdanalysis end -->