### PR TITLE
update Python versions gh-ci-cron.yaml

### DIFF
--- a/.github/workflows/gh-ci-cron.yaml
+++ b/.github/workflows/gh-ci-cron.yaml
@@ -237,9 +237,11 @@ jobs:
         fail-fast: false
         matrix:
           # Stick to macos-13 because some of our
-          # optional depss don't support arm64 (i.e. macos-14)
+          # optional deps don't support arm64 (i.e. macos-14)
+          #
+          # add "3.13" once conda-forge packages are available (see #4805)
           os: [ubuntu-latest, macos-13]
-          python-version: ["3.9", "3.10", "3.11", "3.12"]
+          python-version: ["3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
 
@@ -285,11 +287,8 @@ jobs:
         fail-fast: false
         matrix:
           os: [ubuntu-latest, macos-latest, macos-14, windows-latest]
-          python-version: ["3.9", "3.10", "3.11", "3.12"]
+          python-version: ["3.10", "3.11", "3.12", "3.13"]
           wheels: ['true', 'false']
-          exclude:
-          - os: "macos-14"
-            python-version: "3.9"
     steps:
       # Checkout to have access to local actions (i.e. setup-os)
     - uses: actions/checkout@v4


### PR DESCRIPTION
Fixes #4844

Changes made in this Pull Request:
- remove Python 3.9 from GH cron workflow
- add 3.13 to PyPi installation
- hold off on 3.13 for conda because of #4805



PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
