### PR TITLE
Fix: Transformations.py doctest errors

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -20,6 +20,7 @@ The rules for this file:
  * 2.7.0
 
 Fixes
+  * Fix doctest errors of lib/transformations.py (Issue #3925, PR #4370)
   * Fix documentation building errors due to `html_static_path` and unindented
     block of code (Issue #4362, PR #4365)
   * Updated cimport for numpy to maintain cimport consistency (Issue #3908)

--- a/package/MDAnalysis/lib/transformations.py
+++ b/package/MDAnalysis/lib/transformations.py
@@ -1031,7 +1031,7 @@ def euler_matrix(ai, aj, ak, axes='sxyz'):
     ai, aj, ak : Euler's roll, pitch and yaw angles
     axes : One of 24 axis sequences as string or encoded tuple
 
-    >>> from MDAnalysis.lib.transformations import (euler_matrix
+    >>> from MDAnalysis.lib.transformations import (euler_matrix,
     ... _AXES2TUPLE, _TUPLE2AXES)
     >>> import math
     >>> import numpy as np

--- a/package/MDAnalysis/lib/transformations.py
+++ b/package/MDAnalysis/lib/transformations.py
@@ -1454,7 +1454,7 @@ def quaternion_slerp(quat0, quat1, fraction, spin=0, shortestpath=True):
     >>> q = quaternion_slerp(q0, q1, 0.5)
     >>> angle = math.acos(np.dot(q0, q))
     >>> np.allclose(2.0, math.acos(np.dot(q0, q1)) / angle) or \
-        np.allclose(2.0, math.acos(-np.dot(q0, q1)) / angle)
+    ... np.allclose(2.0, math.acos(-np.dot(q0, q1)) / angle)
     True
 
     """

--- a/package/MDAnalysis/lib/transformations.py
+++ b/package/MDAnalysis/lib/transformations.py
@@ -628,7 +628,7 @@ def clip_matrix(left, right, bottom, top, near, far, perspective=False):
     >>> np.dot(M, [frustrum[0], frustrum[2], frustrum[4], 1.0])
     array([-1., -1., -1.,  1.])
     >>> np.dot(M, [frustrum[1], frustrum[3], frustrum[5], 1.0])
-    array([ 1.,  1.,  1.,  1.])
+    array([1., 1., 1., 1.])
     >>> M = clip_matrix(perspective=True, *frustrum)
     >>> v = np.dot(M, [frustrum[0], frustrum[2], frustrum[4], 1.0])
     >>> v / v[3]


### PR DESCRIPTION
Fixes #3925 

Changes made in this Pull Request:
 - Doctest for **Transformations.py** (```package/MDAnalysis/lib/transformations.py```) file contains errors for this three functions:
1) ```clip_matrix``` (Indentation error): Correction in indentation
2) ```uler_matrix``` (Comma error): Added comma
3) ```quaternion_slerp``` (EOF error): Added ```...``` before starting of new line

PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4370.org.readthedocs.build/en/4370/

<!-- readthedocs-preview mdanalysis end -->