### PR TITLE
Add edge case checking for `Universe._resolve_formats`

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -14,11 +14,13 @@ The rules for this file:
 
 
 -------------------------------------------------------------------------------
-??/??/?? IAlibay, orbeckst, marinegor, tylerjereddy
+??/??/?? IAlibay, orbeckst, marinegor, tylerjereddy, ljwoods2
 
  * 2.11.0
 
 Fixes
+ * Fix incorrect assignment of topology_format to format (and vice versa)
+   when a parsing class is provided to either (Issue #5147, PR #5148)
  * Fix incorrect TPR file parsing for GROMACS topologies produced prior
    to version 5.1.0 (Issue #5145, PR #5146)
  * Fixes incorrect assignment of secondary structure to proline residues in

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -60,6 +60,7 @@ import copy
 import warnings
 import contextlib
 import collections
+import inspect
 
 import MDAnalysis
 import sys
@@ -260,20 +261,27 @@ def _resolve_formats(*coordinates, format=None, topology_format=None):
         # fully qualified absolute names prevents circular import
         if format is None:
             format = (
-                topology_format
-                if not issubclass(
-                    topology_format,
-                    MDAnalysis.topology.base.TopologyReaderBase,
+                None
+                if (inspect.isclass(topology_format))
+                and (
+                    issubclass(
+                        topology_format,
+                        MDAnalysis.topology.base.TopologyReaderBase,
+                    )
                 )
-                else None
+                else topology_format
             )
         elif topology_format is None:
             topology_format = (
-                format
-                if not issubclass(
-                    format, MDAnalysis.coordinates.base.ProtoReader
+                None
+                if (inspect.isclass(format))
+                and (
+                    issubclass(
+                        format,
+                        MDAnalysis.Analysis.coordinates.base.ProtoReader,
+                    )
                 )
-                else None
+                else format
             )
     return format, topology_format
 

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -255,10 +255,26 @@ def _topology_from_file_like(topology_file, topology_format=None, **kwargs):
 
 def _resolve_formats(*coordinates, format=None, topology_format=None):
     if not coordinates:
+        # ensure that a TopologyReader is not used to attempt to parse a trajectory
+        # Issue #5147
+        # fully qualified absolute names prevents circular import
         if format is None:
-            format = topology_format
+            format = (
+                topology_format
+                if not issubclass(
+                    topology_format,
+                    MDAnalysis.topology.base.TopologyReaderBase,
+                )
+                else None
+            )
         elif topology_format is None:
-            topology_format = format
+            topology_format = (
+                format
+                if not issubclass(
+                    format, MDAnalysis.coordinates.base.ProtoReader
+                )
+                else None
+            )
     return format, topology_format
 
 

--- a/testsuite/MDAnalysisTests/core/test_universe.py
+++ b/testsuite/MDAnalysisTests/core/test_universe.py
@@ -255,6 +255,28 @@ class TestUniverseCreation(object):
         u = mda.Universe(mol, format="RDKIT")
         assert len(u.atoms) == 0
 
+    def test_Universe_top_format_no_coords(self):
+        # Issue #5147- ensure traj format is not set to topology format
+        u = mda.Universe(
+            PDB,
+            topology_format=MDAnalysis.topology.PDBParser.PDBParser,
+            format=None,
+        )
+        assert not isinstance(
+            u.trajectory, MDAnalysis.topology.PDBParser.PDBParser
+        )
+
+    def test_Universe_traj_format_no_coords(self):
+        # Issue #5147- ensure top format is not set to traj format
+        # no way to get inferred top format from Universe- use internal method call
+        format, topology_format = MDAnalysis.core.universe._resolve_formats(
+            None,
+            format=MDAnalysis.coordinates.PDB.PDBReader,
+            topology_format=None,
+        )
+
+        assert topology_format is None
+
 
 class TestUniverseFromSmiles(object):
     def setup_class(self):


### PR DESCRIPTION
<!-- 
Insert issue number that this PR fixes (if any) just after 'Fixes #'.
If this PR does not fix an existing issue, consider opening one or remove 'Fixes #' from the PR description.
-->
Fixes #5147 

Changes made in this Pull Request:
<!-- Describe the changes that this PR makes. If applicable, use the following bullet list. --> 
- Don't set topology_format = format when format is a coordinate reader
- Don't set format = topology_format when topology_format is a topology reader

## PR Checklist
<!-- Please use the following checklist to ensure the PR is ready to be reviewed/merged. -->
 - [x] Issue raised/referenced?
 - [x] Tests updated/added?
 - [ ] Documentation updated/added?
 - [x] `package/CHANGELOG` file updated?
 - [x] Is your name in `package/AUTHORS`? (If it is not, add it!)

## Developers Certificate of Origin
<!-- 
In order for this PR to be merged you **must certify that you are able to submit your code to be included in MDAnalysis**.
-->

I certify that I can submit this code contribution as described in the [**Developer Certificate of Origin**](https://developercertificate.org/), under the MDAnalysis [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--5148.org.readthedocs.build/en/5148/

<!-- readthedocs-preview mdanalysis end -->