### PR TITLE
Fix incorrect self.atom assignment in SingleFrameReaderBase

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -21,6 +21,7 @@ The rules for this file:
  * 2.10.0
 
 Fixes
+ * Fix incorrect `self.atom` assignment in SingleFrameReaderBase (Issue #5052, PR #5055)
  * Fixes bug in `analysis/hydrogenbonds.py`: `_donors` and `_hydrogens`
    were not updated when the `acceptors_sel` and `hydrogens_sel` were provided
    after initialization. (Issue #5010, PR #5018)
@@ -33,7 +34,6 @@ Fixes
  * Fixes the benchmark `SimpleRmsBench` in `benchmarks/analysis/rms.py`
    by changing the way weights for RMSD are calculated, instead of
    directly passing them. (Issue #3520, PR #5006)
- * Fix incorrect `self.atom` assignment in SingleFrameReaderBase (Issue #5052, PR #5055)
 
 Enhancements
  * Improve parsing of topology information from LAMMPS dump files to allow

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -33,6 +33,7 @@ Fixes
  * Fixes the benchmark `SimpleRmsBench` in `benchmarks/analysis/rms.py`
    by changing the way weights for RMSD are calculated, instead of
    directly passing them. (Issue #3520, PR #5006)
+ * Fix incorrect `self.atom` assignment in SingleFrameReaderBase (Issue #5052, PR #5055)
 
 Enhancements
  * Improve parsing of topology information from LAMMPS dump files to allow

--- a/package/MDAnalysis/coordinates/LAMMPS.py
+++ b/package/MDAnalysis/coordinates/LAMMPS.py
@@ -240,11 +240,11 @@ class DATAReader(base.SingleFrameReaderBase):
 
     @store_init_arguments
     def __init__(self, filename, **kwargs):
-        self.n_atoms = kwargs.pop("n_atoms", None)
-        if self.n_atoms is None:  # this should be done by parsing DATA first
+        n_atoms = kwargs.pop("n_atoms", None)
+        if n_atoms is None:  # this should be done by parsing DATA first
             raise ValueError("DATAReader requires n_atoms keyword")
         self.atom_style = kwargs.pop("atom_style", None)
-        super(DATAReader, self).__init__(filename, **kwargs)
+        super(DATAReader, self).__init__(filename, n_atoms=n_atoms, **kwargs)
 
     def _read_first_frame(self):
         with DATAParser(self.filename) as p:

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -1655,6 +1655,9 @@ class SingleFrameReaderBase(ProtoReader):
        Calling `__iter__` now rewinds the reader before yielding a
        :class:`Timestep` object (fixing behavior that was not
        well defined previously).
+    .. versionchanged:: 2.10.0
+       Fixed a typo in the attribute assignment (`self.atom` → `self.atoms`),
+       which may affect subclasses relying on this value.
     """
     _err = "{0} only contains a single frame"
 

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -1666,7 +1666,7 @@ class SingleFrameReaderBase(ProtoReader):
         self.convert_units = convert_units
 
         self.n_frames = 1
-        self.n_atom = n_atoms
+        self.n_atoms = n_atoms
 
         ts_kwargs = {}
         for att in ('dt', 'time_offset'):


### PR DESCRIPTION
<!-- 
Insert issue number that this PR fixes (if any) just after 'Fixes #'.
If this PR does not fix an existing issue, consider opening one or remove 'Fixes #' from the PR description.
-->
Fixes #5052 

Changes made in this Pull Request:
<!-- Describe the changes that this PR makes. If applicable, use the following bullet list. --> 
- Fixed a typo in `SingleFrameReaderBase` where `self.atom` was incorrectly used instead of `self.atoms` to store the number of atoms
- Conform `DATAReader` of LAMPMPS of this upstream setting.


## PR Checklist
<!-- Please use the following checklist to ensure the PR is ready to be reviewed/merged. -->
 - [x] Issue raised/referenced?
 - [x] Tests updated/added?
 - [x] Documentation updated/added?
 - [x] `package/CHANGELOG` file updated?
 - [x] Is your name in `package/AUTHORS`? (If it is not, add it!)

## Developers Certificate of Origin
<!-- 
In order for this PR to be merged you **must certify that you are able to submit your code to be included in MDAnalysis**.
-->

I certify that I can submit this code contribution as described in the [**Developer Certificate of Origin**](https://developercertificate.org/), under the MDAnalysis [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--5055.org.readthedocs.build/en/5055/

<!-- readthedocs-preview mdanalysis end -->