### PR TITLE
Addition of `pytest` case for not `None` values for `frames` and `start`/`stop`/`step`

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -82,7 +82,6 @@ Enhancements
    (Issue #4673) 
  * enables parallelization for analysis.dssp.dssp.DSSP (Issue #4674)
  * Enables parallelization for analysis.hydrogenbonds.hbond_analysis.HydrogenBondAnalysis (Issue #4664)
- * Added pytest case to cover Raise errors cases frames and step/stop/step are present (Issue #4648)
  * Improve error message for `AtomGroup.unwrap()` when bonds are not present.(Issue #4436, PR #4642)
  * Add `analysis.DSSP` module for protein secondary structure assignment, based on [pydssp](https://github.com/ShintaroMinami/PyDSSP)
  * Added a tqdm progress bar for `MDAnalysis.analysis.pca.PCA.transform()`

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -82,6 +82,7 @@ Enhancements
    (Issue #4673) 
  * enables parallelization for analysis.dssp.dssp.DSSP (Issue #4674)
  * Enables parallelization for analysis.hydrogenbonds.hbond_analysis.HydrogenBondAnalysis (Issue #4664)
+ * Added pytest case to cover Raise errors cases frames and step/stop/step are present (Issue #4648)
  * Improve error message for `AtomGroup.unwrap()` when bonds are not present.(Issue #4436, PR #4642)
  * Add `analysis.DSSP` module for protein secondary structure assignment, based on [pydssp](https://github.com/ShintaroMinami/PyDSSP)
  * Added a tqdm progress bar for `MDAnalysis.analysis.pca.PCA.transform()`

--- a/testsuite/MDAnalysisTests/analysis/test_base.py
+++ b/testsuite/MDAnalysisTests/analysis/test_base.py
@@ -121,6 +121,14 @@ def test_incompatible_n_workers(u):
     with pytest.raises(ValueError):
         FrameAnalysis(u).run(backend=backend, n_workers=3)
 
+def test_frame_values_incompatability(u):
+    start, stop, step = 0, 4, 1
+    frames = [1, 2, 3, 4]
+
+    with pytest.raises(ValueError, match="start/stop/step cannot be combined with frames"):
+        FrameAnalysis(u.trajectory).run(frames=frames, start=start, stop=stop, step=step)
+
+
 @pytest.mark.parametrize('run_class,backend,n_workers', [
     (Parallelizable, 'not-existing-backend', 2),
     (Parallelizable, 'not-existing-backend', None),

--- a/testsuite/MDAnalysisTests/analysis/test_base.py
+++ b/testsuite/MDAnalysisTests/analysis/test_base.py
@@ -121,13 +121,19 @@ def test_incompatible_n_workers(u):
     with pytest.raises(ValueError):
         FrameAnalysis(u).run(backend=backend, n_workers=3)
 
+
 def test_frame_values_incompatability(u):
     start, stop, step = 0, 4, 1
     frames = [1, 2, 3, 4]
 
-    with pytest.raises(ValueError, match="start/stop/step cannot be combined with frames"):
-        FrameAnalysis(u.trajectory).run(frames=frames, start=start, stop=stop, step=step)
-
+    with pytest.raises(ValueError, 
+                       match="start/stop/step cannot be combined with frames"):
+        FrameAnalysis(u.trajectory).run(
+            frames=frames,
+            start=start,
+            stop=stop,
+            step=step
+        )
 
 @pytest.mark.parametrize('run_class,backend,n_workers', [
     (Parallelizable, 'not-existing-backend', 2),

--- a/testsuite/MDAnalysisTests/analysis/test_base.py
+++ b/testsuite/MDAnalysisTests/analysis/test_base.py
@@ -126,7 +126,7 @@ def test_frame_values_incompatability(u):
     start, stop, step = 0, 4, 1
     frames = [1, 2, 3, 4]
 
-    with pytest.raises(ValueError, 
+    with pytest.raises(ValueError,
                        match="start/stop/step cannot be combined with frames"):
         FrameAnalysis(u.trajectory).run(
             frames=frames,


### PR DESCRIPTION
Fixes #4648 

Changes made in this Pull Request:
 - Added a `pytest` case in `test_base.py` to cover the case where `frames` and `start`/`stop`/`step` are both specified as not `None`, leading to an `ValueError`


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4769.org.readthedocs.build/en/4769/

<!-- readthedocs-preview mdanalysis end -->