### PR TITLE
Addition of pytest case coverage of `backend` and `AnalysisBase.run()` using different `n_workers` values

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -82,8 +82,6 @@ Enhancements
    (Issue #4673) 
  * enables parallelization for analysis.dssp.dssp.DSSP (Issue #4674)
  * Enables parallelization for analysis.hydrogenbonds.hbond_analysis.HydrogenBondAnalysis (Issue #4664)
- * Added pytest for case where backend instance and AnalysisBase.run() have both different
-   n_worker values assigned (Issue #4649)
  * Improve error message for `AtomGroup.unwrap()` when bonds are not present.(Issue #4436, PR #4642)
  * Add `analysis.DSSP` module for protein secondary structure assignment, based on [pydssp](https://github.com/ShintaroMinami/PyDSSP)
  * Added a tqdm progress bar for `MDAnalysis.analysis.pca.PCA.transform()`

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -82,6 +82,8 @@ Enhancements
    (Issue #4673) 
  * enables parallelization for analysis.dssp.dssp.DSSP (Issue #4674)
  * Enables parallelization for analysis.hydrogenbonds.hbond_analysis.HydrogenBondAnalysis (Issue #4664)
+ * Added pytest for cases where backend instance and AnalysisBase.run() have both different
+   n_worker values assigned (Issue #4649)
  * Improve error message for `AtomGroup.unwrap()` when bonds are not present.(Issue #4436, PR #4642)
  * Add `analysis.DSSP` module for protein secondary structure assignment, based on [pydssp](https://github.com/ShintaroMinami/PyDSSP)
  * Added a tqdm progress bar for `MDAnalysis.analysis.pca.PCA.transform()`

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -82,7 +82,7 @@ Enhancements
    (Issue #4673) 
  * enables parallelization for analysis.dssp.dssp.DSSP (Issue #4674)
  * Enables parallelization for analysis.hydrogenbonds.hbond_analysis.HydrogenBondAnalysis (Issue #4664)
- * Added pytest for cases where backend instance and AnalysisBase.run() have both different
+ * Added pytest for case where backend instance and AnalysisBase.run() have both different
    n_worker values assigned (Issue #4649)
  * Improve error message for `AtomGroup.unwrap()` when bonds are not present.(Issue #4436, PR #4642)
  * Add `analysis.DSSP` module for protein secondary structure assignment, based on [pydssp](https://github.com/ShintaroMinami/PyDSSP)

--- a/testsuite/MDAnalysisTests/analysis/test_base.py
+++ b/testsuite/MDAnalysisTests/analysis/test_base.py
@@ -128,8 +128,8 @@ def test_n_workers_conflict_raises_value_error(u):
 
     with pytest.raises(ValueError, match="n_workers specified twice"):
         FrameAnalysis(u.trajectory).run(
-            backend=backend_instance, 
-            n_workers=1, 
+            backend=backend_instance,
+            n_workers=1,
             unsupported_backend=True
         )
 

--- a/testsuite/MDAnalysisTests/analysis/test_base.py
+++ b/testsuite/MDAnalysisTests/analysis/test_base.py
@@ -123,7 +123,6 @@ def test_incompatible_n_workers(u):
 
 
 def test_n_workers_conflict_raises_value_error(u):
-    analysis = FrameAnalysis(u.trajectory)
     backend_instance = ManyWorkersBackend(n_workers=4)
 
     with pytest.raises(ValueError, match="n_workers specified twice"):

--- a/testsuite/MDAnalysisTests/analysis/test_base.py
+++ b/testsuite/MDAnalysisTests/analysis/test_base.py
@@ -121,6 +121,13 @@ def test_incompatible_n_workers(u):
     with pytest.raises(ValueError):
         FrameAnalysis(u).run(backend=backend, n_workers=3)
 
+def test_n_workers_conflict_raises_value_error(u):
+    analysis = FrameAnalysis(u.trajectory)
+    backend_instance = ManyWorkersBackend(n_workers=4)
+
+    with pytest.raises(ValueError, match="n_workers specified twice"):
+        FrameAnalysis(u.trajectory).run(backend=backend_instance, n_workers=1, unsupported_backend=True)
+
 @pytest.mark.parametrize('run_class,backend,n_workers', [
     (Parallelizable, 'not-existing-backend', 2),
     (Parallelizable, 'not-existing-backend', None),

--- a/testsuite/MDAnalysisTests/analysis/test_base.py
+++ b/testsuite/MDAnalysisTests/analysis/test_base.py
@@ -121,12 +121,17 @@ def test_incompatible_n_workers(u):
     with pytest.raises(ValueError):
         FrameAnalysis(u).run(backend=backend, n_workers=3)
 
+
 def test_n_workers_conflict_raises_value_error(u):
     analysis = FrameAnalysis(u.trajectory)
     backend_instance = ManyWorkersBackend(n_workers=4)
 
     with pytest.raises(ValueError, match="n_workers specified twice"):
-        FrameAnalysis(u.trajectory).run(backend=backend_instance, n_workers=1, unsupported_backend=True)
+        FrameAnalysis(u.trajectory).run(
+            backend=backend_instance, 
+            n_workers=1, 
+            unsupported_backend=True
+        )
 
 @pytest.mark.parametrize('run_class,backend,n_workers', [
     (Parallelizable, 'not-existing-backend', 2),


### PR DESCRIPTION
Fixes #4649 

Adds the coverage of the `ValueError` case, where `backend` and `AnalysisBase.run()` have
different values for `n_workers`

Changes made in this Pull Request:
 - Added of `test_n_workers_conflict_raises_value_error` in `test_base.py` to cover cases, where
 both `backend` and `AnalysisBase.run()` have different values of `n_workers`


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4768.org.readthedocs.build/en/4768/

<!-- readthedocs-preview mdanalysis end -->