### PR TITLE
MAINT: encore Windows type fixes

### DIFF
--- a/package/MDAnalysis/analysis/encore/clustering/affinityprop.pyx
+++ b/package/MDAnalysis/analysis/encore/clustering/affinityprop.pyx
@@ -99,7 +99,7 @@ def AffinityPropagation(s, preference, float lam, int max_iterations, int conver
 
     # Prepare input and ouput arrays
     cdef numpy.ndarray[numpy.float32_t,  ndim=1] matndarray = numpy.ascontiguousarray(s._elements, dtype=numpy.float32)
-    cdef numpy.ndarray[long,   ndim=1] clusters   = numpy.zeros((s.size),dtype=long)
+    cdef numpy.ndarray[long,   ndim=1] clusters   = numpy.zeros((s.size),dtype=numpy.dtype("long"))
 
     # run C module Affinity Propagation
     iterations = CAffinityPropagation(<float*>matndarray.data, cn, lam, max_iterations, convergence, noise, <long*>clusters.data)


### PR DESCRIPTION
* in NumPy `2.0.0`, the default integer size on Windows will be 64-bit; we have 10 related test failures on Windows alongside NumPy `main` at the moment, and this patch fixes those failures by forcing a reversion to the old behavior, effectively kicking the can down the road

* I think we're going to proceed with a similar solution upstream for now (i.e., https://github.com/scipy/scipy/issues/19605#issuecomment-1852698295);

* I haven't kept up with whether this should actually be targeted at the encore "subproject" now with the reorg happening; feel free to move it if so...

[skip cirrus]

<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4369.org.readthedocs.build/en/4369/

<!-- readthedocs-preview mdanalysis end -->