### PR TITLE
Update Codecov action to v5

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -130,10 +130,10 @@ jobs:
 
     - name: codecov
       if: matrix.codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: coverage.xml
+        files: coverage.xml
         fail_ci_if_error: False
         verbose: True
 


### PR DESCRIPTION
Update codecov action from `v4` to `v5` (changes deprecated variables to new values).

I suspect that the fix for #4576 would be to switch to [token-less access](https://docs.codecov.com/docs/codecov-tokens#uploading-without-a-token), but I need to understand this better.

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4887.org.readthedocs.build/en/4887/

<!-- readthedocs-preview mdanalysis end -->