### PR TITLE
Fixes #3743: Modernize test assertions in test_base.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,4 +52,3 @@ benchmarks/results
 .idea
 .vscode
 *.lock
-md/

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ benchmarks/results
 .idea
 .vscode
 *.lock
+md/

--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -254,6 +254,7 @@ Chronological list of authors
   - Yu-Yuan (Stuart) Yang
   - James Rowe
   - Debasish Mohanty  
+  - Abdulrahman Elbanna
 
 
 External code

--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -254,7 +254,6 @@ Chronological list of authors
   - Yu-Yuan (Stuart) Yang
   - James Rowe
   - Debasish Mohanty  
-  - Abdulrahman Elbanna
 
 
 External code

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -14,7 +14,7 @@ The rules for this file:
 
 
 -------------------------------------------------------------------------------
-??/??/?? IAlibay, orbeckst, BHM-Bob, TRY-ER
+??/??/?? IAlibay, orbeckst, BHM-Bob, TRY-ER, Abdulrahman-PROG
 
 
  * 2.10.0

--- a/testsuite/MDAnalysisTests/analysis/test_base.py
+++ b/testsuite/MDAnalysisTests/analysis/test_base.py
@@ -27,7 +27,7 @@ import MDAnalysis as mda
 import numpy as np
 import pytest
 from MDAnalysis.analysis import backends, base
-from numpy.testing import assert_allclose, assert_almost_equal, assert_equal
+from numpy.testing import assert_allclose, assert_equal
 
 from MDAnalysisTests.datafiles import DCD, PSF, TPR, XTC
 from MDAnalysisTests.util import no_deprecated_call
@@ -279,7 +279,7 @@ def test_start_stop_step_parallel(u, run_kwargs, frames, client_FrameAnalysis):
     assert an.n_frames == len(frames)
     assert_equal(an.found_frames, frames)
     assert_equal(an.frames, frames, err_msg=FRAMES_ERR)
-    assert_almost_equal(an.times, frames + 1, decimal=4, err_msg=TIMES_ERR)
+    assert_allclose(an.times, frames + 1, rtol=0, atol=1e-4, err_msg=TIMES_ERR)
 
 
 def test_reset_n_parts_to_n_frames(u):
@@ -614,7 +614,7 @@ def test_AnalysisFromFunction_args_content(u, client_AnalysisFromFunction):
     assert len(ans.args) == 3
     result = np.sum(ans.run(**client_AnalysisFromFunction).results.timeseries)
     assert_allclose(result, -317054.67757345125, rtol=0, atol=1.5e-6)
-    assert_almost_equal(result, -317054.67757345125, decimal=6)
+    assert_allclose(result, -317054.67757345125, rtol=0, atol=1e-6)
     assert (ans.args[0] is protein) and (ans.args[1] is another)
     assert ans._trajectory is protein.universe.trajectory
 


### PR DESCRIPTION
Fixes #3743

Changes made in this Pull Request:

- Modernized test assertions in `test_base.py` by replacing `assert_almost_equal` with `assert_allclose` to align with the goal of #3743.
- Applied Black formatting to `test_base.py` to ensure compliance with the project's linting standards.
- Initially included changes to `test_align.py` (e.g., adjusting tolerances), but these were removed to focus the PR on #3743, as requested by @RMeli.
- Added my name (Abdulrahman Elbanna) to `package/AUTHORS` as part of this PR.

PR Checklist
- [x] Issue raised/referenced? (Yes, references modernize testing code #3743)
- [x] Tests updated/added? (Yes, updated test assertions in `test_base.py`)
- [ ] Documentation updated/added? (No, not applicable for this change)
- [x] package/CHANGELOG file updated? (No, not applicable for this change)
- [x] Is your name in package/AUTHORS? (Yes, added Abdulrahman Elbanna)

Developers Certificate of Origin
I certify that I can submit this code contribution as described in the Developer Certificate of Origin, under the MDAnalysis LICENSE.