### PR TITLE
Adding arm64-osx to gh deploy action

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - "package-*"
-      - "develop"
   push:
     branches:
       - "package-*"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -52,7 +52,7 @@ jobs:
           fetch-depth: 0
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.2
+        uses: pypa/cibuildwheel@v2.16.5
         with:
           package-dir: package
         env:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - "package-*"
+      - "develop"
   push:
     branches:
       - "package-*"
@@ -40,6 +41,7 @@ jobs:
           - [ubuntu-22.04, manylinux_x86_64, x86_64]
           - [macos-11, macosx_*, x86_64]
           - [windows-2019, win_amd64, AMD64]
+          - [macos-14, macosx_*, arm64]
         python: ["cp39", "cp310", "cp311", "cp312"]
     defaults:
       run:


### PR DESCRIPTION
Following up from @RMeli's PR on #4442 

I would suggest keeping the cirrus tooling as a backup for now, maybe we can look to remove eventually.


PR Checklist
------------
 - Tests?
 - Docs?
 - [ ] CHANGELOG updated?
 - Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4445.org.readthedocs.build/en/4445/

<!-- readthedocs-preview mdanalysis end -->