### PR TITLE
Deprecate fetch mmtf

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -63,6 +63,8 @@ Enhancements
    DOI 10.1021/acs.jpcb.7b11988. (Issue #2039, PR #4524)
 
 Changes
+ * The `fetch_mmtf` method has been removed as the REST API service
+   for MMTF files has ceased to exist (Issue #4634)
  * MDAnalysis now builds against numpy 2.0 rather than the
    minimum supported numpy version (PR #4620)
  * As per SPEC0 the minimum supported Python version has been raised
@@ -82,6 +84,8 @@ Changes
    numpy.testing.assert_allclose #4438)
 
 Deprecations
+ * The MMTF Reader is deprecated and will be removed in version 3.0
+   as the MMTF format is no longer supported (Issue #4634)
  * The MDAnalysis.analysis.waterdynamics module has been deprecated in favour
    of the waterdynamics MDAKit and will be removed in version 3.0.0 (PR #4404)
  * The MDAnalysis.analysis.psa module has been deprecated in favour of

--- a/package/MDAnalysis/__init__.py
+++ b/package/MDAnalysis/__init__.py
@@ -150,7 +150,7 @@ the OPLS/AA force field.
 
 """
 
-__all__ = ['Universe', 'Writer', 'fetch_mmtf',
+__all__ = ['Universe', 'Writer',
            'AtomGroup', 'ResidueGroup', 'SegmentGroup']
 
 import logging
@@ -209,7 +209,6 @@ from .core.groups import AtomGroup, ResidueGroup, SegmentGroup
 from .coordinates.core import writer as Writer
 
 # After Universe import
-from .coordinates.MMTF import fetch_mmtf
 from . import converters
 
 from .due import due, Doi, BibTeX

--- a/package/MDAnalysis/coordinates/MMTF.py
+++ b/package/MDAnalysis/coordinates/MMTF.py
@@ -36,11 +36,11 @@ Classes
 
 .. autoclass:: MMTFReader
    :members:
-.. autofunction:: fetch_mmtf
 
 .. _MMTF: https://mmtf.rcsb.org/
 
 """
+import warnings
 import mmtf
 
 from . import base
@@ -56,8 +56,23 @@ def _parse_mmtf(fn):
 
 
 class MMTFReader(base.SingleFrameReaderBase):
-    """Coordinate reader for the Macromolecular Transmission Format format (MMTF_)."""
+    """Coordinate reader for the Macromolecular Transmission Format format (MMTF_).
+
+
+    .. deprecated:: 2.8.0
+       The MMTF format is no longer supported / serviced by the
+       Protein Data Bank. The Reader will be removed in version 3.0.
+       Users are encouraged to instead use alternative PDB formats.
+    """
     format = 'MMTF'
+
+    @store_init_arguments
+    def __init__(self, filename, convert_units=True, n_atoms=None, **kwargs):
+        wmsg = ("The MMTF Reader is deprecated and will be removed in "
+                "MDAnalysis version 3.0.0")
+        warnings.warn(wmsg, DeprecationWarning)
+
+        super(MMTFReader, self).__init__(**kwargs)
 
     @staticmethod
     def _format_hint(thing):
@@ -90,28 +105,3 @@ class MMTFReader(base.SingleFrameReaderBase):
             ts.dimensions = top.unit_cell
 
         return ts
-
-
-def fetch_mmtf(pdb_id):
-    """Create a Universe from the RCSB Protein Data Bank using mmtf format
-
-    Parameters
-    ----------
-    pdb_id : string
-        PDB code of the desired data, eg '4UCP'
-
-
-    Returns
-    -------
-    Universe
-        MDAnalysis Universe of the corresponding PDB system
-
-
-    See Also
-    --------
-    mmtf.fetch : Function for fetching raw mmtf data
-
-
-    .. versionadded:: 0.16.0
-    """
-    return Universe(mmtf.fetch(pdb_id))

--- a/package/MDAnalysis/coordinates/MMTF.py
+++ b/package/MDAnalysis/coordinates/MMTF.py
@@ -45,6 +45,7 @@ import mmtf
 
 from . import base
 from ..core.universe import Universe
+from ..lib.util import cached, store_init_arguments
 from ..due import due, Doi
 
 
@@ -72,7 +73,10 @@ class MMTFReader(base.SingleFrameReaderBase):
                 "MDAnalysis version 3.0.0")
         warnings.warn(wmsg, DeprecationWarning)
 
-        super(MMTFReader, self).__init__(**kwargs)
+        super(MMTFReader, self).__init__(
+            filename, convert_units, n_atoms,
+            **kwargs
+        )
 
     @staticmethod
     def _format_hint(thing):

--- a/testsuite/MDAnalysisTests/coordinates/test_mmtf.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_mmtf.py
@@ -88,3 +88,10 @@ def test_dimensionless():
     r = MMTFReader(MMTF_skinny2)
 
     assert r.ts.dimensions is None
+
+
+def test_deprecation():
+    wmsg = "The MMTF Reader is deprecated"
+
+    with pytest.warns(DeprecationWarning, match=wmsg):
+        _ = MMTFReader(MMTF_skinny2)

--- a/testsuite/MDAnalysisTests/test_api.py
+++ b/testsuite/MDAnalysisTests/test_api.py
@@ -39,10 +39,6 @@ def test_Universe():
     assert mda.Universe is mda.core.universe.Universe
 
 
-def test_fetch_mmtf():
-    assert mda.fetch_mmtf is mda.coordinates.MMTF.fetch_mmtf
-
-
 def test_Writer():
     assert mda.Writer is mda.coordinates.core.writer
 

--- a/testsuite/MDAnalysisTests/topology/test_mmtf.py
+++ b/testsuite/MDAnalysisTests/topology/test_mmtf.py
@@ -127,16 +127,6 @@ class TestMMTFgzUniverseFromDecoder(TestMMTFgzUniverse):
         return mda.Universe(top)
 
 
-class TestMMTFFetch(TestMMTFUniverse):
-    @pytest.fixture()
-    def u(self):
-        top = mmtf.parse(MMTF)
-        with mock.patch('mmtf.fetch') as mock_fetch:
-            mock_fetch.return_value = top
-
-            return mda.fetch_mmtf('173D')  # string is irrelevant
-
-
 class TestSelectModels(object):
     # tests for 'model' keyword in select_atoms   
     @pytest.fixture()


### PR DESCRIPTION
Fixes #4634

Changes made in this Pull Request:
 - Remove `fetch_mmtf` method
 - Deprecate MMTFReader


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4639.org.readthedocs.build/en/4639/

<!-- readthedocs-preview mdanalysis end -->