### PR TITLE
Add black configuration ignoring all files

### DIFF
--- a/package/pyproject.toml
+++ b/package/pyproject.toml
@@ -118,3 +118,8 @@ find = {}
 MDAnalysis = [
     'analysis/data/*.npy',
 ]
+
+[tool.black]
+line-length = 79
+target-version = ['py39', 'py310', 'py311', 'py312']
+extend-exclude = '.'

--- a/package/pyproject.toml
+++ b/package/pyproject.toml
@@ -123,3 +123,4 @@ MDAnalysis = [
 line-length = 79
 target-version = ['py39', 'py310', 'py311', 'py312']
 extend-exclude = '.'
+required-version = '24'

--- a/package/pyproject.toml
+++ b/package/pyproject.toml
@@ -121,6 +121,6 @@ MDAnalysis = [
 
 [tool.black]
 line-length = 79
-target-version = ['py39', 'py310', 'py311', 'py312']
+target-version = ['py310', 'py311', 'py312']
 extend-exclude = '.'
 required-version = '24'

--- a/testsuite/pyproject.toml
+++ b/testsuite/pyproject.toml
@@ -151,3 +151,8 @@ filterwarnings = [
     # NamedStream warnings
     "ignore:Constructed NamedStream:RuntimeWarning",
 ]
+
+[tool.black]
+line-length = 79
+target-version = ['py39', 'py310', 'py311', 'py312']
+extend-exclude = '.'

--- a/testsuite/pyproject.toml
+++ b/testsuite/pyproject.toml
@@ -156,3 +156,4 @@ filterwarnings = [
 line-length = 79
 target-version = ['py39', 'py310', 'py311', 'py312']
 extend-exclude = '.'
+required-version = '24'

--- a/testsuite/pyproject.toml
+++ b/testsuite/pyproject.toml
@@ -154,6 +154,6 @@ filterwarnings = [
 
 [tool.black]
 line-length = 79
-target-version = ['py39', 'py310', 'py311', 'py312']
+target-version = ['py310', 'py311', 'py312']
 extend-exclude = '.'
 required-version = '24'


### PR DESCRIPTION
Prepare work for addressing #2450, should the developers agree to move forward with adopting `black` as code formatter and incrementally format the whole code base.

This is a companion PR to https://github.com/MDAnalysis/UserGuide/pull/383, which explains the developer workflow for using `black`.

At the beginning, `black package` and `black testsuite` will do nothing (all files are ignored in this PR):

```
No Python files are present to be formatted. Nothing to do 😴
```

Files will be formatted and included incrementally.

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4717.org.readthedocs.build/en/4717/

<!-- readthedocs-preview mdanalysis end -->