### PR TITLE
Partial Fix: groups.py doctest error

### DIFF
--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -2679,12 +2679,12 @@ class AtomGroup(GroupBase):
            >>> ag
            <AtomGroup with 6 atoms>
            >>> ag.ix
-           array([2, 1, 2, 2, 1, 0], dtype=int64)
+           array([2, 1, 2, 2, 1, 0])
            >>> ag2 = ag.unique
            >>> ag2
            <AtomGroup with 3 atoms>
            >>> ag2.ix
-           array([0, 1, 2], dtype=int64)
+           array([0, 1, 2])
            >>> ag2.unique is ag2
            False
 
@@ -2736,14 +2736,14 @@ class AtomGroup(GroupBase):
            >>> ag2 is ag
            True
            >>> ag2.ix
-           array([2, 1, 0], dtype=int64)
+           array([2, 1, 0])
            >>> ag3 = ag.asunique(sorted=True)
            >>> ag3 is ag
            False
            >>> ag3.ix
-           array([0, 1, 2], dtype=int64)
+           array([0, 1, 2])
            >>> u.atoms[[2, 1, 1, 0, 1]].asunique(sorted=False).ix
-           array([2, 1, 0], dtype=int64)
+           array([2, 1, 0])
 
 
         .. versionadded:: 2.0.0


### PR DESCRIPTION
Partially addresses #3925   `group.py` doctest errors

Changes made in this Pull Request:

- Doctest for **groups.py**. Five instances of errors occure in regards to difference between the expected output and obtained output during use of examples using `.ix` with the expected output dispaying `dtype=int64` not present in obtained output. Example of previous expected output:
    - array([0, 1, 2], dtype=int64)

- Corrected expected output according to the generated output as below:
    - array([0, 1, 2])

PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4519.org.readthedocs.build/en/4519/

<!-- readthedocs-preview mdanalysis end -->