### PR TITLE
fix: errors due to ```make html```

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -20,6 +20,7 @@ The rules for this file:
  * 2.7.0
 
 Fixes
+  * Fix `make html` command errors (Issue #4362, PR #4365)
   * Updated cimport for numpy to maintain cimport consistency (Issue #3908)
   * Fix `NoJump` unwrapping for jumps on the second frame in a
     trajectory (PR #4258, Issue #4257)

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -20,7 +20,8 @@ The rules for this file:
  * 2.7.0
 
 Fixes
-  * Fix `make html` command errors (Issue #4362, PR #4365)
+  * Fix documentation building errors due to `html_static_path` and unindented
+    block of code (Issue #4362, PR #4365)
   * Updated cimport for numpy to maintain cimport consistency (Issue #3908)
   * Fix `NoJump` unwrapping for jumps on the second frame in a
     trajectory (PR #4258, Issue #4257)

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -1001,7 +1001,7 @@ class ProtoReader(IOBase, metaclass=_Readermeta):
             of coordinate data is returned.
 
             .. deprecated:: 2.7.0
-            asel argument will be renamed to atomgroup in 3.0.0
+                asel argument will be renamed to atomgroup in 3.0.0
 
         atomgroup: AtomGroup (optional)
             Same as `asel`, will replace `asel` in 3.0.0

--- a/package/doc/sphinx/source/conf.py
+++ b/package/doc/sphinx/source/conf.py
@@ -190,7 +190,7 @@ html_context = {
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 # For RTD theme: custom.css to override theme defaults.
-html_static_path = ['_static']
+html_static_path = []
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.


### PR DESCRIPTION
Fixes #4362 

Changes made in this Pull Request:
1) To solve ```html_static_path``` error,  made the ```html_static_path``` list an empty list 
2) To solve ```Indentation``` error, added an indent of 4 spaces


PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4365.org.readthedocs.build/en/4365/

<!-- readthedocs-preview mdanalysis end -->