### PR TITLE
Fixes deprecation warning and updated CHANGELOG

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -245,6 +245,7 @@ Chronological list of authors
   - Laksh Krishna Sharma
   - Matthew Davies
   - Jia-Xin Zhu
+  - Tanish Yelgoe
 
 
 External code

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -14,11 +14,12 @@ The rules for this file:
 
 
 -------------------------------------------------------------------------------
-??/??/?? IAlibay, ChiahsinChu, RMeli
+??/??/?? IAlibay, ChiahsinChu, RMeli, tanishy7777
 
  * 2.9.0
 
 Fixes
+ * Fixes deprecation warning Array to scalar convertion. Replaced atan2() with np.arctan2() 
 
 Enhancements
  * Add check and warning for empty (all zero) coordinates in RDKit converter (PR #4824)

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -19,7 +19,7 @@ The rules for this file:
  * 2.9.0
 
 Fixes
- * Fixes deprecation warning Array to scalar convertion. Replaced atan2() with np.arctan2() 
+ * Fixes deprecation warning Array to scalar convertion. Replaced atan2() with np.arctan2() (Issue #4339)
 
 Enhancements
  * Add check and warning for empty (all zero) coordinates in RDKit converter (PR #4824)

--- a/package/MDAnalysis/analysis/nuclinfo.py
+++ b/package/MDAnalysis/analysis/nuclinfo.py
@@ -299,7 +299,7 @@ def phase_cp(universe, seg, i):
          + (r3_d * cos(4 * pi * 2.0 / 5.0)) + (r4_d * cos(4 * pi * 3.0 / 5.0))
          + (r5_d * cos(4 * pi * 4.0 / 5.0))) * sqrt(2.0 / 5.0)
 
-    phase_ang = (atan2(D, C) + (pi / 2.)) * 180. / pi
+    phase_ang = (np.arctan2(D, C) + (pi / 2.)) * 180. / pi
     return phase_ang % 360
 
 

--- a/package/MDAnalysis/analysis/nuclinfo.py
+++ b/package/MDAnalysis/analysis/nuclinfo.py
@@ -93,7 +93,7 @@ Dihedral angles
 
 """
 import numpy as np
-from math import pi, sin, cos, atan2, sqrt, pow
+from math import pi, sin, cos, sqrt, pow
 
 from MDAnalysis.lib import mdamath
 
@@ -368,7 +368,7 @@ def phase_as(universe, seg, i):
          + (data4 * cos(2 * 2 * pi * (4 - 1.) / 5.))
          + (data5 * cos(2 * 2 * pi * (5 - 1.) / 5.))) * 2. / 5.
 
-    phase_ang = atan2(B, A) * 180. / pi
+    phase_ang = np.arctan2(B, A) * 180. / pi
     return phase_ang % 360
 
 


### PR DESCRIPTION
Fixes #4339 

Changes made in this Pull Request:
 - Changed the function atan2() to np.atan2() to avoid converting array to scalar


PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4831.org.readthedocs.build/en/4831/

<!-- readthedocs-preview mdanalysis end -->