### PR TITLE
DocFix: Added the documentation for run() method in polymer.rst

### DIFF
--- a/package/doc/sphinx/source/documentation_pages/analysis/polymer.rst
+++ b/package/doc/sphinx/source/documentation_pages/analysis/polymer.rst
@@ -1,3 +1,3 @@
 .. automodule:: MDAnalysis.analysis.polymer
    :members:
-
+   :inherited-members:


### PR DESCRIPTION
Fixes #4793

Changes made in this Pull Request:
 - Added `:inherited-members:` to `polymer.rst` so that run method from AnaylsisBase is added in the documentation for `MDAnalysis.analysis.polymer`


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4864.org.readthedocs.build/en/4864/

<!-- readthedocs-preview mdanalysis end -->