### PR TITLE
Unpin parmed w/ numpy v2

### DIFF
--- a/package/MDAnalysis/converters/ParmEd.py
+++ b/package/MDAnalysis/converters/ParmEd.py
@@ -172,7 +172,7 @@ class ParmEdConverter(base.ConverterBase):
         try:
             import parmed as pmd
         except ImportError:
-            ermsg = (
+            errmsg = (
                 "ParmEd is required for ParmEdConverter but is not "
                 "installed. Try installing it with \n"
                 "pip install parmed"

--- a/package/MDAnalysis/converters/ParmEd.py
+++ b/package/MDAnalysis/converters/ParmEd.py
@@ -83,7 +83,6 @@ import warnings
 
 from ..guesser.tables import SYMB2Z
 import numpy as np
-from numpy.lib import NumpyVersion
 
 from . import base
 from ..coordinates.base import SingleFrameReaderBase
@@ -171,21 +170,13 @@ class ParmEdConverter(base.ConverterBase):
         obj : AtomGroup or Universe or :class:`Timestep`
         """
         try:
-            # TODO: remove this guard when parmed has a release
-            # that supports NumPy 2
-            if NumpyVersion(np.__version__) < "2.0.0":
-                import parmed as pmd
-            else:
-                raise ImportError
+            import parmed as pmd
         except ImportError:
-            if NumpyVersion(np.__version__) >= "2.0.0":
-                ermsg = "ParmEd is not compatible with NumPy 2.0+"
-            else:
-                ermsg = (
-                    "ParmEd is required for ParmEdConverter but is not "
-                    "installed. Try installing it with \n"
-                    "pip install parmed"
-                )
+            ermsg = (
+                "ParmEd is required for ParmEdConverter but is not "
+                "installed. Try installing it with \n"
+                "pip install parmed"
+            )
             raise ImportError(errmsg)
         try:
             # make sure to use atoms (Issue 46)

--- a/testsuite/MDAnalysisTests/converters/test_parmed.py
+++ b/testsuite/MDAnalysisTests/converters/test_parmed.py
@@ -23,9 +23,7 @@
 import pytest
 import MDAnalysis as mda
 
-import numpy as np
 from numpy.testing import assert_allclose, assert_equal
-from numpy.lib import NumpyVersion
 
 from MDAnalysisTests.coordinates.base import _SingleFrameReader
 from MDAnalysisTests.coordinates.reference import RefAdKSmall
@@ -43,12 +41,8 @@ from MDAnalysisTests.datafiles import (
     PRM_UreyBradley,
 )
 
-# TODO: remove this guard when parmed has a release
-# that support NumPy 2
-if NumpyVersion(np.__version__) < "2.0.0":
-    pmd = pytest.importorskip("parmed")
-else:
-    pmd = pytest.importorskip("parmed_skip_with_numpy2")
+
+pmd = pytest.importorskip("parmed")
 
 
 class TestParmEdReaderGRO:

--- a/testsuite/MDAnalysisTests/util.py
+++ b/testsuite/MDAnalysisTests/util.py
@@ -39,8 +39,6 @@ import warnings
 import pytest
 
 from numpy.testing import assert_warns
-import numpy as np
-from numpy.lib import NumpyVersion
 
 
 def block_import(package):
@@ -114,11 +112,6 @@ def import_not_available(module_name):
                         msg="skip test as module_name could not be imported")
 
     """
-    # TODO: remove once these packages have a release
-    # with NumPy 2 support
-    if NumpyVersion(np.__version__) >= "2.0.0":
-        if module_name == "parmed":
-            return True
     try:
         test = importlib.import_module(module_name)
     except ImportError:


### PR DESCRIPTION
Fixes #4625 

Apparently parmed 4.3 now supports np 2+, let's test it out.

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4883.org.readthedocs.build/en/4883/

<!-- readthedocs-preview mdanalysis end -->