### PR TITLE
Fix #4687 -- rdkit values in azure CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -101,7 +101,7 @@ jobs:
     displayName: 'pin to older NumPy (wheel test)'
     condition: and(succeeded(), ne(variables['NUMPY_MIN'], ''))
   - script: >-
-      python -m pip install
+      python -m pip install -vvv
       biopython
       "chemfiles>=0.10,<0.10.4"
       duecredit
@@ -112,8 +112,8 @@ jobs:
       networkx
       parmed
       pytng>=0.2.3
-      tidynamics>=1.0.0
       "rdkit>=2020.03.1,<2024.3.5"
+      tidynamics>=1.0.0
     displayName: 'Install additional dependencies for 64-bit tests'
     condition: and(succeeded(), eq(variables['PYTHON_ARCH'], 'x64'))
   - script: >-

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -113,7 +113,7 @@ jobs:
       parmed
       pytng>=0.2.3
       tidynamics>=1.0.0
-      rdkit>=2020.03.1
+      "rdkit>=2020.03.1,<2024.3.5"
     displayName: 'Install additional dependencies for 64-bit tests'
     condition: and(succeeded(), eq(variables['PYTHON_ARCH'], 'x64'))
   - script: >-

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -112,7 +112,7 @@ jobs:
       networkx
       parmed
       pytng>=0.2.3
-      "rdkit>=2020.03.1,<2024.3.5"
+      rdkit>=2020.03.1
       tidynamics>=1.0.0
     displayName: 'Install additional dependencies for 64-bit tests'
     condition: and(succeeded(), eq(variables['PYTHON_ARCH'], 'x64'))

--- a/package/MDAnalysis/converters/RDKit.py
+++ b/package/MDAnalysis/converters/RDKit.py
@@ -87,7 +87,6 @@ from functools import lru_cache
 from io import StringIO
 
 import numpy as np
-from numpy.lib import NumpyVersion
 
 from . import base
 from ..coordinates import memory
@@ -96,13 +95,8 @@ from ..core.topologyattrs import _TOPOLOGY_ATTRS
 from ..exceptions import NoDataError
 
 try:
-    # TODO: remove this guard when RDKit has a release
-    # that supports NumPy 2
-    if NumpyVersion(np.__version__) < "2.0.0":
-        from rdkit import Chem
-        from rdkit.Chem import AllChem
-    else:
-        raise ImportError
+    from rdkit import Chem
+    from rdkit.Chem import AllChem
 except ImportError:
     pass
 else:

--- a/testsuite/MDAnalysisTests/util.py
+++ b/testsuite/MDAnalysisTests/util.py
@@ -117,7 +117,7 @@ def import_not_available(module_name):
     # TODO: remove once these packages have a release
     # with NumPy 2 support
     if NumpyVersion(np.__version__) >= "2.0.0":
-        if module_name in {"rdkit", "parmed"}:
+        if module_name == "parmed":
             return True
     try:
         test = importlib.import_module(module_name)


### PR DESCRIPTION
Fixes #4687 

It seems like this is not an azure-specific failure, but rather a leftover from the numpy 2.0 migration.


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4688.org.readthedocs.build/en/4688/

<!-- readthedocs-preview mdanalysis end -->