### PR TITLE
Remove macos-13 from standard CI

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -37,11 +37,6 @@ jobs:
               python-version: "3.13"
               full-deps: false
               codecov: true
-            - name: macOS_monterey_py311
-              os: macos-13
-              python-version: "3.12"
-              full-deps: true
-              codecov: true
             - name: macOS_14_arm64_py312
               os: macOS-14
               python-version: "3.12"


### PR DESCRIPTION
Fixes #5023 

## Developers Certificate of Origin
<!-- 
In order for this PR to be merged you **must certify that you are able to submit your code to be included in MDAnalysis**.
-->

I certify that I can submit this code contribution as described in the [**Developer Certificate of Origin**](https://developercertificate.org/), under the MDAnalysis [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--5072.org.readthedocs.build/en/5072/

<!-- readthedocs-preview mdanalysis end -->