### PR TITLE
BUG: large DCD file seeking on Win

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -16,12 +16,14 @@ The rules for this file:
 -------------------------------------------------------------------------------
 ??/??/?? IAlibay, orbeckst, BHM-Bob, TRY-ER, Abdulrahman-PROG, pbuslaev,
          yuxuanzhuang, yuyuan871111, tanishy7777, tulga-rdn, Gareth-elliott,
-         hmacdope
+         hmacdope, tylerjereddy
 
 
  * 2.10.0
 
 Fixes
+ * Fixed an integer overflow in large DCD file seeks on Windows
+   (Issue #4879, PR #5086)
  * Fix compile failure due to numpy issues in transformations.c (Issue #5061, PR #5068)
  * Fix incorrect `self.atom` assignment in SingleFrameReaderBase (Issue #5052, PR #5055)
  * Fixes bug in `analysis/hydrogenbonds.py`: `_donors` and `_hydrogens`

--- a/package/MDAnalysis/lib/formats/libdcd.pyx
+++ b/package/MDAnalysis/lib/formats/libdcd.pyx
@@ -387,13 +387,13 @@ cdef class DCDFile:
             raise EOFError('Trying to seek over max number of frames')
         self.reached_eof = False
 
-        cdef fio_size_t offset
+        cdef long long offset
         if frame == 0:
             offset = self._header_size
         else:
             offset = self._header_size
             offset += self._firstframesize
-            offset += self._framesize * (frame - 1)
+            offset += self._framesize * (<long long>frame - 1)
 
         cdef int ok = fio_fseek(self.fp, offset, _whence_vals['FIO_SEEK_SET'])
         if ok != 0:

--- a/testsuite/MDAnalysisTests/formats/test_libdcd.py
+++ b/testsuite/MDAnalysisTests/formats/test_libdcd.py
@@ -34,6 +34,7 @@ from numpy.testing import (
     assert_almost_equal,
 )
 
+import MDAnalysis as mda
 from MDAnalysis.lib.formats.libdcd import (
     DCDFile,
     DCD_IS_CHARMM,
@@ -41,6 +42,7 @@ from MDAnalysis.lib.formats.libdcd import (
 )
 
 from MDAnalysisTests.datafiles import (
+    PSF,
     DCD,
     DCD_NAMD_TRICLINIC,
     legacy_DCD_ADK_coords,
@@ -671,3 +673,19 @@ def test_write_random_unitcell(tmpdir):
     with DCDFile(testname) as test:
         for index, frame in enumerate(test):
             assert_array_almost_equal(frame.unitcell, random_unitcells[index])
+
+
+@pytest.mark.skipif(
+    not os.environ.get("LARGEDCD", False), reason="Skipping large file test"
+)
+def test_gh_4879(tmpdir):
+    # NOTE: we really only need a trajectory with a frame
+    # count that is large enough to overflow a 32-bit signed
+    # integer in the DCD frame seeking arithmetic to reproduce
+    # the original issue
+    u = mda.Universe(PSF, 800 * [DCD])
+    with tmpdir.as_cwd():
+        f = "large.dcd"
+        u.atoms.write(f, frames="all")
+        u = mda.Universe(f)
+        u.trajectory[-2]


### PR DESCRIPTION
* Fixes gh-4879

* 32-bit signed integer arithemetic was being used in the DCD trajectory seeking Cython logic on Windows, causing an overflow for trajectories with a large number of frames on that platform. The behavior has existed since at least MDAnalysis `2.5.0`, and a regression test and patch have been added here. The regression test is based on the original scripts Oli provided in the matching ticket, though I note in a comment that we likely don't actually need a large file, and could probably simplify the regression test by artificially setting the frame numbers to start from a large value. Nonetheless, this test does fail before and pass after the patch locally on Windows.


## PR Checklist
<!-- Please use the following checklist to ensure the PR is ready to be reviewed/merged. -->
 - [x] Issue raised/referenced?
 - [x] Tests updated/added?
 - [ ] Documentation updated/added?
 - [ ] `package/CHANGELOG` file updated?
 - [x] Is your name in `package/AUTHORS`? (If it is not, add it!)

## Developers Certificate of Origin
<!-- 
In order for this PR to be merged you **must certify that you are able to submit your code to be included in MDAnalysis**.
-->

I certify that I can submit this code contribution as described in the [**Developer Certificate of Origin**](https://developercertificate.org/), under the MDAnalysis [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--5086.org.readthedocs.build/en/5086/

<!-- readthedocs-preview mdanalysis end -->