### PR TITLE
DocFix: Added the documentation for run() method for HydrogenBondAnalysis()

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -246,7 +246,8 @@ Chronological list of authors
   - Matthew Davies
   - Jia-Xin Zhu
   - Tanish Yelgoe
-
+ 2025
+  - Joshua Raphael Uy
 
 External code
 -------------

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -15,7 +15,7 @@ The rules for this file:
 
 -------------------------------------------------------------------------------
 ??/??/?? IAlibay, ChiahsinChu, RMeli, tanishy7777, talagayev, tylerjereddy,
-         marinegor, hmacdope
+         marinegor, hmacdope, jauy123
 
  * 2.9.0
 

--- a/package/MDAnalysis/analysis/hydrogenbonds/hbond_analysis.py
+++ b/package/MDAnalysis/analysis/hydrogenbonds/hbond_analysis.py
@@ -219,6 +219,7 @@ The class and its methods
 
 .. autoclass:: HydrogenBondAnalysis
    :members:
+   :inherited-members: run
 
    .. attribute:: results.hbonds
 


### PR DESCRIPTION
Changes made in this Pull Request:

-  added  `:inherited-members:` run attribute to `HydrogenBondAnalysis`()'s autoclass, so that `BaseAnalysis.run()` is visible for `HydrogenBondAnalysis()` in the MDAnalysis Documentation.

## Developers Certificate of Origin
<!-- 
In order for this PR to be merged you **must certify that you are able to submit your code to be included in MDAnalysis**.
-->

- [x] I certify that I can submit this code contribution as described in the [**Developer Certificate of Origin**](https://developercertificate.org/), under the MDAnalysis [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--4917.org.readthedocs.build/en/4917/

<!-- readthedocs-preview mdanalysis end -->