### PR TITLE
Fix citation notation in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -102,19 +102,18 @@ Citation
 When using MDAnalysis in published work, please cite the following
 two papers:
 
-*   R. J. Gowers, M. Linke, J. Barnoud, T. J. E. Reddy,
-    M. N. Melo, S. L. Seyler, D. L. Dotson, J. Domanski,
-    S. Buchoux, I. M. Kenney, and O. Beckstein. MDAnalysis:
+*   R\. J. Gowers, M. Linke, J. Barnoud, T. J. E. Reddy,
+    M\. N. Melo, S. L. Seyler, D. L. Dotson, J. Domanski,
+    S\. Buchoux, I. M. Kenney, and O. Beckstein. MDAnalysis:
     A Python package for the rapid analysis of molecular
     dynamics simulations. In S. Benthall and S. Rostrup,
     editors, Proceedings of the 15th Python in Science
     Conference, pages 102-109, Austin, TX, 2016. SciPy.
-    doi:`10.25080/Majora-629e541a-00e`_    
-
+    doi: `10.25080/Majora-629e541a-00e`_    
 *   N. Michaud-Agrawal, E. J. Denning, T. B. Woolf,
     and O. Beckstein. MDAnalysis: A Toolkit for the Analysis of Molecular
     Dynamics Simulations. *J. Comput. Chem.* **32** (2011), 2319--2327.
-    doi:`10.1002/jcc.21787`_
+    doi: `10.1002/jcc.21787`_
 
 For citations of included algorithms and sub-modules please see the references_.
 


### PR DESCRIPTION
Current rst notation was parsing the `R.`, `M.` initials, etc. as further enumeration in a list item. It also wasn't reading the DOI links. This escapes the dots and adds a space before the DOI link to correct rendering.

`develop`:
<img width="870" alt="Screenshot 2024-04-21 at 5 14 35 pm" src="https://github.com/MDAnalysis/mdanalysis/assets/31115101/a3265e1c-6c98-42af-9503-40e3b6a4d332">

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4571.org.readthedocs.build/en/4571/

<!-- readthedocs-preview mdanalysis end -->