### PR TITLE
[HOLD] Start 2.9.0-dev0

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -14,6 +14,19 @@ The rules for this file:
 
 
 -------------------------------------------------------------------------------
+??/??/?? IAlibay
+
+ * 2.9.0
+
+Fixes
+
+Enhancements
+
+Changes
+
+Deprecations
+
+
 11/11/24 IAlibay, HeetVekariya, marinegor, lilyminium, RMeli,
          ljwoods2, aditya292002, pstaerk, PicoCentauri, BFedder,
          tyler.je.reddy, SampurnaM, leonwehrhan, kainszs, orionarcher, 

--- a/package/MDAnalysis/version.py
+++ b/package/MDAnalysis/version.py
@@ -67,4 +67,4 @@ Data
 # e.g. with lib.log
 
 #: Release of MDAnalysis as a string, using `semantic versioning`_.
-__version__ = "2.8.0"  # NOTE: keep in sync with RELEASE in setup.py
+__version__ = "2.9.0-dev0"  # NOTE: keep in sync with RELEASE in setup.py

--- a/package/setup.py
+++ b/package/setup.py
@@ -58,7 +58,7 @@ import configparser
 from subprocess import getoutput
 
 # NOTE: keep in sync with MDAnalysis.__version__ in version.py
-RELEASE = "2.8.0"
+RELEASE = "2.9.0-dev0"
 
 is_release = "dev" not in RELEASE
 

--- a/testsuite/MDAnalysisTests/__init__.py
+++ b/testsuite/MDAnalysisTests/__init__.py
@@ -97,7 +97,7 @@ import pytest
 logger = logging.getLogger("MDAnalysisTests.__init__")
 
 # keep in sync with RELEASE in setup.py
-__version__ = "2.8.0"
+__version__ = "2.9.0-dev0"
 
 
 # Do NOT import MDAnalysis at this level. Tests should do it themselves.

--- a/testsuite/setup.py
+++ b/testsuite/setup.py
@@ -74,7 +74,7 @@ class MDA_SDist(sdist.sdist):
 
 if __name__ == '__main__':
     # this must be in-sync with MDAnalysis
-    RELEASE = "2.8.0"
+    RELEASE = "2.9.0-dev0"
 
     setup(
         version=RELEASE,


### PR DESCRIPTION
If this comes back not red (except the 3.9 runners.. they are still pulling old MDAnalysis): https://github.com/MDAnalysis/mdanalysis/actions/runs/12039544989/job/33567570077

Then we're good to go.


PR Checklist
------------
 - [x] CHANGELOG updated?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4803.org.readthedocs.build/en/4803/

<!-- readthedocs-preview mdanalysis end -->