### PR TITLE
Remove default parallelizable parameter in NoJump transformation

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -21,6 +21,7 @@ The rules for this file:
  * 2.8.0
 
 Fixes
+ * Fix #4259 via removing argument `parallelizable` of `NoJump` transformation.
  * Fix doctest errors of analysis/pca.py related to rounding issues 
    (Issue #3925, PR #4377)
  * Convert openmm Quantity to raw value for KE and PE in OpenMMSimulationReader.

--- a/package/MDAnalysis/transformations/nojump.py
+++ b/package/MDAnalysis/transformations/nojump.py
@@ -100,7 +100,9 @@ class NoJump(TransformationBase):
         check_continuity=True,
         max_threads=None,
     ):
-        super().__init__(max_threads=max_threads, parallelizable=False)
+       # NoJump transforms are inherently unparallelizable, since
+       # it depends on the previous frame's unwrapped coordinates
+       super().__init__(max_threads=max_threads, parallelizable=False)
         self.prev = None
         self.old_frame = 0
         self.older_frame = "A"

--- a/package/MDAnalysis/transformations/nojump.py
+++ b/package/MDAnalysis/transformations/nojump.py
@@ -99,11 +99,8 @@ class NoJump(TransformationBase):
         self,
         check_continuity=True,
         max_threads=None,
-        # NoJump transforms are inherently unparallelizable, since
-        # it depends on the previous frame's unwrapped coordinates
-        parallelizable=False,
     ):
-        super().__init__(max_threads=max_threads, parallelizable=parallelizable)
+        super().__init__(max_threads=max_threads, parallelizable=False)
         self.prev = None
         self.old_frame = 0
         self.older_frame = "A"

--- a/package/MDAnalysis/transformations/nojump.py
+++ b/package/MDAnalysis/transformations/nojump.py
@@ -100,9 +100,9 @@ class NoJump(TransformationBase):
         check_continuity=True,
         max_threads=None,
     ):
-       # NoJump transforms are inherently unparallelizable, since
-       # it depends on the previous frame's unwrapped coordinates
-       super().__init__(max_threads=max_threads, parallelizable=False)
+        # NoJump transforms are inherently unparallelizable, since
+        # it depends on the previous frame's unwrapped coordinates
+        super().__init__(max_threads=max_threads, parallelizable=False)
         self.prev = None
         self.old_frame = 0
         self.older_frame = "A"


### PR DESCRIPTION
Fixes #4259

Changes made in this Pull Request:
 - remove `parallelizable` argument of `NoJump` transformation to avoid accidentally passing `parallelizable=True`


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4604.org.readthedocs.build/en/4604/

<!-- readthedocs-preview mdanalysis end -->