### PR TITLE
Addition of test for missing aggregation function when `require_all_aggregators=True`

### DIFF
--- a/testsuite/MDAnalysisTests/analysis/test_results.py
+++ b/testsuite/MDAnalysisTests/analysis/test_results.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 from MDAnalysis.analysis import results as results_module
 from numpy.testing import assert_equal
+from itertools import cycle
 
 
 class Test_Results:
@@ -155,8 +156,6 @@ class Test_ResultsGroup:
 
     @pytest.mark.parametrize("n", [1, 2, 5, 14])
     def test_all_results(self, results_0, results_1, merger, n):
-        from itertools import cycle
-
         objects = [obj for obj, _ in zip(cycle([results_0, results_1]), range(n))]
 
         arr = [i for _, i in zip(range(n), cycle([0, 1]))]
@@ -171,3 +170,13 @@ class Test_ResultsGroup:
         results = merger.merge(objects)
         for attr, merged_value in results.items():
             assert_equal(merged_value, answers.get(attr), err_msg=f"{attr=}, {merged_value=}, {arr=}, {objects=}")
+
+
+    def test_missing_aggregator(self, results_0, results_1, merger):
+        original_float_lookup = merger._lookup.get("float")
+        merger._lookup["float"] = None
+
+        with pytest.raises(ValueError, match="No aggregation function for key='float'"):
+            merger.merge([results_0, results_1], require_all_aggregators=True)
+
+        merger._lookup["float"] = original_float_lookup

--- a/testsuite/MDAnalysisTests/analysis/test_results.py
+++ b/testsuite/MDAnalysisTests/analysis/test_results.py
@@ -171,12 +171,12 @@ class Test_ResultsGroup:
         for attr, merged_value in results.items():
             assert_equal(merged_value, answers.get(attr), err_msg=f"{attr=}, {merged_value=}, {arr=}, {objects=}")
 
-
     def test_missing_aggregator(self, results_0, results_1, merger):
         original_float_lookup = merger._lookup.get("float")
         merger._lookup["float"] = None
 
-        with pytest.raises(ValueError, match="No aggregation function for key='float'"):
+        with pytest.raises(ValueError,
+                           match="No aggregation function for key='float'"):
             merger.merge([results_0, results_1], require_all_aggregators=True)
 
         merger._lookup["float"] = original_float_lookup


### PR DESCRIPTION
Fixes #4650

Changes made in this Pull Request:
 - Addition of `test_missing_aggregator` in `test_results.py` to cover `ValueError` case when
 the aggregation is missing and  `require_all_aggregators=True` in `ResultsGroup.merge()`


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4770.org.readthedocs.build/en/4770/

<!-- readthedocs-preview mdanalysis end -->