### PR TITLE
Fixed high dimensional GroupBase indexing.

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -243,7 +243,7 @@ Chronological list of authors
   - Kurt McKee
   - Fabian Zills
   - Laksh Krishna Sharma
-
+  - Matthew Davies
 
 
 External code

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -22,7 +22,7 @@ The rules for this file:
  * 2.8.0
 
 Fixes
- * Sanitise and catch higher dimensional indexing in GroupBase (Issue #4647)
+ * Catch higher dimensional indexing in GroupBase (Issue #4647)
  * Do not raise an Error reading H5MD files with datasets like
    `observables/<particle>/<property>` (part of Issue #4598, PR #4615)
  * Fix failure in double-serialization of TextIOPicklable file reader.

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -22,6 +22,7 @@ The rules for this file:
  * 2.8.0
 
 Fixes
+ * Sanitise and catch higher dimensional indexing in GroupBase (Issue #4647)
  * Do not raise an Error reading H5MD files with datasets like
    `observables/<particle>/<property>` (part of Issue #4598, PR #4615)
  * Fix failure in double-serialization of TextIOPicklable file reader.

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -597,6 +597,16 @@ class GroupBase(_MutableBase):
                 # hack to make lists into numpy arrays
                 # important for boolean slicing
                 item = np.array(item)
+            
+            # correctly flatten oddly shaped, but 1d arrays
+            # raises issues if flattening already suitable arrays
+            if isinstance(item, np.ndarray) and item.ndim > 1: # ignore slices
+                item = np.squeeze(item)
+                # disallow high dimensional indexing.
+                # this doesnt stop the underlying issue
+                if item.ndim > 1:
+                    raise IndexError('Group index must be 1d')
+
             # We specify _derived_class instead of self.__class__ to allow
             # subclasses, such as UpdatingAtomGroup, to control the class
             # resulting from slicing.

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -597,10 +597,10 @@ class GroupBase(_MutableBase):
                 # hack to make lists into numpy arrays
                 # important for boolean slicing
                 item = np.array(item)
-            
+
             # correctly flatten oddly shaped, but 1d arrays
             # raises issues if flattening already suitable arrays
-            if isinstance(item, np.ndarray) and item.ndim > 1: # ignore slices
+            if isinstance(item, np.ndarray) and item.ndim > 1:
                 item = np.squeeze(item)
                 # disallow high dimensional indexing.
                 # this doesnt stop the underlying issue

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -598,14 +598,10 @@ class GroupBase(_MutableBase):
                 # important for boolean slicing
                 item = np.array(item)
 
-            # correctly flatten oddly shaped, but 1d arrays
-            # raises issues if flattening already suitable arrays
             if isinstance(item, np.ndarray) and item.ndim > 1:
-                item = np.squeeze(item)
                 # disallow high dimensional indexing.
                 # this doesnt stop the underlying issue
-                if item.ndim > 1:
-                    raise IndexError('Group index must be 1d')
+                raise IndexError('Group index must be 1d')
 
             # We specify _derived_class instead of self.__class__ to allow
             # subclasses, such as UpdatingAtomGroup, to control the class

--- a/testsuite/MDAnalysisTests/core/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/core/test_atomgroup.py
@@ -1592,18 +1592,6 @@ class TestAtomGroup(object):
                                                            "an AtomGroup")
         assert_equal(ag[1], ag[-1], "advanced slicing does not preserve order")
 
-    @pytest.mark.parametrize('shape', [(-1, 1), (1, -1)])
-    def test_1d_index_invariance(self, universe, shape):
-        u = universe
-        ag1 = u.atoms[np.arange(5)]
-        ag2 = u.atoms[np.arange(5).reshape(shape)]
-
-        # without correct sanitising, n_atoms is 1 when reshaped 'incorrectly'
-        assert ag2.n_atoms == 5, ("indexing with a 1d array was not "
-                                  "invarient of row vs column order")
-        assert_equal(ag1, ag2), ("indexing with a 1d array was not "
-                                 "invarient of row vs column order")
-
     def test_2d_indexing_caught(self, universe):
         u = universe
         index_2d = [[1, 2, 3],

--- a/testsuite/MDAnalysisTests/core/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/core/test_atomgroup.py
@@ -1592,6 +1592,25 @@ class TestAtomGroup(object):
                                                            "an AtomGroup")
         assert_equal(ag[1], ag[-1], "advanced slicing does not preserve order")
 
+    @pytest.mark.parametrize('shape', [(-1, 1), (1, -1)])
+    def test_1d_index_invariance(self, universe, shape):
+        u = universe
+        ag1 = u.atoms[np.arange(5)]
+        ag2 = u.atoms[np.arange(5).reshape(shape)]
+
+        # without correct sanitising, n_atoms is 1 when reshaped 'incorrectly'
+        assert ag2.n_atoms == 5, ("indexing with a 1d array was not "
+                                  "invarient of row vs column order")
+        assert_equal(ag1, ag2), ("indexing with a 1d array was not "
+                                 "invarient of row vs column order")
+
+    def test_2d_indexing_caught(self, universe):
+        u = universe
+        index_2d = [[1, 2, 3],
+                    [4, 5, 6]]
+        with pytest.raises(IndexError):
+            u.atoms[index_2d]
+
     @pytest.mark.parametrize('sel', (np.array([True, False, True]),
                                      [True, False, True]))
     def test_boolean_indexing_2(self, universe, sel):


### PR DESCRIPTION
Fixes #4647 
This does not fix the underlying "Frankenatoms" issue, but stops it from occuring due to GroupBase indexing by  raising an error if improperly shaped indices are provided.

Changes made in this Pull Request:
 - Added test confirming 2d index raises an IndexError.
 - Added a dimensionality check to GroupBase.\_\_getitem__ to raise an error on invalid higher dimensional inputs.


PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4656.org.readthedocs.build/en/4656/

<!-- readthedocs-preview mdanalysis end -->