### PR TITLE
Partial Fix: Change order of arguments for adding auxiliary data for 3.0 release (Issue #3811)

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -236,6 +236,7 @@ Chronological list of authors
   2024
   - Aditya Keshari
   - Philipp Stärk
+  - Valerij Talagayev
 
 External code
 -------------

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -16,7 +16,7 @@ The rules for this file:
 -------------------------------------------------------------------------------
 ??/??/?? IAlibay, HeetVekariya, marinegor, lilyminium, RMeli,
          ljwoods2, aditya292002, pstaerk, PicoCentauri, BFedder,
-         tyler.je.reddy
+         tyler.je.reddy, talagayev
 
  * 2.8.0
 
@@ -34,6 +34,7 @@ Fixes
  * Fix deploy action to use the correct version of the pypi upload action.
 
 Enhancements
+ * Change order of arguments for adding auxiliary data (Issue #3811)
  * Improved performance of PDBWriter (Issue #2785, PR #4472)
  * Added parsing of arbitrary columns of the LAMMPS dump parser. (Issue #3504)
  * Documented the r0 attribute in the `Contacts` class and added the 

--- a/package/MDAnalysis/auxiliary/EDR.py
+++ b/package/MDAnalysis/auxiliary/EDR.py
@@ -142,8 +142,10 @@ specify which data to add under which name. Any number of terms can be added
 using this method. The data is then accessible in the `ts.aux` namespace via
 both attribute and dictionary syntax::
 
-    In [4]: u.trajectory.add_auxiliary({"epot": "Potential",
-                                        "angle": "Angle"}, aux)
+    In [4]: u.trajectory.add_auxiliary(aux,
+                                        {"epot": "Potential",
+                                        "angle": "Angle"}, 
+                                        )
     In [5]: u.trajectory.ts.aux.epot
     Out[5]: -525164.0625
     In [6]: u.trajectory.ts.aux.Angle

--- a/package/MDAnalysis/auxiliary/__init__.py
+++ b/package/MDAnalysis/auxiliary/__init__.py
@@ -131,7 +131,7 @@ which case :func:`~MDAnalysis.auxiliary.core.get_auxreader_for` is used to
 guess an appropriate reader. e.g.::
 
     u = MDAnalysis.Universe(PDB, XTC)
-    u.trajectory.add_auxiliary('pullforce', './pull_force.xvg')
+    u.trajectory.add_auxiliary('./pull_force.xvg', 'pullforce')
 
 As the trajectory frame is updated, the auxiliary data will be read 
 correspondingly, 
@@ -149,7 +149,7 @@ through only trajectory timesteps to which one or more steps that fall within
 avoid representative values set to ``np.nan``, particularly when auxiliary data
 is less frequent::
 
-    u.trajectory.add_auxiliary('low_f', 'low_freq_aux_data.xvg')
+    u.trajectory.add_auxiliary('low_freq_aux_data.xvg', 'low_f')
     for ts in u.trajectory.iter_as_aux('low_f'):
         do_something(ts.aux.low_f) # do something with 'low_f' auxiliary data without
                                    # worrying about having to deal with np.nan

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -1074,7 +1074,7 @@ class ProtoReader(IOBase, metaclass=_Readermeta):
         return coordinates
 
     def add_auxiliary(self,
-                      auxdata: Union[str, AuxReader] = None,
+                      auxdata: Union[str, AuxReader],
                       aux_spec: Union[str, Dict[str, str]] = None,
                       format: str = None,
                       **kwargs) -> None:
@@ -1139,9 +1139,6 @@ class ProtoReader(IOBase, metaclass=_Readermeta):
         Auxiliary data is assumed to be time-ordered, with no duplicates. See
         the :ref:`Auxiliary API`.
         """
-        if auxdata is None:
-            raise ValueError("No input `auxdata` specified, but it needs "
-                             "to be provided.")
         if type(auxdata) not in list(_AUXREADERS.values()):
             # i.e. if auxdata is a file, not an instance of an AuxReader
             reader_type = get_auxreader_for(auxdata)

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -1073,10 +1073,9 @@ class ProtoReader(IOBase, metaclass=_Readermeta):
                 raise ValueError(errmsg)
         return coordinates
 
-# TODO: Change order of aux_spec and auxdata for 3.0 release, cf. Issue #3811
     def add_auxiliary(self,
-                      aux_spec: Union[str, Dict[str, str]] = None,
                       auxdata: Union[str, AuxReader] = None,
+                      aux_spec: Union[str, Dict[str, str]] = None,
                       format: str = None,
                       **kwargs) -> None:
         """Add auxiliary data to be read alongside trajectory.

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -1100,7 +1100,7 @@ class ProtoReader(IOBase, metaclass=_Readermeta):
         pull-force.xvg::
 
             u = MDAnalysis.Universe(PDB, XTC)
-            u.trajectory.add_auxiliary('pull', 'pull-force.xvg')
+            u.trajectory.add_auxiliary('pull-force.xvg', 'pull')
 
         The representative value for the current timestep may then be accessed
         as ``u.trajectory.ts.aux.pull`` or ``u.trajectory.ts.aux['pull']``.
@@ -1119,7 +1119,7 @@ class ProtoReader(IOBase, metaclass=_Readermeta):
         added as identified by a :attr:`data_selector`::
 
             term_dict = {"temp": "Temperature", "epot": "Potential"}
-            u.trajectory.add_auxiliary(term_dict, "ener.edr")
+            u.trajectory.add_auxiliary("ener.edr", term_dict)
 
         Adding this data can be useful, for example, to filter trajectory
         frames based on non-coordinate data like the potential energy of each
@@ -1700,7 +1700,7 @@ class SingleFrameReaderBase(ProtoReader):
 
         new.ts = self.ts.copy()
         for auxname, auxread in self._auxs.items():
-            new.add_auxiliary(auxname, auxread.copy())
+            new.add_auxiliary(auxread.copy(), auxname)
         # since the transformations have already been applied to the frame
         # simply copy the property
         new.transformations = self.transformations

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -1522,7 +1522,7 @@ class ReaderBase(ProtoReader):
         # been modified since initial load
         new.ts = self.ts.copy()
         for auxname, auxread in self._auxs.items():
-            new.add_auxiliary(auxname, auxread.copy())
+            new.add_auxiliary(auxread.copy(), auxname)
         return new
 
     def __del__(self):

--- a/package/MDAnalysis/coordinates/memory.py
+++ b/package/MDAnalysis/coordinates/memory.py
@@ -451,7 +451,7 @@ class MemoryReader(base.ProtoReader):
         new[self.ts.frame]
 
         for auxname, auxread in self._auxs.items():
-            new.add_auxiliary(auxname, auxread.copy())
+            new.add_auxiliary(auxread.copy(), auxname)
         # since transformations are already applied to the whole trajectory
         # simply copy the property
         new.transformations = self.transformations

--- a/testsuite/MDAnalysisTests/auxiliary/base.py
+++ b/testsuite/MDAnalysisTests/auxiliary/base.py
@@ -128,7 +128,7 @@ class BaseAuxReference(object):
 class BaseAuxReaderTest(object):
 
     def test_raise_error_no_auxdata_provided(self, ref, ref_universe):
-        with pytest.raises(ValueError, match="No input `auxdata`"):
+        with pytest.raises(TypeError):
             ref_universe.trajectory.add_auxiliary()
 
     def test_n_steps(self, ref, reader):

--- a/testsuite/MDAnalysisTests/auxiliary/test_edr.py
+++ b/testsuite/MDAnalysisTests/auxiliary/test_edr.py
@@ -195,8 +195,7 @@ class TestEDRReader(BaseAuxReaderTest):
     @pytest.fixture
     def ref_universe(ref):
         u = mda.Universe(AUX_EDR_TPR, AUX_EDR_XTC)
-# TODO: Change order of aux_spec and auxdata for 3.0 release, cf. Issue #3811
-        u.trajectory.add_auxiliary({"test": "Bond"}, ref.testdata)
+        u.trajectory.add_auxiliary(ref.testdata, {"test": "Bond"})
         return u
 
     @staticmethod
@@ -309,7 +308,6 @@ class TestEDRReader(BaseAuxReaderTest):
                         err_msg="Representative value does not match when "
                                 "applying cutoff")
 
-# TODO: Change order of aux_spec and auxdata for 3.0 release, cf. Issue #3811
     def test_add_all_terms_from_file(self, ref, ref_universe):
         ref_universe.trajectory.add_auxiliary(auxdata=ref.testdata)
         # adding "test" manually to match above addition of test term
@@ -317,57 +315,54 @@ class TestEDRReader(BaseAuxReaderTest):
         terms = [key for key in ref_universe.trajectory._auxs]
         assert ref_terms == terms
 
-# TODO: Change order of aux_spec and auxdata for 3.0 release, cf. Issue #3811
     def test_add_all_terms_from_reader(self, ref_universe, reader):
         ref_universe.trajectory.add_auxiliary(auxdata=reader)
         ref_terms = ["test"] + [key for key in get_auxstep_data(0).keys()]
         terms = [key for key in ref_universe.trajectory._auxs]
         assert ref_terms == terms
 
-# TODO: Change order of aux_spec and auxdata for 3.0 release, cf. Issue #3811
     def test_add_term_list_custom_names_from_file(self, ref, ref_universe):
-        ref_universe.trajectory.add_auxiliary({"bond": "Bond",
+        ref_universe.trajectory.add_auxiliary(ref.testdata,
+                                              {"bond": "Bond",
                                                "temp": "Temperature"},
-                                              ref.testdata)
+                                              )
         ref_dict = get_auxstep_data(0)
         assert ref_universe.trajectory.ts.aux.bond == ref_dict["Bond"]
         assert ref_universe.trajectory.ts.aux.temp == ref_dict["Temperature"]
 
-# TODO: Change order of aux_spec and auxdata for 3.0 release, cf. Issue #3811
     def test_add_term_list_custom_names_from_reader(self, ref_universe,
                                                     reader):
-        ref_universe.trajectory.add_auxiliary({"bond": "Bond",
+        ref_universe.trajectory.add_auxiliary(reader,
+                                              {"bond": "Bond",
                                                "temp": "Temperature"},
-                                              reader)
+                                              )
         ref_dict = get_auxstep_data(0)
         assert ref_universe.trajectory.ts.aux.bond == ref_dict["Bond"]
         assert ref_universe.trajectory.ts.aux.temp == ref_dict["Temperature"]
 
-# TODO: Change order of aux_spec and auxdata for 3.0 release, cf. Issue #3811
     def test_raise_error_if_auxname_already_assigned(self, ref_universe,
                                                      reader):
         with pytest.raises(ValueError, match="Auxiliary data with name"):
-            ref_universe.trajectory.add_auxiliary("test", reader, "Bond")
+            ref_universe.trajectory.add_auxiliary(reader, "test", "Bond")
 
-# TODO: Change order of aux_spec and auxdata for 3.0 release, cf. Issue #3811
     def test_add_single_term_custom_name_from_file(self, ref, ref_universe):
-        ref_universe.trajectory.add_auxiliary({"temp": "Temperature"},
-                                              ref.testdata)
+        ref_universe.trajectory.add_auxiliary(ref.testdata,
+                                              {"temp": "Temperature"},
+                                              )
         ref_dict = get_auxstep_data(0)
         assert ref_universe.trajectory.ts.aux.temp == ref_dict["Temperature"]
 
-# TODO: Change order of aux_spec and auxdata for 3.0 release, cf. Issue #3811
     def test_add_single_term_custom_name_from_reader(self, ref_universe,
                                                      reader):
-        ref_universe.trajectory.add_auxiliary({"temp": "Temperature"}, reader)
+        ref_universe.trajectory.add_auxiliary(reader, {"temp": "Temperature"})
         ref_dict = get_auxstep_data(0)
         assert ref_universe.trajectory.ts.aux.temp == ref_dict["Temperature"]
 
-# TODO: Change order of aux_spec and auxdata for 3.0 release, cf. Issue #3811
     def test_terms_update_on_iter(self, ref_universe, reader):
-        ref_universe.trajectory.add_auxiliary({"bond": "Bond",
+        ref_universe.trajectory.add_auxiliary(reader,
+                                              {"bond": "Bond",
                                                "temp": "Temperature"},
-                                              reader)
+                                              )
         ref_dict = get_auxstep_data(0)
         assert ref_universe.trajectory.ts.aux.bond == ref_dict["Bond"]
         assert ref_universe.trajectory.ts.aux.temp == ref_dict["Temperature"]
@@ -376,11 +371,11 @@ class TestEDRReader(BaseAuxReaderTest):
         assert ref_universe.trajectory.ts.aux.bond == ref_dict["Bond"]
         assert ref_universe.trajectory.ts.aux.temp == ref_dict["Temperature"]
 
-# TODO: Change order of aux_spec and auxdata for 3.0 release, cf. Issue #3811
     def test_invalid_data_selector(self, ref, ref_universe):
         with pytest.raises(KeyError, match="'Nonsense' is not a key"):
-            ref_universe.trajectory.add_auxiliary({"something": "Nonsense"},
-                                                  AUX_EDR)
+            ref_universe.trajectory.add_auxiliary(AUX_EDR,
+                                                  {"something": "Nonsense"},
+                                                  )
 
     def test_read_all_times(self, reader):
         all_times_expected = np.array([0., 0.02, 0.04, 0.06])
@@ -414,20 +409,20 @@ class TestEDRReader(BaseAuxReaderTest):
         with pytest.raises(KeyError, match="data selector"):
             reader.get_data(get_data_input)
 
-# TODO: Change order of aux_spec and auxdata for 3.0 release, cf. Issue #3811
     def test_warning_when_space_in_aux_spec(self, ref_universe, reader):
         with pytest.warns(UserWarning, match="Auxiliary name"):
-            ref_universe.trajectory.add_auxiliary({"Pres. DC": "Pres. DC"},
-                                                  reader)
+            ref_universe.trajectory.add_auxiliary(reader,
+                                                  {"Pres. DC": "Pres. DC"},
+                                                  )
 
-# TODO: Change order of aux_spec and auxdata for 3.0 release, cf. Issue #3811
     def test_warn_too_much_memory_usage(self, ref_universe, reader):
         with pytest.warns(UserWarning, match="AuxReader: memory usage "
                           "warning! Auxiliary data takes up 3[0-9.]*e-06 GB of"
                           r" memory \(Warning limit: 1e-08 GB\)"):
-            ref_universe.trajectory.add_auxiliary({"temp": "Temperature"},
-                                                  reader,
-                                                  memory_limit=10)
+            ref_universe.trajectory.add_auxiliary(reader,
+                                                  {"temp": "Temperature"},
+                                                  memory_limit=10,
+                                                  )
 
     def test_auxreader_picklable(self, reader):
         new_reader = pickle.loads(pickle.dumps(reader))
@@ -441,11 +436,11 @@ class TestEDRReader(BaseAuxReaderTest):
         for term in ["Box-X", "Box-Vel-XX"]:
             assert original_units[term] != reader_units[term]
 
-# TODO: Change order of aux_spec and auxdata for 3.0 release, cf. Issue #3811
     def test_warning_when_unknown_unit(self, ref_universe, reader):
         with pytest.warns(UserWarning, match="Could not find"):
-            ref_universe.trajectory.add_auxiliary({"temp": "Temperature"},
-                                                  reader)
+            ref_universe.trajectory.add_auxiliary(reader,
+                                                  {"temp": "Temperature"},
+                                                  )
 
     def test_unit_conversion_is_optional(self, ref):
         reader = ref.reader(

--- a/testsuite/MDAnalysisTests/auxiliary/test_xvg.py
+++ b/testsuite/MDAnalysisTests/auxiliary/test_xvg.py
@@ -84,8 +84,7 @@ class TestXVGReader(BaseAuxReaderTest):
     @pytest.fixture
     def ref_universe(ref):
         u = mda.Universe(COORDINATES_TOPOLOGY, COORDINATES_XTC)
-# TODO: Change order of aux_spec and auxdata for 3.0 release, cf. Issue #3811
-        u.trajectory.add_auxiliary('test', ref.testdata)
+        u.trajectory.add_auxiliary(ref.testdata, 'test')
         return u
 
     @staticmethod
@@ -137,8 +136,7 @@ class TestXVGFileReader(TestXVGReader):
     @pytest.fixture
     def ref_universe(ref):
         u = mda.Universe(COORDINATES_TOPOLOGY, COORDINATES_XTC)
-# TODO: Change order of aux_spec and auxdata for 3.0 release, cf. Issue #3811
-        u.trajectory.add_auxiliary('test', ref.testdata)
+        u.trajectory.add_auxiliary(ref.testdata, 'test')
         return u
 
     @staticmethod

--- a/testsuite/MDAnalysisTests/coordinates/base.py
+++ b/testsuite/MDAnalysisTests/coordinates/base.py
@@ -213,8 +213,8 @@ class BaseReaderTest(object):
     @pytest.fixture()
     def reader(ref):
         reader = ref.reader(ref.trajectory)
-        reader.add_auxiliary('lowf', ref.aux_lowf, dt=ref.aux_lowf_dt, initial_time=0, time_selector=None)
-        reader.add_auxiliary('highf', ref.aux_highf, dt=ref.aux_highf_dt, initial_time=0, time_selector=None)
+        reader.add_auxiliary(ref.aux_lowf, 'lowf', dt=ref.aux_lowf_dt, initial_time=0, time_selector=None)
+        reader.add_auxiliary(ref.aux_highf, 'highf', dt=ref.aux_highf_dt, initial_time=0, time_selector=None)
         return reader
 
     @staticmethod
@@ -303,7 +303,7 @@ class BaseReaderTest(object):
 
     def test_add_same_auxname_raises_ValueError(self, ref, reader):
         with pytest.raises(ValueError):
-            reader.add_auxiliary('lowf', ref.aux_lowf)
+            reader.add_auxiliary(ref.aux_lowf, 'lowf')
 
     def test_remove_auxiliary(self, reader):
         reader.remove_auxiliary('lowf')
@@ -330,7 +330,7 @@ class BaseReaderTest(object):
     def test_iter_as_aux_cutoff(self, ref, reader):
         # load an auxiliary with the same dt but offset from trajectory, and a
         # cutoff of 0
-        reader.add_auxiliary('offset', ref.aux_lowf,
+        reader.add_auxiliary(ref.aux_lowf, 'offset',
                                   dt=ref.dt, time_selector=None,
                                   initial_time=ref.aux_offset_by,
                                   cutoff=0)

--- a/testsuite/MDAnalysisTests/coordinates/test_chemfiles.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_chemfiles.py
@@ -69,15 +69,15 @@ class TestChemfileXYZ(MultiframeReaderTest):
     def reader(self, ref):
         reader = ChemfilesReader(ref.trajectory)
         reader.add_auxiliary(
-            "lowf",
             ref.aux_lowf,
+            "lowf",
             dt=ref.aux_lowf_dt,
             initial_time=0,
             time_selector=None,
         )
         reader.add_auxiliary(
-            "highf",
             ref.aux_highf,
+            "highf",
             dt=ref.aux_highf_dt,
             initial_time=0,
             time_selector=None,

--- a/testsuite/MDAnalysisTests/coordinates/test_copying.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_copying.py
@@ -294,7 +294,7 @@ def test_positions_share_memory(original_and_copy):
 def test_copy_with_auxiliary_no_pyedr():
     # Check that AuxReaders are copied when reader is copied
     u = mda.Universe(XYZ_mini)
-    u.trajectory.add_auxiliary("myaux", AUX_XVG)
+    u.trajectory.add_auxiliary(AUX_XVG, "myaux")
     reader = u.trajectory
     copy = reader.copy()
     for auxname in reader._auxs:
@@ -306,8 +306,8 @@ def test_copy_with_auxiliary_no_pyedr():
 def test_copy_with_auxiliary_pyedr():
     # Check that AuxReaders are copied when reader is copied
     u = mda.Universe(XYZ_mini)
-    u.trajectory.add_auxiliary("myaux", AUX_XVG)
-    u.trajectory.add_auxiliary({"1": "Bond", "2": "Angle"}, AUX_EDR)
+    u.trajectory.add_auxiliary(AUX_XVG, "myaux")
+    u.trajectory.add_auxiliary(AUX_EDR, {"1": "Bond", "2": "Angle"})
 
     reader = u.trajectory
     copy = reader.copy()

--- a/testsuite/MDAnalysisTests/coordinates/test_gro.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_gro.py
@@ -285,10 +285,10 @@ class TestGROReaderNoConversion(BaseReaderTest):
     @pytest.fixture(scope='class')
     def reader(ref):
         reader = ref.reader(ref.trajectory, convert_units=False)
-        reader.add_auxiliary('lowf', ref.aux_lowf,
+        reader.add_auxiliary(ref.aux_lowf, 'lowf',
                              dt=ref.aux_lowf_dt,
                              initial_time=0, time_selector=None)
-        reader.add_auxiliary('highf', ref.aux_highf,
+        reader.add_auxiliary(ref.aux_highf, 'highf',
                              dt=ref.aux_highf_dt,
                              initial_time=0, time_selector=None)
         return reader


### PR DESCRIPTION
Partially Fixes #3811 

Partially, since currently i modified the order of `add_auxiliary`, but retained `aux_data` as optional, since some of the pytests, which would have only `aux_spec` would display errors in pytests and since it is already multiple files, that were modified i thought that it makes sense to first change the order and then make it mandatory if desired.

Changes made in this Pull Request:
 - Change order of arguments of `aux_data` and `aux_spec` in `package/MDAnalysis/coordinates/base.py`.
 - Adjusted the Order of those arguments in `testsuite/MDAnalysisTests/auxiliary` and `testsuite/MDAnalysisTests/coordinates` tests that used `add_auxiliary`
 - Changed the order of `add_auxiliary` in `package/MDAnalysis/coordinates/base.py` in `copy` in classes `class ReaderBase` and `class SingleFrameReaderBase` that both used this function
 - Changed the order of `add_auxiliary` in the docs of `package/MDAnalysis/auxiliary/EDR.py` and `package/MDAnalysis/coordinates/base.py`

I am not sure if these are all of the docs where `add_auxiliary` is used, i checked the package and didn't find any other cases of usage of `add_auxiliary` in docs, except for the ones that i modified

PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4532.org.readthedocs.build/en/4532/

<!-- readthedocs-preview mdanalysis end -->