### PR TITLE
mark analysis.pca.PCA as not parallelizable

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -17,7 +17,7 @@ The rules for this file:
 ??/??/?? IAlibay, HeetVekariya, marinegor, lilyminium, RMeli,
          ljwoods2, aditya292002, pstaerk, PicoCentauri, BFedder,
          tyler.je.reddy, SampurnaM, leonwehrhan, kainszs, orionarcher,
-         yuxuanzhuang, PythonFZ, laksh-krishna-sharma
+         yuxuanzhuang, PythonFZ, laksh-krishna-sharma, orbeckst
 
  * 2.8.0
 
@@ -55,6 +55,7 @@ Fixes
 Enhancements
  * Introduce parallelization API to `AnalysisBase` and to `analysis.rms.RMSD` class
    (Issue #4158, PR #4304)
+ * explicitly mark `analysis.pca.PCA` as not parallelizable (Issue #4680)
  * Improve error message for `AtomGroup.unwrap()` when bonds are not present.(Issue #4436, PR #4642)
  * Add `analysis.DSSP` module for protein secondary structure assignment, based on [pydssp](https://github.com/ShintaroMinami/PyDSSP)
  * Added a tqdm progress bar for `MDAnalysis.analysis.pca.PCA.transform()`

--- a/package/MDAnalysis/analysis/pca.py
+++ b/package/MDAnalysis/analysis/pca.py
@@ -143,7 +143,7 @@ class PCA(AnalysisBase):
     generates the principal components of the backbone of the atomgroup and
     then transforms those atomgroup coordinates by the direction of those
     variances. Please refer to the :ref:`PCA-tutorial` for more detailed
-    instructions. When using mean selections, the first frame of the selected 
+    instructions. When using mean selections, the first frame of the selected
     trajectory slice is used as a reference.
 
     Parameters
@@ -239,6 +239,7 @@ class PCA(AnalysisBase):
        incorrectly handle cases where the ``frame`` argument
        was passed.
     """
+    _analysis_algorithm_is_parallelizable = False
 
     def __init__(self, universe, select='all', align=False, mean=None,
                  n_components=None, **kwargs):

--- a/testsuite/MDAnalysisTests/analysis/test_pca.py
+++ b/testsuite/MDAnalysisTests/analysis/test_pca.py
@@ -23,6 +23,7 @@
 import numpy as np
 import MDAnalysis as mda
 from MDAnalysis.analysis import align
+import MDAnalysis.analysis.pca
 from MDAnalysis.analysis.pca import (PCA, cosine_content,
                                      rmsip, cumulative_overlap)
 
@@ -384,3 +385,23 @@ def test_pca_attr_warning(u, attr):
     wmsg = f"The `{attr}` attribute was deprecated in MDAnalysis 2.0.0"
     with pytest.warns(DeprecationWarning, match=wmsg):
         getattr(pca, attr) is pca.results[attr]
+
+@pytest.mark.parametrize(
+    "classname,is_parallelizable",
+    [
+        (MDAnalysis.analysis.pca.PCA, False),
+    ]
+)
+def test_class_is_parallelizable(classname, is_parallelizable):
+    assert classname._analysis_algorithm_is_parallelizable == is_parallelizable
+
+
+@pytest.mark.parametrize(
+    "classname,backends",
+    [
+        (MDAnalysis.analysis.pca.PCA,  ('serial',)),
+    ]
+)
+def test_supported_backends(classname, backends):
+    assert classname.get_supported_backends() == backends
+


### PR DESCRIPTION
Fixes #4680

Changes made in this Pull Request:
- PCA explicitly marked as not parallelizable (at least not with simple split-apply-combine)


PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4684.org.readthedocs.build/en/4684/

<!-- readthedocs-preview mdanalysis end -->