### PR TITLE
Fix wrong element assignment for carbon of the style C*S

### DIFF
--- a/package/MDAnalysis/guesser/default_guesser.py
+++ b/package/MDAnalysis/guesser/default_guesser.py
@@ -352,6 +352,8 @@ class DefaultGuesser(GuesserBase):
 
             # just in case
             if name in tables.atomelements:
+                if name == "CS" and  isinstance(eval(atomname[1:-1]), int): #"Adding these two lines correctly assigns this C*S atoms as carbons"
+                    name = "AC"  # AC maps to C in the elements table
                 return tables.atomelements[name]
 
             while name:


### PR DESCRIPTION
The current MDAnalysis atom guesser incorrectly assigns the element type for certain atoms. This misassignment leads to incorrect bond guessing, particularly in DSM lipids—which is how the issue was originally identified.

Fixes #5102 

Changes made in this Pull Request:

Added two lines in default_guesser.py to the method guess_atom_element():


            if name in tables.atomelements:
                if name == "CS" and  isinstance(eval(atomname[1:-1]), int): #"Adding these two lines correctly assigns this C*S atoms as carbons"
                    name = "AC"    # AC maps to C as per the MDAnalysis table
                return tables.atomelements[name]
-
A detailed explanation of the bug and the proposed solution can be found at https://github.com/ricard1997/MDAnalysis_issue_fix.git

## PR Checklist
<!-- Please use the following checklist to ensure the PR is ready to be reviewed/merged. -->
 - [x] Issue raised/referenced?
 - [x] Tests updated/added?


## Developers Certificate of Origin

I certify that I can submit this code contribution as described in the [**Developer Certificate of Origin**](https://developercertificate.org/), under the MDAnalysis [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--5149.org.readthedocs.build/en/5149/

<!-- readthedocs-preview mdanalysis end -->