### PR TITLE
MAINT: shims for array copy semantics

### DIFF
--- a/package/MDAnalysis/analysis/helix_analysis.py
+++ b/package/MDAnalysis/analysis/helix_analysis.py
@@ -121,7 +121,7 @@ def vector_of_best_fit(coordinates):
     """
     centered = coordinates - coordinates.mean(axis=0)
     Mt_M = np.matmul(centered.T, centered)
-    u, s, vh = np.linalg.linalg.svd(Mt_M)
+    u, s, vh = np.linalg.svd(Mt_M)
     vector = vh[0]
 
     # does vector face first local helix origin?

--- a/package/MDAnalysis/lib/formats/cython_util.pyx
+++ b/package/MDAnalysis/lib/formats/cython_util.pyx
@@ -26,6 +26,8 @@ cimport numpy as cnp
 from libc.stdlib cimport free
 from cpython cimport PyObject, Py_INCREF
 
+from MDAnalysis.lib.util import no_copy_shim
+
 cnp.import_array()
 
 
@@ -71,7 +73,7 @@ cdef class ArrayWrapper:
         self.data_type = data_type
         self.ndim = ndim
 
-    def __array__(self, copy=None):
+    def __array__(self, dtype=None, copy=None):
         """ Here we use the __array__ method, that is called when numpy
             tries to get an array from the object."""
         ndarray = cnp.PyArray_SimpleNewFromData(self.ndim,
@@ -110,11 +112,7 @@ cdef cnp.ndarray ptr_to_ndarray(void* data_ptr, cnp.int64_t[:] dim, int data_typ
     array_wrapper = ArrayWrapper()
     array_wrapper.set_data(<void*> data_ptr, <int*> &dim[0], dim.size, data_type)
 
-    if np.__version__[0] == "2":
-        copy = None
-    else:
-        copy = False
-    cdef cnp.ndarray ndarray = np.array(array_wrapper, copy=copy)
+    cdef cnp.ndarray ndarray = np.array(array_wrapper, copy=no_copy_shim)
     # Assign our object to the 'base' of the ndarray object
     ndarray[:] = array_wrapper.__array__()
     # Increment the reference count, as the above assignement was done in

--- a/package/MDAnalysis/lib/formats/cython_util.pyx
+++ b/package/MDAnalysis/lib/formats/cython_util.pyx
@@ -71,7 +71,7 @@ cdef class ArrayWrapper:
         self.data_type = data_type
         self.ndim = ndim
 
-    def __array__(self):
+    def __array__(self, copy=None):
         """ Here we use the __array__ method, that is called when numpy
             tries to get an array from the object."""
         ndarray = cnp.PyArray_SimpleNewFromData(self.ndim,
@@ -110,7 +110,11 @@ cdef cnp.ndarray ptr_to_ndarray(void* data_ptr, cnp.int64_t[:] dim, int data_typ
     array_wrapper = ArrayWrapper()
     array_wrapper.set_data(<void*> data_ptr, <int*> &dim[0], dim.size, data_type)
 
-    cdef cnp.ndarray ndarray = np.array(array_wrapper, copy=False)
+    if np.__version__[0] == "2":
+        copy = None
+    else:
+        copy = False
+    cdef cnp.ndarray ndarray = np.array(array_wrapper, copy=copy)
     # Assign our object to the 'base' of the ndarray object
     ndarray[:] = array_wrapper.__array__()
     # Increment the reference count, as the above assignement was done in

--- a/package/MDAnalysis/lib/transformations.py
+++ b/package/MDAnalysis/lib/transformations.py
@@ -325,8 +325,12 @@ def rotation_matrix(angle, direction, point=None):
     M = np.identity(4)
     M[:3, :3] = R
     if point is not None:
+        if np.__version__[0] == "2":
+            copy = None
+        else:
+            copy = False
         # rotation not around origin
-        point = np.array(point[:3], dtype=np.float64, copy=False)
+        point = np.array(point[:3], dtype=np.float64, copy=copy)
         M[:3, 3] = point - np.dot(R, point)
     return M
 
@@ -497,7 +501,11 @@ def projection_matrix(point, normal, direction=None,
 
     """
     M = np.identity(4)
-    point = np.array(point[:3], dtype=np.float64, copy=False)
+    if np.__version__[0] == "2":
+        copy = None
+    else:
+        copy = False
+    point = np.array(point[:3], dtype=np.float64, copy=copy)
     normal = unit_vector(normal[:3])
     if perspective is not None:
         # perspective projection
