### PR TITLE
Fix changelog authors

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -81,6 +81,7 @@ Chronological list of authors
   - Tone Bengtsen
   - Shantanu Srivastava
   - Pedro Reis
+  - Zhenbo Li
  2017
   - Ruggero Cortini
   - Kashish Punjani

--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -231,6 +231,7 @@ Chronological list of authors
   - Sumit Gupta
   - Heet Vekariya
   - Johannes Stöckelmaier
+  - Jenna M. Swarthout Goddard
 
 External code
 -------------

--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -128,6 +128,7 @@ Chronological list of authors
   - Matthijs Tadema
   - Joao Miguel Correia Teixeira
   - Michael Gecht
+  - Bradley Dice
 2020
   - Charlie Cook
   - Yuanyu Chang

--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -157,6 +157,7 @@ Chronological list of authors
   - Ramon Crehuet
   - Haochuan Chen
   - Karthikeyan Singaravelan
+  - David Minh
 2021
   - Ian M. Kenney
   - Aditya Kamath

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -1048,7 +1048,7 @@ Deprecations
          Yuan-Yu, xiki-tempula, HTian1997, Iv-Hristov, hmacdope, AnshulAngaria,
          ss62171, Luthaf, yuxuanzhuang, abhishandy, mlnance, shfrz, orbeckst,
          wvandertoorn, cbouy, AmeyaHarmalkar, Oscuro-Phoenix, andrrizzi, WG150,
