### PR TITLE
BENCH: fix time_geometric_selections

### DIFF
--- a/benchmarks/benchmarks/selections.py
+++ b/benchmarks/benchmarks/selections.py
@@ -72,11 +72,9 @@ class GeoSelectionBench(object):
                                   dynamic_selection,
                                   periodic_selection):
 
-        # set core flags for PBC accounting
-        MDAnalysis.core.flags['use_periodic_selections'] = periodic_selection[0]
-        MDAnalysis.core.flags['use_KDTree_routines'] = periodic_selection[1]
-
-        if hasattr(MDAnalysis.Universe, 'select_atoms'):
-            self.u.select_atoms(selection_string, updating=dynamic_selection)
-        else:
-            self.u.selectAtoms(selection_string, updating=dynamic_selection)
+        # TODO: Do we need a kwarg similar to old `use_KDTree_routines`
+        # flag? We used to benchmark that.
+        self.u.select_atoms(selection_string,
+                            updating=dynamic_selection,
+                            periodic=periodic_selection[0],
+                            )


### PR DESCRIPTION
* Fixes gh-3519

* There is no good reason to keep the flags in the benchmark--this benchmark has been broken for over a year so we should just use the appropriate kwargs where possible and leave a `TODO` comment for core flags that we don't have a substitute for

* better to have this running than hard failing all the time, even if we've lost one of the parametrization dimensions

* if someone comes along with the confidence to say we can delete the `TODO` comment, then we can also delete some of the extra parametrization complexity of course

[skip cirrus]

<!-- readthedocs-preview mdanalysis start -->
----
:books: Documentation preview :books:: https://mdanalysis--4360.org.readthedocs.build/en/4360/

<!-- readthedocs-preview mdanalysis end -->