### PR TITLE
Add py3.13 support w/ minimal deps

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -41,7 +41,7 @@ jobs:
           - [macos-12, macosx_*, x86_64]
           - [windows-2019, win_amd64, AMD64]
           - [macos-14, macosx_*, arm64]
-        python: ["cp310", "cp311", "cp312"]
+        python: ["cp310", "cp311", "cp312", "cp313"]
     defaults:
       run:
         working-directory: ./package
@@ -243,7 +243,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         type: ["FULL", "MIN"]
         exclude:
           # Multiple deps don't like windows

--- a/.github/workflows/gh-ci-cron.yaml
+++ b/.github/workflows/gh-ci-cron.yaml
@@ -41,8 +41,6 @@ jobs:
         os-type: "ubuntu"
 
     - uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
 
     # minimally install nightly wheels & core deps
     - name: nightly_wheels
@@ -197,7 +195,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          python-version: ["3.10", "3.11", "3.12"]
+          python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -32,6 +32,11 @@ jobs:
           full-deps: [true, ]
           codecov: [true, ]
           include:
+            - name: python_313
+              os: ubunut-latest
+              python-version: "3.13"
+              full-deps: false
+              codecov: true
             - name: macOS_monterey_py311
               os: macOS-12
               python-version: "3.12"

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -33,7 +33,7 @@ jobs:
           codecov: [true, ]
           include:
             - name: python_313
-              os: ubunut-latest
+              os: ubuntu-latest
               python-version: "3.13"
               full-deps: false
               codecov: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,13 +26,13 @@ jobs:
           PYTHON_ARCH: 'x64'
           BUILD_TYPE: 'normal'
           imageName: 'windows-2019'
-        Win-Python312-64bit-full:
-          PYTHON_VERSION: '3.12'
+        Win-Python313-64bit-full:
+          PYTHON_VERSION: '3.13'
           PYTHON_ARCH: 'x64'
           BUILD_TYPE: 'normal'
           imageName: 'windows-2019'
-        Win-Python312-64bit-full-wheel:
-          PYTHON_VERSION: '3.12'
+        Win-Python313-64bit-full-wheel:
+          PYTHON_VERSION: '3.13'
           PYTHON_ARCH: 'x64'
           BUILD_TYPE: 'wheel'
           NUMPY_MIN: '1.26.0'
@@ -43,8 +43,8 @@ jobs:
           BUILD_TYPE: 'wheel'
           NUMPY_MIN: '1.23.2'
           imageName: 'windows-2019'
-        Linux-Python312-64bit-full-wheel:
-          PYTHON_VERSION: '3.12'
+        Linux-Python313-64bit-full-wheel:
+          PYTHON_VERSION: '3.13'
           PYTHON_ARCH: 'x64'
           BUILD_TYPE: 'wheel'
           NUMPY_MIN: '1.26.0'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,13 +26,13 @@ jobs:
           PYTHON_ARCH: 'x64'
           BUILD_TYPE: 'normal'
           imageName: 'windows-2019'
-        Win-Python313-64bit-full:
-          PYTHON_VERSION: '3.13'
+        Win-Python312-64bit-full:
+          PYTHON_VERSION: '3.12'
           PYTHON_ARCH: 'x64'
           BUILD_TYPE: 'normal'
           imageName: 'windows-2019'
-        Win-Python313-64bit-full-wheel:
-          PYTHON_VERSION: '3.13'
+        Win-Python312-64bit-full-wheel:
+          PYTHON_VERSION: '3.12'
           PYTHON_ARCH: 'x64'
           BUILD_TYPE: 'wheel'
           NUMPY_MIN: '1.26.0'
@@ -43,8 +43,8 @@ jobs:
           BUILD_TYPE: 'wheel'
           NUMPY_MIN: '1.23.2'
           imageName: 'windows-2019'
-        Linux-Python313-64bit-full-wheel:
-          PYTHON_VERSION: '3.13'
+        Linux-Python312-64bit-full-wheel:
+          PYTHON_VERSION: '3.12'
           PYTHON_ARCH: 'x64'
           BUILD_TYPE: 'wheel'
           NUMPY_MIN: '2.1.0'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,7 +47,7 @@ jobs:
           PYTHON_VERSION: '3.13'
           PYTHON_ARCH: 'x64'
           BUILD_TYPE: 'wheel'
