### PR TITLE
Fix types on XDR::xdr_ops function struct for clang16 compilation

### DIFF
--- a/package/MDAnalysis/lib/formats/src/xdrfile.c
+++ b/package/MDAnalysis/lib/formats/src/xdrfile.c
@@ -132,8 +132,8 @@ struct XDR
 		int (*x_getbytes) (XDR *__xdrs, char *__addr, unsigned int __len);
 		int (*x_putbytes) (XDR *__xdrs, char *__addr, unsigned int __len);
 		/* two next routines are not 64-bit IO safe - don't use! */
-		unsigned int (*x_getpostn) (XDR *__xdrs);
-		int (*x_setpostn) (XDR *__xdrs, unsigned int __pos);
+		int64_t (*x_getpostn) (XDR *__xdrs);
+		int (*x_setpostn) (XDR *__xdrs, int64_t __pos, int __whence);
 		void (*x_destroy) (XDR *__xdrs);
 	}
     *x_ops;


### PR DESCRIPTION
Fixes #4397 

Changes made in this Pull Request:
 - Changes struct function signatures to match stricter type checking on function pointers in Clang16:
 - https://releases.llvm.org/16.0.0/tools/clang/docs/ReleaseNotes.html


PR Checklist
------------
 - [NA] Tests?
 - [NA] Docs?
 - [ ] CHANGELOG updated?
 - [X] Issue raised/referenced?

## Developers certificate of origin
- [X] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4408.org.readthedocs.build/en/4408/

<!-- readthedocs-preview mdanalysis end -->