### PR TITLE
`versionchanged` adjustment for `LAMMPS.DumpReader`

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -16,7 +16,7 @@ The rules for this file:
 -------------------------------------------------------------------------------
 ??/??/?? IAlibay, orbeckst, BHM-Bob, TRY-ER, Abdulrahman-PROG, pbuslaev,
          yuxuanzhuang, yuyuan871111, tanishy7777, tulga-rdn, Gareth-elliott,
-         hmacdope, tylerjereddy, cbouy
+         hmacdope, tylerjereddy, cbouy, talagayev
 
 
  * 2.10.0

--- a/package/MDAnalysis/coordinates/LAMMPS.py
+++ b/package/MDAnalysis/coordinates/LAMMPS.py
@@ -616,9 +616,9 @@ class DumpReader(base.ReaderBase):
        Other keyword arguments used in :class:`~MDAnalysis.coordinates.base.ReaderBase`
 
 
-    .. versionchanged:: 2.7.0
+    .. versionchanged:: 2.8.0
        Reading of arbitrary, additional columns is now supported.
-       (Issue #3608)
+       (Issue `#3504 <https://github.com/MDAnalysis/mdanalysis/issues/3504>`__)
     .. versionchanged:: 2.4.0
        Now imports velocities and forces, translates the box to the origin,
        and optionally unwraps trajectories with image flags upon loading.


### PR DESCRIPTION
<!-- 
Insert issue number that this PR fixes (if any) just after 'Fixes #'.
If this PR does not fix an existing issue, consider opening one or remove 'Fixes #' from the PR description.
-->
Fixes #5044 

As mentioned in the Issue the docs state that in [LAMMPS.DumpReader](https://docs.mdanalysis.org/2.9.0/documentation_pages/coordinates/LAMMPS.html#MDAnalysis.coordinates.LAMMPS.DumpReader) the arbitrary columns were supposedly implemented in 2.7.0 but the according to the CHANGELOG it was in version 2.8.0

Additionally, The # was for the PR #3608 and not the Issue #3504. To make it consistent with the other case where an Issue is mentioned in the docs I adjusted it to refere to the Issue# and not the PR#

Changes made in this Pull Request:
<!-- Describe the changes that this PR makes. If applicable, use the following bullet list. --> 
- Adjustment of `versionchanged` to `2.8.0` in accordance to the CHANGELOG
- Adjustment of the reference to the Issue to maintain consistency in Docs

## PR Checklist
<!-- Please use the following checklist to ensure the PR is ready to be reviewed/merged. -->
 - [x] Issue raised/referenced?
 - [ ] Tests updated/added?
 - [x] Documentation updated/added?
 - [ ] `package/CHANGELOG` file updated?
 - [x] Is your name in `package/AUTHORS`? (If it is not, add it!)

## Developers Certificate of Origin
<!-- 
In order for this PR to be merged you **must certify that you are able to submit your code to be included in MDAnalysis**.
-->

I certify that I can submit this code contribution as described in the [**Developer Certificate of Origin**](https://developercertificate.org/), under the MDAnalysis [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--5091.org.readthedocs.build/en/5091/

<!-- readthedocs-preview mdanalysis end -->