### PR TITLE
Refine pep8speaks

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -4,7 +4,7 @@ scanner:
 
 pycodestyle:  # Valid if scanner.linter is pycodestyle
     max-line-length: 79
-    ignore: ["E203", "E701"]
+    ignore: ["E203", "E701", "W503"]
     exclude: []
     count: False
     first: False
@@ -17,7 +17,7 @@ pycodestyle:  # Valid if scanner.linter is pycodestyle
 
 flake8:  # Valid if scanner.linter is flake8
     max-line-length: 79
-    ignore: ["E203", "E501", "E701"]
+    ignore: ["E203", "E501", "E701", "W503"]
     exclude: []
     count: False
     show-source: False


### PR DESCRIPTION
Follow up to #4858. Ignores `W503`, which still shows up (see #4874) and is not recommended in PEP8 ([Should a Line Break Before or After a Binary Operator?](https://peps.python.org/pep-0008/#should-a-line-break-before-or-after-a-binary-operator)).

<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4877.org.readthedocs.build/en/4877/

<!-- readthedocs-preview mdanalysis end -->