### PR TITLE
Ruff

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -45,6 +45,21 @@ jobs:
         src: "./testsuite"
         version: "~= 24.0"
 
+  ruff:
+    if: "github.repository == 'MDAnalysis/mdanalysis'"
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - uses: astral-sh/ruff-action@v2
+      with:
+        args: check --select B006,B008
+        src: "package"
+    - uses: astral-sh/ruff-action@v2
+      with:
+        args: check --select B006,B008
+        src: "testsuite"
 
   pylint_check:
     if: "github.repository == 'MDAnalysis/mdanalysis'"


### PR DESCRIPTION
Suggested in #4810. Enable `ruff` with very minimal checks `B006` and `B008`. Currently blocked by #4810.

This can be eventually expanded once the re-formatting with `black` is over. Related to #2450.


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4825.org.readthedocs.build/en/4825/

<!-- readthedocs-preview mdanalysis end -->