### PR TITLE
Update polymer.py to add clarity to the docs for persistent length

### DIFF
--- a/package/MDAnalysis/analysis/polymer.py
+++ b/package/MDAnalysis/analysis/polymer.py
@@ -123,6 +123,12 @@ class PersistenceLength(AnalysisBase):
 
        C(n) = \langle \cos\theta_{i, i+n} \rangle =
                \langle \mathbf{a_i} \cdot \mathbf{a_{i+n}} \rangle
+               
+    where :math:`\mathbf{a}_i \text{ and } \mathbf{a}_{i+n}` are unit vectors
+    along the bonds. (Because for two vectors a and b, 
+    :math:`\mathbf{a} \cdot \mathbf{b} = |\mathbf{a}| |\mathbf{b}| \cos{\alpha}`)
+    – see 
+    `Wikipedia <https://en.wikipedia.org/wiki/Dot_product#Geometric_definition>`_.
 
     An exponential decay is then fitted to this, which yields the
     persistence length

--- a/package/MDAnalysis/analysis/polymer.py
+++ b/package/MDAnalysis/analysis/polymer.py
@@ -124,11 +124,10 @@ class PersistenceLength(AnalysisBase):
        C(n) = \langle \cos\theta_{i, i+n} \rangle =
                \langle \mathbf{a_i} \cdot \mathbf{a_{i+n}} \rangle
                
-    where :math:`\mathbf{a}_i \text{ and } \mathbf{a}_{i+n}` are unit vectors
-    along the bonds. (Because for two vectors a and b, 
-    :math:`\mathbf{a} \cdot \mathbf{b} = |\mathbf{a}| |\mathbf{b}| \cos{\alpha}`)
-    – see 
-    `Wikipedia <https://en.wikipedia.org/wiki/Dot_product#Geometric_definition>`_.
+    where :math:`a_i` and :math:`a_{i+n}` are unit vectors
+    along the bonds. (Because for two vectors :math:`\mathbf{a}` and :math:`\mathbf{b}`, 
+    :math:`\mathbf{a} \cdot \mathbf{b} = |\mathbf{a}| |\mathbf{b}| \cos{\alpha}`,
+    where :math:`\alpha` is the angle between the two vectors.)
 
     An exponential decay is then fitted to this, which yields the
     persistence length

--- a/package/MDAnalysis/analysis/polymer.py
+++ b/package/MDAnalysis/analysis/polymer.py
@@ -125,9 +125,7 @@ class PersistenceLength(AnalysisBase):
                \langle \mathbf{a_i} \cdot \mathbf{a_{i+n}} \rangle
 
     where :math:`a_i` and :math:`a_{i+n}` are unit vectors
-    along the bonds. (Because for two vectors :math:`\mathbf{a}` and :math:`\mathbf{b}`,
-    :math:`\mathbf{a} \cdot \mathbf{b} = |\mathbf{a}| |\mathbf{b}| \cos{\alpha}`,
-    where :math:`\alpha` is the angle between the two vectors.)
+    along the bonds.
 
     An exponential decay is then fitted to this, which yields the
     persistence length

--- a/package/MDAnalysis/analysis/polymer.py
+++ b/package/MDAnalysis/analysis/polymer.py
@@ -123,9 +123,9 @@ class PersistenceLength(AnalysisBase):
 
        C(n) = \langle \cos\theta_{i, i+n} \rangle =
                \langle \mathbf{a_i} \cdot \mathbf{a_{i+n}} \rangle
-               
+
     where :math:`a_i` and :math:`a_{i+n}` are unit vectors
