### PR TITLE
ChainedReader __repr__ fix for MemoryReader sub-readers

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -25,7 +25,7 @@ Fixes
    `DistanceMatrix.run(frames=...)` (PR #4433)
  * Fix doctest errors of lib/picklable_file_io.py (Issue #3925, PR #4371)
  * Fix deploy action to use the correct version of the pypi upload action.
- * Fix ChainReader repr() method when sub-reader is MemoryReader 
+ * Fix ChainReader `__repr__()` method when sub-reader is MemoryReader 
    (Issue #3349, PR #4407)
 
 Enhancements

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -14,7 +14,7 @@ The rules for this file:
 
 
 -------------------------------------------------------------------------------
-??/??/?? IAlibay, HeetVekariya, marinegor
+??/??/?? IAlibay, HeetVekariya, marinegor, ljwoods2
 
  * 2.8.0
 
@@ -25,6 +25,8 @@ Fixes
    `DistanceMatrix.run(frames=...)` (PR #4433)
  * Fix doctest errors of lib/picklable_file_io.py (Issue #3925, PR #4371)
  * Fix deploy action to use the correct version of the pypi upload action.
+ * Fix ChainReader repr() method when sub-reader is MemoryReader 
+   (Issue #3349, PR #4407)
 
 Enhancements
 

--- a/package/MDAnalysis/coordinates/chain.py
+++ b/package/MDAnalysis/coordinates/chain.py
@@ -269,7 +269,7 @@ class ChainReader(base.ReaderBase):
             kwargs['dt'] = dt
         self.readers = [core.reader(filename, convert_units=convert_units, **kwargs)
                         for filename in filenames]
-        # Iterate through
+        # Iterate through all filenames, appending NoneType None for ndarrays
         self.filenames = []
         for fn in filenames:
             if isinstance(fn, np.ndarray):
@@ -610,7 +610,7 @@ class ChainReader(base.ReaderBase):
             fname = (os.path.basename(self.filenames[0])
                      if self.filenames[0] else "numpy.ndarray")
             fnames = "{fname} and {nfnames} more".format(
-                
+
                     fname=fname,
                     nfnames=len(self.filenames) - 1)
         else:

--- a/package/MDAnalysis/coordinates/chain.py
+++ b/package/MDAnalysis/coordinates/chain.py
@@ -271,6 +271,13 @@ class ChainReader(base.ReaderBase):
                         for filename in filenames]
         self.filenames = np.array([fn[0] if isinstance(fn, tuple) else fn
                                                         for fn in filenames])
+        # Set filenames array to array of "None" if chainreader initialized with
+        # numpy arrays
+        if isinstance(filenames[0], np.ndarray):
+            self.filenames = np.array(["None" for _ in range(len(filenames))])
+        else:
+            self.filenames = np.array([fn[0] if isinstance(fn, tuple) else fn
+                                      for fn in filenames])
         # pointer to "active" trajectory index into self.readers
         self.__active_reader_index = 0
 
@@ -597,7 +604,9 @@ class ChainReader(base.ReaderBase):
         self._apply('close')
 
     def __repr__(self):
-        if len(self.filenames) > 3:
+        if self.filenames[0] == "None":
+            fnames = "NumPy array"
+        elif len(self.filenames) > 3:
             fnames = "{fname} and {nfanmes} more".format(
                     fname=os.path.basename(self.filenames[0]),
                     nfanmes=len(self.filenames) - 1)

--- a/package/MDAnalysis/coordinates/chain.py
+++ b/package/MDAnalysis/coordinates/chain.py
@@ -269,15 +269,17 @@ class ChainReader(base.ReaderBase):
             kwargs['dt'] = dt
         self.readers = [core.reader(filename, convert_units=convert_units, **kwargs)
                         for filename in filenames]
-        self.filenames = np.array([fn[0] if isinstance(fn, tuple) else fn
-                                                        for fn in filenames])
-        # Set filenames array to array of "None" if chainreader initialized with
-        # numpy arrays
-        if isinstance(filenames[0], np.ndarray):
-            self.filenames = np.array(["None" for _ in range(len(filenames))])
-        else:
-            self.filenames = np.array([fn[0] if isinstance(fn, tuple) else fn
-                                      for fn in filenames])
+        # Iterate through
+        self.filenames = []
+        for fn in filenames:
+            if isinstance(fn, np.ndarray):
+                self.filenames.append(None)
+            elif isinstance(fn, tuple):
+                self.filenames.append(fn[0])
+            else:
+                self.filenames.append(fn)
+        self.filenames = np.array(self.filenames)
+
         # pointer to "active" trajectory index into self.readers
         self.__active_reader_index = 0
 
@@ -604,14 +606,16 @@ class ChainReader(base.ReaderBase):
         self._apply('close')
 
     def __repr__(self):
-        if self.filenames[0] == "None":
-            fnames = "NumPy array"
-        elif len(self.filenames) > 3:
-            fnames = "{fname} and {nfanmes} more".format(
-                    fname=os.path.basename(self.filenames[0]),
-                    nfanmes=len(self.filenames) - 1)
+        if len(self.filenames) > 3:
+            fname = (os.path.basename(self.filenames[0])
+                     if self.filenames[0] else "numpy.ndarray")
+            fnames = "{fname} and {nfnames} more".format(
+                
+                    fname=fname,
+                    nfnames=len(self.filenames) - 1)
         else:
-            fnames = ", ".join([os.path.basename(fn) for fn in self.filenames])
+            fnames = ", ".join([os.path.basename(fn) if fn else "numpy.ndarray"
+                                for fn in self.filenames])
         return ("<{clsname} containing {fname} with {nframes} frames of {natoms} atoms>"
                 "".format(
                     clsname=self.__class__.__name__,

--- a/package/MDAnalysis/coordinates/chain.py
+++ b/package/MDAnalysis/coordinates/chain.py
@@ -610,7 +610,6 @@ class ChainReader(base.ReaderBase):
             fname = (os.path.basename(self.filenames[0])
                      if self.filenames[0] else "numpy.ndarray")
             fnames = "{fname} and {nfnames} more".format(
-
                     fname=fname,
                     nfnames=len(self.filenames) - 1)
         else:

--- a/testsuite/MDAnalysisTests/coordinates/test_chainreader.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_chainreader.py
@@ -455,3 +455,9 @@ def test_issue_4008():
     # in the issue report values of ~25 were seen before the fix
     # with the fix all values should be <1e-6
     assert np.abs(com).max() < 1e-6
+
+def test_issue_3349():
+    # test for repr of a chainreader when the subreaders are memoryreaders 
+    cdx = np.random.random(3341*3*10).reshape(-1, 3341, 3).astype(np.float32) * 10
+    u = mda.Universe(PSF, (cdx, cdx))
+    assert(repr(u.trajectory) == "<ChainReader containing NumPy array with 20 frames of 3341 atoms>")

--- a/testsuite/MDAnalysisTests/coordinates/test_chainreader.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_chainreader.py
@@ -463,7 +463,6 @@ def test_issue_3349():
     cdx = cdx.reshape(-1, 3341, 3).astype(np.float32) * 10
     u = mda.Universe(PSF, (cdx, DCD))
     u2 = mda.Universe(PSF, (cdx, cdx, cdx, DCD))
-    print(u.trajectory.filenames)
     u_expected_filenames = np.array([None, str(DCD)])
     u2_expected_filenames = np.array([None, None, None, str(DCD)])
 

--- a/testsuite/MDAnalysisTests/coordinates/test_chainreader.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_chainreader.py
@@ -461,6 +461,11 @@ def test_issue_3349():
     # test for repr of a chainreader when the subreaders are memoryreaders
     cdx = np.random.random(3341 * 3 * 10)
     cdx = cdx.reshape(-1, 3341, 3).astype(np.float32) * 10
-    u = mda.Universe(PSF, (cdx, cdx))
-    assert_equal("<ChainReader containing NumPy array with 20 frames of 3341 atoms>",
-                  u.trajectory.__repr__())
+    u = mda.Universe(PSF, (cdx, DCD))
+    u2 = mda.Universe(PSF, (cdx, cdx, cdx, DCD))
+    assert_equal("<ChainReader containing numpy.ndarray, adk_dims.dcd with " +
+                 "108 frames of 3341 atoms>",
+                 u.trajectory.__repr__())
+    assert_equal("<ChainReader containing numpy.ndarray and 3 more with " +
+                 "128 frames of 3341 atoms>",
+                 u2.trajectory.__repr__())

--- a/testsuite/MDAnalysisTests/coordinates/test_chainreader.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_chainreader.py
@@ -462,5 +462,5 @@ def test_issue_3349():
     cdx = np.random.random(3341 * 3 * 10)
     cdx = cdx.reshape(-1, 3341, 3).astype(np.float32) * 10
     u = mda.Universe(PSF, (cdx, cdx))
-    assert(repr(u.trajectory) == "<ChainReader containing NumPy array with 20 frames of 3341 atoms>")
-    
+    assert_equal("<ChainReader containing NumPy array with 20 frames of 3341 atoms>",
+                  u.trajectory.__repr__())

--- a/testsuite/MDAnalysisTests/coordinates/test_chainreader.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_chainreader.py
@@ -463,9 +463,15 @@ def test_issue_3349():
     cdx = cdx.reshape(-1, 3341, 3).astype(np.float32) * 10
     u = mda.Universe(PSF, (cdx, DCD))
     u2 = mda.Universe(PSF, (cdx, cdx, cdx, DCD))
+    print(u.trajectory.filenames)
+    u_expected_filenames = np.array([None, str(DCD)])
+    u2_expected_filenames = np.array([None, None, None, str(DCD)])
+
     assert_equal("<ChainReader containing numpy.ndarray, adk_dims.dcd with " +
                  "108 frames of 3341 atoms>",
                  u.trajectory.__repr__())
+    assert_equal(u_expected_filenames, u.trajectory.filenames)
     assert_equal("<ChainReader containing numpy.ndarray and 3 more with " +
                  "128 frames of 3341 atoms>",
                  u2.trajectory.__repr__())
+    assert_equal(u2_expected_filenames, u2.trajectory.filenames)

--- a/testsuite/MDAnalysisTests/coordinates/test_chainreader.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_chainreader.py
@@ -456,8 +456,11 @@ def test_issue_4008():
     # with the fix all values should be <1e-6
     assert np.abs(com).max() < 1e-6
 
+
 def test_issue_3349():
-    # test for repr of a chainreader when the subreaders are memoryreaders 
-    cdx = np.random.random(3341*3*10).reshape(-1, 3341, 3).astype(np.float32) * 10
+    # test for repr of a chainreader when the subreaders are memoryreaders
+    cdx = np.random.random(3341 * 3 * 10)
+    cdx = cdx.reshape(-1, 3341, 3).astype(np.float32) * 10
     u = mda.Universe(PSF, (cdx, cdx))
     assert(repr(u.trajectory) == "<ChainReader containing NumPy array with 20 frames of 3341 atoms>")
+    


### PR DESCRIPTION
Fixes #3349 

Changes made in this Pull Request:
 - If ChainedReader is initialized with filenames that are trajectory ndarrays rather than files, the stored filenames will be "None" for each ndarray rather than a filename
 - The __repr__ function will check if the filenames are ndarrays before calling os.path.basename

If there is a use case for a ChainedReader with both MemoryReader sub-readers and other sub-reader types, this solution won't work because it depends on all the filenames being the same type. Let me know and I can fix it!

PR Checklist
------------
 - [X] Tests?
 - [X] Docs?
 - [X] CHANGELOG updated?
 - [X] Issue raised/referenced?

## Developers certificate of origin
- [X] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4407.org.readthedocs.build/en/4407/

<!-- readthedocs-preview mdanalysis end -->