### PR TITLE
Raise Python version to 3.10

### DIFF
--- a/.github/workflows/darkerbot.yaml
+++ b/.github/workflows/darkerbot.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: "3.10"
 
       - name: setup_dependencies
         run: |

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -243,7 +243,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
         type: ["FULL", "MIN"]
         exclude:
           # Multiple deps don't like windows

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -28,7 +28,7 @@ jobs:
         fail-fast: false
         matrix:
           os: [ubuntu-latest, ]
-          python-version: ["3.9", "3.10", "3.11", "3.12"]
+          python-version: ["3.10", "3.11", "3.12"]
           full-deps: [true, ]
           codecov: [true, ]
           include:
@@ -44,13 +44,13 @@ jobs:
               codecov: true
             - name: numpy_min
               os: ubuntu-latest
-              python-version: 3.9
+              python-version: "3.10"
               full-deps: false
               codecov: true
               numpy: numpy=1.23.2
             - name: asv_check
               os: ubuntu-latest
-              python-version: 3.9
+              python-version: "3.10"
               full-deps: true
               codecov: false
               extra-pip-deps: asv
@@ -147,7 +147,7 @@ jobs:
       with:
         environment-name: mda
         create-args: >-
-          python=3.9
+          python=3.10
           pip
         # using jaime's shim to avoid pulling down the cudatoolkit
         condarc: |

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -33,7 +33,7 @@ jobs:
 
     - uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: "3.10"
 
     - name: darker-main-code
       id: darker-main-code
@@ -106,7 +106,7 @@ jobs:
 
     - uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: "3.10"
 
     - name: install
       run: |
@@ -131,7 +131,7 @@ jobs:
         with:
           environment-name: mda
           create-args: >-
-            python=3.9
+            python=3.10
             pip
           # using jaime's shim to avoid pulling down the cudatoolkit
           condarc: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,8 +21,8 @@ jobs:
     MPLBACKEND: agg
   strategy:
     matrix:
-        Win-Python39-64bit-full:
-          PYTHON_VERSION: '3.9'
+        Win-Python310-64bit-full:
+          PYTHON_VERSION: '3.10'
           PYTHON_ARCH: 'x64'
           BUILD_TYPE: 'normal'
           imageName: 'windows-2019'
@@ -37,8 +37,8 @@ jobs:
           BUILD_TYPE: 'wheel'
           NUMPY_MIN: '1.26.0'
           imageName: 'windows-2019'
-        Win-Python39-64bit-full-wheel:
-          PYTHON_VERSION: '3.9'
+        Win-Python310-64bit-full-wheel:
+          PYTHON_VERSION: '3.10'
           PYTHON_ARCH: 'x64'
           BUILD_TYPE: 'wheel'
           NUMPY_MIN: '1.23.2'
@@ -49,8 +49,8 @@ jobs:
           BUILD_TYPE: 'wheel'
           NUMPY_MIN: '1.26.0'
           imageName: 'ubuntu-latest'
-        Linux-Python39-64bit-full-wheel:
-          PYTHON_VERSION: '3.9'
+        Linux-Python310-64bit-full-wheel:
+          PYTHON_VERSION: '3.10'
           PYTHON_ARCH: 'x64'
           BUILD_TYPE: 'wheel'
           NUMPY_MIN: '1.23.2'

--- a/maintainer/conda/environment.yml
+++ b/maintainer/conda/environment.yml
@@ -20,7 +20,7 @@ dependencies:
   - networkx
   - numpy>=1.23.2
   - pytest
-  - python==3.9
+  - python==3.10
   - pytng>=0.2.3
   - scikit-learn
   - scipy

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -35,6 +35,8 @@ Enhancements
    `n_initial_contacts` attribute, with documentation. (Issue #2604, PR #4415)
 
 Changes
+ * As per SPEC0 the minimum supported Python version has been raised
+   to 3.10 (PR #4502)
  * MDAnalysis.analysis.hole2 is now directly imported from the mdakit
    mdahole2. This module is deprecated and will be fully removed in
    MDAnalysis version 3.0 (PR #4464)

--- a/package/pyproject.toml
+++ b/package/pyproject.toml
@@ -29,7 +29,7 @@ authors = [
 maintainers = [
     {name = 'MDAnalysis Core Developers', email = 'mdanalysis@numfocus.org'}
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     'numpy>=1.23.2',
     'GridDataFormats>=0.4.0',
@@ -60,7 +60,6 @@ classifiers = [
     'Operating System :: MacOS :: MacOS X',
     'Operating System :: Microsoft :: Windows',
     'Programming Language :: Python',
-    'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',

--- a/testsuite/pyproject.toml
+++ b/testsuite/pyproject.toml
@@ -24,7 +24,6 @@ classifiers = [
     "Operating System :: Microsoft :: Windows ",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -35,7 +34,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 readme = {file = "README", content-type = "text/x-rst"}
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dynamic = ["version", "dependencies"]
 
 [project.urls]


### PR DESCRIPTION
Whether or not we follow SPEC0 or NEP29, Python 3.9 is getting dropped in early April. Since there's nearly no chance we would release until then, we might as well go ahead and bump Python up.

Changes made in this Pull Request:
 - Minimum supported Python version is not 3.10


PR Checklist
------------
 - Tests?
 - Docs?
 - [x] CHANGELOG updated?
 - Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4503.org.readthedocs.build/en/4503/

<!-- readthedocs-preview mdanalysis end -->