### PR TITLE
DOC: CHANGELOG MM/DD/YY

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -80,7 +80,7 @@ Deprecations
     PR #3735)
 
 
-28/08/23 IAlibay, hmacdope, pillose, jaclark5, tylerjereddy
+08/28/23 IAlibay, hmacdope, pillose, jaclark5, tylerjereddy
 
  * 2.6.1
 
@@ -103,7 +103,7 @@ Changes
 Deprecations
 
 
-15/08/23 IAlibay, jaclark5, MohitKumar020291, orionarcher, xhgchen,
+08/15/23 IAlibay, jaclark5, MohitKumar020291, orionarcher, xhgchen,
          ztimol, orbeckst
 
  * 2.6.0


### PR DESCRIPTION
* I merged gh-4361 a bit early, so I should clean up the mess; I think this fixes the two cases where the datetime string was not formatted to match our documented convention

[skip cirrus]

<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4368.org.readthedocs.build/en/4368/

<!-- readthedocs-preview mdanalysis end -->