-         tylerjereddy, Marcello-Sega, mimischi
+         tylerjereddy, Marcello-Sega, mimischi, mquevill
 
   * 1.0.0
 

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -1717,7 +1717,7 @@ Changes
     they are part of the Universe topology (Issue #1092 PR #1186)
 
 
-06/29/17 richardjgowers, rathann, jbarnoud, orbeckst, utkbansal
+06/29/17 richardjgowers, rathann, jbarnoud, orbeckst, utkbansal, bsipocz
 
   * 0.16.2
 
@@ -1792,7 +1792,7 @@ Changes
 04/10/17 kain88-de, fiona-naughton, richardjgowers, tyler.je.reddy, jdetle
          euhruska, orbeckst, rbrtdlg, jbarnoud, wouterboomsma, shanmbic,
          dotsdl, manuel.nuno.melo, utkbansal, vedantrathore, shobhitagarwal1612,
-         xiki-tempula, kash1102, Akshay0724
+         xiki-tempula, kash1102, Akshay0724, bsipocz
 
   * 0.16.0
 

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -1263,7 +1263,8 @@ Fixes
 08/28/19 micaela-matta, xiki-tempula, zemanj, mattwthompson, orbeckst, aliehlen,
          dpadula85, jbarnoud, manuel.nuno.melo, richardjgowers,
          ayushsuhane, picocentauri, NinadBhat, bieniekmateusz, p-j-smith, Lp0lp,
-         IAlibay, tyler.je.reddy, aakognole, RMeli, lilyminium, fenilsuchak
+         IAlibay, tyler.je.reddy, aakognole, RMeli, lilyminium, fenilsuchak,
+         Yibo-Zhang
 
   * 0.20.0
 

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -1263,7 +1263,7 @@ Fixes
 08/28/19 micaela-matta, xiki-tempula, zemanj, mattwthompson, orbeckst, aliehlen,
          dpadula85, jbarnoud, manuel.nuno.melo, richardjgowers,
          ayushsuhane, picocentauri, NinadBhat, bieniekmateusz, p-j-smith, Lp0lp,
-         IAlibay, tyler.je.reddy, aakognole, RMeli, lilyminium
+         IAlibay, tyler.je.reddy, aakognole, RMeli, lilyminium, fenilsuchak
 
   * 0.20.0
 

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -166,7 +166,7 @@ Deprecations
          ooprathamm, MeetB7, BFedder, v-parmar, MoSchaeffler, jbarnoud, jandom,
          xhgchen, jaclark5, DrDomenicoMarson, AHMED-salah00, schlaicha,
          SophiaRuan, g2707, p-j-smith, tylerjereddy, xiki-tempula, richardjgowers,
-         cbouy
+         cbouy, DanielJamesEvans
 
  * 2.5.0
 

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -1048,7 +1048,7 @@ Deprecations
          Yuan-Yu, xiki-tempula, HTian1997, Iv-Hristov, hmacdope, AnshulAngaria,
          ss62171, Luthaf, yuxuanzhuang, abhishandy, mlnance, shfrz, orbeckst,
          wvandertoorn, cbouy, AmeyaHarmalkar, Oscuro-Phoenix, andrrizzi, WG150,
-         tylerjereddy, Marcello-Sega
+         tylerjereddy, Marcello-Sega, mimischi
 
   * 1.0.0
 

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -1048,7 +1048,7 @@ Deprecations
          Yuan-Yu, xiki-tempula, HTian1997, Iv-Hristov, hmacdope, AnshulAngaria,
          ss62171, Luthaf, yuxuanzhuang, abhishandy, mlnance, shfrz, orbeckst,
          wvandertoorn, cbouy, AmeyaHarmalkar, Oscuro-Phoenix, andrrizzi, WG150,
-         tylerjereddy, Marcello-Sega, mimischi, mquevill
+         tylerjereddy, Marcello-Sega, mimischi, mquevill, siddharthjain1611
 
   * 1.0.0
 

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -3097,7 +3097,7 @@ Testsuite
     removal in 0.8
   * uses cython instead of pyrex
 
-11/05/10 orbeckst, denniej0, tyler.je.reddy, danny.parton, joseph.goose
+11/05/10 orbeckst, denniej0, tyler.je.reddy, danny.parton, joseph.goose, dspoel
   * major release 0.7.0
     (includes changes that can BREAK BACKWARDS COMPATIBILITY)
   * Removed ALL DEPRECATED code:

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -1962,7 +1962,7 @@ Testsuite
 
 05/15/16 jandom, abhinavgupta94, orbeckst, kain88-de, hainm, jbarnoud,
          dotsdl, richardjgowers, BartBruininks, jdetle, pedrishi,
-         fiona-naughton, jdetle
+         fiona-naughton, jdetle, Endle
 
   * 0.15.0
 

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -423,7 +423,7 @@ Deprecations
          HenokB, umak1106, tamandeeps, Mrqeoqqt, megosato, AnirG, rishu235,
          mtiberti, manishsaini6421, Sukeerti1, robotjellyzone, markvrma, alescoulie,
          mjtadema, PicoCentauri, Atharva7K, aditi2906, orbeckst, yuxuanzhuang,
-         rsexton2, rafaelpap, richardjgowers, orioncohen
+         rsexton2, rafaelpap, richardjgowers, orioncohen, mdpoleto
 
  * 2.2.0
 

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -166,7 +166,7 @@ Deprecations
          ooprathamm, MeetB7, BFedder, v-parmar, MoSchaeffler, jbarnoud, jandom,
          xhgchen, jaclark5, DrDomenicoMarson, AHMED-salah00, schlaicha,
          SophiaRuan, g2707, p-j-smith, tylerjereddy, xiki-tempula, richardjgowers,
-         cbouy, DanielJamesEvans
+         cbouy, DanielJamesEvans, jvermaas
 
  * 2.5.0
 

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -16,7 +16,7 @@ The rules for this file:
 -------------------------------------------------------------------------------
 ??/??/?? IAlibay, ianmkenney, PicoCentauri, pgbarletta, p-j-smith, 
          richardjgowers, lilyminium, ALescoulie, hmacdope, HeetVekariya,
-         JoStoe
+         JoStoe, jennaswa
 
  * 2.7.0
 

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -1793,7 +1793,7 @@ Changes
 04/10/17 kain88-de, fiona-naughton, richardjgowers, tyler.je.reddy, jdetle
          euhruska, orbeckst, rbrtdlg, jbarnoud, wouterboomsma, shanmbic,
          dotsdl, manuel.nuno.melo, utkbansal, vedantrathore, shobhitagarwal1612,
-         xiki-tempula, kash1102, Akshay0724, bsipocz, jeiros, tone.bengtsen
+         xiki-tempula, kash1102, Akshay0724, bsipocz, jeiros, tbengtsen
 
   * 0.16.0
 

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -1261,7 +1261,7 @@ Fixes
 
 
 08/28/19 micaela-matta, xiki-tempula, zemanj, mattwthompson, orbeckst, aliehlen,
-         dpadula85, jbarnoud, manuel.nuno.melo, richardjgowers, mattwthompson,
+         dpadula85, jbarnoud, manuel.nuno.melo, richardjgowers,
          ayushsuhane, picocentauri, NinadBhat, bieniekmateusz, p-j-smith, Lp0lp,
          IAlibay, tyler.je.reddy, aakognole, RMeli, lilyminium
 

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -1792,7 +1792,7 @@ Changes
 04/10/17 kain88-de, fiona-naughton, richardjgowers, tyler.je.reddy, jdetle
          euhruska, orbeckst, rbrtdlg, jbarnoud, wouterboomsma, shanmbic,
          dotsdl, manuel.nuno.melo, utkbansal, vedantrathore, shobhitagarwal1612,
-         xiki-tempula, kash1102, Akshay0724, bsipocz
+         xiki-tempula, kash1102, Akshay0724, bsipocz, jeiros
 
   * 0.16.0
 

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -1792,7 +1792,7 @@ Changes
 04/10/17 kain88-de, fiona-naughton, richardjgowers, tyler.je.reddy, jdetle
          euhruska, orbeckst, rbrtdlg, jbarnoud, wouterboomsma, shanmbic,
          dotsdl, manuel.nuno.melo, utkbansal, vedantrathore, shobhitagarwal1612,
-         xiki-tempula, kash1102, Akshay0724, bsipocz, jeiros
+         xiki-tempula, kash1102, Akshay0724, bsipocz, jeiros, tone.bengtsen
 
   * 0.16.0
 

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -107,7 +107,7 @@ Deprecations
 
 
 08/15/23 IAlibay, jaclark5, MohitKumar020291, orionarcher, xhgchen,
-         ztimol, orbeckst
+         ztimol, orbeckst, Shubx10
 
  * 2.6.0
 

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -166,7 +166,7 @@ Deprecations
          ooprathamm, MeetB7, BFedder, v-parmar, MoSchaeffler, jbarnoud, jandom,
          xhgchen, jaclark5, DrDomenicoMarson, AHMED-salah00, schlaicha,
          SophiaRuan, g2707, p-j-smith, tylerjereddy, xiki-tempula, richardjgowers,
-         cbouy, DanielJamesEvans, jvermaas
+         cbouy, DanielJamesEvans, jvermaas, egormarin
 
  * 2.5.0
 

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -1792,7 +1792,7 @@ Changes
 04/10/17 kain88-de, fiona-naughton, richardjgowers, tyler.je.reddy, jdetle
          euhruska, orbeckst, rbrtdlg, jbarnoud, wouterboomsma, shanmbic,
          dotsdl, manuel.nuno.melo, utkbansal, vedantrathore, shobhitagarwal1612,
-         xiki-tempula, kash1102
+         xiki-tempula, kash1102, Akshay0724
 
   * 0.16.0
 


### PR DESCRIPTION
## Overview of changes & rationale

1. Removed duplicate `mattwthompson` in 0.20.0 changelog entry.

`mattwthompson` was placed twice by accident, this removes this duplication.

2. Addition of missing authors.

An retrospective analysis of the authors found via `git shortlog -s -n --email --branches="develop"` found several commits by authors which were not present in the `AUTHORS.md` file.

* Zhenbo Li: commited via PR #803 and #771, Jenna M. Swarthout via PR #4289 and #4298, Bradley Dice via PR #2384 , and David Minh via PR 2668

There seemed to be no indications in the above mentioned PRs that the author did not want to be in the authors file, it looks like it was just forgotten.

3. Addition of missing entries from the changelog

Continued cross referencing of the git shortlog output but also accounting for the changelog identified several individuals that had not been included in the changelog entries for the release they contributed under. They were added to the relevant entry of the changelog based on the merge commit date.

Please note that for Tone Bengsten, we a) had no github handle (so they were assigned tone.bengsten), and b) no specific commit. Given we know that this individual was including alongside the `encore` merge, they were assigned to the 0.16.0 release.

## Acknowledgements

Thanks to @fiona-naughton for helping out with digging into this data :)


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [ ] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4372.org.readthedocs.build/en/4372/

<!-- readthedocs-preview mdanalysis end -->