### PR TITLE
Fix: Align.py doctest error

### DIFF
--- a/package/MDAnalysis/analysis/align.py
+++ b/package/MDAnalysis/analysis/align.py
@@ -138,7 +138,7 @@ To **fit a whole trajectory** to a reference structure with the
    >>> trj = mda.Universe(PSF, DCD)         # trajectory of change 1AKE->4AKE
    >>> alignment = align.AlignTraj(trj, ref, filename='rmsfit.dcd')
    >>> alignment.run()
-   <MDAnalysis.analysis.align.AlignTraj object at ...> 
+   <MDAnalysis.analysis.align.AlignTraj object at ...
 
 It is also possible to align two arbitrary structures by providing a
 mapping between atoms based on a sequence alignment. This allows


### PR DESCRIPTION
Partially address #3925 

Changes made in this Pull Request:
 - Doctest for **align.py** (package/MDAnalysis/analysis/align.py) file contains error because wildcard match is not correctly implemented.
 - Removed ```>``` from the Expected output such that error can be solved.


PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4373.org.readthedocs.build/en/4373/

<!-- readthedocs-preview mdanalysis end -->