### PR TITLE
Convert "Quantity" to raw value for kinetic_energy and potential_energy in OpenMM reader

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -16,11 +16,12 @@ The rules for this file:
 -------------------------------------------------------------------------------
 ??/??/?? IAlibay, HeetVekariya, marinegor, lilyminium, RMeli,
          ljwoods2, aditya292002, pstaerk, PicoCentauri, BFedder,
-         tyler.je.reddy, SampurnaM, leonwehrhan, kainszs
+         tyler.je.reddy, SampurnaM, leonwehrhan, kainszs, orionarcher
 
  * 2.8.0
 
 Fixes
+ * Convert openmm Quantity to raw value for KE and PE in OpenMMSimulationReader.
  * Atomname methods can handle empty groups (Issue #2879, PR #4529)
  * Add support for TPR files produced by Gromacs 2024.1 (PR #4523)
  * Remove mutable data from ``progressbar_kwargs`` argument in ``AnalysisBase.run()``

--- a/package/MDAnalysis/converters/OpenMM.py
+++ b/package/MDAnalysis/converters/OpenMM.py
@@ -125,10 +125,10 @@ class OpenMMSimulationReader(base.SingleFrameReaderBase):
         ts.frame = 0
         ts.data["time"] = state.getTime()._value
         ts.data["potential_energy"] = (
-            state.getPotentialEnergy().in_units_of(u.kilojoule/u.mole)
+            state.getPotentialEnergy().in_units_of(u.kilojoule/u.mole)._value
         )
         ts.data["kinetic_energy"] = (
-            state.getKineticEnergy().in_units_of(u.kilojoule/u.mole)
+            state.getKineticEnergy().in_units_of(u.kilojoule/u.mole)._value
         )
         ts.triclinic_dimensions = state.getPeriodicBoxVectors(
                 asNumpy=True)._value

--- a/testsuite/MDAnalysisTests/converters/test_openmm.py
+++ b/testsuite/MDAnalysisTests/converters/test_openmm.py
@@ -87,6 +87,10 @@ class TestOpenMMBasicSimulationReader():
         assert omm_sim_uni.segments.segids[0] == '0'
         assert len(omm_sim_uni.bonds.indices) == 0
 
+    def test_data(self, omm_sim_uni):
+        assert isinstance(omm_sim_uni.trajectory.ts.data["kinetic_energy"], float)
+        assert isinstance(omm_sim_uni.trajectory.ts.data["potential_energy"], float)
+
 
 class TestOpenMMPDBFileReader(_SingleFrameReader):
     __test__ = True

--- a/testsuite/MDAnalysisTests/converters/test_openmm.py
+++ b/testsuite/MDAnalysisTests/converters/test_openmm.py
@@ -88,8 +88,9 @@ class TestOpenMMBasicSimulationReader():
         assert len(omm_sim_uni.bonds.indices) == 0
 
     def test_data(self, omm_sim_uni):
-        assert isinstance(omm_sim_uni.trajectory.ts.data["kinetic_energy"], float)
-        assert isinstance(omm_sim_uni.trajectory.ts.data["potential_energy"], float)
+        data = omm_sim_uni.trajectory.ts.data
+        assert isinstance(data["kinetic_energy"], float)
+        assert isinstance(data["potential_energy"], float)
 
 
 class TestOpenMMPDBFileReader(_SingleFrameReader):


### PR DESCRIPTION
Changes made in this Pull Request:
 - added `.value` to kinetic_energy and potential_energy

This is breaking the ability of a downstream MDAkit to write H5MD files. [Issue here](https://github.com/sef43/openmm-mdanalysis-reporter/issues/5). I suspect it is more generally breaking the ability to take in OpenMM and output H5MD, but it is only in `openmm-reporter` that I came across it.


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4548.org.readthedocs.build/en/4548/

<!-- readthedocs-preview mdanalysis end -->