### PR TITLE
Tie off 2.7.0, add release upper pin (numpy)

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -14,7 +14,7 @@ The rules for this file:
 
 
 -------------------------------------------------------------------------------
-??/??/?? IAlibay, ianmkenney, PicoCentauri, pgbarletta, p-j-smith, 
+12/26/23 IAlibay, ianmkenney, PicoCentauri, pgbarletta, p-j-smith, 
          richardjgowers, lilyminium, ALescoulie, hmacdope, HeetVekariya, 
          JoStoe, jennaswa, ljwoods2
 

--- a/package/MDAnalysis/version.py
+++ b/package/MDAnalysis/version.py
@@ -67,4 +67,4 @@ Data
 # e.g. with lib.log
 
 #: Release of MDAnalysis as a string, using `semantic versioning`_.
-__version__ = "2.7.0-dev0"  # NOTE: keep in sync with RELEASE in setup.py
+__version__ = "2.7.0"  # NOTE: keep in sync with RELEASE in setup.py

--- a/package/pyproject.toml
+++ b/package/pyproject.toml
@@ -35,7 +35,7 @@ maintainers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    'numpy>=1.22.3',
+    'numpy>=1.22.3,<2.0',
     'GridDataFormats>=0.4.0',
     'mmtf-python>=1.0.0',
     'joblib>=0.12',

--- a/package/setup.py
+++ b/package/setup.py
@@ -65,7 +65,7 @@ import configparser
 from subprocess import getoutput
 
 # NOTE: keep in sync with MDAnalysis.__version__ in version.py
-RELEASE = "2.7.0-dev0"
+RELEASE = "2.7.0"
 
 is_release = 'dev' not in RELEASE
 

--- a/testsuite/MDAnalysisTests/__init__.py
+++ b/testsuite/MDAnalysisTests/__init__.py
@@ -97,7 +97,7 @@ import pytest
 logger = logging.getLogger("MDAnalysisTests.__init__")
 
 # keep in sync with RELEASE in setup.py
-__version__ = "2.7.0-dev0"
+__version__ = "2.7.0"
 
 
 # Do NOT import MDAnalysis at this level. Tests should do it themselves.

--- a/testsuite/setup.py
+++ b/testsuite/setup.py
@@ -87,7 +87,7 @@ if sys.version_info[:2] < (3, 9):
 
 if __name__ == '__main__':
     # this must be in-sync with MDAnalysis
-    RELEASE = "2.7.0-dev0"
+    RELEASE = "2.7.0"
     with open("README") as summary:
         LONG_DESCRIPTION = summary.read()
 


### PR DESCRIPTION
Towards #4382 

Changes made in this Pull Request:
 - Set version numbers of 2.7.0
 - Add upper pin for numpy in pyproject.toml 
 - Tie off the changelog


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4389.org.readthedocs.build/en/4389/

<!-- readthedocs-preview mdanalysis end -->