### PR TITLE
IMDv3 Integration

### DIFF
--- a/package/MDAnalysis/coordinates/IMD.py
+++ b/package/MDAnalysis/coordinates/IMD.py
@@ -1,0 +1,289 @@
+"""
+
+Example: Streaming an IMD v3 trajectory
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To stream a trajectory from GROMACS or another simulation engine that supports 
+IMD v3, ensure that the simulation engine is running and waiting for an IMD connection.
+
+For example, in GROMACS, you can use ``gmx mdrun`` with the ``-imdwait`` flag
+to ensure that GROMACS will wait for a client before starting the simulation.
+In GROMACS, you will know that the simulation is ready and waiting for the
+MDAnalysis IMDReader client when this line is printed to the terminal:
+
+.. code-block:: none
+
+    IMD: Will wait until I have a connection and IMD_GO orders.
+
+Once the simulation is ready for a client connection, setup your :class:`Universe`
+like this: ::
+
+    import MDAnalysis as mda
+    # Pass host and port of the listening GROMACS simulation
+    # server as the trajectory argument
+    u = mda.Universe("topology.tpr", "localhost:8888")
+
+Classes
+^^^^^^^
+
+.. autoclass:: IMDReader
+   :members:
+   :inherited-members:
+
+"""
+
+import queue
+from MDAnalysis.coordinates.base import (
+    ReaderBase,
+    FrameIteratorIndices,
+    FrameIteratorAll,
+    FrameIteratorSliced,
+)
+from MDAnalysis.coordinates import core
+from MDAnalysis.lib.util import store_init_arguments
+
+import imdclient
+from imdclient.utils import parse_host_port
+import numpy as np
+import logging
+import warnings
+from typing import Optional
+import numbers
+
+logger = logging.getLogger("imdclient.IMDClient")
+
+
+class IMDReader(ReaderBase):
+    """
+    Reader for IMD protocol packets.
+    """
+
+    format = "IMD"
+
+    @store_init_arguments
+    def __init__(
+        self,
+        filename,
+        convert_units=True,
+        n_atoms=None,
+        **kwargs,
+    ):
+        """
+        Parameters
+        ----------
+        filename : a string of the form "host:port" where host is the hostname
+            or IP address of the listening GROMACS server and port
+            is the port number.
+        n_atoms : int (optional)
+            number of atoms in the system. defaults to number of atoms
+            in the topology. don't set this unless you know what you're doing.
+        """
+        self._init_scope = True
+        self._reopen_called = False
+
+        super(IMDReader, self).__init__(filename, **kwargs)
+
+        logger.debug("IMDReader initializing")
+
+        if n_atoms is None:
+            raise ValueError("IMDReader: n_atoms must be specified")
+        self.n_atoms = n_atoms
+
+        host, port = parse_host_port(filename)
+
+        # This starts the simulation
+        self._imdclient = imdclient.IMDClient(host, port, n_atoms, **kwargs)
+
+        imdsinfo = self._imdclient.get_imdsessioninfo()
+        # NOTE: after testing phase, fail out on IMDv2
+
+        self.ts = self._Timestep(
+            self.n_atoms,
+            positions=imdsinfo.positions,
+            velocities=imdsinfo.velocities,
+            forces=imdsinfo.forces,
+            **self._ts_kwargs,
+        )
+
+        self._frame = -1
+
+        try:
+            self._read_next_timestep()
+        except StopIteration:
+            raise RuntimeError("IMDReader: No data found in stream")
+
+    def _read_next_timestep(self):
+        # No rewinding- to both load the first frame after  __init__
+        # and access it again during iteration, we need to store first ts in mem
+        if not self._init_scope and self._frame == -1:
+            self._frame += 1
+            # can't simply return the same ts again- transformations would be applied twice
+            # instead, return the pre-transformed copy
+            return self._first_ts
+
+        return self._read_frame(self._frame + 1)
+
+    def _read_frame(self, frame):
+
+        try:
+            imdf = self._imdclient.get_imdframe()
+        except EOFError:
+            # Not strictly necessary, but for clarity
+            raise StopIteration
+
+        self._frame = frame
+        self._load_imdframe_into_ts(imdf)
+
+        if self._init_scope:
+            self._first_ts = self.ts.copy()
+            self._init_scope = False
+
+        logger.debug(f"IMDReader: Loaded frame {self._frame}")
+        return self.ts
+
+    def _load_imdframe_into_ts(self, imdf):
+        self.ts.frame = self._frame
+        if imdf.time is not None:
+            self.ts.time = imdf.time
+            # NOTE: timestep.pyx "dt" method is suspicious bc it uses "new" keyword for a float
+            self.ts.data["dt"] = imdf.dt
+        if imdf.energies is not None:
+            self.ts.data.update(imdf.energies)
+        if imdf.box is not None:
+            self.ts.dimensions = core.triclinic_box(*imdf.box)
+        if imdf.positions is not None:
+            # must call copy because reference is expected to reset
+            # see 'test_frame_collect_all_same' in MDAnalysisTests.coordinates.base
+            self.ts.positions = imdf.positions
+        if imdf.velocities is not None:
+            self.ts.velocities = imdf.velocities
+        if imdf.forces is not None:
+            self.ts.forces = imdf.forces
+
+    @property
+    def n_frames(self):
+        """Changes as stream is processed unlike other readers"""
+        raise RuntimeError("IMDReader: n_frames is unknown")
+
+    def next(self):
+        """Don't rewind after iteration. When _reopen() is called,
+        an error will be raised
+        """
+        try:
+            ts = self._read_next_timestep()
+        except (EOFError, IOError):
+            # Don't rewind here like we normally would
+            raise StopIteration from None
+        else:
+            for auxname, reader in self._auxs.items():
+                ts = self._auxs[auxname].update_ts(ts)
+
+            ts = self._apply_transformations(ts)
+
+        return ts
+
+    def rewind(self):
+        """Raise error on rewind"""
+        raise RuntimeError("IMDReader: Stream-based readers can't be rewound")
+
+    @staticmethod
+    def _format_hint(thing):
+        try:
+            parse_host_port(thing)
+        except:
+            return False
+        return True
+
+    def close(self):
+        """Gracefully shut down the reader. Stops the producer thread."""
+        logger.debug("IMDReader close() called")
+        self._imdclient.stop()
+        # NOTE: removeme after testing
+        logger.debug("IMDReader shut down gracefully.")
+
+    # Incompatible methods
+    def copy(self):
+        raise NotImplementedError("IMDReader does not support copying")
+
+    def _reopen(self):
+        if self._reopen_called:
+            raise RuntimeError("IMDReader: Cannot reopen IMD stream")
+        self._frame = -1
+        self._reopen_called = True
+
+    def __getitem__(self, frame):
+        """This method from ProtoReader must be overridden
+        to prevent slicing that doesn't make sense in a stream.
+        """
+        raise RuntimeError("IMDReader: Trajectory can only be read in for loop")
+
+    def check_slice_indices(self, start, stop, step):
+        """Check frame indices are valid and clip to fit trajectory.
+
+        The usage follows standard Python conventions for :func:`range` but see
+        the warning below.
+
+        Parameters
+        ----------
+        start : int or None
+          Starting frame index (inclusive). ``None`` corresponds to the default
+          of 0, i.e., the initial frame.
+        stop : int or None
+          Last frame index (exclusive). ``None`` corresponds to the default
+          of n_frames, i.e., it includes the last frame of the trajectory.
+        step : int or None
+          step size of the slice, ``None`` corresponds to the default of 1, i.e,
+          include every frame in the range `start`, `stop`.
+
+        Returns
+        -------
+        start, stop, step : tuple (int, int, int)
+          Integers representing the slice
+
+        Warning
+        -------
+        The returned values `start`, `stop` and `step` give the expected result
+        when passed in :func:`range` but gives unexpected behavior when passed
+        in a :class:`slice` when ``stop=None`` and ``step=-1``
+
+        This can be a problem for downstream processing of the output from this
+        method. For example, slicing of trajectories is implemented by passing
+        the values returned by :meth:`check_slice_indices` to :func:`range` ::
+
+          range(start, stop, step)
+
+        and using them as the indices to randomly seek to. On the other hand,
+        in :class:`MDAnalysis.analysis.base.AnalysisBase` the values returned
+        by :meth:`check_slice_indices` are used to splice the trajectory by
+        creating a :class:`slice` instance ::
+
+          slice(start, stop, step)
+
+        This creates a discrepancy because these two lines are not equivalent::
+
+            range(10, -1, -1)             # [10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
+            range(10)[slice(10, -1, -1)]  # []
+
+        """
+        if start is not None:
+            raise ValueError(
+                "IMDReader: Cannot slice a stream, 'start' must be None"
+            )
+        if stop is not None:
+            raise ValueError(
+                "IMDReader: Cannot slice a stream, 'stop' must be None"
+            )
+        if step is not None:
+            if isinstance(step, numbers.Integral):
+                if step != 1:
+                    raise ValueError(
+                        "IMDReader: Cannot slice a stream, 'step' must be None or 1"
+                    )
+
+        return start, stop, step
+
+    def __getstate__(self):
+        raise NotImplementedError("IMDReader does not support pickling")
+
+    def __setstate__(self, state: object):
+        raise NotImplementedError("IMDReader does not support pickling")

