### PR TITLE
[CI] switched from macOS-12 to macOS-13 GH images

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -38,7 +38,7 @@ jobs:
       matrix:
         buildplat:
           - [ubuntu-22.04, manylinux_x86_64, x86_64]
-          - [macos-12, macosx_*, x86_64]
+          - [macos-13, macosx_*, x86_64]
           - [windows-2019, win_amd64, AMD64]
           - [macos-14, macosx_*, arm64]
         python: ["cp310", "cp311", "cp312", "cp313"]

--- a/.github/workflows/gh-ci-cron.yaml
+++ b/.github/workflows/gh-ci-cron.yaml
@@ -146,7 +146,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-12]
+        os: [ubuntu-20.04, macos-13]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -38,7 +38,7 @@ jobs:
               full-deps: false
               codecov: true
             - name: macOS_monterey_py311
-              os: macOS-12
+              os: macos-13
               python-version: "3.12"
               full-deps: true
               codecov: true


### PR DESCRIPTION
fix #4835

Changes made in this Pull Request:
 - use macos-13 instead of macos-12 images in all CI workflows


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4836.org.readthedocs.build/en/4836/

<!-- readthedocs-preview mdanalysis end -->