### PR TITLE
Don't fail on codecov upload error

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -127,7 +127,7 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: coverage.xml
-        fail_ci_if_error: True
+        fail_ci_if_error: False
         verbose: True
 
 


### PR DESCRIPTION
Temp patch for #4574 


This will make it so that jobs don't fail if there's an upload issue (i.e. what currently happens with PRs from forks)

*HOWEVER*

It also means that codecov might not report properlly if things fail. I.e. for reviewers, be aware that codecov suddenly saying there's no coverage could just be that nothing got uploaded.


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4575.org.readthedocs.build/en/4575/

<!-- readthedocs-preview mdanalysis end -->