### PR TITLE
add default None -> UserWarning

### DIFF
--- a/testsuite/MDAnalysisTests/topology/test_itp.py
+++ b/testsuite/MDAnalysisTests/topology/test_itp.py
@@ -26,6 +26,7 @@ import MDAnalysis as mda
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 
+from MDAnalysisTests.util import no_deprecated_call
 from MDAnalysisTests.topology.base import ParserBase
 from MDAnalysisTests.datafiles import (
     ITP,  # GROMACS itp
@@ -490,6 +491,8 @@ def test_missing_elements_no_attribute():
         u = mda.Universe(ITP_atomtypes)
     with pytest.raises(AttributeError):
         _ = u.atoms.elements
+    with no_deprecated_call():
+        mda.Universe(ITP_atomtypes)
 
 
 def test_elements_deprecation_warning():

--- a/testsuite/MDAnalysisTests/util.py
+++ b/testsuite/MDAnalysisTests/util.py
@@ -233,6 +233,9 @@ class _NoDeprecatedCallContext(object):
         if isinstance(message, Warning):
             self._captured_categories.append(message.__class__)
         else:
+            # as follows Python documentation at
+            # https://docs.python.org/3/library/warnings.html#warnings.warn
+            # if category is None, the default UserWarning is used
             if category is None:
                 category = UserWarning
             self._captured_categories.append(category)

--- a/testsuite/MDAnalysisTests/util.py
+++ b/testsuite/MDAnalysisTests/util.py
@@ -233,6 +233,8 @@ class _NoDeprecatedCallContext(object):
         if isinstance(message, Warning):
             self._captured_categories.append(message.__class__)
         else:
+            if category is None:
+                category = UserWarning
             self._captured_categories.append(category)
 
     def __exit__(self, exc_type, exc_val, exc_tb):


### PR DESCRIPTION
Fixes #4746

Changes made in this Pull Request:
 - This mimics the Python warnings library by setting `category=None` to `UserWarning` by default

We don't appear to test our utilities anywhere so I haven't added a formal test -- but running it with #4744 worked.

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4747.org.readthedocs.build/en/4747/

<!-- readthedocs-preview mdanalysis end -->