### PR TITLE
Deprecate encore

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -99,6 +99,8 @@ Changes
    numpy.testing.assert_allclose #4438)
 
 Deprecations
+ * The MDAnalysis.anaylsis.encore module has been deprecated in favour of the
+   mdaencore MDAKit and will be removed in version 3.0.0 (PR #4737)
  * The MMTF Reader is deprecated and will be removed in version 3.0
    as the MMTF format is no longer supported (Issue #4634)
  * The MDAnalysis.analysis.waterdynamics module has been deprecated in favour

--- a/package/MDAnalysis/analysis/encore/__init__.py
+++ b/package/MDAnalysis/analysis/encore/__init__.py
@@ -34,6 +34,14 @@ from .utils import merge_universes
 
 __all__ = ['covariance', 'similarity', 'confdistmatrix', 'clustering']
 
+import warnings
+
+wmsg = ("Deprecation in version 2.8.0\n"
+        "MDAnalysis.analysis.encore is deprecated in favour of the "
+        "MDAKit mdaencore (https://www.mdanalysis.org/mdaencore/) "
+        "and will be removed in MDAnalysis version 3.0.0.")
+warnings.warn(wmsg, category=DeprecationWarning)
+
 from ...due import due, Doi
 
 due.cite(Doi("10.1371/journal.pcbi.1004415"),

--- a/package/MDAnalysis/analysis/encore/bootstrap.py
+++ b/package/MDAnalysis/analysis/encore/bootstrap.py
@@ -32,6 +32,11 @@ objects) or distance matrices, by resampling with replacement.
 
 .. versionadded:: 0.16.0
 
+.. deprecated:: 2.8.0
+   This module is deprecated in favour of the 
+   MDAKit `mdaencore <https://mdanalysis.org/mdaencore/>`_ and will be removed
+   in MDAnalysis 3.0.0.
+
 """
 import numpy as np
 import logging

--- a/package/MDAnalysis/analysis/encore/clustering/ClusterCollection.py
+++ b/package/MDAnalysis/analysis/encore/clustering/ClusterCollection.py
@@ -31,6 +31,11 @@ designed to store results from clustering algorithms.
 
 .. versionadded:: 0.16.0
 
+.. deprecated:: 2.8.0
+   This module is deprecated in favour of the 
+   MDAKit `mdaencore <https://mdanalysis.org/mdaencore/>`_ and will be removed
+   in MDAnalysis 3.0.0.
+
 """
 import numpy as np
 

--- a/package/MDAnalysis/analysis/encore/clustering/ClusteringMethod.py
+++ b/package/MDAnalysis/analysis/encore/clustering/ClusteringMethod.py
@@ -32,6 +32,11 @@ others are available only if scikit-learn is installed
 
 .. versionadded:: 0.16.0
 
+.. deprecated:: 2.8.0
+   This module is deprecated in favour of the 
+   MDAKit `mdaencore <https://mdanalysis.org/mdaencore/>`_ and will be removed
+   in MDAnalysis 3.0.0.
+
 """
 import numpy as np
 import warnings

--- a/package/MDAnalysis/analysis/encore/clustering/cluster.py
+++ b/package/MDAnalysis/analysis/encore/clustering/cluster.py
@@ -31,6 +31,11 @@ algorithms, wrapping them to allow them to be used interchangably.
 
 .. versionadded:: 0.16.0
 
+.. deprecated:: 2.8.0
+   This module is deprecated in favour of the 
+   MDAKit `mdaencore <https://mdanalysis.org/mdaencore/>`_ and will be removed
+   in MDAnalysis 3.0.0.
+
 """
 import numpy as np
 from ..utils import ParallelCalculation, merge_universes

--- a/package/MDAnalysis/analysis/encore/confdistmatrix.py
+++ b/package/MDAnalysis/analysis/encore/confdistmatrix.py
@@ -34,6 +34,11 @@ class to compute an RMSD matrix in such a way is also available.
 
 .. versionadded:: 0.16.0
 
+.. deprecated:: 2.8.0
+   This module is deprecated in favour of the 
+   MDAKit `mdaencore <https://mdanalysis.org/mdaencore/>`_ and will be removed
+   in MDAnalysis 3.0.0.
+
 """
 from joblib import Parallel, delayed
 import numpy as np

--- a/package/MDAnalysis/analysis/encore/covariance.py
+++ b/package/MDAnalysis/analysis/encore/covariance.py
@@ -30,6 +30,12 @@ an ensemble of structures.
 :Author: Matteo Tiberti, Wouter Boomsma, Tone Bengtsen
 
 .. versionadded:: 0.16.0
+
+.. deprecated:: 2.8.0
+   This module is deprecated in favour of the 
+   MDAKit `mdaencore <https://mdanalysis.org/mdaencore/>`_ and will be removed
+   in MDAnalysis 3.0.0.
+
 """
 import numpy as np
 

--- a/package/MDAnalysis/analysis/encore/dimensionality_reduction/DimensionalityReductionMethod.py
+++ b/package/MDAnalysis/analysis/encore/dimensionality_reduction/DimensionalityReductionMethod.py
@@ -32,6 +32,11 @@ while others are available only if scikit-learn is installed
 
 .. versionadded:: 0.16.0
 
+.. deprecated:: 2.8.0
+   This module is deprecated in favour of the 
+   MDAKit `mdaencore <https://mdanalysis.org/mdaencore/>`_ and will be removed
+   in MDAnalysis 3.0.0.
+
 """
 import logging
 import warnings

--- a/package/MDAnalysis/analysis/encore/dimensionality_reduction/reduce_dimensionality.py
+++ b/package/MDAnalysis/analysis/encore/dimensionality_reduction/reduce_dimensionality.py
@@ -31,6 +31,11 @@ reduction algorithms, wrapping them to allow them to be used interchangably.
 
 .. versionadded:: 0.16.0
 
+.. deprecated:: 2.8.0
+   This module is deprecated in favour of the 
+   MDAKit `mdaencore <https://mdanalysis.org/mdaencore/>`_ and will be removed
+   in MDAnalysis 3.0.0.
+
 """
 import numpy as np
 from ..confdistmatrix import get_distance_matrix

--- a/package/MDAnalysis/analysis/encore/similarity.py
+++ b/package/MDAnalysis/analysis/encore/similarity.py
@@ -29,6 +29,11 @@ Ensemble Similarity Calculations --- :mod:`MDAnalysis.analysis.encore.similarity
 
 .. versionadded:: 0.16.0
 
+.. deprecated:: 2.8.0
+   This module is deprecated in favour of the 
+   MDAKit `mdaencore <https://mdanalysis.org/mdaencore/>`_ and will be removed
+   in MDAnalysis 3.0.0.
+
 The module contains implementations of similarity measures between protein
 ensembles described in :footcite:p:`LindorffLarsen2009`. The implementation and
 examples are described in :footcite:p:`Tiberti2015`.

--- a/package/doc/sphinx/source/documentation_pages/analysis/encore.rst
+++ b/package/doc/sphinx/source/documentation_pages/analysis/encore.rst
@@ -9,6 +9,12 @@
 
 .. versionadded:: 0.16.0
 
+
+.. deprecated:: 2.8.0
+   This module is deprecated in favour of the 
+   MDAKit `mdaencore <https://mdanalysis.org/mdaencore/>`_ and will be removed
+   in MDAnalysis 3.0.0.
+
 The module contains implementations of similarity measures between protein
 ensembles described in :footcite:p:`LindorffLarsen2009`. The implementation and examples
 are described in :footcite:p:`Tiberti2015`.

--- a/package/doc/sphinx/source/documentation_pages/analysis/encore/utils.rst
+++ b/package/doc/sphinx/source/documentation_pages/analysis/encore/utils.rst
@@ -2,6 +2,11 @@
  Utility functions for ENCORE
 ==============================
 
+.. deprecated:: 2.8.0
+   This module is deprecated in favour of the 
+   MDAKit `mdaencore <https://mdanalysis.org/mdaencore/>`_ and will be removed
+   in MDAnalysis 3.0.0.
+
 .. automodule:: MDAnalysis.analysis.encore.utils
    :members:
 

--- a/testsuite/MDAnalysisTests/analysis/test_encore.py
+++ b/testsuite/MDAnalysisTests/analysis/test_encore.py
@@ -30,6 +30,7 @@ import sys
 import os
 import warnings
 import platform
+from importlib import reload
 
 import pytest
 from numpy.testing import assert_equal, assert_allclose
@@ -45,6 +46,11 @@ import MDAnalysis.analysis.encore.confdistmatrix as confdistmatrix
 def function(x):
     return x**2
 
+
+def test_moved_to_mdakit_warning():
+    wmsg = "MDAnalysis.analysis.encore is deprecated"
+    with pytest.warns(DeprecationWarning, match=wmsg):
+        reload(encore)
 
 class TestEncore(object):
     @pytest.fixture(scope='class')


### PR DESCRIPTION
Add deprecation messages/warnings for encore referencing the MDAKit mdaencore, per #4274 

(The code itself is left for now, but could be replaced (prior to deprecation in 3.0) with the MDAKit later, as for hole2/waterdynamics/psa)

PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4737.org.readthedocs.build/en/4737/

<!-- readthedocs-preview mdanalysis end -->