### PR TITLE
TST, MAINT: test_frame_bool_fail compat

### DIFF
--- a/testsuite/MDAnalysisTests/analysis/test_base.py
+++ b/testsuite/MDAnalysisTests/analysis/test_base.py
@@ -233,7 +233,7 @@ def test_frame_bool_fail():
     u = mda.Universe(TPR, XTC)  # dt = 100
     an = FrameAnalysis(u.trajectory)
     frames = [True, True, False]
-    msg = 'boolean index did not match indexed array along dimension 0'
+    msg = 'boolean index did not match indexed array along (axis|dimension) 0'
     with pytest.raises(IndexError, match=msg):
         an.run(frames=frames)
 


### PR DESCRIPTION
* adjust `test_frame_bool_fail` such that it passes with both NumPy `1.26.2` and NumPy `main`; the error message string changed on the latter, so a small shim was needed

[skip cirrus]

<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4367.org.readthedocs.build/en/4367/

<!-- readthedocs-preview mdanalysis end -->