### PR TITLE
Change error to warning on Universe creation

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -23,6 +23,8 @@ The rules for this file:
  * 2.8.0
 
 Fixes
+ * Changes error to warning on Universe creation if guessing fails
+   due to missing information (Issue #4750, PR #4754)
  * Adds guessed attributes documentation back to each parser page
    and updates overall guesser docs (Issue #4696)
  * Fix Bohrium (Bh) atomic mass in tables.py (PR #3753)

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -1530,6 +1530,8 @@ class Universe(object):
             If True, raise an error if the guesser cannot guess the attribute
             due to missing TopologyAttrs used as the inputs for guessing.
             If False, a warning will be raised instead.
+            Errors will always be raised if an attribute is in the
+            ``force_guess`` list, even if this parameter is set to False.
 
         **kwargs: extra arguments to be passed to the guesser class
 
@@ -1592,7 +1594,7 @@ class Universe(object):
                     try:
                         values = guesser.guess_attr(attr, fg)
                     except ValueError as e:
-                        if error_if_missing:
+                        if error_if_missing or fg:
                             raise e
                         else:
                             warnings.warn(str(e))

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -376,11 +376,13 @@ class Universe(object):
 
         format, topology_format = _resolve_formats(*coordinates, format=format,
                                                    topology_format=topology_format)
+
         if not isinstance(topology, Topology) and not topology is None:
             self.filename = _check_file_like(topology)
             topology = _topology_from_file_like(self.filename,
                                                 topology_format=topology_format,
                                                 **kwargs)
+
         if topology is not None:
             self._topology = topology
         else:

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -1527,9 +1527,9 @@ class Universe(object):
             effect. If the TopologyAttr does already exist, all values will
             be overwritten by guessed values.
         error_if_missing: bool
-            If True, raise an error if the guesser cannot guess the attribute
+            If `True`, raise an error if the guesser cannot guess the attribute
             due to missing TopologyAttrs used as the inputs for guessing.
-            If False, a warning will be raised instead.
+            If `False`, a warning will be raised instead.
             Errors will always be raised if an attribute is in the
             ``force_guess`` list, even if this parameter is set to False.
 

--- a/package/MDAnalysis/guesser/default_guesser.py
+++ b/package/MDAnalysis/guesser/default_guesser.py
@@ -293,7 +293,7 @@ class DefaultGuesser(GuesserBase):
                 atom_types = self._universe.atoms.names
             except AttributeError:
                 raise ValueError(
-                    "there is no reference attributes in this universe"
+                    "there is no reference attributes in this universe "
                     "to guess types from")
 
         if indices_to_guess is not None:

--- a/package/doc/sphinx/source/documentation_pages/guesser_modules.rst
+++ b/package/doc/sphinx/source/documentation_pages/guesser_modules.rst
@@ -17,7 +17,8 @@ Default behavior
 
 By default, MDAnalysis will guess the "mass" and "type" (atom type) attributes for all particles in the Universe
 using the :class:`~MDAnalysis.guesser.default_guesser.DefaultGuesser` at the time of Universe creation,
-if they are not read from the input file.
+if they are not read from the input file. If the required information is not present in the input file,
+a warning will be raised.
 Please see the :class:`~MDAnalysis.guesser.default_guesser.DefaultGuesser` for more information.
 
 

--- a/testsuite/MDAnalysisTests/guesser/test_base.py
+++ b/testsuite/MDAnalysisTests/guesser/test_base.py
@@ -108,3 +108,12 @@ class TestBaseGuesser():
 )
 def test_universe_creation_from_coordinates(universe_input):
     mda.Universe(universe_input)
+
+
+def test_universe_creation_from_specific_array():
+    a = np.array([
+        [0., 0., 150.], [0., 0., 150.], [200., 0., 150.],
+        [0., 0., 150.], [100., 100., 150.], [200., 100., 150.],
+        [0., 200., 150.], [100., 200., 150.], [200., 200., 150.]
+    ])
+    mda.Universe(a, n_atoms=9)

--- a/testsuite/MDAnalysisTests/guesser/test_base.py
+++ b/testsuite/MDAnalysisTests/guesser/test_base.py
@@ -30,7 +30,7 @@ import MDAnalysis.tests.datafiles as datafiles
 from numpy.testing import assert_allclose, assert_equal
 
 
-class TesttBaseGuesser():
+class TestBaseGuesser():
 
     def test_get_guesser(self):
         class TestGuesser1(GuesserBase):
@@ -100,3 +100,11 @@ class TesttBaseGuesser():
         top = Topology(4, 1, 1, attrs=[names, types, ])
         u = mda.Universe(top, to_guess=['types'])
         assert_equal(u.atoms.types, ['', '', '', ''])
+
+
+@pytest.mark.parametrize(
+    "universe_input",
+    [datafiles.DCD, datafiles.XTC, np.random.rand(3, 3), datafiles.PDB]
+)
+def test_universe_creation_from_coordinates(universe_input):
+    mda.Universe(universe_input)

--- a/testsuite/MDAnalysisTests/guesser/test_default_guesser.py
+++ b/testsuite/MDAnalysisTests/guesser/test_default_guesser.py
@@ -117,9 +117,8 @@ class TestGuessTypes(object):
 
     def test_guess_elements_from_no_data(self):
         top = Topology(5)
-        msg = "there is no reference attributes in this universe"
-        "to guess types from"
-        with pytest.raises(ValueError, match=(msg)):
+        msg = "there is no reference attributes in this universe to guess types from"
+        with pytest.warns(UserWarning, match=msg):
             mda.Universe(top, to_guess=['types'])
 
     @pytest.mark.parametrize('name, element', (
@@ -234,6 +233,19 @@ def test_guess_bonds_water():
                          (0, 2),
                          (3, 4),
                          (3, 5)))
+    
+
+@pytest.mark.parametrize(
+    "fudge_factor, n_bonds",
+    [(0, 0), (0.55, 4), (200, 6)]
+)
+def test_guess_bonds_water_fudge_factor_passed(fudge_factor, n_bonds):
+    u = mda.Universe(
+            datafiles.two_water_gro,
+            fudge_factor=fudge_factor,
+            to_guess=("types", "bonds")
+        )
+    assert len(u.atoms.bonds) == n_bonds
 
 
 def test_guess_bonds_adk():

--- a/testsuite/MDAnalysisTests/guesser/test_default_guesser.py
+++ b/testsuite/MDAnalysisTests/guesser/test_default_guesser.py
@@ -117,7 +117,10 @@ class TestGuessTypes(object):
 
     def test_guess_elements_from_no_data(self):
         top = Topology(5)
-        msg = "there is no reference attributes in this universe to guess types from"
+        msg = (
+            "there is no reference attributes in this "
+            "universe to guess types from"
+        )
         with pytest.warns(UserWarning, match=msg):
             mda.Universe(top, to_guess=['types'])
 
@@ -233,7 +236,7 @@ def test_guess_bonds_water():
                          (0, 2),
                          (3, 4),
                          (3, 5)))
-    
+
 
 @pytest.mark.parametrize(
     "fudge_factor, n_bonds",


### PR DESCRIPTION
Fixes #4750

Changes made in this Pull Request:
 - This changes the error to a warning on Universe creation for types and masses guessing, which is set by default.
 - Also fixes something I noticed about kwargs not getting passed into bond guessing.
 - And Universe kwargs were getting passed into guessing when they're documented as being for topologies.


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
