### PR TITLE
Fix: Similarity.py doctest error

### DIFF
--- a/package/MDAnalysis/analysis/encore/similarity.py
+++ b/package/MDAnalysis/analysis/encore/similarity.py
@@ -76,8 +76,8 @@ two ensemble objects are first created and then used for calculation:
     >>> ens2 = Universe(PSF, DCD2)
     >>> HES, details = encore.hes([ens1, ens2])
     >>> print(HES)
-    [[       0.         38279540.04524205]
-     [38279540.04524205        0.        ]]
+    [[       0.         38279540.04524206]
+     [38279540.04524206        0.        ]]
 
 HES can assume any non-negative value, i.e. no upper bound exists and the
 measurement can therefore be used as an absolute scale.
@@ -801,8 +801,8 @@ def hes(ensembles,
         >>> ens2 = Universe(PSF, DCD2)
         >>> HES, details = encore.hes([ens1, ens2])
         >>> print(HES)
-        [[       0.         38279540.04524205]
-         [38279540.04524205        0.        ]]
+        [[       0.         38279540.04524206]
+         [38279540.04524206        0.        ]]
         >>> print(encore.hes([ens1, ens2], align=True)[0])
         [[   0.         6889.89729056]
          [6889.89729056    0.        ]]


### PR DESCRIPTION
Partially address #3925 

Changes made in this Pull Request:
  - Doctest for **similarity.py** (```package/MDAnalysis/analysis/encore/similarity.py```) file contains two error due to wrong output in Expected matrix:
    - ```38279540.04524205```
- Corrected expected output according to the generated output as below:
   - ```38279540.04524206```

PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4379.org.readthedocs.build/en/4379/

<!-- readthedocs-preview mdanalysis end -->