### PR TITLE
Implementation of `WaterSelection` for water resiude selection

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -25,6 +25,7 @@ Fixes
    the function to prevent shared state. (Issue #4655)
 
 Enhancements
+ * Addition of 'water' token for water selection (Issue #4839)
  * Enables parallelization for analysis.density.DensityAnalysis (Issue #4677, PR #4729)
  * Enables parallelization for analysis.contacts.Contacts (Issue #4660)
  * Enable parallelization for analysis.nucleicacids.NucPairDist (Issue #4670)

--- a/package/MDAnalysis/core/selection.py
+++ b/package/MDAnalysis/core/selection.py
@@ -1094,6 +1094,36 @@ class NucleicSelection(Selection):
         return group[mask]
 
 
+class WaterSelection(Selection):
+    """All atoms in water residues with recognized water residue names.
+
+    Recognized residue names:
+
+    * recognized 3 Letter resnames: 'H2O', 'HOH', 'OH2', 'HHO', 'OHH'
+        'TIP', 'T3P', 'T4P', 'T5P', 'SOL', 'WAT'
+
+    * recognized 4 Letter resnames: 'TIP2', 'TIP3', 'TIP4'
+
+    .. versionadded:: 2.9.0
+    """
+    token = 'water'
+
+    water_res = {
+        'H2O', 'HOH', 'OH2', 'HHO', 'OHH',
+        'T3P', 'T4P', 'T5P', 'SOL', 'WAT',
+        'TIP', 'TIP2', 'TIP3', 'TIP4'
+    }
+
+    def _apply(self, group):
+        resnames = group.universe._topology.resnames
+        nmidx = resnames.nmidx[group.resindices]
+
+        matches = [ix for (nm, ix) in resnames.namedict.items()
+                   if nm in self.water_res]
+        mask = np.isin(nmidx, matches)
+
+        return group[mask]
+
 class BackboneSelection(ProteinSelection):
     """A BackboneSelection contains all atoms with name 'N', 'CA', 'C', 'O'.
 

--- a/package/MDAnalysis/core/selection.py
+++ b/package/MDAnalysis/core/selection.py
@@ -1108,6 +1108,7 @@ class WaterSelection(Selection):
     """
     token = 'water'
 
+    # Recognized water resnames
     water_res = {
         'H2O', 'HOH', 'OH2', 'HHO', 'OHH',
         'T3P', 'T4P', 'T5P', 'SOL', 'WAT',

--- a/testsuite/MDAnalysisTests/core/test_atomselections.py
+++ b/testsuite/MDAnalysisTests/core/test_atomselections.py
@@ -48,6 +48,8 @@ from MDAnalysis.tests.datafiles import (
     PDB_helix,
     PDB_elements,
     PDB_charges,
+    waterPSF,
+    PDB_full,
 )
 from MDAnalysisTests import make_Universe
 
@@ -648,6 +650,38 @@ class TestSelectionsNucleicAcids(object):
         rna = universe.select_atoms("nucleicsugar")
         assert_equal(rna.n_residues, 23)
         assert_equal(rna.n_atoms, rna.n_residues * 5)
+
+
+class TestSelectionsWater(object):
+    @pytest.fixture(scope='class')
+    def universe(self):
+        return MDAnalysis.Universe(GRO)
+
+    @pytest.fixture(scope='class')
+    def universe2(self):
+        return MDAnalysis.Universe(waterPSF)
+
+    @pytest.fixture(scope='class')
+    def universe3(self):
+        return MDAnalysis.Universe(PDB_full)
+
+    def test_water_gro(self, universe):
+        # Test SOL water with 4 atoms
+        water_gro = universe.select_atoms("water")
+        assert_equal(water_gro.n_atoms, 44336)
+        assert_equal(water_gro.n_residues, 11084)
+
+    def test_water_tip3(self, universe2):
+        # Test TIP3 water with 3 atoms
+        water_tip3 = universe2.select_atoms('water')
+        assert_equal(water_tip3.n_atoms, 15)
+        assert_equal(water_tip3.n_residues, 5)
+
+    def test_water_pdb(self, universe3):
+        # Test HOH water with 1 atom
+        water_pdb = universe3.select_atoms("water")
+        assert_equal(water_pdb.n_residues, 188)
+        assert_equal(water_pdb.n_atoms, 188)
 
 
 class BaseDistanceSelection(object):


### PR DESCRIPTION
Fixes #4839 through the addition of the `water` token.

Changes made in this Pull Request:
 - Addition of `WaterSelection` class with the `water` token to select water residues
 - Addition of `TestSelectionsWater` with tests to cover `water` token in `test_atomselections.py`


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4854.org.readthedocs.build/en/4854/

<!-- readthedocs-preview mdanalysis end -->