### PR TITLE
Add deprecation warning for ITPParser

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -110,6 +110,8 @@ Changes
    numpy.testing.assert_allclose #4438)
 
 Deprecations
+ * Element guessing in the ITPParser is deprecated and will be removed in version 3.0
+   (Issue #4698)
  * Unknown masses are set to 0.0 for current version, this will be depracated
    in version 3.0.0 and replaced by :class:`Masses`' no_value_label attribute(np.nan)
    (PR #3753)

--- a/package/MDAnalysis/topology/ITPParser.py
+++ b/package/MDAnalysis/topology/ITPParser.py
@@ -595,7 +595,7 @@ class ITPParser(TopologyReaderBase):
             attrs.append(Elements(np.array(self.elements,
                          dtype=object), guessed=True))
             warnings.warn(
-                "Element guessing has been added temporarily to the ITPParser "
+                "Element guessing from types has been added temporarily to the ITPParser "
                 "to preserve the previous behavior of guessing any masses of particles "
                 "that were not defined in the ITP file as we transition to the new "
                 "guessing API. This behavior will be removed in release 3.0. "

--- a/package/MDAnalysis/topology/ITPParser.py
+++ b/package/MDAnalysis/topology/ITPParser.py
@@ -595,10 +595,10 @@ class ITPParser(TopologyReaderBase):
             attrs.append(Elements(np.array(self.elements,
                          dtype=object), guessed=True))
             warnings.warn(
-                "Element guessing from types has been added temporarily to "
-                "the ITPParser to preserve the previous behavior of "
-                "guessing any masses of particles that were not defined "
-                "in the ITP file as we transition to the new guessing API. "
+                "The elements attribute has been populated by guessing "
+                "elements from atom types. This behaviour has been "
+                "temporarily added to the ITPParser as we transition "
+                "to the new guessing API. "
                 "This behavior will be removed in release 3.0. "
                 "Please see issue #4698 for more information. ",
                 DeprecationWarning

--- a/package/MDAnalysis/topology/ITPParser.py
+++ b/package/MDAnalysis/topology/ITPParser.py
@@ -595,10 +595,11 @@ class ITPParser(TopologyReaderBase):
             attrs.append(Elements(np.array(self.elements,
                          dtype=object), guessed=True))
             warnings.warn(
-                "Element guessing from types has been added temporarily to the ITPParser "
-                "to preserve the previous behavior of guessing any masses of particles "
-                "that were not defined in the ITP file as we transition to the new "
-                "guessing API. This behavior will be removed in release 3.0. "
+                "Element guessing from types has been added temporarily to "
+                "the ITPParser to preserve the previous behavior of "
+                "guessing any masses of particles that were not defined "
+                "in the ITP file as we transition to the new guessing API. "
+                "This behavior will be removed in release 3.0. "
                 "Please see issue #4698 for more information. ",
                 DeprecationWarning
             )

--- a/package/MDAnalysis/topology/ITPParser.py
+++ b/package/MDAnalysis/topology/ITPParser.py
@@ -594,7 +594,14 @@ class ITPParser(TopologyReaderBase):
         if all(e.capitalize() in SYMB2Z for e in self.elements):
             attrs.append(Elements(np.array(self.elements,
                          dtype=object), guessed=True))
-
+            warnings.warn(
+                "Element guessing has been added temporarily to the ITPParser "
+                "to preserve the previous behavior of guessing any masses of particles "
+                "that were not defined in the ITP file as we transition to the new "
+                "guessing API. This behavior will be removed in release 3.0. "
+                "Please see issue #4698 for more information. ",
+                DeprecationWarning
+            )
         else:
             warnings.warn("Element information is missing, elements attribute "
                           "will not be populated. If needed these can be "

--- a/testsuite/MDAnalysisTests/topology/test_itp.py
+++ b/testsuite/MDAnalysisTests/topology/test_itp.py
@@ -498,7 +498,7 @@ def test_elements_deprecation_warning():
         mda.Universe(ITP_nomass)
 
 
-def test_nodeprecation_warning():
+def test_elements_nodeprecation_warning():
     "Test deprecation warning is not present if elements isn't guessed"
     with pytest.warns(UserWarning) as record:
         mda.Universe(ITP_atomtypes)

--- a/testsuite/MDAnalysisTests/topology/test_itp.py
+++ b/testsuite/MDAnalysisTests/topology/test_itp.py
@@ -497,14 +497,13 @@ def test_deprecation_warning():
     with pytest.warns(DeprecationWarning, match="removed in release 3.0"):
         mda.Universe(ITP_nomass)
 
+
 def test_nodeprecation_warning():
     "Test deprecation warning is not present if elements isn't guessed"
     with pytest.warns(UserWarning) as record:
         mda.Universe(ITP_atomtypes)
     assert len(record) == 2
-    
+
     warned = [warn.message.args[0] for warn in record]
     assert "Element information is missing" in warned[0]
     assert "No coordinate reader found" in warned[1]
-    
-    

--- a/testsuite/MDAnalysisTests/topology/test_itp.py
+++ b/testsuite/MDAnalysisTests/topology/test_itp.py
@@ -490,3 +490,21 @@ def test_missing_elements_no_attribute():
         u = mda.Universe(ITP_atomtypes)
     with pytest.raises(AttributeError):
         _ = u.atoms.elements
+
+
+def test_deprecation_warning():
+    "Test deprecation warning is present"
+    with pytest.warns(DeprecationWarning, match="removed in release 3.0"):
+        mda.Universe(ITP_nomass)
+
+def test_nodeprecation_warning():
+    "Test deprecation warning is not present if elements isn't guessed"
+    with pytest.warns(UserWarning) as record:
+        mda.Universe(ITP_atomtypes)
+    assert len(record) == 2
+    
+    warned = [warn.message.args[0] for warn in record]
+    assert "Element information is missing" in warned[0]
+    assert "No coordinate reader found" in warned[1]
+    
+    

--- a/testsuite/MDAnalysisTests/topology/test_itp.py
+++ b/testsuite/MDAnalysisTests/topology/test_itp.py
@@ -493,13 +493,13 @@ def test_missing_elements_no_attribute():
 
 
 def test_elements_deprecation_warning():
-    "Test deprecation warning is present"
+    """Test deprecation warning is present"""
     with pytest.warns(DeprecationWarning, match="removed in release 3.0"):
         mda.Universe(ITP_nomass)
 
 
 def test_elements_nodeprecation_warning():
-    "Test deprecation warning is not present if elements isn't guessed"
+    """Test deprecation warning is not present if elements isn't guessed"""
     with pytest.warns(UserWarning) as record:
         mda.Universe(ITP_atomtypes)
     assert len(record) == 2

--- a/testsuite/MDAnalysisTests/topology/test_itp.py
+++ b/testsuite/MDAnalysisTests/topology/test_itp.py
@@ -492,7 +492,7 @@ def test_missing_elements_no_attribute():
         _ = u.atoms.elements
 
 
-def test_deprecation_warning():
+def test_elements_deprecation_warning():
     "Test deprecation warning is present"
     with pytest.warns(DeprecationWarning, match="removed in release 3.0"):
         mda.Universe(ITP_nomass)


### PR DESCRIPTION
Fixes #4698

Changes made in this Pull Request:
 - Adds deprecation warning for element guessing in ITPParser

Please feel free to make any changes desired and push into this branch!

PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4744.org.readthedocs.build/en/4744/

<!-- readthedocs-preview mdanalysis end -->