### PR TITLE
mark `analysis.atomicdistances.AtomicDistances` as not parallelizable

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -14,13 +14,14 @@ The rules for this file:
 
 
 -------------------------------------------------------------------------------
-??/??/?? IAlibay
+??/??/?? IAlibay, talagayev
 
  * 2.9.0
 
 Fixes
 
 Enhancements
+ * marked `analysis.atomicdistances.AtomicDistances` as not parallelizable (Issue #4662)
 
 Changes
 

--- a/package/MDAnalysis/analysis/atomicdistances.py
+++ b/package/MDAnalysis/analysis/atomicdistances.py
@@ -146,6 +146,7 @@ class AtomicDistances(AnalysisBase):
 
     .. versionadded:: 2.5.0
     """
+    _analysis_algorithm_is_parallelizable = False
 
     def __init__(self, ag1, ag2, pbc=True, **kwargs):
         # check ag1 and ag2 have the same number of atoms

--- a/testsuite/MDAnalysisTests/analysis/test_atomicdistances.py
+++ b/testsuite/MDAnalysisTests/analysis/test_atomicdistances.py
@@ -134,3 +134,22 @@ class TestAtomicDistances(object):
 
         # compare with expected values from dist()
         assert_allclose(actual, expected_pbc_dist)
+
+@pytest.mark.parametrize(
+    "classname,is_parallelizable",
+    [
+        (ad.AtomicDistances, False),
+    ]
+)
+def test_class_is_parallelizable(classname, is_parallelizable):
+    assert classname._analysis_algorithm_is_parallelizable == is_parallelizable
+
+
+@pytest.mark.parametrize(
+    "classname,backends",
+    [
+        (ad.AtomicDistances,  ('serial',)),
+    ]
+)
+def test_supported_backends(classname, backends):
+    assert classname.get_supported_backends() == backends

--- a/testsuite/MDAnalysisTests/analysis/test_atomicdistances.py
+++ b/testsuite/MDAnalysisTests/analysis/test_atomicdistances.py
@@ -135,6 +135,7 @@ class TestAtomicDistances(object):
         # compare with expected values from dist()
         assert_allclose(actual, expected_pbc_dist)
 
+
 @pytest.mark.parametrize(
     "classname,is_parallelizable",
     [


### PR DESCRIPTION
Fixes #4662 

Changes made in this Pull Request:
 - `atomicdistances.AtomicDistances` explicitly marked as not parallelizable
 - Addition of tests to `test_atomicdistances.py` to assert `serial` backend

Reason why `atomicdistances.AtomicDistances` is not parallelizable: 
- Currently `Results` uses `UserDict` as input, while `atomicdistances.AtomicDistances` outputs an `numpy.ndarray`
so it would require the modification of the output or modification of `Results` to make it parallelizable

PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4808.org.readthedocs.build/en/4808/

<!-- readthedocs-preview mdanalysis end -->