@@ -515,7 +523,7 @@ def projection_matrix(point, normal, direction=None,
         M[3, 3] = np.dot(perspective, normal)
     elif direction is not None:
         # parallel projection
-        direction = np.array(direction[:3], dtype=np.float64, copy=False)
+        direction = np.array(direction[:3], dtype=np.float64, copy=copy)
         scale = np.dot(direction, normal)
         M[:3, :3] -= np.outer(direction, normal) / scale
         M[:3, 3] = direction * (np.dot(point, normal) / scale)
@@ -970,8 +978,12 @@ def superimposition_matrix(v0, v1, scaling=False, usesvd=True):
     True
 
     """
-    v0 = np.array(v0, dtype=np.float64, copy=False)[:3]
-    v1 = np.array(v1, dtype=np.float64, copy=False)[:3]
+    if np.__version__[0] == "2":
+        copy = None
+    else:
+        copy = False
+    v0 = np.array(v0, dtype=np.float64, copy=copy)[:3]
+    v1 = np.array(v1, dtype=np.float64, copy=copy)[:3]
 
     if v0.shape != v1.shape or v0.shape[1] < 3:
         raise ValueError("vector sets are of wrong shape or type")
@@ -1314,7 +1326,11 @@ def quaternion_from_matrix(matrix, isprecise=False):
     True
 
     """
-    M = np.array(matrix, dtype=np.float64, copy=False)[:4, :4]
+    if np.__version__[0] == "2":
+        copy = None
+    else:
+        copy = False
+    M = np.array(matrix, dtype=np.float64, copy=copy)[:4, :4]
     if isprecise:
         q = np.empty((4, ), dtype=np.float64)
         t = np.trace(M)

--- a/package/MDAnalysis/lib/transformations.py
+++ b/package/MDAnalysis/lib/transformations.py
@@ -170,6 +170,7 @@ import numpy as np
 from numpy.linalg import norm
 
 from .mdamath import angle as vecangle
+from MDAnalysis.lib.util import no_copy_shim
 
 def identity_matrix():
     """Return 4x4 identity/unit matrix.
@@ -325,12 +326,8 @@ def rotation_matrix(angle, direction, point=None):
     M = np.identity(4)
     M[:3, :3] = R
     if point is not None:
-        if np.__version__[0] == "2":
-            copy = None
-        else:
-            copy = False
         # rotation not around origin
-        point = np.array(point[:3], dtype=np.float64, copy=copy)
+        point = np.array(point[:3], dtype=np.float64, copy=no_copy_shim)
         M[:3, 3] = point - np.dot(R, point)
     return M
 
@@ -501,11 +498,7 @@ def projection_matrix(point, normal, direction=None,
 
     """
     M = np.identity(4)
-    if np.__version__[0] == "2":
-        copy = None
-    else:
-        copy = False
-    point = np.array(point[:3], dtype=np.float64, copy=copy)
+    point = np.array(point[:3], dtype=np.float64, copy=no_copy_shim)
     normal = unit_vector(normal[:3])
     if perspective is not None:
         # perspective projection
@@ -523,7 +516,7 @@ def projection_matrix(point, normal, direction=None,
         M[3, 3] = np.dot(perspective, normal)
     elif direction is not None:
         # parallel projection
-        direction = np.array(direction[:3], dtype=np.float64, copy=copy)
+        direction = np.array(direction[:3], dtype=np.float64, copy=no_copy_shim)
         scale = np.dot(direction, normal)
         M[:3, :3] -= np.outer(direction, normal) / scale
         M[:3, 3] = direction * (np.dot(point, normal) / scale)
@@ -978,12 +971,8 @@ def superimposition_matrix(v0, v1, scaling=False, usesvd=True):
     True
 
     """
-    if np.__version__[0] == "2":
-        copy = None
-    else:
-        copy = False
-    v0 = np.array(v0, dtype=np.float64, copy=copy)[:3]
-    v1 = np.array(v1, dtype=np.float64, copy=copy)[:3]
+    v0 = np.array(v0, dtype=np.float64, copy=no_copy_shim)[:3]
+    v1 = np.array(v1, dtype=np.float64, copy=no_copy_shim)[:3]
 
     if v0.shape != v1.shape or v0.shape[1] < 3:
         raise ValueError("vector sets are of wrong shape or type")
@@ -1326,11 +1315,7 @@ def quaternion_from_matrix(matrix, isprecise=False):
     True
 
     """
-    if np.__version__[0] == "2":
-        copy = None
-    else:
-        copy = False
-    M = np.array(matrix, dtype=np.float64, copy=copy)[:4, :4]
+    M = np.array(matrix, dtype=np.float64, copy=no_copy_shim)[:4, :4]
     if isprecise:
         q = np.empty((4, ), dtype=np.float64)
         t = np.trace(M)

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -2555,7 +2555,7 @@ def store_init_arguments(func):
 
 
 def no_copy_shim():
-    if np.__version__[0] == "2":
+    if np.lib.NumpyVersion >= "2.0.0rc1":
         copy = None
     else:
         copy = False

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -2552,3 +2552,11 @@ def store_init_arguments(func):
                         self._kwargs[key] = arg
         return func(self, *args, **kwargs)
     return wrapper
+
+
+def no_copy_shim():
+    if np.__version__[0] == "2":
+        copy = None
+    else:
+        copy = False
+    return copy


### PR DESCRIPTION
* Fixes #4481

* this gets rid of segfaults/many test failurse against latest NumPy `main` while still passing the full suite against NumPy `1.26.4`; it is pretty hard to test since needs special branch of SciPy (for the same reason, upstream hasn't fully resolved copy semantics)

* I still see 2-3 test failures against `main` locally, but likely still a large improvement; may want to let this sit a little bit while the upstream storm settles, but I suspect this is the gist of the shims we'd want

One thing I didn't try was building against NumPy `main` and testing against `1.26.4`, just did each completely separately (that's a good thing to try though). Upstream pre-release wheels will probably be delayed reflecting the related issues for a bit.

Getting late, so short explanation--`copy=False` got stricter, `copy=None` is the "try your best not to copy, but you can if you need to" old NumPy way.

<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4482.org.readthedocs.build/en/4482/

<!-- readthedocs-preview mdanalysis end -->