### PR TITLE
Fix broken links from MDanalysis Docs

### DIFF
--- a/package/doc/sphinx/source/documentation_pages/overview.rst
+++ b/package/doc/sphinx/source/documentation_pages/overview.rst
@@ -129,7 +129,7 @@ Finally, the :meth:`MDAnalysis.Universe.select_atoms` method generates a new
 as described in :ref:`selection-commands-label`.
 
 .. _SciPy: http://www.scipy.org/
-.. _IPython: http://ipython.scipy.org/
+.. _IPython: https://ipython.org/
 .. _MDAnalysis test suite: https://github.com/MDAnalysis/mdanalysis/wiki/UnitTests
 
 

--- a/package/doc/sphinx/source/documentation_pages/visualization_modules.rst
+++ b/package/doc/sphinx/source/documentation_pages/visualization_modules.rst
@@ -21,7 +21,7 @@ import them from :mod:`MDAnalysis.visualization`, for instance: ::
   scipy_.
 
 .. _matplotlib: http://matplotlib.org
-.. _scipy: https://www.scipy.org/scipylib/index.html
+.. _scipy: https://scipy.org/
 
 
 Visualization of Lipid Flow

--- a/package/doc/sphinx/source/index.rst
+++ b/package/doc/sphinx/source/index.rst
@@ -29,7 +29,7 @@ also be manipulated (for instance, fit to a reference structure) and
 written out in a range of formats.
 
 .. _`www.mdanalysis.org`: https://www.mdanalysis.org
-.. _NumPy: http://numpy.scipy.org
+.. _NumPy: https://numpy.org/
 .. _CHARMM:  http://www.charmm.org/
 .. _Amber:   http://ambermd.org/
 .. _LAMMPS:  http://lammps.sandia.gov/


### PR DESCRIPTION
Fixes #4735

Changes made in this Pull Request:
 - Fixed link for `numpy` ,`Iphython`, `scipy`


PR Checklist
------------
 - [ ] Tests?
 - [x] Docs?
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4882.org.readthedocs.build/en/4882/

<!-- readthedocs-preview mdanalysis end -->