### PR TITLE
Change the target build names for cibuildwheels for cirrus

### DIFF
--- a/maintainer/ci/cirrus-deploy.yml
+++ b/maintainer/ci/cirrus-deploy.yml
@@ -17,7 +17,7 @@ linux_aarch64_wheel_task:
     memory: 4G
   env:
     CIBW_BUILD: cp39-manylinux_* cp310-manylinux_* cp311-manylinux_* cp312-manylinux_*
-    CIBW_ARCHS: ARM64
+    CIBW_ARCHS: aarch64
 
   build_script: |
     apt install -y python3-venv python-is-python3
@@ -31,7 +31,7 @@ macos_arm64_wheel_task:
     image: ghcr.io/cirruslabs/macos-monterey-xcode:14
   env:
     CIBW_BUILD: cp39-* cp310-* cp311-* cp312-*
-    CIBW_ARCHS: ARM64
+    CIBW_ARCHS: arm64
     PATH: /opt/homebrew/opt/python@3.10/bin:$PATH
 
   build_script: |


### PR DESCRIPTION
Fixes #4391 

We're deviating from scipy here, so I'm not 100% sure, but we'll have to try it out in practice and see what happens.

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4392.org.readthedocs.build/en/4392/

<!-- readthedocs-preview mdanalysis end -->