### PR TITLE
Fixes MDAnalysis.analysis.density.convert_density() method has an invalid default unit value

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -245,6 +245,7 @@ Chronological list of authors
   - Laksh Krishna Sharma
   - Matthew Davies
   - Jia-Xin Zhu
+  - Tanish Yelgoe
 
 
 External code

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -14,11 +14,12 @@ The rules for this file:
 
 
 -------------------------------------------------------------------------------
-??/??/?? IAlibay, ChiahsinChu, RMeli
+??/??/?? IAlibay, ChiahsinChu, RMeli, tanishy7777
 
  * 2.9.0
 
 Fixes
+ * Fixes invalid default unit from Angstrom to Angstrom^{-3} for convert_density() function. (Issue #4829)
 
 Enhancements
  * Add check and warning for empty (all zero) coordinates in RDKit converter (PR #4824)

--- a/package/MDAnalysis/analysis/density.py
+++ b/package/MDAnalysis/analysis/density.py
@@ -826,7 +826,7 @@ class Density(Grid):
         self.units['length'] = unit
         self._update()  # needed to recalculate midpoints and origin
 
-    def convert_density(self, unit='Angstrom'):
+    def convert_density(self, unit='Angstrom^{-3}'):
         """Convert the density to the physical units given by `unit`.
 
         Parameters

--- a/testsuite/MDAnalysisTests/analysis/test_density.py
+++ b/testsuite/MDAnalysisTests/analysis/test_density.py
@@ -384,6 +384,12 @@ class TestDensityAnalysis(DensityParameters):
         with pytest.warns(DeprecationWarning, match=wmsg):
             assert_equal(D.density.grid, D.results.density.grid)
 
+    def test_density_analysis_invalid_unit(self):
+        u = mda.Universe(TPR, XTC)
+        ow = u.select_atoms("name OW")
+        D = mda.analysis.density.DensityAnalysis(ow, delta=1.0)
+        D.run()
+        D.results.density.convert_density()
 
 class TestGridImport(object):
 

--- a/testsuite/MDAnalysisTests/analysis/test_density.py
+++ b/testsuite/MDAnalysisTests/analysis/test_density.py
@@ -384,7 +384,7 @@ class TestDensityAnalysis(DensityParameters):
         with pytest.warns(DeprecationWarning, match=wmsg):
             assert_equal(D.density.grid, D.results.density.grid)
 
-    def test_density_analysis_invalid_unit(self):
+    def test_density_analysis_conversion_default_unit(self):
         u = mda.Universe(TPR, XTC)
         ow = u.select_atoms("name OW")
         D = mda.analysis.density.DensityAnalysis(ow, delta=1.0)


### PR DESCRIPTION
Fixes #4829 

Changes made in this Pull Request:
 - Changed the default unit in the convert_density() function to `Angstrom^{-3}` from `Angstrom`
 - Added new tests to check if the changes to the code(default unit) solve the issue in the `testsuite/MDAnalysisTests/analysis/test_density.py`


Before 
```python
def convert_density(self, unit='Angstrom'):
```

After
```python
def convert_density(self, unit='Angstrom^{-3}'):
```

PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4833.org.readthedocs.build/en/4833/

<!-- readthedocs-preview mdanalysis end -->