### PR TITLE
Pin to version of rdkit that works with mypy

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -146,6 +146,7 @@ jobs:
           micromamba: true
           full-deps: true
           numpy: numpy=1.23.2
+          rdkit: rdkit=2023.09.3
 
       - name: install
         run: |


### PR DESCRIPTION
Changes made in this Pull Request:
 - Pin mypy linting action to 2023.09.3 

Not 100% sure why this is happening, we're tracking this elsewhere: https://github.com/OpenFreeEnergy/openfe/issues/844

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4580.org.readthedocs.build/en/4580/

<!-- readthedocs-preview mdanalysis end -->