### PR TITLE
Addition of `isInstance` test of `BackendSerial`

### DIFF
--- a/testsuite/MDAnalysisTests/analysis/test_base.py
+++ b/testsuite/MDAnalysisTests/analysis/test_base.py
@@ -286,6 +286,7 @@ def test_parallelizable_transformations():
     with pytest.raises(ValueError):
         FrameAnalysis(u.trajectory).run(backend='multiprocessing')
 
+
 def test_instance_serial_backend(u):
     serial_backend = backends.BackendSerial(n_workers=1)
 

--- a/testsuite/MDAnalysisTests/analysis/test_base.py
+++ b/testsuite/MDAnalysisTests/analysis/test_base.py
@@ -286,6 +286,18 @@ def test_parallelizable_transformations():
     with pytest.raises(ValueError):
         FrameAnalysis(u.trajectory).run(backend='multiprocessing')
 
+def test_instance_serial_backend(u):
+    serial_backend = backends.BackendSerial(n_workers=1)
+
+    FrameAnalysis(u.trajectory).run(
+        backend=serial_backend,
+        verbose=True,
+        progressbar_kwargs={"leave": True},
+        unsupported_backend=True
+    )
+
+    assert isinstance(serial_backend, backends.BackendSerial)
+
 def test_frame_bool_fail(client_FrameAnalysis):
     u = mda.Universe(TPR, XTC)  # dt = 100
     an = FrameAnalysis(u.trajectory)

--- a/testsuite/MDAnalysisTests/analysis/test_base.py
+++ b/testsuite/MDAnalysisTests/analysis/test_base.py
@@ -288,16 +288,16 @@ def test_parallelizable_transformations():
 
 
 def test_instance_serial_backend(u):
-    serial_backend = backends.BackendSerial(n_workers=1)
+    # test that isinstance is checked and the correct ValueError raise appears
+    msg = 'Can not display progressbar with non-serial backend'
+    with pytest.raises(ValueError, match=msg):
+        FrameAnalysis(u.trajectory).run(
+            backend=backends.BackendMultiprocessing(n_workers=2),
+            verbose=True,
+            progressbar_kwargs={"leave": True},
+            unsupported_backend=True
+        )
 
-    FrameAnalysis(u.trajectory).run(
-        backend=serial_backend,
-        verbose=True,
-        progressbar_kwargs={"leave": True},
-        unsupported_backend=True
-    )
-
-    assert isinstance(serial_backend, backends.BackendSerial)
 
 def test_frame_bool_fail(client_FrameAnalysis):
     u = mda.Universe(TPR, XTC)  # dt = 100


### PR DESCRIPTION
Fixes #4657

Changes made in this Pull Request:
 - Addition of `test_instance_serial_backend` to `test_base.py` to check that the function works and the instance is correct


Currently I just create a variable of `BackendSerial` for `serial_backend` , which I use in `FrameAnalysis(u.trajectory).run` to display that it runs with the `backend=serial_backend` and also then check the correct instance of `serial_backend`

I wasn't sure here if I should check the instance of `backend` of the `run()` in `FrameAnalysis(u.trajectory).run(backend=serial_backend)`, since then I would need to modify the code to get the instance of `backend` from `run()`


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4773.org.readthedocs.build/en/4773/

<!-- readthedocs-preview mdanalysis end -->