### PR TITLE
[doc] fix RDF equation (and hole link)

### DIFF
--- a/package/MDAnalysis/analysis/rdf.py
+++ b/package/MDAnalysis/analysis/rdf.py
@@ -32,7 +32,7 @@ The RDF :math:`g_{ab}(r)` between types of particles :math:`a` and :math:`b` is
 
 .. math::
 
-   g_{ab}(r) = (N_{a} N_{b})^{-1} \sum_{i=1}^{N_a} \sum_{j=1}^{N_b}
+   g_{ab}(r) = \frac{1}{N_{a}} \frac{1}{N_{b}/V} \sum_{i=1}^{N_a} \sum_{j=1}^{N_b}
                \langle \delta(|\mathbf{r}_i - \mathbf{r}_j| - r) \rangle
 
 which is normalized so that the RDF becomes 1 for large separations in a

--- a/package/doc/sphinx/source/documentation_pages/analysis/hole2.rst
+++ b/package/doc/sphinx/source/documentation_pages/analysis/hole2.rst
@@ -24,6 +24,8 @@ under the Apache v2.0 license.)
    `mdahole2 <https://www.mdanalysis.org/mdahole2/>`_ and
    will be removed in MDAnalysis 3.0.0.
 
+.. _HOLE: http://www.holeprogram.org/
+
 
 See Also
 --------


### PR DESCRIPTION
Corrects error in the RDF equation as noted by @rodpollet https://github.com/MDAnalysis/mdanalysis/discussions/4437#discussioncomment-9021926

Changes made in this Pull Request:
 - fix RDF g_ab equation
 - fix missing reST link in the (deprecated) hole2 module


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4591.org.readthedocs.build/en/4591/

<!-- readthedocs-preview mdanalysis end -->