### PR TITLE
Update ARRAY numpy macros in transformations.c

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -15,12 +15,14 @@ The rules for this file:
 
 -------------------------------------------------------------------------------
 ??/??/?? IAlibay, orbeckst, BHM-Bob, TRY-ER, Abdulrahman-PROG, pbuslaev,
-         yuxuanzhuang, yuyuan871111, tanishy7777, tulga-rdn, Gareth-elliott
+         yuxuanzhuang, yuyuan871111, tanishy7777, tulga-rdn, Gareth-elliott,
+         hmacdope
 
 
  * 2.10.0
 
 Fixes
+ *
  * Fix incorrect `self.atom` assignment in SingleFrameReaderBase (Issue #5052, PR #5055)
  * Fixes bug in `analysis/hydrogenbonds.py`: `_donors` and `_hydrogens`
    were not updated when the `acceptors_sel` and `hydrogens_sel` were provided

--- a/package/MDAnalysis/lib/src/transformations/transformations.c
+++ b/package/MDAnalysis/lib/src/transformations/transformations.c
@@ -775,7 +775,7 @@ PyConverter_DoubleArray(
     PyObject *object,
     PyObject **address)
 {
-    *address = PyArray_FROM_OTF(object, NPY_DOUBLE, NPY_IN_ARRAY);
+    *address = PyArray_FROM_OTF(object, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
      if (*address == NULL) return NPY_FAIL;
      return NPY_SUCCEED;
 }
@@ -808,7 +808,7 @@ PyConverter_DoubleArrayOrNone(
     if ((object == NULL) || (object == Py_None)) {
         *address = NULL;
     } else {
-        *address = PyArray_FROM_OTF(object, NPY_DOUBLE, NPY_IN_ARRAY);
+        *address = PyArray_FROM_OTF(object, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
         if (*address == NULL) {
             PyErr_Format(PyExc_ValueError, "can not convert to array");
             return NPY_FAIL;
@@ -823,7 +823,7 @@ PyConverter_DoubleMatrix44(
     PyObject **address)
 {
     PyArrayObject *obj;
-    *address = PyArray_FROM_OTF(object, NPY_DOUBLE, NPY_IN_ARRAY);
+    *address = PyArray_FROM_OTF(object, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
     if (*address == NULL) {
         PyErr_Format(PyExc_ValueError, "can not convert to array");
         return NPY_FAIL;
@@ -846,7 +846,7 @@ PyConverter_DoubleMatrix44Copy(
 {
     PyArrayObject *obj;
     *address = PyArray_FROM_OTF(object, NPY_DOUBLE,
-                                NPY_ENSURECOPY|NPY_IN_ARRAY);
+                                NPY_ENSURECOPY|NPY_ARRAY_IN_ARRAY);
     if (*address == NULL) {
         PyErr_Format(PyExc_ValueError, "can not convert to array");
         return NPY_FAIL;
@@ -868,7 +868,7 @@ PyConverter_DoubleVector3(
     PyObject **address)
 {
     PyArrayObject *obj;
-    *address = PyArray_FROM_OTF(object, NPY_DOUBLE, NPY_IN_ARRAY);
+    *address = PyArray_FROM_OTF(object, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
     if (*address == NULL) {
         PyErr_Format(PyExc_ValueError, "can not convert to array");
         return NPY_FAIL;
@@ -890,7 +890,7 @@ PyConverter_DoubleVector4(
     PyObject **address)
 {
     PyArrayObject *obj;
-    *address = PyArray_FROM_OTF(object, NPY_DOUBLE, NPY_IN_ARRAY);
+    *address = PyArray_FROM_OTF(object, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
     if (*address == NULL) {
         PyErr_Format(PyExc_ValueError, "can not convert to array");
         return NPY_FAIL;
@@ -913,7 +913,7 @@ PyConverter_DoubleVector4Copy(
 {
     PyArrayObject *obj;
     *address = PyArray_FROM_OTF(object, NPY_DOUBLE,
-                                NPY_ENSURECOPY|NPY_IN_ARRAY);
+                                NPY_ENSURECOPY|NPY_ARRAY_IN_ARRAY);
     if (*address == NULL) {
         PyErr_Format(PyExc_ValueError, "can not convert to array");
         return NPY_FAIL;
@@ -938,7 +938,7 @@ PyConverter_DoubleVector3OrNone(
         *address = NULL;
     } else {
         PyArrayObject *obj;
-        *address = PyArray_FROM_OTF(object, NPY_DOUBLE, NPY_IN_ARRAY);
+        *address = PyArray_FROM_OTF(object, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
         if (*address == NULL) {
             PyErr_Format(PyExc_ValueError, "can not convert to array");
             return NPY_FAIL;
@@ -3137,7 +3137,7 @@ py_inverse_matrix(
         goto _fail;
 
     matrix = (PyArrayObject *)PyArray_FROM_OTF(object, NPY_DOUBLE,
-                                               NPY_IN_ARRAY);
+                                               NPY_ARRAY_IN_ARRAY);
     if (matrix == NULL) {
         PyErr_Format(PyExc_ValueError, "not an array");
         goto _fail;

--- a/package/MDAnalysis/lib/src/transformations/transformations.c
+++ b/package/MDAnalysis/lib/src/transformations/transformations.c
@@ -791,7 +791,7 @@ PyConverter_AnyDoubleArray(
         Py_INCREF(object);
         return NPY_SUCCEED;
     } else {
-        *address = PyArray_FROM_OTF(object, NPY_DOUBLE, NPY_ALIGNED);
+        *address = PyArray_FROM_OTF(object, NPY_DOUBLE, NPY_ARRAY_ALIGNED);
         if (*address == NULL) {
             PyErr_Format(PyExc_ValueError, "can not convert to array");
             return NPY_FAIL;
@@ -846,7 +846,7 @@ PyConverter_DoubleMatrix44Copy(
 {
     PyArrayObject *obj;
     *address = PyArray_FROM_OTF(object, NPY_DOUBLE,
-                                NPY_ENSURECOPY|NPY_ARRAY_IN_ARRAY);
+                                NPY_ARRAY_ENSURECOPY|NPY_ARRAY_IN_ARRAY);
     if (*address == NULL) {
         PyErr_Format(PyExc_ValueError, "can not convert to array");
         return NPY_FAIL;
@@ -913,7 +913,7 @@ PyConverter_DoubleVector4Copy(
 {
     PyArrayObject *obj;
     *address = PyArray_FROM_OTF(object, NPY_DOUBLE,
-                                NPY_ENSURECOPY|NPY_ARRAY_IN_ARRAY);
+                                NPY_ARRAY_ENSURECOPY|NPY_ARRAY_IN_ARRAY);
     if (*address == NULL) {
         PyErr_Format(PyExc_ValueError, "can not convert to array");
         return NPY_FAIL;


### PR DESCRIPTION
<!-- 
Insert issue number that this PR fixes (if any) just after 'Fixes #'.
If this PR does not fix an existing issue, consider opening one or remove 'Fixes #' from the PR description.
-->

Possible investigation fix to #5061

Changes the old NPY_XX macro sto NPY_ARRAY_XXX macros

Got the hint here: https://github.com/matplotlib/matplotlib/issues/2092/

Changes made in this Pull Request:
<!-- Describe the changes that this PR makes. If applicable, use the following bullet list. --> 
- Change instances of NPY_IN_ARRAY to NPY_ARRAY_IN_ARRAY in `transformations.c`
- Change instances of NPY_ALIGNED to NPY_ARRAY_ALIGNED in `transformations.c`
- Change instances of NPY_ENSURECOPY to NPY_ARRAY_ENSURECOPY in `transformations.c`


## PR Checklist
<!-- Please use the following checklist to ensure the PR is ready to be reviewed/merged. -->
 - [X] Issue raised/referenced?
 - [ ] `package/CHANGELOG` file updated?

## Developers Certificate of Origin
<!-- 
In order for this PR to be merged you **must certify that you are able to submit your code to be included in MDAnalysis**.
-->

I certify that I can submit this code contribution as described in the [**Developer Certificate of Origin**](https://developercertificate.org/), under the MDAnalysis [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE).
