### PR TITLE
fix links to LAMMPS docs

### DIFF
--- a/package/MDAnalysis/coordinates/LAMMPS.py
+++ b/package/MDAnalysis/coordinates/LAMMPS.py
@@ -105,15 +105,15 @@ See Also
 
    For further discussion follow the reports for `Issue 84`_ and `Issue 64`_.
 
-.. _LAMMPS: http://lammps.sandia.gov/
-.. _write DCD: http://lammps.sandia.gov/doc/dump.html
+.. _LAMMPS: https://www.lammps.org/
+.. _write DCD: https://docs.lammps.org/dump.html
 .. _CHARMM trajectory: http://www.charmm.org/documentation/c36b1/dynamc.html#%20Trajectory
 .. _AKMA: http://www.charmm.org/documentation/c36b1/usage.html#%20AKMA
-.. _units real: http://lammps.sandia.gov/doc/units.html
-.. _units command: http://lammps.sandia.gov/doc/units.html
+.. _units real: https://docs.lammps.org/units.html
+.. _units command: https://docs.lammps.org/units.html
 .. _`Issue 64`: https://github.com/MDAnalysis/mdanalysis/issues/64
 .. _`Issue 84`: https://github.com/MDAnalysis/mdanalysis/issues/84
-.. _`LAMMPS dump format`: http://lammps.sandia.gov/doc/dump.html
+.. _`LAMMPS dump format`: https://docs.lammps.org/dump.html
 
 Classes
 -------
@@ -198,7 +198,7 @@ class DCDReader(DCD.DCDReader):
     "Angstrom", corresponding to LAMMPS `units style`_ "**real**". See
     :mod:`MDAnalysis.units` for other recognized values.
 
-    .. _units style: http://lammps.sandia.gov/doc/units.html
+    .. _units style: https://docs.lammps.org/units.html
     """
 
     format = "LAMMPS"

--- a/package/MDAnalysis/topology/LAMMPSParser.py
+++ b/package/MDAnalysis/topology/LAMMPSParser.py
@@ -33,9 +33,9 @@ Parses data_ or dump_ files produced by LAMMPS_.
     read from the input file. This may change in release 3.0.
     See :ref:`Guessers` for more information.
 
-.. _LAMMPS: http://lammps.sandia.gov/
-.. _data: DATA file format: :http://lammps.sandia.gov/doc/2001/data_format.html
-.. _dump: http://lammps.sandia.gov/doc/dump.html
+.. _LAMMPS: https://www.lammps.org/
+.. _data: DATA file format: :https://docs.lammps.org/2001/data_format.html
+.. _dump: https://docs.lammps.org/dump.html
 
 .. versionchanged:: 1.0.0
    Deprecated :class:`LAMMPSDataConverter` has now been removed.
@@ -67,7 +67,7 @@ The following code could be used::
   >>> u = mda.Universe('myfile.data', atom_style='id type x y z')
 
 
-.. _`atom_style`: http://lammps.sandia.gov/doc/atom_style.html
+.. _`atom_style`: https://docs.lammps.org/atom_style.html
 
 Classes
 -------
@@ -469,7 +469,7 @@ class DATAParser(TopologyReaderBase):
         Lammps atoms can have lots of different formats,
         and even custom formats
 
-        http://lammps.sandia.gov/doc/atom_style.html
+        https://docs.lammps.org/atom_style.html
 
         Treated here are
         - atoms with 7 fields (with charge) "full"

--- a/package/doc/sphinx/source/documentation_pages/overview.rst
+++ b/package/doc/sphinx/source/documentation_pages/overview.rst
@@ -40,7 +40,7 @@ of a protein and the radius of gyration of the backbone atoms are calculated::
 
 .. _NumPy:   https://numpy.org/
 .. _CHARMM:  http://www.charmm.org/
-.. _LAMMPS:  http://lammps.sandia.gov/
+.. _LAMMPS:  https://www.lammps.org/
 .. _NAMD:    http://www.ks.uiuc.edu/Research/namd/
 .. _Gromacs: http://www.gromacs.org/
 

--- a/package/doc/sphinx/source/index.rst
+++ b/package/doc/sphinx/source/index.rst
@@ -32,7 +32,7 @@ written out in a range of formats.
 .. _NumPy: https://numpy.org/
 .. _CHARMM:  http://www.charmm.org/
 .. _Amber:   http://ambermd.org/
-.. _LAMMPS:  http://lammps.sandia.gov/
+.. _LAMMPS:  https://www.lammps.org/
 .. _NAMD:    http://www.ks.uiuc.edu/Research/namd/
 .. _Gromacs: http://www.gromacs.org/
 .. _`DL_POLY`: https://www.sc.stfc.ac.uk/software/type/computational-materials-and-molecular-science/?searchquery=dl_poly


### PR DESCRIPTION

<!-- 
Insert issue number that this PR fixes (if any) just after 'Fixes #'.
If this PR does not fix an existing issue, consider opening one or remove 'Fixes #' from the PR description.
-->
Fixes #

Changes made in this Pull Request:
- links broke when LAMMPS moved from lammps.sandia.gov to lammps.org
- `git grep -l sandia | xargs perl -wpi~ -e 's(http://lammps\.sandia\.gov/doc)(https://docs.lammps.org)' --`
- `git grep -l sandia | xargs perl -wpi~ -e 's(http://lammps\.sandia\.gov)(https://www.lammps.org)' --`

## PR Checklist
<!-- Please use the following checklist to ensure the PR is ready to be reviewed/merged. -->
 - [ ] Issue raised/referenced?
 - [ ] Tests updated/added?
 - [x] Documentation updated/added?
 - [ ] `package/CHANGELOG` file updated?
 - [x] Is your name in `package/AUTHORS`? (If it is not, add it!)

## Developers Certificate of Origin
<!-- 
In order for this PR to be merged you **must certify that you are able to submit your code to be included in MDAnalysis**.
-->

I certify that I can submit this code contribution as described in the [**Developer Certificate of Origin**](https://developercertificate.org/), under the MDAnalysis [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--5063.org.readthedocs.build/en/5063/

<!-- readthedocs-preview mdanalysis end -->