### PR TITLE
Revert to artifact upload/download to v3 for 2.8.0 release

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -63,7 +63,7 @@ jobs:
         if: |
           (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/package')) ||
           (github.event_name == 'release' && github.event.action == 'published')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           path: wheelhouse/*.whl
           retention-days: 7
@@ -88,7 +88,7 @@ jobs:
         if: |
           (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/package')) ||
           (github.event_name == 'release' && github.event.action == 'published')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           path: package/dist/*.tar.gz
           retention-days: 7
@@ -113,7 +113,7 @@ jobs:
         if: |
           (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/package')) ||
           (github.event_name == 'release' && github.event.action == 'published')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           path: testsuite/dist/*.tar.gz
           retention-days: 7
@@ -131,7 +131,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build_wheels, build_sdist, build_sdist_tests]
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           name: artifact
           path: dist
@@ -160,7 +160,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build_wheels, build_sdist, build_sdist_tests]
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           name: artifact
           path: dist
@@ -190,7 +190,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build_wheels, build_sdist, build_sdist_tests]
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           name: artifact
           path: dist
@@ -216,7 +216,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build_wheels, build_sdist, build_sdist_tests]
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           name: artifact
           path: dist


### PR DESCRIPTION
Related to #4783 

Artifacts are no longer mutable in v4, which means that the workflow will need to changes to allow for multiple artifacts to be uploaded at the same time.

To avoid spending a lot of time fixing multiple things at the same time (and blocking through review), we rever to the v3 version. After the v2.8.0 release of MDAnalysis, work will be done to update the deploy workflow to v4.

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4784.org.readthedocs.build/en/4784/

<!-- readthedocs-preview mdanalysis end -->