### PR TITLE
Add a Dependabot config to auto-update GitHub action versions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -240,6 +240,7 @@ Chronological list of authors
   - Sampurna Mukherjee
   - Leon Wehrhan
   - Valerij Talagayev
+  - Kurt McKee
 
 
 


### PR DESCRIPTION
Currently, deprecation warnings are being thrown due to actions using out-of-date Node versions ([recent example](https://github.com/MDAnalysis/mdanalysis/actions/runs/9544980203)). Rather than submitting a PR to update them manually, this PR configures Dependabot to regularly submit PRs to update GitHub action versions as needed.

If this PR merges, you can expect Dependabot to immediately submit a PR to update actions to newer versions.

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4618.org.readthedocs.build/en/4618/

<!-- readthedocs-preview mdanalysis end -->