### PR TITLE
Update guesser docs

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -23,6 +23,8 @@ The rules for this file:
  * 2.8.0
 
 Fixes
+ * Adds guessed attributes documentation back to each parser page
+   and updates overall guesser docs (Issue #4696)
  * Fix Bohrium (Bh) atomic mass in tables.py (PR #3753)
  * set `n_parts` to the total number of frames being analyzed if
    `n_parts` is bigger. (Issue #4685)

--- a/package/MDAnalysis/guesser/default_guesser.py
+++ b/package/MDAnalysis/guesser/default_guesser.py
@@ -314,6 +314,8 @@ class DefaultGuesser(GuesserBase):
         still not found, we iteratively continue to remove the last character
         or first character until we find a match. If ultimately no match
         is found, the first character of the stripped name is returned.
+        
+        If the input name is an empty string, an empty string is returned.
 
         The table comes from CHARMM and AMBER atom
         types, where the first character is not sufficient to determine the

--- a/package/MDAnalysis/guesser/default_guesser.py
+++ b/package/MDAnalysis/guesser/default_guesser.py
@@ -51,9 +51,9 @@ Types
 We attempt to guess the atom type based on the atom name (``name``).
 The name is first stripped of any numbers and symbols, and then looked up in
 the :data:`MDAnalysis.guesser.tables.atomelements` table. If the name is not
-found, we continue checking variations of the name following the logic in 
-:meth:`DefaultGuesser.guess_atom_element`. Ultimately, if no match is found, the first character
-of the stripped name is returned.
+found, we continue checking variations of the name following the logic in
+:meth:`DefaultGuesser.guess_atom_element`. Ultimately, if no match is found,
+the first character of the stripped name is returned.
 
 Elements
 ~~~~~~~~
@@ -306,14 +306,15 @@ class DefaultGuesser(GuesserBase):
         """Guess the element of the atom from the name.
 
         First all numbers and symbols are stripped from the name.
-        Then the name is looked up in the :data:`MDAnalysis.guesser.tables.atomelements`
-        table. If the name is not found, we remove the last
-        character or first character from the name and check the table for both,
-        with a preference for removing the last character. If the name is still
-        not found, we iteratively continue to remove the last character or
-        first character until we find a match. If ultimately no match is found,
-        the first character of the stripped name is returned.
-        
+        Then the name is looked up in the
+        :data:`MDAnalysis.guesser.tables.atomelements` table.
+        If the name is not found, we remove the last character or
+        first character from the name and check the table for both,
+        with a preference for removing the last character. If the name is
+        still not found, we iteratively continue to remove the last character
+        or first character until we find a match. If ultimately no match
+        is found, the first character of the stripped name is returned.
+
         The table comes from CHARMM and AMBER atom
         types, where the first character is not sufficient to determine the
         atom type. Some GROMOS ions have also been added.

--- a/package/MDAnalysis/topology/CRDParser.py
+++ b/package/MDAnalysis/topology/CRDParser.py
@@ -37,7 +37,7 @@ while segments are detected according to changes in segid.
 
         By default, atomtypes and masses will be guessed on Universe creation.
         This may change in release 3.0.
-        See :ref:`Guessers`_ for more information.
+        See :ref:`Guessers` for more information.
 
 .. _CRD: https://www.charmmtutorial.org/index.php/CHARMM:The_Basics
 
@@ -83,7 +83,7 @@ class CRDParser(TopologyReaderBase):
 
         By default, atomtypes and masses will be guessed on Universe creation.
         This may change in release 3.0.
-        See :ref:`Guessers`_ for more information.
+        See :ref:`Guessers` for more information.
 
     .. versionchanged:: 2.8.0
        Type and mass are not longer guessed here. Until 3.0 these will still be

--- a/package/MDAnalysis/topology/CRDParser.py
+++ b/package/MDAnalysis/topology/CRDParser.py
@@ -33,6 +33,12 @@ resids (RESID), residue numbers (RESNO), residue names (RESNames), segment ids
 Residues are detected through a change is either resid or resname
 while segments are detected according to changes in segid.
 
+.. note::
+
+        By default, atomtypes and masses will be guessed on Universe creation.
+        This may change in release 3.0.
+        See :ref:`Guessers`_ for more information.
+
 .. _CRD: https://www.charmmtutorial.org/index.php/CHARMM:The_Basics
 
 
@@ -71,6 +77,13 @@ class CRDParser(TopologyReaderBase):
      - Resnames
      - Resnums
      - Segids
+
+    
+    .. note::
+
+        By default, atomtypes and masses will be guessed on Universe creation.
+        This may change in release 3.0.
+        See :ref:`Guessers`_ for more information.
 
     .. versionchanged:: 2.8.0
        Type and mass are not longer guessed here. Until 3.0 these will still be

--- a/package/MDAnalysis/topology/CRDParser.py
+++ b/package/MDAnalysis/topology/CRDParser.py
@@ -78,7 +78,7 @@ class CRDParser(TopologyReaderBase):
      - Resnums
      - Segids
 
-    
+
     .. note::
 
         By default, atomtypes and masses will be guessed on Universe creation.

--- a/package/MDAnalysis/topology/DLPolyParser.py
+++ b/package/MDAnalysis/topology/DLPolyParser.py
@@ -30,6 +30,12 @@ DLPoly files have the following Attributes:
  - Atomnames
  - Atomids
 
+.. note::
+
+        By default, atomtypes and masses will be guessed on Universe creation.
+        This may change in release 3.0.
+        See :ref:`Guessers`_ for more information.
+
 .. _Poly: http://www.stfc.ac.uk/SCD/research/app/ccg/software/DL_POLY/44516.aspx
 
 Classes

--- a/package/MDAnalysis/topology/DLPolyParser.py
+++ b/package/MDAnalysis/topology/DLPolyParser.py
@@ -34,7 +34,7 @@ DLPoly files have the following Attributes:
 
         By default, atomtypes and masses will be guessed on Universe creation.
         This may change in release 3.0.
-        See :ref:`Guessers`_ for more information.
+        See :ref:`Guessers` for more information.
 
 .. _Poly: http://www.stfc.ac.uk/SCD/research/app/ccg/software/DL_POLY/44516.aspx
 

--- a/package/MDAnalysis/topology/DMSParser.py
+++ b/package/MDAnalysis/topology/DMSParser.py
@@ -90,7 +90,7 @@ class DMSParser(TopologyReaderBase):
 
         By default, atomtypes will be guessed on Universe creation.
         This may change in release 3.0.
-        See :ref:`Guessers`_ for more information.
+        See :ref:`Guessers` for more information.
 
     .. _DESRES: http://www.deshawresearch.com
     .. _Desmond: http://www.deshawresearch.com/resources_desmond.html

--- a/package/MDAnalysis/topology/DMSParser.py
+++ b/package/MDAnalysis/topology/DMSParser.py
@@ -86,11 +86,17 @@ class DMSParser(TopologyReaderBase):
       Segment:
         - Segids
 
+    .. note::
+
+        By default, atomtypes will be guessed on Universe creation.
+        This may change in release 3.0.
+        See :ref:`Guessers`_ for more information.
+
     .. _DESRES: http://www.deshawresearch.com
     .. _Desmond: http://www.deshawresearch.com/resources_desmond.html
     .. _DMS: http://www.deshawresearch.com/Desmond_Users_Guide-0.7.pdf
     .. versionchanged:: 2.8.0
-        Removed type and mass guessing (attributes guessing takes place now
+        Removed type guessing (attributes guessing takes place now
         through universe.guess_TopologyAttrs() API).
 
     """

--- a/package/MDAnalysis/topology/ExtendedPDBParser.py
+++ b/package/MDAnalysis/topology/ExtendedPDBParser.py
@@ -77,6 +77,12 @@ class ExtendedPDBParser(PDBParser.PDBParser):
      - elements
      - bonds
      - formalcharges
+   
+   .. note::
+
+      By default, atomtypes and masses will be guessed on Universe creation.
+      This may change in release 3.0.
+      See :ref:`Guessers`_ for more information.
 
 
     See Also

--- a/package/MDAnalysis/topology/ExtendedPDBParser.py
+++ b/package/MDAnalysis/topology/ExtendedPDBParser.py
@@ -82,7 +82,7 @@ class ExtendedPDBParser(PDBParser.PDBParser):
 
       By default, atomtypes and masses will be guessed on Universe creation.
       This may change in release 3.0.
-      See :ref:`Guessers`_ for more information.
+      See :ref:`Guessers` for more information.
 
 
     See Also

--- a/package/MDAnalysis/topology/ExtendedPDBParser.py
+++ b/package/MDAnalysis/topology/ExtendedPDBParser.py
@@ -77,7 +77,7 @@ class ExtendedPDBParser(PDBParser.PDBParser):
      - elements
      - bonds
      - formalcharges
-   
+
    .. note::
 
       By default, atomtypes and masses will be guessed on Universe creation.

--- a/package/MDAnalysis/topology/FHIAIMSParser.py
+++ b/package/MDAnalysis/topology/FHIAIMSParser.py
@@ -66,6 +66,13 @@ class FHIAIMSParser(TopologyReaderBase):
     Creates the following attributes:
      - Atomnames
 
+
+    .. note::
+
+        By default, atomtypes and masses will be guessed on Universe creation.
+        This may change in release 3.0.
+        See :ref:`Guessers`_ for more information.
+
     .. versionchanged:: 2.8.0
         Removed type and mass guessing (attributes guessing takes place now
         through universe.guess_TopologyAttrs() API).

--- a/package/MDAnalysis/topology/FHIAIMSParser.py
+++ b/package/MDAnalysis/topology/FHIAIMSParser.py
@@ -71,7 +71,7 @@ class FHIAIMSParser(TopologyReaderBase):
 
         By default, atomtypes and masses will be guessed on Universe creation.
         This may change in release 3.0.
-        See :ref:`Guessers`_ for more information.
+        See :ref:`Guessers` for more information.
 
     .. versionchanged:: 2.8.0
         Removed type and mass guessing (attributes guessing takes place now

--- a/package/MDAnalysis/topology/GMSParser.py
+++ b/package/MDAnalysis/topology/GMSParser.py
@@ -78,7 +78,7 @@ class GMSParser(TopologyReaderBase):
 
         By default, atomtypes and masses will be guessed on Universe creation.
         This may change in release 3.0.
-        See :ref:`Guessers`_ for more information.
+        See :ref:`Guessers` for more information.
 
     .. versionadded:: 0.9.1
     .. versionchanged:: 2.8.0

--- a/package/MDAnalysis/topology/GMSParser.py
+++ b/package/MDAnalysis/topology/GMSParser.py
@@ -73,7 +73,7 @@ class GMSParser(TopologyReaderBase):
      - names
      - atomic charges
 
-    
+
     .. note::
 
         By default, atomtypes and masses will be guessed on Universe creation.

--- a/package/MDAnalysis/topology/GMSParser.py
+++ b/package/MDAnalysis/topology/GMSParser.py
@@ -73,6 +73,13 @@ class GMSParser(TopologyReaderBase):
      - names
      - atomic charges
 
+    
+    .. note::
+
+        By default, atomtypes and masses will be guessed on Universe creation.
+        This may change in release 3.0.
+        See :ref:`Guessers`_ for more information.
+
     .. versionadded:: 0.9.1
     .. versionchanged:: 2.8.0
         Removed type and mass guessing (attributes guessing takes place now

--- a/package/MDAnalysis/topology/GROParser.py
+++ b/package/MDAnalysis/topology/GROParser.py
@@ -66,6 +66,12 @@ class GROParser(TopologyReaderBase):
       - resnames
       - atomids
       - atomnames
+    
+    .. note::
+
+        By default, atomtypes and masses will be guessed on Universe creation.
+        This may change in release 3.0.
+        See :ref:`Guessers`_ for more information.
 
     .. versionchanged:: 2.8.0
         Removed type and mass guessing (attributes guessing takes place now

--- a/package/MDAnalysis/topology/GROParser.py
+++ b/package/MDAnalysis/topology/GROParser.py
@@ -71,7 +71,7 @@ class GROParser(TopologyReaderBase):
 
         By default, atomtypes and masses will be guessed on Universe creation.
         This may change in release 3.0.
-        See :ref:`Guessers`_ for more information.
+        See :ref:`Guessers` for more information.
 
     .. versionchanged:: 2.8.0
         Removed type and mass guessing (attributes guessing takes place now

--- a/package/MDAnalysis/topology/GROParser.py
+++ b/package/MDAnalysis/topology/GROParser.py
@@ -66,7 +66,7 @@ class GROParser(TopologyReaderBase):
       - resnames
       - atomids
       - atomnames
-    
+
     .. note::
 
         By default, atomtypes and masses will be guessed on Universe creation.

--- a/package/MDAnalysis/topology/ITPParser.py
+++ b/package/MDAnalysis/topology/ITPParser.py
@@ -473,6 +473,13 @@ class ITPParser(TopologyReaderBase):
     .. _ITP: http://manual.gromacs.org/current/reference-manual/topologies/topology-file-formats.html#molecule-itp-file
     .. _TOP: http://manual.gromacs.org/current/reference-manual/file-formats.html#top
 
+    .. note::
+
+        By default, atomtypes and masses will be guessed on Universe creation
+        if they are not read from the input file.
+        This may change in release 3.0.
+        See :ref:`Guessers`_ for more information.
+
     .. versionchanged:: 2.2.0
       no longer adds angles for water molecules with SETTLE constraint
     .. versionchanged:: 2.8.0

--- a/package/MDAnalysis/topology/ITPParser.py
+++ b/package/MDAnalysis/topology/ITPParser.py
@@ -478,7 +478,7 @@ class ITPParser(TopologyReaderBase):
         By default, atomtypes and masses will be guessed on Universe creation
         if they are not read from the input file.
         This may change in release 3.0.
-        See :ref:`Guessers`_ for more information.
+        See :ref:`Guessers` for more information.
 
     .. versionchanged:: 2.2.0
       no longer adds angles for water molecules with SETTLE constraint

--- a/package/MDAnalysis/topology/LAMMPSParser.py
+++ b/package/MDAnalysis/topology/LAMMPSParser.py
@@ -29,8 +29,8 @@ Parses data_ or dump_ files produced by LAMMPS_.
 
 .. note::
 
-    By default, masses will be guessed on Universe creation if they are not read
-    from the input file. This may change in release 3.0.
+    By default, masses will be guessed on Universe creation if they are not
+    read from the input file. This may change in release 3.0.
     See :ref:`Guessers` for more information.
 
 .. _LAMMPS: http://lammps.sandia.gov/

--- a/package/MDAnalysis/topology/LAMMPSParser.py
+++ b/package/MDAnalysis/topology/LAMMPSParser.py
@@ -27,6 +27,12 @@ LAMMPSParser
 
 Parses data_ or dump_ files produced by LAMMPS_.
 
+.. note::
+
+    By default, masses will be guessed on Universe creation if they are not read
+    from the input file. This may change in release 3.0.
+    See :ref:`Guessers`_ for more information.
+
 .. _LAMMPS: http://lammps.sandia.gov/
 .. _data: DATA file format: :http://lammps.sandia.gov/doc/2001/data_format.html
 .. _dump: http://lammps.sandia.gov/doc/dump.html

--- a/package/MDAnalysis/topology/LAMMPSParser.py
+++ b/package/MDAnalysis/topology/LAMMPSParser.py
@@ -31,7 +31,7 @@ Parses data_ or dump_ files produced by LAMMPS_.
 
     By default, masses will be guessed on Universe creation if they are not read
     from the input file. This may change in release 3.0.
-    See :ref:`Guessers`_ for more information.
+    See :ref:`Guessers` for more information.
 
 .. _LAMMPS: http://lammps.sandia.gov/
 .. _data: DATA file format: :http://lammps.sandia.gov/doc/2001/data_format.html

--- a/package/MDAnalysis/topology/MMTFParser.py
+++ b/package/MDAnalysis/topology/MMTFParser.py
@@ -68,7 +68,7 @@ Segments:
 
     By default, masses will be guessed on Universe creation.
     This may change in release 3.0.
-    See :ref:`Guessers`_ for more information.
+    See :ref:`Guessers` for more information.
 
 Classes
 -------

--- a/package/MDAnalysis/topology/MMTFParser.py
+++ b/package/MDAnalysis/topology/MMTFParser.py
@@ -64,6 +64,12 @@ Segments:
  - segid
  - model
 
+ .. note::
+
+    By default, masses will be guessed on Universe creation.
+    This may change in release 3.0.
+    See :ref:`Guessers`_ for more information.
+
 Classes
 -------
 

--- a/package/MDAnalysis/topology/MOL2Parser.py
+++ b/package/MDAnalysis/topology/MOL2Parser.py
@@ -77,6 +77,13 @@ class MOL2Parser(TopologyReaderBase):
      - Bonds
      - Elements
 
+    
+    .. note::
+
+        By default, masses will be guessed on Universe creation.
+        This may change in release 3.0.
+        See :ref:`Guessers`_ for more information.
+
 
     Notes
     -----

--- a/package/MDAnalysis/topology/MOL2Parser.py
+++ b/package/MDAnalysis/topology/MOL2Parser.py
@@ -77,7 +77,7 @@ class MOL2Parser(TopologyReaderBase):
      - Bonds
      - Elements
 
-    
+
     .. note::
 
         By default, masses will be guessed on Universe creation.

--- a/package/MDAnalysis/topology/MOL2Parser.py
+++ b/package/MDAnalysis/topology/MOL2Parser.py
@@ -82,7 +82,7 @@ class MOL2Parser(TopologyReaderBase):
 
         By default, masses will be guessed on Universe creation.
         This may change in release 3.0.
-        See :ref:`Guessers`_ for more information.
+        See :ref:`Guessers` for more information.
 
 
     Notes

--- a/package/MDAnalysis/topology/PDBParser.py
+++ b/package/MDAnalysis/topology/PDBParser.py
@@ -41,7 +41,7 @@ numbers up to 99,999.
     Otherwise, they will be guessed on Universe creation.
     By default, masses will also be guessed on Universe creation.
     This may change in release 3.0.
-    See :ref:`Guessers`_ for more information.
+    See :ref:`Guessers` for more information.
 
 
 .. Note::

--- a/package/MDAnalysis/topology/PDBParser.py
+++ b/package/MDAnalysis/topology/PDBParser.py
@@ -35,6 +35,13 @@ a different file format (e.g. the "extended" PDB, *XPDB* format, see
 :mod:`~MDAnalysis.topology.ExtendedPDBParser`) that can handle residue
 numbers up to 99,999.
 
+.. note::
+
+    Atomtypes will be created from elements if they are present and valid.
+    Otherwise, they will be guessed on Universe creation.
+    By default, masses will also be guessed on Universe creation.
+    This may change in release 3.0.
+    See :ref:`Guessers`_ for more information.
 
 
 .. Note::

--- a/package/MDAnalysis/topology/PDBQTParser.py
+++ b/package/MDAnalysis/topology/PDBQTParser.py
@@ -32,6 +32,12 @@ partial charges (:attr:`Atom.charge`).
 * Reads a PDBQT file line by line and does not require sequential atom numbering.
 * Multi-model PDBQT files are not supported.
 
+.. note::
+
+    By default, masses will be guessed on Universe creation.
+    This may change in release 3.0.
+    See :ref:`Guessers`_ for more information.
+
 Notes
 -----
 Only reads atoms and their names; connectivity is not

--- a/package/MDAnalysis/topology/PDBQTParser.py
+++ b/package/MDAnalysis/topology/PDBQTParser.py
@@ -36,7 +36,7 @@ partial charges (:attr:`Atom.charge`).
 
     By default, masses will be guessed on Universe creation.
     This may change in release 3.0.
-    See :ref:`Guessers`_ for more information.
+    See :ref:`Guessers` for more information.
 
 Notes
 -----

--- a/package/MDAnalysis/topology/PQRParser.py
+++ b/package/MDAnalysis/topology/PQRParser.py
@@ -86,7 +86,7 @@ class PQRParser(TopologyReaderBase):
         (e.g. GROMACS PQR files). Otherwise, they will be guessed on Universe
         creation. By default, masses will also be guessed on Universe creation.
         This may change in release 3.0.
-        See :ref:`Guessers`_ for more information.
+        See :ref:`Guessers` for more information.
 
 
     .. versionchanged:: 0.9.0

--- a/package/MDAnalysis/topology/PQRParser.py
+++ b/package/MDAnalysis/topology/PQRParser.py
@@ -80,6 +80,14 @@ class PQRParser(TopologyReaderBase):
      - Resnames
      - Segids
 
+     .. note::
+
+        Atomtypes will be read from the input file if they are present
+        (e.g. GROMACS PQR files). Otherwise, they will be guessed on Universe
+        creation. By default, masses will also be guessed on Universe creation.
+        This may change in release 3.0.
+        See :ref:`Guessers`_ for more information.
+
 
     .. versionchanged:: 0.9.0
        Read chainID from a PQR file and use it as segid (before we always used

--- a/package/MDAnalysis/topology/TXYZParser.py
+++ b/package/MDAnalysis/topology/TXYZParser.py
@@ -73,6 +73,12 @@ class TXYZParser(TopologyReaderBase):
     - Atomtypes
     - Elements (if all atom names are element symbols)
 
+    .. note::
+
+        By default, masses will be guessed on Universe creation.
+        This may change in release 3.0.
+        See :ref:`Guessers`_ for more information.
+
     .. versionadded:: 0.17.0
     .. versionchanged:: 2.4.0
        Adding the `Element` attribute if all names are valid element symbols.

--- a/package/MDAnalysis/topology/TXYZParser.py
+++ b/package/MDAnalysis/topology/TXYZParser.py
@@ -77,7 +77,7 @@ class TXYZParser(TopologyReaderBase):
 
         By default, masses will be guessed on Universe creation.
         This may change in release 3.0.
-        See :ref:`Guessers`_ for more information.
+        See :ref:`Guessers` for more information.
 
     .. versionadded:: 0.17.0
     .. versionchanged:: 2.4.0

--- a/package/MDAnalysis/topology/XYZParser.py
+++ b/package/MDAnalysis/topology/XYZParser.py
@@ -59,6 +59,12 @@ class XYZParser(TopologyReaderBase):
     Creates the following attributes:
      - Atomnames
 
+    .. note::
+
+        By default, atomtypes and masses will be guessed on Universe creation.
+        This may change in release 3.0.
+        See :ref:`Guessers`_ for more information.
+
 
     .. versionadded:: 0.9.1
 

--- a/package/MDAnalysis/topology/XYZParser.py
+++ b/package/MDAnalysis/topology/XYZParser.py
@@ -63,7 +63,7 @@ class XYZParser(TopologyReaderBase):
 
         By default, atomtypes and masses will be guessed on Universe creation.
         This may change in release 3.0.
-        See :ref:`Guessers`_ for more information.
+        See :ref:`Guessers` for more information.
 
 
     .. versionadded:: 0.9.1

--- a/package/doc/sphinx/source/documentation_pages/guesser_modules.rst
+++ b/package/doc/sphinx/source/documentation_pages/guesser_modules.rst
@@ -1,18 +1,29 @@
 .. Contains the formatted docstrings from the guesser modules located in 'mdanalysis/package/MDAnalysis/guesser'
 
+.. _Guessers:
+
 **************************
 Guesser modules
 **************************
-This module contains the context-aware guessers, which are used by the :meth:`~MDAnalysis.core.Universe.Universe.guess_TopologyAttrs` API. Context-aware guessers' main purpose
+This module contains the context-aware guessers, which are used by the :meth:`~MDAnalysis.core.universe.Universe.guess_TopologyAttrs` API. Context-aware guessers' main purpose
 is to be tailored guesser classes that target specific file format or force field (eg. PDB file format, or Martini forcefield).
-Having such guessers makes attribute guessing more accurate and reliable than having generic guessing methods that doesn't fit all topologies.
+Having such guessers makes attribute guessing more accurate and reliable than having generic guessing methods that don't fit all scenarios.
 
 Example uses of guessers
 ------------------------
 
+Default behavior
+~~~~~~~~~~~~~~~~
+
+By default, MDAnalysis will guess the "mass" and "type" (atom type) attributes for all particles in the Universe
+using the :class:`~MDAnalysis.guesser.default_guesser.DefaultGuesser` at the time of Universe creation,
+if they are not read from the input file.
+Please see the :ref:`DefaultGuesser`_ for more information.
+
+
+
 Guessing using :meth:`~MDAnalysis.core.universe.Universe.guess_TopologyAttrs` API
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
 
 Guessing can be done through the Universe's :meth:`~MDAnalysis.core.universe.Universe.guess_TopologyAttrs` as following::
 
@@ -24,12 +35,12 @@ Guessing can be done through the Universe's :meth:`~MDAnalysis.core.universe.Uni
   u.guess_TopologyAttrs(to_guess=['elements'])
   print(u.atoms.elements) # print ['N' 'H' 'H' ... 'NA' 'NA' 'NA']
 
-In the above example, we passed ``elements`` as the attribute we want to guess, and
+In the above example, we passed ``elements`` as the attribute we want to guess
 :meth:`~MDAnalysis.core.universe.Universe.guess_TopologyAttrs` guess then add it as a topology
 attribute to the ``AtomGroup`` of the universe.
 
-If the attribute already exist in the universe, passing the attribute of interest to the ``to_guess`` parameter will only fill the empty values of the attribute if any exists.
-To override all the attribute values, you can pass the attribute to the ``force_guess`` parameter instead of the to_guess one as following::
+If the attribute already exists in the universe, passing the attribute of interest to the ``to_guess`` parameter will only fill the empty values of the attribute if any exists.
+To override all the attribute values, you can pass the attribute to the ``force_guess`` parameter instead of ``to_guess`` as following::
 
    import MDAnalysis as mda
    from MDAnalysisTests.datafiles import PRM12
@@ -38,9 +49,14 @@ To override all the attribute values, you can pass the attribute to the ``force_
 
    u.guess_TopologyAttrs(force_guess=['types']) # types ['H', 'O', ..]
 
-N.B.: If you didn't pass any ``context`` to the API, it will use the :class:`~MDAnalysis.guesser.default_guesser.DefaultGuesser`
 
-.. rubric:: available guessers
+.. note::
+   The default ``context`` will use the :class:`~MDAnalysis.guesser.default_guesser.DefaultGuesser`
+
+
+
+
+.. rubric:: Available guessers
 .. toctree::
    :maxdepth: 1
 
@@ -48,7 +64,7 @@ N.B.: If you didn't pass any ``context`` to the API, it will use the :class:`~MD
    guesser_modules/default_guesser
 
 
-.. rubric:: guesser core modules
+.. rubric:: Guesser core modules
 
 The remaining pages are primarily of interest to developers as they
 contain functions and classes that are used in the implementation of

--- a/package/doc/sphinx/source/documentation_pages/guesser_modules.rst
+++ b/package/doc/sphinx/source/documentation_pages/guesser_modules.rst
@@ -18,7 +18,7 @@ Default behavior
 By default, MDAnalysis will guess the "mass" and "type" (atom type) attributes for all particles in the Universe
 using the :class:`~MDAnalysis.guesser.default_guesser.DefaultGuesser` at the time of Universe creation,
 if they are not read from the input file.
-Please see the :ref:`DefaultGuesser` for more information.
+Please see the :class:`~MDAnalysis.guesser.default_guesser.DefaultGuesser` for more information.
 
 
 

--- a/package/doc/sphinx/source/documentation_pages/guesser_modules.rst
+++ b/package/doc/sphinx/source/documentation_pages/guesser_modules.rst
@@ -18,7 +18,7 @@ Default behavior
 By default, MDAnalysis will guess the "mass" and "type" (atom type) attributes for all particles in the Universe
 using the :class:`~MDAnalysis.guesser.default_guesser.DefaultGuesser` at the time of Universe creation,
 if they are not read from the input file.
-Please see the :ref:`DefaultGuesser`_ for more information.
+Please see the :ref:`DefaultGuesser` for more information.
 
 
 


### PR DESCRIPTION
Fixes #4696

Changes made in this Pull Request:
 - This adds back the documentation on guessed attributes as a note, whereever the previous guessed attribute documentation was (this varied between the module docs and class docs). The note contains a link to the overall guesser docs
 - The overall guesser docs contain more info about the default guessing involved.

Please feel free to make any changes desired and push into this branch!

PR Checklist
------------
 - [ ] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4743.org.readthedocs.build/en/4743/

<!-- readthedocs-preview mdanalysis end -->