### PR TITLE
Fix: Psa.py doctest error

### DIFF
--- a/package/MDAnalysis/analysis/psa.py
+++ b/package/MDAnalysis/analysis/psa.py
@@ -460,6 +460,7 @@ def hausdorff_wavg(P, Q):
     Example
     -------
 
+     >>> import numpy
      >>> import MDAnalysis as mda
      >>> from MDAnalysis import Universe
      >>> from MDAnalysis.tests.datafiles import PSF, DCD

--- a/package/MDAnalysis/analysis/psa.py
+++ b/package/MDAnalysis/analysis/psa.py
@@ -519,6 +519,7 @@ def hausdorff_avg(P, Q):
     Example
     -------
 
+     >>> import numpy
      >>> import MDAnalysis as mda
      >>> from MDAnalysis.tests.datafiles import PSF, DCD
      >>> from MDAnalysis.analysis import psa


### PR DESCRIPTION
Partially address #3925 

Changes made in this Pull Request:
 - Doctest for **psa.py** (```package/MDAnalysis/analysis/psa.py```) file contains errors for this two functions:
1) ```hausdorff_wavg``` 
2) ```hausdorff_avg``` 

Error: Not imported ```numpy```

- Added import for ```numpy``` in both functions


PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4378.org.readthedocs.build/en/4378/

<!-- readthedocs-preview mdanalysis end -->