--- a/package/MDAnalysis/coordinates/__init__.py
+++ b/package/MDAnalysis/coordinates/__init__.py
@@ -757,7 +757,7 @@ Methods
    raw :class:`~MDAnalysis.coordinates.Timestep` objects.
 
 """
-__all__ = ['reader', 'writer', 'timestep']
+__all__ = ["reader", "writer", "timestep"]
 
 from . import base
 from . import timestep
@@ -770,6 +770,7 @@ from . import DLPoly
 from . import DMS
 from . import GMS
 from . import GRO
+from . import IMD
 from . import INPCRD
 from . import LAMMPS
 from . import MOL2

--- a/package/pyproject.toml
+++ b/package/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
     'waterdynamics',
     'pathsimanalysis',
     'mdahole2',
+    "imdclient @ git+https://github.com/ljwoods2/imdclient.git@main",
 ]
 keywords = [
     "python", "science", "chemistry", "biophysics", "molecular-dynamics",

--- a/testsuite/MDAnalysisTests/coordinates/test_imd.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_imd.py
@@ -1,0 +1,526 @@
+from MDAnalysisTests.datafiles import (
+    COORDINATES_TOPOLOGY,
+    COORDINATES_TRR,
+    COORDINATES_H5MD,
+)
+import MDAnalysis as mda
+from imdclient.tests.utils import (
+    get_free_port,
+    create_default_imdsinfo_v3,
+)
+
+from imdclient.tests.server import InThreadIMDServer
+from MDAnalysisTests.coordinates.base import (
+    MultiframeReaderTest,
+    BaseReference,
+    BaseWriterTest,
+    assert_timestep_almost_equal,
+)
+from numpy.testing import (
+    assert_almost_equal,
+    assert_array_almost_equal,
+    assert_equal,
+    assert_allclose,
+)
+import numpy as np
+import logging
+import pytest
+from MDAnalysis.transformations import translate
+import pickle
+
+
+logger = logging.getLogger("imdclient.IMDClient")
+file_handler = logging.FileHandler("test.log")
+formatter = logging.Formatter(
+    "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
+file_handler.setFormatter(formatter)
+logger.addHandler(file_handler)
+logger.setLevel(logging.DEBUG)
+
+
+class IMDReference(BaseReference):
+    def __init__(self):
+        super(IMDReference, self).__init__()
+        self.port = get_free_port()
+        # Serve TRR traj data via the server
+        traj = mda.coordinates.TRR.TRRReader(COORDINATES_TRR)
+        self.server = InThreadIMDServer(traj)
+        self.server.set_imdsessioninfo(create_default_imdsinfo_v3())
+
+        self.n_atoms = traj.n_atoms
+        self.prec = 3
+
+        self.trajectory = f"localhost:{self.port}"
+        self.topology = COORDINATES_TOPOLOGY
+        self.changing_dimensions = True
+        self.reader = mda.coordinates.IMD.IMDReader
+
+        self.first_frame.velocities = self.first_frame.positions / 10
+        self.first_frame.forces = self.first_frame.positions / 100
+
+        self.second_frame.velocities = self.second_frame.positions / 10
+        self.second_frame.forces = self.second_frame.positions / 100
+
+        self.last_frame.velocities = self.last_frame.positions / 10
+        self.last_frame.forces = self.last_frame.positions / 100
+
+        self.jump_to_frame.velocities = self.jump_to_frame.positions / 10
+        self.jump_to_frame.forces = self.jump_to_frame.positions / 100
+
+    def iter_ts(self, i):
+        ts = self.first_frame.copy()
+        ts.positions = 2**i * self.first_frame.positions
+        ts.velocities = ts.positions / 10
+        ts.forces = ts.positions / 100
+        ts.time = i
+        ts.frame = i
+        return ts
+
+
+class TestIMDReaderBaseAPI(MultiframeReaderTest):
+
+    @pytest.fixture()
+    def ref(self):
+        """Not a static method like in base class- need new server for each test"""
+        return IMDReference()
+
+    @pytest.fixture()
+    def reader(self, ref):
+        # This will start the test IMD Server, waiting for a connection
+        # to then send handshake & first frame
+        ref.server.handshake_sequence("localhost", ref.port)
+        # This will connect to the test IMD Server and read the first frame
+        reader = ref.reader(ref.trajectory, n_atoms=ref.n_atoms)
+        # Send the rest of the frames- small enough to all fit in socket itself
+        ref.server.send_frames(1, 5)
+
+        reader.add_auxiliary(
+            "lowf",
+            ref.aux_lowf,
+            dt=ref.aux_lowf_dt,
+            initial_time=0,
+            time_selector=None,
+        )
+        reader.add_auxiliary(
+            "highf",
+            ref.aux_highf,
+            dt=ref.aux_highf_dt,
+            initial_time=0,
+            time_selector=None,
+        )
+        return reader
+
+    @pytest.fixture()
+    def transformed(self, ref):
+        # This will start the test IMD Server, waiting for a connection
+        # to then send handshake & first frame
+        ref.server.handshake_sequence("localhost", ref.port)
+        # This will connect to the test IMD Server and read the first frame
+        transformed = ref.reader(ref.trajectory, n_atoms=ref.n_atoms)
+        # Send the rest of the frames- small enough to all fit in socket itself
+        ref.server.send_frames(1, 5)
+        transformed.add_transformations(
+            translate([1, 1, 1]), translate([0, 0, 0.33])
+        )
+        return transformed
+
+    @pytest.mark.skip(
+        reason="Stream-based reader cannot determine n_frames until EOF"
+    )
+    def test_n_frames(self, reader, ref):
+        assert_equal(
+            self.universe.trajectory.n_frames,
+            1,
+            "wrong number of frames in pdb",
+        )
+
+    def test_first_frame(self, ref, reader):
+        # don't rewind here as in inherited base test
+        assert_timestep_almost_equal(
+            reader.ts, ref.first_frame, decimal=ref.prec
+        )
+
+    @pytest.mark.skip(reason="IMD is not a writeable format")
+    def test_get_writer_1(self, ref, reader, tmpdir):
+        with tmpdir.as_cwd():
+            outfile = "test-writer." + ref.ext
+            with reader.Writer(outfile) as W:
+                assert_equal(isinstance(W, ref.writer), True)
+                assert_equal(W.n_atoms, reader.n_atoms)
+
+    @pytest.mark.skip(reason="IMD is not a writeable format")
+    def test_get_writer_2(self, ref, reader, tmpdir):
+        with tmpdir.as_cwd():
+            outfile = "test-writer." + ref.ext
+            with reader.Writer(outfile, n_atoms=100) as W:
+                assert_equal(isinstance(W, ref.writer), True)
+                assert_equal(W.n_atoms, 100)
+
+    @pytest.mark.skip(
+        reason="Stream-based reader cannot determine total_time until EOF"
+    )
+    def test_total_time(self, reader, ref):
+        assert_almost_equal(reader.totaltime, ref.totaltime, decimal=ref.prec)
+
+    @pytest.mark.skip(reason="Stream-based reader can only be read iteratively")
+    def test_changing_dimensions(self, ref, reader):
+        if ref.changing_dimensions:
+            reader.rewind()
+            if ref.dimensions is None:
+                assert reader.ts.dimensions is None
+            else:
+                assert_array_almost_equal(
+                    reader.ts.dimensions, ref.dimensions, decimal=ref.prec
+                )
+            reader[1]
+            if ref.dimensions_second_frame is None:
+                assert reader.ts.dimensions is None
+            else:
+                assert_array_almost_equal(
+                    reader.ts.dimensions,
+                    ref.dimensions_second_frame,
+                    decimal=ref.prec,
+                )
+
+    def test_iter(self, ref, reader):
+        for i, ts in enumerate(reader):
+            assert_timestep_almost_equal(ts, ref.iter_ts(i), decimal=ref.prec)
+
+    def test_first_dimensions(self, ref, reader):
+        # don't rewind here as in inherited base test
+        if ref.dimensions is None:
+            assert reader.ts.dimensions is None
+        else:
+            assert_array_almost_equal(
+                reader.ts.dimensions, ref.dimensions, decimal=ref.prec
+            )
+
+    def test_volume(self, ref, reader):
+        # don't rewind here as in inherited base test
+        vol = reader.ts.volume
+        # Here we can only be sure about the numbers upto the decimal point due
+        # to floating point impressions.
+        assert_almost_equal(vol, ref.volume, 0)
+
+    @pytest.mark.skip(reason="Cannot create new reader from same stream")
+    def test_reload_auxiliaries_from_description(self, ref, reader):
+        # get auxiliary desscriptions form existing reader
+        descriptions = reader.get_aux_descriptions()
+        # load a new reader, without auxiliaries
+        reader = ref.reader(ref.trajectory)
+        # load auxiliaries into new reader, using description...
+        for aux in descriptions:
+            reader.add_auxiliary(**aux)
+        # should have the same number of auxiliaries
+        assert_equal(
+            reader.aux_list,
+            reader.aux_list,
+            "Number of auxiliaries does not match",
+        )
+        # each auxiliary should be the same
+        for auxname in reader.aux_list:
+            assert_equal(
+                reader._auxs[auxname],
+                reader._auxs[auxname],
+                "AuxReaders do not match",
+            )
+
+    @pytest.mark.skip(reason="Stream can only be read in for loop")
+    def test_stop_iter(self, reader):
+        # reset to 0
+        reader.rewind()
+        for ts in reader[:-1]:
+            pass
+        assert_equal(reader.frame, 0)
+
+    @pytest.mark.skip(reason="Cannot rewind stream")
+    def test_iter_rewinds(self, reader, accessor):
+        for ts_indices in accessor(reader):
+            pass
+        assert_equal(ts_indices.frame, 0)
+
+    @pytest.mark.skip(
+        reason="Timeseries currently requires n_frames to be known"
+    )
+    @pytest.mark.parametrize(
+        "order", ("fac", "fca", "afc", "acf", "caf", "cfa")
+    )
+    def test_timeseries_shape(self, reader, order):
+        timeseries = reader.timeseries(order=order)
+        a_index = order.index("a")
+        # f_index = order.index("f")
+        c_index = order.index("c")
+        assert timeseries.shape[a_index] == reader.n_atoms
+        # assert timeseries.shape[f_index] == len(reader)
+        assert timeseries.shape[c_index] == 3
+
+    @pytest.mark.skip(
+        reason="Timeseries currently requires n_frames to be known"
+    )
+    @pytest.mark.parametrize("asel", ("index 1", "index 2", "index 1 to 3"))
+    def test_timeseries_asel_shape(self, reader, asel):
+        atoms = mda.Universe(reader.filename).select_atoms(asel)
+        timeseries = reader.timeseries(atoms, order="fac")
+        assert timeseries.shape[0] == len(reader)
+        assert timeseries.shape[1] == len(atoms)
+        assert timeseries.shape[2] == 3
+
+    @pytest.mark.skip("Cannot slice stream")
+    @pytest.mark.parametrize("slice", ([0, 2, 1], [0, 10, 2], [0, 10, 3]))
+    def test_timeseries_values(self, reader, slice):
+        ts_positions = []
+        if isinstance(reader, mda.coordinates.memory.MemoryReader):
+            pytest.xfail(
+                "MemoryReader uses deprecated stop inclusive"
+                " indexing, see Issue #3893"
+            )
+        if slice[1] > len(reader):
+            pytest.skip("too few frames in reader")
+        for i in range(slice[0], slice[1], slice[2]):
+            ts = reader[i]
+            ts_positions.append(ts.positions.copy())
+        positions = np.asarray(ts_positions)
+        timeseries = reader.timeseries(
+            start=slice[0], stop=slice[1], step=slice[2], order="fac"
+        )
+        assert_allclose(timeseries, positions)
+
+    @pytest.mark.skip(reason="Cannot rewind stream")
+    def test_transformations_2iter(self, ref, transformed):
+        # Are the transformations applied and
+        # are the coordinates "overtransformed"?
+        v1 = np.float32((1, 1, 1))
+        v2 = np.float32((0, 0, 0.33))
+        idealcoords = []
+        for i, ts in enumerate(transformed):
+            idealcoords.append(ref.iter_ts(i).positions + v1 + v2)
+            assert_array_almost_equal(
+                ts.positions, idealcoords[i], decimal=ref.prec
+            )
+
+        for i, ts in enumerate(transformed):
+            assert_almost_equal(ts.positions, idealcoords[i], decimal=ref.prec)
+
+    @pytest.mark.skip(reason="Cannot slice stream")
+    def test_transformations_slice(self, ref, transformed):
+        # Are the transformations applied when iterating over a slice of the trajectory?
+        v1 = np.float32((1, 1, 1))
+        v2 = np.float32((0, 0, 0.33))
+        for i, ts in enumerate(transformed[2:3:1]):
+            idealcoords = ref.iter_ts(ts.frame).positions + v1 + v2
+            assert_array_almost_equal(
+                ts.positions, idealcoords, decimal=ref.prec
+            )
+
+    @pytest.mark.skip(reason="Cannot slice stream")
+    def test_transformations_switch_frame(self, ref, transformed):
+        # This test checks if the transformations are applied and if the coordinates
+        # "overtransformed" on different situations
+        # Are the transformations applied when we switch to a different frame?
+        v1 = np.float32((1, 1, 1))
+        v2 = np.float32((0, 0, 0.33))
+        first_ideal = ref.iter_ts(0).positions + v1 + v2
+        if len(transformed) > 1:
+            assert_array_almost_equal(
+                transformed[0].positions, first_ideal, decimal=ref.prec
+            )
+            second_ideal = ref.iter_ts(1).positions + v1 + v2
+            assert_array_almost_equal(
+                transformed[1].positions, second_ideal, decimal=ref.prec
+            )
+
+            # What if we comeback to the previous frame?
+            assert_array_almost_equal(
+                transformed[0].positions, first_ideal, decimal=ref.prec
+            )
+
+            # How about we switch the frame to itself?
+            assert_array_almost_equal(
+                transformed[0].positions, first_ideal, decimal=ref.prec
+            )
+        else:
+            assert_array_almost_equal(
+                transformed[0].positions, first_ideal, decimal=ref.prec
+            )
+
+    @pytest.mark.skip(reason="Cannot rewind stream")
+    def test_transformation_rewind(self, ref, transformed):
+        # this test checks if the transformations are applied after rewinding the
+        # trajectory
+        v1 = np.float32((1, 1, 1))
+        v2 = np.float32((0, 0, 0.33))
+        ideal_coords = ref.iter_ts(0).positions + v1 + v2
+        transformed.rewind()
+        assert_array_almost_equal(
+            transformed[0].positions, ideal_coords, decimal=ref.prec
+        )
+
+    @pytest.mark.skip(reason="Cannot make a copy of a stream")
+    def test_copy(self, ref, transformed):
+        # this test checks if transformations are carried over a copy and if the
+        # coordinates of the copy are equal to the original's
+        v1 = np.float32((1, 1, 1))
+        v2 = np.float32((0, 0, 0.33))
+        new = transformed.copy()
+        assert_equal(
+            transformed.transformations,
+            new.transformations,
+            "transformations are not equal",
+        )
+        for i, ts in enumerate(new):
+            ideal_coords = ref.iter_ts(i).positions + v1 + v2
+            assert_array_almost_equal(
+                ts.positions, ideal_coords, decimal=ref.prec
+            )
+
+    @pytest.mark.skip(reason="Cannot pickle socket")
+    def test_pickle_reader(self, reader):
+        """It probably wouldn't be a good idea to pickle a
+        reader that is connected to a server"""
+        reader_p = pickle.loads(pickle.dumps(reader))
+        assert_equal(len(reader), len(reader_p))
+        assert_equal(
+            reader.ts, reader_p.ts, "Timestep is changed after pickling"
+        )
+
+    @pytest.mark.skip(reason="Cannot pickle socket")
+    def test_pickle_next_ts_reader(self, reader):
+        reader_p = pickle.loads(pickle.dumps(reader))
+        assert_equal(
+            next(reader),
+            next(reader_p),
+            "Next timestep is changed after pickling",
+        )
+
+    @pytest.mark.skip(reason="Cannot pickle socket")
+    def test_pickle_last_ts_reader(self, reader):
+        #  move current ts to last frame.
+        reader[-1]
+        reader_p = pickle.loads(pickle.dumps(reader))
+        assert_equal(
+            len(reader),
+            len(reader_p),
+            "Last timestep is changed after pickling",
+        )
+        assert_equal(
+            reader.ts, reader_p.ts, "Last timestep is changed after pickling"
+        )
+
+    @pytest.mark.skip(reason="Cannot copy stream")
+    def test_transformations_copy(self, ref, transformed):
+        # this test checks if transformations are carried over a copy and if the
+        # coordinates of the copy are equal to the original's
+        v1 = np.float32((1, 1, 1))
+        v2 = np.float32((0, 0, 0.33))
+        new = transformed.copy()
+        assert_equal(
+            transformed.transformations,
+            new.transformations,
+            "transformations are not equal",
+        )
+        for i, ts in enumerate(new):
+            ideal_coords = ref.iter_ts(i).positions + v1 + v2
+            assert_array_almost_equal(
+                ts.positions, ideal_coords, decimal=ref.prec
+            )
+
+    @pytest.mark.skip(
+        reason="Timeseries currently requires n_frames to be known"
+    )
+    def test_timeseries_empty_asel(self, reader):
+        with pytest.warns(
+            UserWarning,
+            match="Empty string to select atoms, empty group returned.",
+        ):
+            atoms = mda.Universe(reader.filename).select_atoms(None)
+        with pytest.raises(ValueError, match="Timeseries requires at least"):
+            reader.timeseries(asel=atoms)
+
+    @pytest.mark.skip(
+        reason="Timeseries currently requires n_frames to be known"
+    )
+    def test_timeseries_empty_atomgroup(self, reader):
+        with pytest.warns(
+            UserWarning,
+            match="Empty string to select atoms, empty group returned.",
+        ):
+            atoms = mda.Universe(reader.filename).select_atoms(None)
+        with pytest.raises(ValueError, match="Timeseries requires at least"):
+            reader.timeseries(atomgroup=atoms)
+
+    @pytest.mark.skip(
+        reason="Timeseries currently requires n_frames to be known"
+    )
+    def test_timeseries_asel_warns_deprecation(self, reader):
+        atoms = mda.Universe(reader.filename).select_atoms("index 1")
+        with pytest.warns(DeprecationWarning, match="asel argument to"):
+            timeseries = reader.timeseries(asel=atoms, order="fac")
+
+    @pytest.mark.skip(
+        reason="Timeseries currently requires n_frames to be known"
+    )
+    def test_timeseries_atomgroup(self, reader):
+        atoms = mda.Universe(reader.filename).select_atoms("index 1")
+        timeseries = reader.timeseries(atomgroup=atoms, order="fac")
+
+    @pytest.mark.skip(
+        reason="Timeseries currently requires n_frames to be known"
+    )
+    def test_timeseries_atomgroup_asel_mutex(self, reader):
+        atoms = mda.Universe(reader.filename).select_atoms("index 1")
+        with pytest.raises(ValueError, match="Cannot provide both"):
+            timeseries = reader.timeseries(
+                atomgroup=atoms, asel=atoms, order="fac"
+            )
+
+    @pytest.mark.skip("Cannot slice stream")
+    def test_last_frame(self, ref, reader):
+        ts = reader[-1]
+        assert_timestep_almost_equal(ts, ref.last_frame, decimal=ref.prec)
+
+    @pytest.mark.skip("Cannot slice stream")
+    def test_go_over_last_frame(self, ref, reader):
+        with pytest.raises(IndexError):
+            reader[ref.n_frames + 1]
+
+    @pytest.mark.skip("Cannot slice stream")
+    def test_frame_jump(self, ref, reader):
+        ts = reader[ref.jump_to_frame.frame]
+        assert_timestep_almost_equal(ts, ref.jump_to_frame, decimal=ref.prec)
+
+    @pytest.mark.skip("Cannot slice stream")
+    def test_frame_jump_issue1942(self, ref, reader):
+        """Test for issue 1942 (especially XDR on macOS)"""
+        reader.rewind()
+        try:
+            for ii in range(ref.n_frames + 2):
+                reader[0]
+        except StopIteration:
+            pytest.fail("Frame-seeking wrongly iterated (#1942)")
+
+    def test_next_gives_second_frame(self, ref, reader):
+        # don't recreate reader here as in inherited base test
+        ts = reader.next()
+        assert_timestep_almost_equal(ts, ref.second_frame, decimal=ref.prec)
+
+    @pytest.mark.skip(
+        reason="Stream isn't rewound after iteration- base reference is the same but it is the last frame"
+    )
+    def test_frame_collect_all_same(self, reader):
+        # check that the timestep resets so that the base reference is the same
+        # for all timesteps in a collection with the exception of memoryreader
+        # and DCDReader
+        if isinstance(reader, mda.coordinates.memory.MemoryReader):
+            pytest.xfail("memoryreader allows independent coordinates")
+        if isinstance(reader, mda.coordinates.DCD.DCDReader):
+            pytest.xfail(
+                "DCDReader allows independent coordinates."
+                "This behaviour is deprecated and will be changed"
+                "in 3.0"
+            )
+        collected_ts = []
+        for i, ts in enumerate(reader):
+            collected_ts.append(ts.positions)
+        for array in collected_ts:
+            assert_allclose(array, collected_ts[0])


### PR DESCRIPTION
Draft PR for integrating the IMD (Interactive Molecular Dynamics) new v3 protocol into MDAnalysis. 

The IMDReader hooks into the [IMDClient](https://github.com/ljwoods2/imdclient) API, which is comprised of 4 methods:

```
__init__(): Connect to the simulation engine and send it a go signal to start sending IMD data

get_imdsessioninfo(): Returns an `IMDSessionInfo` object which contains info on whether xvf/energies/dimensions are sent in the stream

get_imdframe(): Returns an `IMDFrame` or raises EOFError if the IMD stream is over

stop(): Cleanup method that ensures the `IMDClient` disconnects from the simulation server
```

There are a few different alternatives for how the IMDReader is integrated into MDAnalysis.

## IMDReader in main codebase, IMDClient in a separate (non-MDAKit) repo

The first rule of MDAKits is don't talk about MDAKits. The second first rule is that an MDAKit [has to actually use MDAnalysis](https://mdakits.mdanalysis.org/makingakit.html), so if the IMDReader is in this codebase, IMDClient can't be an MDAKit.

The advantage of splitting up the classes like this is that:

1. Users can use IMDv3 in MDAnalysis without installing additional packages
2. IMDClient remains decoupled from MDAnalysis, meaning other groups can use the client to parse IMDv3 streams
3. The IMDClient is free to do time-consuming and client-specific tasks like:
    - Test the IMDClient's ability to automatically pause a running simulation when its buffer fills, which is a complex multithreaded testcase that looks nothing like anything else in MDAnalysis. [Here's some example tests](https://github.com/ljwoods2/imdclient/blob/main/imdclient/tests/test_imdclient.py)
    - Build simulation engines that implement IMDv3 in the CI and test them against the client. These tests will potentially take several hours but add a lot of value. For example, LAMMPS offers several compiler options that impact IMD which are currently untested in the LAMMPS codebase. These options could be tested in the CI for different releases and on the develop branch. Example LAMMPS integration test class: [base class](https://github.com/ljwoods2/imdclient/blob/main/imdclient/tests/base.py), [lammps class](https://github.com/ljwoods2/imdclient/blob/main/imdclient/tests/test_lammps.py)

This is the solution I'm most excited about and that this PR illustrates, but I can see that having the IMDReader and IMDClient in separate repos could create an integration challenge if the IMDClient needs to change significantly in ways that impact the API.

## IMDReader & IMDClient in an MDAKit

This option still allows the client to be distributed separately from MDAnalysis and still allows more complex CI usage to stay out of the main codebase, but makes it so that users of MDA will have to install an additional package to use the IMDReader

## IMDReader & IMDClient in MDAnalysis main codebase

I feel strongly that this is not a good idea. The IMDClient tests would add complexity and runtime to an already complex MDA CI/CD pipeline, add a (very annoying, multithreaded) maintenance burden to core MDA developers, makes IMDClient unusable by other groups, and makes it more difficult to make rapid future changes to the IMDClient (like potentially replacing the implementation of socket interaction codes with Cython while keeping the API the same).


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4694.org.readthedocs.build/en/4694/

<!-- readthedocs-preview mdanalysis end -->