### PR TITLE
BLD: use C11 standard

### DIFF
--- a/package/setup.py
+++ b/package/setup.py
@@ -259,7 +259,7 @@ def extensions(config):
     use_openmp = config.get('use_openmp', default=True)
     annotate_cython = config.get('annotate_cython', default=False)
 
-    extra_compile_args = ['-std=c99', '-O3', '-funroll-loops',
+    extra_compile_args = ['-std=c11', '-O3', '-funroll-loops',
                           '-fsigned-zeros'] # see #2722
     define_macros = []
     if config.get('debug_cflags', default=False):


### PR DESCRIPTION
* Fixes gh-4651

* The reason that bumping to the C11 standard for the C language helps us build with free-threaded CPython `3.13.0rc1` is described at: https://github.com/scikit-learn/scikit-learn/issues/28977

For now I'll set title to WIP since I'm admittedly flushing the CI to check for problems (I only tested with `3.13.0rc1` on ARM mac locally).



PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4652.org.readthedocs.build/en/4652/

<!-- readthedocs-preview mdanalysis end -->