### PR TITLE
Frankenatom fix

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -17,12 +17,12 @@ The rules for this file:
 ??/??/?? IAlibay, HeetVekariya, marinegor, lilyminium, RMeli,
          ljwoods2, aditya292002, pstaerk, PicoCentauri, BFedder,
          tyler.je.reddy, SampurnaM, leonwehrhan, kainszs, orionarcher,
-         yuxuanzhuang, PythonFZ, laksh-krishna-sharma, orbeckst
+         yuxuanzhuang, PythonFZ, laksh-krishna-sharma, orbeckst, MattTDavies
 
  * 2.8.0
 
 Fixes
- * Catch higher dimensional indexing in GroupBase (Issue #4647)
+ * Catch higher dimensional indexing in GroupBase & ComponentBase (Issue #4647)
  * Do not raise an Error reading H5MD files with datasets like
    `observables/<particle>/<property>` (part of Issue #4598, PR #4615)
  * Fix failure in double-serialization of TextIOPicklable file reader.

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -570,7 +570,10 @@ class GroupBase(_MutableBase):
             raise TypeError(errmsg) from None
 
         # indices for the objects I hold
-        self._ix = np.asarray(ix, dtype=np.intp)
+        ix = np.asarray(ix, dtype=np.intp)
+        if ix.ndim > 1:
+            raise IndexError('Group index must be 1d')
+        self._ix = ix
         self._u = u
         self._cache = dict()
 
@@ -597,11 +600,6 @@ class GroupBase(_MutableBase):
                 # hack to make lists into numpy arrays
                 # important for boolean slicing
                 item = np.array(item)
-
-            if isinstance(item, np.ndarray) and item.ndim > 1:
-                # disallow high dimensional indexing.
-                # this doesnt stop the underlying issue
-                raise IndexError('Group index must be 1d')
 
             # We specify _derived_class instead of self.__class__ to allow
             # subclasses, such as UpdatingAtomGroup, to control the class
@@ -4252,6 +4250,9 @@ class ComponentBase(_MutableBase):
 
     def __init__(self, ix, u):
         # index of component
+        if not isinstance(ix, numbers.Integral):
+            raise IndexError('Component can only be indexed by a single integer')
+
         self._ix = ix
         self._u = u
 

--- a/testsuite/MDAnalysisTests/core/test_atom.py
+++ b/testsuite/MDAnalysisTests/core/test_atom.py
@@ -121,6 +121,11 @@ class TestAtom(object):
         atm_in = pickle.loads(pickle.dumps(atm_out))
         assert atm_in == atm_out
 
+    def test_improper_initialisation(self, universe):
+        with pytest.raises(IndexError):
+            indices = [0, 1]
+            mda.core.groups.Atom(indices, universe)
+
 
 class TestAtomNoForceNoVel(object):
     @staticmethod

--- a/testsuite/MDAnalysisTests/core/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/core/test_atomgroup.py
@@ -1237,6 +1237,11 @@ class TestAtomGroup(object):
         with pytest.raises(TypeError):
             mda.core.groups.AtomGroup(['these', 'are', 'not', 'atoms'])
 
+    def test_invalid_index_initialisation(self, universe):
+        indices = [[1,2,3],[4,5,6]]
+        with pytest.raises(IndexError):
+            mda.core.groups.AtomGroup(indices, universe)
+
     def test_n_atoms(self, ag):
         assert ag.n_atoms == 3341
 

--- a/testsuite/MDAnalysisTests/core/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/core/test_atomgroup.py
@@ -1238,7 +1238,8 @@ class TestAtomGroup(object):
             mda.core.groups.AtomGroup(['these', 'are', 'not', 'atoms'])
 
     def test_invalid_index_initialisation(self, universe):
-        indices = [[1,2,3],[4,5,6]]
+        indices = [[1, 2, 3],
+                   [4, 5, 6]]
         with pytest.raises(IndexError):
             mda.core.groups.AtomGroup(indices, universe)
 


### PR DESCRIPTION
Made the "Frankenatom" protection more robust. 
Since indexing initialises a new GroupBase, moving the dimension check to initialisation is more robust as it will also capture incorrectly created atomgroups using the `AtomGroup(indices, universe)` initialisation as well as just when indexing a preexisting atomgroup as was covered previously.

Fixes #4647 

Changes made in this Pull Request:
 - Added index dimension check to GroupBase initialisation
 - Added test for improperly indexed AtomGroup initialisation
 - Removed dimension check during GroupBase indexing
 - Added integral check to CompontBase initialisation index value
 - Added test for improperly indexed Atom initialisation


PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4692.org.readthedocs.build/en/4692/

<!-- readthedocs-preview mdanalysis end -->