### PR TITLE
Fix upper python+numpy pin for build system

### DIFF
--- a/package/pyproject.toml
+++ b/package/pyproject.toml
@@ -17,7 +17,7 @@ requires = [
     "numpy==1.26.0; python_version=='3.12' and platform_python_implementation != 'PyPy'",
     # For unreleased versions of Python there is currently no known supported
     # NumPy version. In that case we just let it be a bare NumPy install
-    "numpy<2.0; python_version>='3.12'",
+    "numpy<2.0; python_version>='3.13'",
     "setuptools",
     "wheel",
 ]


### PR DESCRIPTION
Should be 3.13 not 3.12

Changes made in this Pull Request:
 - Updates upper build to be >=3.13 instead of >=3.12

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4385.org.readthedocs.build/en/4385/

<!-- readthedocs-preview mdanalysis end -->