### PR TITLE
pin distopia<0.3.0

### DIFF
--- a/.github/actions/setup-deps/action.yaml
+++ b/.github/actions/setup-deps/action.yaml
@@ -59,7 +59,7 @@ inputs:
   dask:
     default: 'dask'
   distopia:
-    default: 'distopia>=0.2.0'
+    default: 'distopia>=0.2.0,<0.3.0'
   h5py:
     default: 'h5py>=2.10'
   hole2:

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -78,6 +78,7 @@ Enhancements
    DOI 10.1021/acs.jpcb.7b11988. (Issue #2039, PR #4524)
 
 Changes
+ * only use distopia < 0.3.0 due to API changes (Issue #4739)
  * The `fetch_mmtf` method has been removed as the REST API service
    for MMTF files has ceased to exist (Issue #4634)
  * MDAnalysis now builds against numpy 2.0 rather than the

--- a/package/MDAnalysis/lib/_distopia.py
+++ b/package/MDAnalysis/lib/_distopia.py
@@ -27,6 +27,7 @@
 This module is a stub to provide distopia distance functions to `distances.py`
 as a selectable backend.
 """
+import warnings
 
 # check for distopia
 try:
@@ -36,10 +37,22 @@ except ImportError:
 else:
     HAS_DISTOPIA = True
 
+    # check for compatibility: currently needs to be >=0.2.0,<0.3.0 (issue
+    # #4740) No distopia.__version__ available so we have to do some probing.
+    needed_funcs = ['calc_bonds_no_box_float', 'calc_bonds_ortho_float']
+    has_distopia_020 = all([hasattr(distopia, func) for func in needed_funcs])
+    if not has_distopia_020:
+        warnings.warn("Install 'distopia>=0.2.0,<0.3.0' to be used with this "
+                      "release of MDAnalysis. Your installed version of "
+                      "distopia >=0.3.0 will NOT be used.",
+                      category=RuntimeWarning)
+        del distopia
+        HAS_DISTOPIA = False
+
+
 from .c_distances import (
     calc_bond_distance_triclinic as _calc_bond_distance_triclinic_serial,
 )
-import warnings
 import numpy as np
 
 

--- a/testsuite/MDAnalysisTests/lib/test_distances.py
+++ b/testsuite/MDAnalysisTests/lib/test_distances.py
@@ -20,6 +20,8 @@
 # MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
+import sys
+from unittest.mock import Mock, patch
 import pytest
 import numpy as np
 from numpy.testing import assert_equal, assert_almost_equal, assert_allclose
@@ -788,9 +790,10 @@ class TestTriclinicDistances(object):
         # expected.
         assert np.linalg.norm(point_a - point_b) != dist[0, 0]
 
-@pytest.mark.parametrize("box", 
+
+@pytest.mark.parametrize("box",
     [
-        None, 
+        None,
         np.array([10., 15., 20., 90., 90., 90.]), # otrho
         np.array([10., 15., 20., 70.53571, 109.48542, 70.518196]), # TRIC
     ]
@@ -834,6 +837,39 @@ def distopia_conditional_backend():
     else:
         return ["serial", "openmp"]
 
+
+def test_HAS_DISTOPIA_incompatible_distopia():
+    # warn if distopia is the wrong version and set HAS_DISTOPIA to False
+    sys.modules.pop("distopia", None)
+    sys.modules.pop("MDAnalysis.lib._distopia", None)
+
+    # fail any Attribute access for calc_bonds_ortho_float,
+    # calc_bonds_no_box_float but pretend to have the distopia
+    # 0.3.0 functions (from
+    # https://github.com/MDAnalysis/distopia/blob/main/distopia/__init__.py
+    # __all__):
+    mock_distopia_030 = Mock(spec=[
+        'calc_bonds_ortho',
+        'calc_bonds_no_box',
+        'calc_bonds_triclinic',
+        'calc_angles_no_box',
+        'calc_angles_ortho',
+        'calc_angles_triclinic',
+        'calc_dihedrals_no_box',
+        'calc_dihedrals_ortho',
+        'calc_dihedrals_triclinic',
+        'calc_distance_array_no_box',
+        'calc_distance_array_ortho',
+        'calc_distance_array_triclinic',
+        'calc_self_distance_array_no_box',
+        'calc_self_distance_array_ortho',
+        'calc_self_distance_array_triclinic',
+    ])
+    with patch.dict("sys.modules", {"distopia": mock_distopia_030}):
+        with pytest.warns(RuntimeWarning,
+                          match="Install 'distopia>=0.2.0,<0.3.0' to"):
+            import MDAnalysis.lib._distopia
+        assert not MDAnalysis.lib._distopia.HAS_DISTOPIA
 
 class TestCythonFunctions(object):
     # Unit tests for calc_bonds calc_angles and calc_dihedrals in lib.distances
@@ -1597,7 +1633,7 @@ class TestEmptyInputCoordinates(object):
             assert_equal(res[1], np.empty((0,), dtype=np.float64))
         else:
             assert_equal(res, np.empty((0, 2), dtype=np.int64))
-    
+
     @pytest.mark.parametrize('box', boxes[:2])
     @pytest.mark.parametrize('backend', ['serial', 'openmp'])
     def test_empty_input_transform_RtoS(self, empty_coord, box, backend):


### PR DESCRIPTION
Fixes #4739

Changes made in this Pull Request:
- [x] temporarily restrict distopia in CI to >=0.2.0,<0.3.0 until MDAnalysis has caught up with distopia API changes
- [x] updated CHANGELOG
- [x] version check in code

PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4740.org.readthedocs.build/en/4740/

<!-- readthedocs-preview mdanalysis end -->