-    along the bonds. (Because for two vectors :math:`\mathbf{a}` and :math:`\mathbf{b}`, 
+    along the bonds. (Because for two vectors :math:`\mathbf{a}` and :math:`\mathbf{b}`,
     :math:`\mathbf{a} \cdot \mathbf{b} = |\mathbf{a}| |\mathbf{b}| \cos{\alpha}`,
     where :math:`\alpha` is the angle between the two vectors.)
 

--- a/package/MDAnalysis/core/selection.py
+++ b/package/MDAnalysis/core/selection.py
@@ -1106,24 +1106,40 @@ class WaterSelection(Selection):
 
     .. versionadded:: 2.9.0
     """
-    token = 'water'
+
+    token = "water"
 
     # Recognized water resnames
     water_res = {
-        'H2O', 'HOH', 'OH2', 'HHO', 'OHH',
-        'T3P', 'T4P', 'T5P', 'SOL', 'WAT',
-        'TIP', 'TIP2', 'TIP3', 'TIP4'
+        "H2O",
+        "HOH",
+        "OH2",
+        "HHO",
+        "OHH",
+        "T3P",
+        "T4P",
+        "T5P",
+        "SOL",
+        "WAT",
+        "TIP",
+        "TIP2",
+        "TIP3",
+        "TIP4",
     }
 
     def _apply(self, group):
         resnames = group.universe._topology.resnames
         nmidx = resnames.nmidx[group.resindices]
 
-        matches = [ix for (nm, ix) in resnames.namedict.items()
-                   if nm in self.water_res]
+        matches = [
+            ix
+            for (nm, ix) in resnames.namedict.items()
+            if nm in self.water_res
+        ]
         mask = np.isin(nmidx, matches)
 
         return group[mask]
+
 
 class BackboneSelection(ProteinSelection):
     """A BackboneSelection contains all atoms with name 'N', 'CA', 'C', 'O'.

--- a/testsuite/MDAnalysisTests/coordinates/test_xdr.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_xdr.py
@@ -984,10 +984,12 @@ class _GromacsReader_offsets(object):
         shutil.copy(self.filename, str(tmpdir))
 
         filename = str(tmpdir.join(os.path.basename(self.filename)))
-        print('filename', filename)
+        print("filename", filename)
         ref_offset = trajectory._xdr.offsets
         # Mock filelock acquire to raise an error
-        with patch.object(FileLock, "acquire", side_effect=PermissionError):  # Simulate failure
+        with patch.object(
+            FileLock, "acquire", side_effect=PermissionError
+        ):  # Simulate failure
             with pytest.warns(UserWarning, match="Cannot write lock"):
                 reader = self._reader(filename)
                 saved_offsets = reader._xdr.offsets
@@ -1008,12 +1010,10 @@ class _GromacsReader_offsets(object):
 
     @pytest.mark.skipif(
         sys.platform.startswith("win"),
-        reason="The lock file only exists when it's locked in windows"
+        reason="The lock file only exists when it's locked in windows",
     )
     def test_offset_lock_created(self, traj):
-        assert os.path.exists(
-            XDR.offsets_filename(traj, ending="lock")
-        )
+        assert os.path.exists(XDR.offsets_filename(traj, ending="lock"))
 
 
 class TestXTCReader_offsets(_GromacsReader_offsets):


### PR DESCRIPTION
Fixes #4900 

Changes made in this Pull Request:
Adds
```
.. math::

   C(n) = \langle \cos\theta_{i, i+n} \rangle =
           \langle \mathbf{a_i} \cdot \mathbf{a_{i+n}} \rangle
           
where :math:`\mathbf{a}_i \text{ and } \mathbf{a}_{i+n}` are unit vectors
along the bonds. (Because for two vectors a and b, 
:math:`\mathbf{a} \cdot \mathbf{b} = |\mathbf{a}| |\mathbf{b}| \cos{\alpha}`)
– see 
`Wikipedia <https://en.wikipedia.org/wiki/Dot_product#Geometric_definition>`_.
```
PR Checklist
------------
 - [ ] Tests?
 - [x] Docs?
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4901.org.readthedocs.build/en/4901/

<!-- readthedocs-preview mdanalysis end -->