### PR TITLE
MAINT: rounding residue partial charges

### DIFF
--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -2146,6 +2146,11 @@ class Charges(AtomAttr):
     transplants = defaultdict(list)
     dtype = float
 
+
+    def __init__(self, values, guessed=False, round_val=None):
+        super().__init__(values, guessed)
+        self.round = round_val
+
     @staticmethod
     def _gen_initial_values(na, nr, ns):
         return np.zeros(na)
@@ -2159,6 +2164,9 @@ class Charges(AtomAttr):
             charges = np.empty(len(rg))
             for i, row in enumerate(resatoms):
                 charges[i] = self.values[row].sum()
+
+        if self.round is not None:
+            charges = np.round(charges, self.round)
 
         return charges
 

--- a/package/MDAnalysis/topology/TOPParser.py
+++ b/package/MDAnalysis/topology/TOPParser.py
@@ -453,7 +453,12 @@ class TOPParser(TopologyReaderBase):
         vals = self.parsesection_mapper(numlines, lambda x: float(x))
         charges = np.array(vals, dtype=np.float32)
         charges /= 18.2223  # to electron charge units
-        attr = Charges(charges)
+        # in practice, the precision of partial charges
+        # in MD simulation forcefields is typically limited
+        # to a few decimal places (i.e., 1e-4 is already optimistic)
+        # see gh-5032
+        # here, we round the residue net charges to 4 decimal places
+        attr = Charges(charges, round_val=4)
         return attr
 
     def parse_masses(self, num_per_record, numlines):

--- a/testsuite/MDAnalysisTests/topology/test_top.py
+++ b/testsuite/MDAnalysisTests/topology/test_top.py
@@ -27,7 +27,7 @@ import warnings
 import MDAnalysis as mda
 import numpy as np
 import pytest
-from numpy.testing import assert_equal
+from numpy.testing import assert_equal, assert_allclose
 
 from MDAnalysisTests.datafiles import PRM  # ache.prmtop
 from MDAnalysisTests.datafiles import PRM7  # tz2.truncoct.parm7.bz2
@@ -837,3 +837,29 @@ class TestErrorsAndWarnings(object):
 
         for msg in errmsgs:
             assert any(msg in recmsg for recmsg in messages)
+
+
+def test_gh_5032():
+    u = mda.Universe(PRM)
+    # check individual residue.charge
+    actual = []
+    for res in u.residues:
+        actual.append(res.charge)
+    expected = [1.0, # N-terminal A
+                -1.0, # E
+                0.0, # F
+                0.0, # H (HIE)
+                1.0, # R
+                0.0, # W
+                0.0, # S
+                0.0, # S
+                0.0, # Y
+                0.0, # M
+                0.0, # V
+                0.0, # H (HIE)
+                0.0, # W
+                0.0] # C-terminal K
+    assert_allclose(actual, expected)
+    # check residues.charges, which are set
+    # separately
+    assert_allclose(u.residues.charges, expected)


### PR DESCRIPTION
* Fixes gh-5032.

* Given that 1e-4 is already optimistic for electron charge unit precision in MD forcefields, this patch proposes to round residue net charges to 4 decimal places to avoid the confusion described in the matching ticket.

* Some obvious questions might include: why are we only doing this for AMBER topologies? why only round at the residue level and not i.e., upstream at atom level and also at "segment" levels? This is mostly for scoping, because this initial patch is targeted at the specific issue raised, and because it probably doesn't make sense to proceed much farther until things are discussed.


## PR Checklist
<!-- Please use the following checklist to ensure the PR is ready to be reviewed/merged. -->
 - [ ] Issue raised/referenced?
 - [ ] Tests updated/added?
 - [ ] Documentation updated/added?
 - [ ] `package/CHANGELOG` file updated?
 - [ ] Is your name in `package/AUTHORS`? (If it is not, add it!)

## Developers Certificate of Origin
<!-- 
In order for this PR to be merged you **must certify that you are able to submit your code to be included in MDAnalysis**.
-->

I certify that I can submit this code contribution as described in the [**Developer Certificate of Origin**](https://developercertificate.org/), under the MDAnalysis [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--5035.org.readthedocs.build/en/5035/

<!-- readthedocs-preview mdanalysis end -->