### PR TITLE
BLD: NumPy 2 compat for wheel builds

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -56,6 +56,8 @@ Enhancements
    DOI 10.1021/acs.jpcb.7b11988. (Issue #2039, PR #4524)
 
 Changes
+ * MDAnalysis now builds against numpy 2.0 rather than the
+   minimum supported numpy version (PR #4620)
  * As per SPEC0 the minimum supported Python version has been raised
    to 3.10 (PR #4502)
  * MDAnalysis.analysis.hole2 is now directly imported from the mdakit

--- a/package/MDAnalysis/converters/ParmEd.py
+++ b/package/MDAnalysis/converters/ParmEd.py
@@ -81,6 +81,8 @@ import functools
 import itertools
 import warnings
 
+from numpy.lib import NumpyVersion
+
 from . import base
 from ..coordinates.base import SingleFrameReaderBase
 from ..topology.tables import SYMB2Z
@@ -168,11 +170,20 @@ class ParmEdConverter(base.ConverterBase):
         obj : AtomGroup or Universe or :class:`Timestep`
         """
         try:
-            import parmed as pmd
+            # TODO: remove this guard when parmed has a release
+            # that supports NumPy 2
+            if NumpyVersion(np.__version__) < "2.0.0":
+                import parmed as pmd
+            else:
+                raise ImportError
         except ImportError:
-            raise ImportError('ParmEd is required for ParmEdConverter but '
-                              'is not installed. Try installing it with \n'
-                              'pip install parmed')
+            if NumpyVersion(np.__version__) >= "2.0.0":
+                ermsg = "ParmEd is not compatible with NumPy 2.0+"
+            else:
+                ermsg = ("ParmEd is required for ParmEdConverter but is not "
+                         "installed. Try installing it with \n"
+                         "pip install parmed")
+            raise ImportError(errmsg)
         try:
             # make sure to use atoms (Issue 46)
             ag_or_ts = obj.atoms

--- a/package/MDAnalysis/converters/ParmEd.py
+++ b/package/MDAnalysis/converters/ParmEd.py
@@ -81,6 +81,7 @@ import functools
 import itertools
 import warnings
 
+import numpy as np
 from numpy.lib import NumpyVersion
 
 from . import base

--- a/package/MDAnalysis/converters/RDKit.py
+++ b/package/MDAnalysis/converters/RDKit.py
@@ -87,6 +87,7 @@ from functools import lru_cache
 from io import StringIO
 
 import numpy as np
+from numpy.lib import NumpyVersion
 
 from . import base
 from ..coordinates import memory
@@ -95,8 +96,13 @@ from ..core.topologyattrs import _TOPOLOGY_ATTRS
 from ..exceptions import NoDataError
 
 try:
-    from rdkit import Chem
-    from rdkit.Chem import AllChem
+    # TODO: remove this guard when RDKit has a release
+    # that supports NumPy 2
+    if NumpyVersion(np.__version__) < "2.0.0":
+        from rdkit import Chem
+        from rdkit.Chem import AllChem
+    else:
+        raise ImportError
 except ImportError:
     pass
 else:

--- a/package/pyproject.toml
+++ b/package/pyproject.toml
@@ -3,15 +3,13 @@
 requires = [
     "Cython>=0.28",
     "packaging",
-    # lowest NumPy we can use for a given Python,
-    # In part adapted from: https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg
-    # As per NEP29, we set the minimum version to 1.23.2 for Python <=3.11
-    # and 1.26.0 (first to support) for Python 3.12
-    "numpy==1.23.2; python_version<='3.11' and platform_python_implementation != 'PyPy'",
-    "numpy==1.26.0; python_version=='3.12' and platform_python_implementation != 'PyPy'",
-    # For unreleased versions of Python there is currently no known supported
-    # NumPy version. In that case we just let it be a bare NumPy install
-    "numpy<2.0; python_version>='3.13'",
+    # numpy requirement for wheel builds for distribution on PyPI - building
+    # against 2.x yields wheels that are also compatible with numpy 1.x at
+    # runtime.
+    # Note that building against numpy 1.x works fine too - users and
+    # redistributors can do this by installing the numpy version they like and
+    # disabling build isolation.
+    "numpy>=2.0.0",
     # Set to minimum version of setuptools that allows pyproject.toml
     "setuptools >= 40.9.0",
     "wheel",

--- a/testsuite/MDAnalysisTests/converters/test_parmed.py
+++ b/testsuite/MDAnalysisTests/converters/test_parmed.py
@@ -23,7 +23,9 @@
 import pytest
 import MDAnalysis as mda
 
+import numpy as np
 from numpy.testing import (assert_allclose, assert_equal)
+from numpy.lib import NumpyVersion
 
 from MDAnalysisTests.coordinates.base import _SingleFrameReader
 from MDAnalysisTests.coordinates.reference import RefAdKSmall
@@ -41,7 +43,13 @@ from MDAnalysisTests.datafiles import (
     PRM_UreyBradley,
 )
 
-pmd = pytest.importorskip('parmed')
+# TODO: remove this guard when parmed has a release
+# that support NumPy 2
+if NumpyVersion(np.__version__) < "2.0.0":
+    pmd = pytest.importorskip('parmed')
+else:
+    pmd = pytest.importorskip('parmed_skip_with_numpy2')
+
 
 
 class TestParmEdReaderGRO:

--- a/testsuite/MDAnalysisTests/converters/test_rdkit.py
+++ b/testsuite/MDAnalysisTests/converters/test_rdkit.py
@@ -27,6 +27,7 @@ from io import StringIO
 
 import MDAnalysis as mda
 import numpy as np
+from numpy.lib import NumpyVersion
 import pytest
 from MDAnalysis.topology.guessers import guess_atom_element
 from MDAnalysisTests.datafiles import GRO, PDB_full, PDB_helix, mol2_molecule
@@ -55,6 +56,8 @@ requires_rdkit = pytest.mark.skipif(import_not_available("rdkit"),
                     reason="only for min dependencies build")
 class TestRequiresRDKit(object):
     def test_converter_requires_rdkit(self):
+        if NumpyVersion(np.__version__) >= "2.0.0":
+            pytest.skip("RDKit not compatible with NumPy 2")
         u = mda.Universe(PDB_full)
         with pytest.raises(ImportError,
                            match="RDKit is required for the RDKitConverter"):

--- a/testsuite/MDAnalysisTests/converters/test_rdkit_parser.py
+++ b/testsuite/MDAnalysisTests/converters/test_rdkit_parser.py
@@ -24,14 +24,21 @@
 import warnings
 import pytest
 import numpy as np
+from numpy.lib import NumpyVersion
 from numpy.testing import assert_equal
 
 import MDAnalysis as mda
 from MDAnalysisTests.topology.base import ParserBase
 from MDAnalysisTests.datafiles import mol2_molecule, PDB_helix, SDF_molecule
 
-Chem = pytest.importorskip('rdkit.Chem')
-AllChem = pytest.importorskip('rdkit.Chem.AllChem')
+# TODO: remove these shims when RDKit
+# has a release supporting NumPy 2
+if NumpyVersion(np.__version__) < "2.0.0":
+    Chem = pytest.importorskip('rdkit.Chem')
+    AllChem = pytest.importorskip('rdkit.Chem.AllChem')
+else:
+    Chem = pytest.importorskip("RDKit_does_not_support_NumPy_2")
+    AllChem = pytest.importorskip("RDKit_does_not_support_NumPy_2")
 
 class RDKitParserBase(ParserBase):
     parser = mda.converters.RDKitParser.RDKitParser

--- a/testsuite/MDAnalysisTests/core/test_atomselections.py
+++ b/testsuite/MDAnalysisTests/core/test_atomselections.py
@@ -25,6 +25,7 @@ import textwrap
 from io import StringIO
 import itertools
 import numpy as np
+from numpy.lib import NumpyVersion
 from numpy.testing import(
     assert_equal,
 )
@@ -539,7 +540,10 @@ class TestSelectionsTPR(object):
 
 class TestSelectionRDKit(object):
     def setup_class(self):
-        pytest.importorskip("rdkit.Chem")
+        if NumpyVersion(np.__version__) < "2.0.0":
+            pytest.importorskip("rdkit.Chem")
+        else:
+            pytest.skip("RDKit does not support NumPy 2")
 
     @pytest.fixture
     def u(self):
@@ -1413,13 +1417,19 @@ def test_negative_resid():
     ("aromaticity False", 15),
 ])
 def test_bool_sel(selstr, n_atoms):
-    pytest.importorskip("rdkit.Chem")
+    if NumpyVersion(np.__version__) >= "2.0.0":
+        pytest.skip("RDKit does not support NumPy 2")
+    else:
+        pytest.importorskip("rdkit.Chem")
     u = MDAnalysis.Universe.from_smiles("Nc1cc(C[C@H]([O-])C=O)c[nH]1")
     assert len(u.select_atoms(selstr)) == n_atoms
 
 
 def test_bool_sel_error():
-    pytest.importorskip("rdkit.Chem")
+    if NumpyVersion(np.__version__) >= "2.0.0":
+        pytest.skip("RDKit does not support NumPy 2")
+    else:
+        pytest.importorskip("rdkit.Chem")
     u = MDAnalysis.Universe.from_smiles("Nc1cc(C[C@H]([O-])C=O)c[nH]1")
     with pytest.raises(SelectionError, match="'fragrant' is an invalid value"):
         u.select_atoms("aromaticity fragrant")

--- a/testsuite/MDAnalysisTests/core/test_universe.py
+++ b/testsuite/MDAnalysisTests/core/test_universe.py
@@ -30,6 +30,7 @@ from io import StringIO
 import warnings
 
 import numpy as np
+from numpy.lib import NumpyVersion
 from numpy.testing import (
     assert_allclose,
     assert_almost_equal,
@@ -224,7 +225,10 @@ class TestUniverseCreation(object):
 
 class TestUniverseFromSmiles(object):
     def setup_class(self):
-        pytest.importorskip("rdkit.Chem")
+        if NumpyVersion(np.__version__) < "2.0.0":
+            pytest.importorskip("rdkit.Chem")
+        else:
+            pytest.importorskip("RDKit_does_not_support_NumPy_2")
 
     def test_default(self):
         smi = "CN1C=NC2=C1C(=O)N(C(=O)N2C)C"

--- a/testsuite/MDAnalysisTests/util.py
+++ b/testsuite/MDAnalysisTests/util.py
@@ -39,6 +39,8 @@ import warnings
 import pytest
 
 from numpy.testing import assert_warns
+import numpy as np
+from numpy.lib import NumpyVersion
 
 
 def block_import(package):
@@ -112,6 +114,11 @@ def import_not_available(module_name):
                         msg="skip test as module_name could not be imported")
 
     """
+    # TODO: remove once these packages have a release
+    # with NumPy 2 support
+    if NumpyVersion(np.__version__) >= "2.0.0":
+        if module_name in {"rdkit", "parmed"}:
+            return True
     try:
         test = importlib.import_module(module_name)
     except ImportError:


### PR DESCRIPTION
* Related to #4619

* We should build against NumPy `2.0.0` so that we're backwards compatible to NumPy `1.x` while still supporting 2.x series. This is simpler to maintain as well. In theory, should support as far back as NumPy `1.19` if we needed it.


PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [ ] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4620.org.readthedocs.build/en/4620/

<!-- readthedocs-preview mdanalysis end -->