-          NUMPY_MIN: '1.26.0'
+          NUMPY_MIN: '2.1.0'
           imageName: 'ubuntu-latest'
         Linux-Python310-64bit-full-wheel:
           PYTHON_VERSION: '3.10'

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -56,6 +56,7 @@ Fixes
  * Fix groups.py doctests using sphinx directives (Issue #3925, PR #4374)
 
 Enhancements
+ * MDAnalysis now supports Python 3.13 (PR #4732)
  * Introduce parallelization API to `AnalysisBase` and to `analysis.rms.RMSD` class
    (Issue #4158, PR #4304)
  * Enables parallelization for analysis.gnm.GNMAnalysis (Issue #4672)

--- a/package/pyproject.toml
+++ b/package/pyproject.toml
@@ -61,6 +61,7 @@ classifiers = [
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
     'Programming Language :: C',
     'Topic :: Scientific/Engineering',
     'Topic :: Scientific/Engineering :: Bio-Informatics',
@@ -124,6 +125,6 @@ MDAnalysis = [
 
 [tool.black]
 line-length = 79
-target-version = ['py310', 'py311', 'py312']
+target-version = ['py310', 'py311', 'py312', 'py313']
 extend-exclude = '.'
 required-version = '24'

--- a/testsuite/MDAnalysisTests/analysis/test_base.py
+++ b/testsuite/MDAnalysisTests/analysis/test_base.py
@@ -347,7 +347,7 @@ def test_verbose_progressbar_run(u, capsys):
     _, err = capsys.readouterr()
     expected = u'100%|██████████'
     actual = err.strip().split('\r')[-1]
-    assert expected == actual[:15]
+    assert actual[:15] == expected
 
 def test_verbose_progressbar_run_with_kwargs(u, capsys):
     FrameAnalysis(u.trajectory).run(
@@ -355,7 +355,7 @@ def test_verbose_progressbar_run_with_kwargs(u, capsys):
     _, err = capsys.readouterr()
     expected = u'custom: 100%|██████████'
     actual = err.strip().split('\r')[-1]
-    assert expected == actual[:23]
+    assert actual[:23] == expected
 
 
 def test_progressbar_multiprocessing(u):

--- a/testsuite/MDAnalysisTests/analysis/test_base.py
+++ b/testsuite/MDAnalysisTests/analysis/test_base.py
@@ -345,17 +345,17 @@ def test_verbose_progressbar(u, capsys):
 def test_verbose_progressbar_run(u, capsys):
     FrameAnalysis(u.trajectory).run(verbose=True)
     _, err = capsys.readouterr()
-    expected = u'100%|██████████| 98/98 [00:00<00:00, 8799.49it/s]'
+    expected = u'100%|██████████'
     actual = err.strip().split('\r')[-1]
-    assert actual[:24] == expected[:24]
+    assert expected == actual[:15]
 
 def test_verbose_progressbar_run_with_kwargs(u, capsys):
     FrameAnalysis(u.trajectory).run(
         verbose=True, progressbar_kwargs={'desc': 'custom'})
     _, err = capsys.readouterr()
-    expected = u'custom: 100%|██████████| 98/98 [00:00<00:00, 8799.49it/s]'
+    expected = u'custom: 100%|██████████'
     actual = err.strip().split('\r')[-1]
-    assert actual[:30] == expected[:30]
+    assert expected == actual[:23]
 
 
 def test_progressbar_multiprocessing(u):

--- a/testsuite/MDAnalysisTests/lib/test_log.py
+++ b/testsuite/MDAnalysisTests/lib/test_log.py
@@ -32,9 +32,9 @@ class TestProgressBar(object):
         for i in ProgressBar(list(range(10))):
             pass
         out, err = capsys.readouterr()
-        expected = u'100%|██████████| 10/10 [00:00<00:00, 583.67it/s]'
+        expected = u'100%|██████████'
         actual = err.strip().split('\r')[-1]
-        assert actual[:24] == expected[:24]
+        assert actual[:15] == expected
 
     def test_disable(self, capsys):
         for i in ProgressBar(list(range(10)), disable=True):


### PR DESCRIPTION
Python 3.13 should now work with minimal deps. Optional deps like OpenMM don't have compatible releases yet.

Changes made in this Pull Request:
 - Bump up non-optional deps workflows to include py3.13
 - Add py3.13 to the classifiers list


PR Checklist
------------
 - [x] Tests?
 - [x] CHANGELOG updated?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4732.org.readthedocs.build/en/4732/

<!-- readthedocs-preview mdanalysis end -->