### PR TITLE
Remove default channel from RTD conda env

### DIFF
--- a/maintainer/conda/environment.yml
+++ b/maintainer/conda/environment.yml
@@ -1,6 +1,5 @@
 name: mda-dev
 channels:
-  - defaults
   - conda-forge
 dependencies:
   - chemfiles>=0.10

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -48,6 +48,7 @@ Enhancements
    (Issue #4948 #2874, PR #4965)
  * Enables parallelization for analysis.lineardensity.LinearDensity
    (Issue #4678, PR #5007)
+ * Remove `default` channel from RTD conda env. (Issue # 5036, PR # 5037)
 
 Changes
  * Removed undocumented and unused attribute


### PR DESCRIPTION
Fixes #5036

Changes made in this Pull Request:
<!-- Describe the changes that this PR makes. If applicable, use the following bullet list. --> 
- Removes the `default` channel from the RTD conda env as the packages are already available on `conda-forge` channel.


## PR Checklist
<!-- Please use the following checklist to ensure the PR is ready to be reviewed/merged. -->
 - [x] Issue raised/referenced?
 - [ ] Tests updated/added?
 - [ ] Documentation updated/added?
 - [x] `package/CHANGELOG` file updated?
 - [x] Is your name in `package/AUTHORS`? (If it is not, add it!)

## Developers Certificate of Origin
<!-- 
In order for this PR to be merged you **must certify that you are able to submit your code to be included in MDAnalysis**.
-->

I certify that I can submit this code contribution as described in the [**Developer Certificate of Origin**](https://developercertificate.org/), under the MDAnalysis [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--5037.org.readthedocs.build/en/5037/

<!-- readthedocs-preview mdanalysis end -->