### PR TITLE
Add workflow dispatch to CI actions

### DIFF
--- a/.github/workflows/gh-ci-cron.yaml
+++ b/.github/workflows/gh-ci-cron.yaml
@@ -3,6 +3,7 @@ on:
   schedule:
     # 3 am Tuesdays and Fridays
     - cron: "0 3 * * 2,5"
+  workflow_dispatch:
 
 concurrency:
   # Probably overly cautious group naming.

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches:
       - develop
+  workflow_dispatch:
 
 concurrency:
   # Probably overly cautious group naming.


### PR DESCRIPTION

Changes made in this Pull Request:
 - Add workflow_dispatch to actions

This will allow us to manually trigger CI as necessary. I find myself quite often needing to manually dispatch cron CI so this will make life a bit easier.

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4398.org.readthedocs.build/en/4398/

<!-- readthedocs-preview mdanalysis end -->