### PR TITLE
Implementation of Parallelization to analysis.hydrogenbonds.hbond_analysis

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -59,6 +59,7 @@ Enhancements
  * Enables parallelization for analysis.gnm.GNMAnalysis (Issue #4672)
  * explicitly mark `analysis.pca.PCA` as not parallelizable (Issue #4680)
  * enables parallelization for analysis.bat.BAT (Issue #4663)
+ * Enables parallelization for analysis.hydrogenbonds.hbond_analysis.HydrogenBondAnalysis (Issue #4664)
  * Improve error message for `AtomGroup.unwrap()` when bonds are not present.(Issue #4436, PR #4642)
  * Add `analysis.DSSP` module for protein secondary structure assignment, based on [pydssp](https://github.com/ShintaroMinami/PyDSSP)
  * Added a tqdm progress bar for `MDAnalysis.analysis.pca.PCA.transform()`

--- a/package/MDAnalysis/analysis/hydrogenbonds/hbond_analysis.py
+++ b/package/MDAnalysis/analysis/hydrogenbonds/hbond_analysis.py
@@ -267,7 +267,7 @@ class HydrogenBondAnalysis(AnalysisBase):
     Perform an analysis of hydrogen bonds in a Universe.
     """
 
-      _analysis_algorithm_is_parallelizable = True
+    _analysis_algorithm_is_parallelizable = True
 
     @classmethod
     def get_supported_backends(cls):

--- a/package/MDAnalysis/analysis/hydrogenbonds/hbond_analysis.py
+++ b/package/MDAnalysis/analysis/hydrogenbonds/hbond_analysis.py
@@ -389,6 +389,17 @@ class HydrogenBondAnalysis(AnalysisBase):
         self.results = Results()
         self.results.hbonds = None
 
+        # Set atom selections if they have not been provided
+        if self.acceptors_sel is None:
+            self.acceptors_sel = self.guess_acceptors()
+        if self.hydrogens_sel is None:
+            self.hydrogens_sel = self.guess_hydrogens()
+
+        # Select atom groups
+        self._acceptors = self.u.select_atoms(self.acceptors_sel,
+                                              updating=self.update_selections)
+        self._donors, self._hydrogens = self._get_dh_pairs()
+
     def guess_hydrogens(self,
                         select='all',
                         max_mass=1.1,
@@ -705,16 +716,6 @@ class HydrogenBondAnalysis(AnalysisBase):
     def _prepare(self):
         self.results.hbonds = [[], [], [], [], [], []]
 
-        # Set atom selections if they have not been provided
-        if self.acceptors_sel is None:
-            self.acceptors_sel = self.guess_acceptors()
-        if self.hydrogens_sel is None:
-            self.hydrogens_sel = self.guess_hydrogens()
-
-        # Select atom groups
-        self._acceptors = self.u.select_atoms(self.acceptors_sel,
-                                              updating=self.update_selections)
-        self._donors, self._hydrogens = self._get_dh_pairs()
 
     def _single_frame(self):
 

--- a/package/MDAnalysis/analysis/hydrogenbonds/hbond_analysis.py
+++ b/package/MDAnalysis/analysis/hydrogenbonds/hbond_analysis.py
@@ -241,7 +241,7 @@ from collections.abc import Iterable
 
 import numpy as np
 
-from ..base import AnalysisBase, Results
+from ..base import AnalysisBase, Results, ResultsGroup
 from MDAnalysis.lib.distances import capped_distance, calc_angles
 from MDAnalysis.lib.correlations import autocorrelation, correct_intermittency
 from MDAnalysis.exceptions import NoDataError
@@ -266,6 +266,12 @@ class HydrogenBondAnalysis(AnalysisBase):
     """
     Perform an analysis of hydrogen bonds in a Universe.
     """
+
+      _analysis_algorithm_is_parallelizable = True
+
+    @classmethod
+    def get_supported_backends(cls):
+        return ('serial', 'multiprocessing', 'dask',)
 
     def __init__(self, universe,
                  donors_sel=None, hydrogens_sel=None, acceptors_sel=None,
@@ -787,6 +793,9 @@ class HydrogenBondAnalysis(AnalysisBase):
     def _conclude(self):
 
         self.results.hbonds = np.asarray(self.results.hbonds).T
+
+    def _get_aggregator(self):
+        return ResultsGroup(lookup={'hbonds': ResultsGroup.ndarray_hstack})
 
     @property
     def hbonds(self):

--- a/package/MDAnalysis/analysis/hydrogenbonds/hbond_analysis.py
+++ b/package/MDAnalysis/analysis/hydrogenbonds/hbond_analysis.py
@@ -341,7 +341,9 @@ class HydrogenBondAnalysis(AnalysisBase):
         .. versionchanged:: 2.4.0
             Added use of atom types in selection strings for hydrogen atoms, 
             bond donors, or bond acceptors
-
+        .. versionchanged:: 2.8.0
+            Introduced :meth:`get_supported_backends` allowing for parallel execution on
+            :mod:`multiprocessing` and :mod:`dask` backends.
         """
 
         self.u = universe

--- a/testsuite/MDAnalysisTests/analysis/conftest.py
+++ b/testsuite/MDAnalysisTests/analysis/conftest.py
@@ -10,6 +10,7 @@ from MDAnalysis.analysis.rms import RMSD, RMSF
 from MDAnalysis.analysis.bat import BAT
 from MDAnalysis.lib.util import is_installed
 from MDAnalysis.analysis.gnm import GNMAnalysis
+from MDAnalysis.analysis.hydrogenbonds.hbond_analysis import HydrogenBondAnalysis
 
 
 def params_for_cls(cls, exclude: list[str] = None):
@@ -99,3 +100,8 @@ def client_GNMAnalysis(request):
 @pytest.fixture(scope='module', params=params_for_cls(BAT))
 def client_BAT(request):
   return request.param
+
+
+@pytest.fixture(scope='module', params=params_for_cls(HydrogenBondAnalysis))
+def client_HydrogenBondAnalysis(request):
+    return request.param

--- a/testsuite/MDAnalysisTests/analysis/conftest.py
+++ b/testsuite/MDAnalysisTests/analysis/conftest.py
@@ -127,6 +127,7 @@ def client_GNMAnalysis(request):
 def client_BAT(request):
     return request.param
 
+# MDAnalysis.analysis.hydrogenbonds
   
 @pytest.fixture(scope='module', params=params_for_cls(HydrogenBondAnalysis))
 def client_HydrogenBondAnalysis(request):

--- a/testsuite/MDAnalysisTests/analysis/conftest.py
+++ b/testsuite/MDAnalysisTests/analysis/conftest.py
@@ -10,7 +10,9 @@ from MDAnalysis.analysis.rms import RMSD, RMSF
 from MDAnalysis.analysis.bat import BAT
 from MDAnalysis.lib.util import is_installed
 from MDAnalysis.analysis.gnm import GNMAnalysis
-from MDAnalysis.analysis.hydrogenbonds.hbond_analysis import HydrogenBondAnalysis
+from MDAnalysis.analysis.hydrogenbonds.hbond_analysis import (
+    HydrogenBondAnalysis,
+)
 
 
 def params_for_cls(cls, exclude: list[str] = None):
@@ -99,7 +101,7 @@ def client_GNMAnalysis(request):
   
 @pytest.fixture(scope='module', params=params_for_cls(BAT))
 def client_BAT(request):
-  return request.param
+    return request.param
 
 
 @pytest.fixture(scope='module', params=params_for_cls(HydrogenBondAnalysis))

--- a/testsuite/MDAnalysisTests/analysis/test_hydrogenbonds_analysis.py
+++ b/testsuite/MDAnalysisTests/analysis/test_hydrogenbonds_analysis.py
@@ -53,9 +53,9 @@ class TestHydrogenBondAnalysisTIP3P(object):
     }
 
     @pytest.fixture(scope='class')
-    def h(self, universe):
+    def h(self, universe, client_HydrogenBondAnalysis):
         h = HydrogenBondAnalysis(universe, **self.kwargs)
-        h.run()
+        h.run(**client_HydrogenBondAnalysis)
         return h
 
     def test_hbond_analysis(self, h):
@@ -181,12 +181,12 @@ class TestHydrogenBondAnalysisIdeal(object):
 
     @staticmethod
     @pytest.fixture(scope='class')
-    def hydrogen_bonds(universe):
+    def hydrogen_bonds(universe, client_HydrogenBondAnalysis):
         h = HydrogenBondAnalysis(
             universe,
             **TestHydrogenBondAnalysisIdeal.kwargs
         )
-        h.run()
+        h.run(**client_HydrogenBondAnalysis)
         return h
 
     def test_count_by_type(self, hydrogen_bonds):
@@ -263,10 +263,10 @@ class TestHydrogenBondAnalysisIdeal(object):
         with pytest.raises(NoDataError, match=".hbonds attribute is None"):
             hbonds.lifetime(tau_max=2, intermittency=1)
 
-    def test_logging_step_not_1(self, universe, caplog):
+    def test_logging_step_not_1(self, universe, caplog, client_HydrogenBondAnalysis):
         hbonds = HydrogenBondAnalysis(universe, **self.kwargs)
         # using step 2
-        hbonds.run(step=2)
+        hbonds.run(**client_HydrogenBondAnalysis, step=2)
 
         caplog.set_level(logging.WARNING)
         hbonds.lifetime(tau_max=2, intermittency=1)
@@ -342,12 +342,12 @@ class TestHydrogenBondAnalysisNoRes(TestHydrogenBondAnalysisIdeal):
 
     @staticmethod
     @pytest.fixture(scope='class')
-    def hydrogen_bonds(universe):
+    def hydrogen_bonds(universe, client_HydrogenBondAnalysis):
         h = HydrogenBondAnalysis(
             universe,
             **TestHydrogenBondAnalysisNoRes.kwargs
         )
-        h.run()
+        h.run(**client_HydrogenBondAnalysis)
         return h
 
     def test_no_hydrogen_bonds(self, universe):
@@ -441,10 +441,10 @@ class TestHydrogenBondAnalysisBetween(object):
 
         return u
 
-    def test_between_all(self, universe):
+    def test_between_all(self, universe, client_HydrogenBondAnalysis):
         # don't specify groups between which to find hydrogen bonds
         hbonds = HydrogenBondAnalysis(universe, between=None, **self.kwargs)
-        hbonds.run()
+        hbonds.run(**client_HydrogenBondAnalysis)
 
         # indices of [donor, hydrogen, acceptor] for each hydrogen bond
         expected_hbond_indices = [
@@ -457,14 +457,14 @@ class TestHydrogenBondAnalysisBetween(object):
                            expected_hbond_indices)
         assert_allclose(hbonds.results.hbonds[:, 4], expected_hbond_distances)
 
-    def test_between_PW(self, universe):
+    def test_between_PW(self, universe, client_HydrogenBondAnalysis):
         # Find only protein-water hydrogen bonds
         hbonds = HydrogenBondAnalysis(
             universe,
             between=["resname PROT", "resname SOL"],
             **self.kwargs
         )
-        hbonds.run()
+        hbonds.run(**client_HydrogenBondAnalysis)
 
         # indices of [donor, hydrogen, acceptor] for each hydrogen bond
         expected_hbond_indices = [
@@ -475,7 +475,7 @@ class TestHydrogenBondAnalysisBetween(object):
                            expected_hbond_indices)
         assert_allclose(hbonds.results.hbonds[:, 4], expected_hbond_distances)
 
-    def test_between_PW_PP(self, universe):
+    def test_between_PW_PP(self, universe, client_HydrogenBondAnalysis):
         # Find protein-water and protein-protein hydrogen bonds (not
         # water-water)
         hbonds = HydrogenBondAnalysis(
@@ -486,7 +486,7 @@ class TestHydrogenBondAnalysisBetween(object):
             ],
             **self.kwargs
         )
-        hbonds.run()
+        hbonds.run(**client_HydrogenBondAnalysis)
 
         # indices of [donor, hydrogen, acceptor] for each hydrogen bond
         expected_hbond_indices = [
@@ -512,7 +512,7 @@ class TestHydrogenBondAnalysisTIP3P_GuessAcceptors_GuessHydrogens_UseTopology_(T
         'd_h_a_angle_cutoff': 120.0
     }
 
-    def test_no_hydrogens(self, universe):
+    def test_no_hydrogens(self, universe, client_HydrogenBondAnalysis):
         # If no hydrogens are identified at a given frame, check an
         # empty donor atom group is created
         test_kwargs = TestHydrogenBondAnalysisTIP3P.kwargs.copy()
@@ -520,7 +520,7 @@ class TestHydrogenBondAnalysisTIP3P_GuessAcceptors_GuessHydrogens_UseTopology_(T
         test_kwargs['hydrogens_sel'] = "name H"  # no atoms have name H
 
         h = HydrogenBondAnalysis(universe, **test_kwargs)
-        h.run()
+        h.run(**client_HydrogenBondAnalysis)
 
         assert h._hydrogens.n_atoms == 0
         assert h._donors.n_atoms == 0
@@ -629,9 +629,9 @@ class TestHydrogenBondAnalysisTIP3PStartStep(object):
     }
 
     @pytest.fixture(scope='class')
-    def h(self, universe):
+    def h(self, universe, client_HydrogenBondAnalysis):
         h = HydrogenBondAnalysis(universe, **self.kwargs)
-        h.run(start=1, step=2)
+        h.run(**client_HydrogenBondAnalysis, start=1, step=2)
         return h
 
     def test_hbond_analysis(self, h):
@@ -690,11 +690,11 @@ class TestHydrogenBondAnalysisEmptySelections:
         with pytest.warns(UserWarning, match=self.msg.format(seltype)):
             HydrogenBondAnalysis(universe, **sel_kwarg)
 
-    def test_hbond_analysis(self, universe):
+    def test_hbond_analysis(self, universe, client_HydrogenBondAnalysis):
 
         h = HydrogenBondAnalysis(universe, donors_sel=' ', hydrogens_sel=' ',
                                  acceptors_sel=' ')
-        h.run()
+        h.run(**client_HydrogenBondAnalysis)
 
         assert h.donors_sel == ''
         assert h.hydrogens_sel == ''

--- a/testsuite/MDAnalysisTests/analysis/test_hydrogenbonds_analysis.py
+++ b/testsuite/MDAnalysisTests/analysis/test_hydrogenbonds_analysis.py
@@ -208,9 +208,12 @@ class TestHydrogenBondAnalysisIdeal(object):
             'd_h_a_angle_cutoff': 120.0
         }
 
+        u = universe.copy()
+        n_residues = 2
+        u.add_TopologyAttr('mass', [15.999, 1.008, 1.008] * n_residues)
+        u.add_TopologyAttr('charge', [-1.04, 0.52, 0.52] * n_residues)
         with pytest.raises(NoDataError, match="no bond information"):
-            h = HydrogenBondAnalysis(universe, **kwargs)
-            h._get_dh_pairs()
+            h = HydrogenBondAnalysis(u, **kwargs)
 
     def test_no_bond_donor_sel(self, universe):
 

--- a/testsuite/MDAnalysisTests/analysis/test_hydrogenbonds_analysis.py
+++ b/testsuite/MDAnalysisTests/analysis/test_hydrogenbonds_analysis.py
@@ -263,7 +263,8 @@ class TestHydrogenBondAnalysisIdeal(object):
         with pytest.raises(NoDataError, match=".hbonds attribute is None"):
             hbonds.lifetime(tau_max=2, intermittency=1)
 
-    def test_logging_step_not_1(self, universe, caplog, client_HydrogenBondAnalysis):
+    def test_logging_step_not_1(self, universe, caplog,
+                                client_HydrogenBondAnalysis):
         hbonds = HydrogenBondAnalysis(universe, **self.kwargs)
         # using step 2
         hbonds.run(**client_HydrogenBondAnalysis, step=2)


### PR DESCRIPTION
Fixes #4664 

Changes made in this Pull Request:
 - Parallelization of the backend support to the class `HydrogenBondAnalysis` in `hbond_analysis.py`
 - Addition of parallelization tests in `test_hydrogenbonds_analysis.py` and fixtures in `conftest.py`
 - Updated Changelog

There is still the case that one of the pytests raises an Failure, while the remainder work fine, I am currently not sure what the reason for this is.

The Failure is due to this:
`AttributeError: 'HydrogenBondAnalysis' object has no attribute '_hydrogens'` and appears only in `test_no_hydrogens`

PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4718.org.readthedocs.build/en/4718/

<!-- readthedocs-preview mdanalysis end -->