### PR TITLE
Enable Python 3.14 wheel builds and publishing

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -29,7 +29,6 @@ defaults:
 
 jobs:
   build_wheels:
-    if: "github.repository == 'MDAnalysis/mdanalysis'"
     name: Build wheels
     runs-on: ${{ matrix.buildplat[0] }}
     timeout-minutes: 15

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -15,7 +15,6 @@ on:
   schedule:
     # 3 am Tuesdays and Fridays
     - cron: "0 3 * * 2,5"
-  workflow_dispatch: # Allows running this workflow manually
 
 concurrency:
   group: "${{ github.ref }}-${{ github.head_ref }}-${{ github.workflow }}"
@@ -29,6 +28,7 @@ defaults:
 
 jobs:
   build_wheels:
+    if: "github.repository == 'MDAnalysis/mdanalysis'"
     name: Build wheels
     runs-on: ${{ matrix.buildplat[0] }}
     timeout-minutes: 15

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -15,7 +15,7 @@ on:
   schedule:
     # 3 am Tuesdays and Fridays
     - cron: "0 3 * * 2,5"
-
+  workflow_dispatch: # Allows running this workflow manually
 
 concurrency:
   group: "${{ github.ref }}-${{ github.head_ref }}-${{ github.workflow }}"
@@ -41,7 +41,7 @@ jobs:
           - [macos-13, macosx_*, x86_64]
           - [windows-2022, win_amd64, AMD64]
           - [macos-14, macosx_*, arm64]
-        python: ["cp310", "cp311", "cp312", "cp313"]
+        python: ["cp310", "cp311", "cp312", "cp313", "cp314"]
     defaults:
       run:
         working-directory: ./package

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -50,7 +50,7 @@ jobs:
           fetch-depth: 0
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.23.0
+        uses: pypa/cibuildwheel@v3.2.0
         with:
           package-dir: package
         env:


### PR DESCRIPTION
This PR adds cp314 to the list of supported Python versions in the build configuration. This enables CI builds and wheel publishing for Python 3.14 on PyPI.

Tested in CI: https://github.com/blueraft/mdanalysis/actions/runs/18370481380


## PR Checklist
 - [ ] Issue raised/referenced?
 - [ ] Tests updated/added?
 - [ ] Documentation updated/added?
 - [ ] `package/CHANGELOG` file updated?
 - [ ] Is your name in `package/AUTHORS`? (If it is not, add it!)

## Developers Certificate of Origin


I certify that I can submit this code contribution as described in the [**Developer Certificate of Origin**](https://developercertificate.org/), under the MDAnalysis [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--5120.org.readthedocs.build/en/5120/

<!-- readthedocs-preview mdanalysis end -->