### PR TITLE
Modernize assertions in test_density.py (Contributes to #3743)

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -263,6 +263,7 @@ Chronological list of authors
   - Amruthesh Thirumalaiswamy
   - Ch Zhang
   - Raúl Lois-Cuns  
+  - Pranay Pelapkar
 
 External code
 -------------

--- a/testsuite/MDAnalysisTests/analysis/test_density.py
+++ b/testsuite/MDAnalysisTests/analysis/test_density.py
@@ -261,11 +261,19 @@ class TestDensityAnalysis(DensityParameters):
             D = density.DensityAnalysis(ag, delta=self.delta, **kwargs).run(
                 **runargs, **client_DensityAnalysis
             )
-            assert D.results.density.grid.mean() == pytest.approx(ref_meandensity), "mean density does not match"
+            assert D.results.density.grid.mean() == pytest.approx(
+                ref_meandensity
+            ), "mean density does not match"
             D.results.density.export(self.outfile)
 
             D2 = density.Density(self.outfile)
-            np.testing.assert_allclose(D.results.density.grid, D2.grid, rtol=0, atol=10**(-self.precision), err_msg="DX export failed: different grid sizes")
+            np.testing.assert_allclose(
+                D.results.density.grid,
+                D2.grid,
+                rtol=0,
+                atol=10 ** (-self.precision),
+                err_msg="DX export failed: different grid sizes",
+            )
 
     @pytest.mark.parametrize("mode", ("static", "dynamic"))
     def test_run(self, mode, universe, tmpdir, client_DensityAnalysis):

--- a/testsuite/MDAnalysisTests/analysis/test_density.py
+++ b/testsuite/MDAnalysisTests/analysis/test_density.py
@@ -77,30 +77,30 @@ class TestDensity(object):
 
     def test_edges(self, bins, D):
         for dim, (edges, fixture) in enumerate(zip(D.edges, bins)):
-            assert_almost_equal(
-                edges, fixture, err_msg="edges[{0}] mismatch".format(dim)
+            np.testing.assert_allclose(
+                edges, fixture, err_msg=f"edges[{dim}] mismatch"
             )
 
     def test_midpoints(self, bins, D):
         midpoints = [0.5 * (b[:-1] + b[1:]) for b in bins]
         for dim, (mp, fixture) in enumerate(zip(D.midpoints, midpoints)):
-            assert_almost_equal(
-                mp, fixture, err_msg="midpoints[{0}] mismatch".format(dim)
+            np.testing.assert_allclose(
+                mp, fixture, err_msg=f"midpoints[{dim}] mismatch"
             )
 
     def test_delta(self, D):
         deltas = np.array([self.Lmax]) / np.array(self.nbins)
-        assert_almost_equal(D.delta, deltas)
+        np.testing.assert_allclose(D.delta, deltas)
 
     def test_grid(self, D):
         dV = D.delta.prod()  # orthorhombic grids only!
         # counts = (rho[0] * dV[0] + rho[1] * dV[1] ...) = sum_i rho[i] * dV
-        assert_almost_equal(D.grid.sum() * dV, self.counts)
+        assert D.grid.sum() * dV == pytest.approx(self.counts)
 
     def test_origin(self, bins, D):
         midpoints = [0.5 * (b[:-1] + b[1:]) for b in bins]
         origin = [m[0] for m in midpoints]
-        assert_almost_equal(D.origin, origin)
+        np.testing.assert_allclose(D.origin, origin)
 
     def test_check_set_unit_keyerror(self, D):
         units = {"weight": "A"}
@@ -146,28 +146,28 @@ class TestDensity(object):
         D_orig = copy.deepcopy(D)
         D.convert_density(unit)
         assert D.units["density"] == D_orig.units["density"] == unit
-        assert_almost_equal(D.grid, D_orig.grid)
+        np.testing.assert_allclose(D.grid, D_orig.grid)
 
     def test_check_convert_density_units_density(self, D):
         unit = "nm^{-3}"
         D_orig = copy.deepcopy(D)
         D.convert_density(unit)
         assert D.units["density"] == "nm^{-3}"
-        assert_almost_equal(D.grid, 10**3 * D_orig.grid)
+        np.testing.assert_allclose(D.grid, 10**3 * D_orig.grid)
 
     def test_convert_length_same_length_units(self, D):
         unit = "A"
         D_orig = copy.deepcopy(D)
         D.convert_length(unit)
         assert D.units["length"] == D_orig.units["length"] == unit
-        assert_almost_equal(D.grid, D_orig.grid)
+        np.testing.assert_allclose(D.grid, D_orig.grid)
 
     def test_convert_length_other_length_units(self, D):
         unit = "nm"
         D_orig = copy.deepcopy(D)
         D.convert_length(unit)
         assert D.units["length"] == unit
-        assert_almost_equal(D.grid, D_orig.grid)
+        np.testing.assert_allclose(D.grid, D_orig.grid)
 
     def test_repr(self, D, D1):
         assert str(D) == "<Density density with (3, 4, 5) bins>"
@@ -178,14 +178,14 @@ class TestDensity(object):
         unit = "nm"
         D.convert_length(unit)
         for prev_edge, conv_edge in zip(D1.edges, D.edges):
-            assert_almost_equal(prev_edge, 10 * conv_edge)
+            np.testing.assert_allclose(prev_edge, 10 * conv_edge)
 
     def test_check_convert_density_edges(self, D):
         unit = "nm^{-3}"
         D_orig = copy.deepcopy(D)
         D.convert_density(unit)
         for new_den, orig_den in zip(D.edges, D_orig.edges):
-            assert_almost_equal(new_den, orig_den)
+            np.testing.assert_allclose(new_den, orig_den)
 
     @pytest.mark.parametrize("dxtype", ("float", "double", "int", "byte"))
     def test_export_types(self, D, dxtype, tmpdir, outfile="density.dx"):
@@ -261,20 +261,11 @@ class TestDensityAnalysis(DensityParameters):
             D = density.DensityAnalysis(ag, delta=self.delta, **kwargs).run(
                 **runargs, **client_DensityAnalysis
             )
-            assert_almost_equal(
-                D.results.density.grid.mean(),
-                ref_meandensity,
-                err_msg="mean density does not match",
-            )
+            assert D.results.density.grid.mean() == pytest.approx(ref_meandensity), "mean density does not match"
             D.results.density.export(self.outfile)
 
             D2 = density.Density(self.outfile)
-            assert_almost_equal(
-                D.results.density.grid,
-                D2.grid,
-                decimal=self.precision,
-                err_msg="DX export failed: different grid sizes",
-            )
+            np.testing.assert_allclose(D.results.density.grid, D2.grid, rtol=0, atol=10**(-self.precision), err_msg="DX export failed: different grid sizes")
 
     @pytest.mark.parametrize("mode", ("static", "dynamic"))
     def test_run(self, mode, universe, tmpdir, client_DensityAnalysis):

--- a/testsuite/MDAnalysisTests/analysis/test_density.py
+++ b/testsuite/MDAnalysisTests/analysis/test_density.py
@@ -27,7 +27,7 @@ import sys
 import warnings
 from unittest.mock import Mock, patch
 
-from numpy.testing import assert_equal, assert_almost_equal
+from numpy.testing import assert_equal, assert_allclose
 
 import gridData.OpenDX
 
@@ -77,20 +77,20 @@ class TestDensity(object):
 
     def test_edges(self, bins, D):
         for dim, (edges, fixture) in enumerate(zip(D.edges, bins)):
-            np.testing.assert_allclose(
+            assert_allclose(
                 edges, fixture, err_msg=f"edges[{dim}] mismatch"
             )
 
     def test_midpoints(self, bins, D):
         midpoints = [0.5 * (b[:-1] + b[1:]) for b in bins]
         for dim, (mp, fixture) in enumerate(zip(D.midpoints, midpoints)):
-            np.testing.assert_allclose(
+            assert_allclose(
                 mp, fixture, err_msg=f"midpoints[{dim}] mismatch"
             )
 
     def test_delta(self, D):
         deltas = np.array([self.Lmax]) / np.array(self.nbins)
-        np.testing.assert_allclose(D.delta, deltas)
+        assert_allclose(D.delta, deltas)
 
     def test_grid(self, D):
         dV = D.delta.prod()  # orthorhombic grids only!
@@ -100,7 +100,7 @@ class TestDensity(object):
     def test_origin(self, bins, D):
         midpoints = [0.5 * (b[:-1] + b[1:]) for b in bins]
         origin = [m[0] for m in midpoints]
-        np.testing.assert_allclose(D.origin, origin)
+        assert_allclose(D.origin, origin)
 
     def test_check_set_unit_keyerror(self, D):
         units = {"weight": "A"}
@@ -146,28 +146,28 @@ class TestDensity(object):
         D_orig = copy.deepcopy(D)
         D.convert_density(unit)
         assert D.units["density"] == D_orig.units["density"] == unit
-        np.testing.assert_allclose(D.grid, D_orig.grid)
+        assert_allclose(D.grid, D_orig.grid)
 
     def test_check_convert_density_units_density(self, D):
         unit = "nm^{-3}"
         D_orig = copy.deepcopy(D)
         D.convert_density(unit)
         assert D.units["density"] == "nm^{-3}"
-        np.testing.assert_allclose(D.grid, 10**3 * D_orig.grid)
+        assert_allclose(D.grid, 10**3 * D_orig.grid)
 
     def test_convert_length_same_length_units(self, D):
         unit = "A"
         D_orig = copy.deepcopy(D)
         D.convert_length(unit)
         assert D.units["length"] == D_orig.units["length"] == unit
-        np.testing.assert_allclose(D.grid, D_orig.grid)
+        assert_allclose(D.grid, D_orig.grid)
 
     def test_convert_length_other_length_units(self, D):
         unit = "nm"
         D_orig = copy.deepcopy(D)
         D.convert_length(unit)
         assert D.units["length"] == unit
-        np.testing.assert_allclose(D.grid, D_orig.grid)
+        assert_allclose(D.grid, D_orig.grid)
 
     def test_repr(self, D, D1):
         assert str(D) == "<Density density with (3, 4, 5) bins>"
@@ -178,14 +178,14 @@ class TestDensity(object):
         unit = "nm"
         D.convert_length(unit)
         for prev_edge, conv_edge in zip(D1.edges, D.edges):
-            np.testing.assert_allclose(prev_edge, 10 * conv_edge)
+            assert_allclose(prev_edge, 10 * conv_edge)
 
     def test_check_convert_density_edges(self, D):
         unit = "nm^{-3}"
         D_orig = copy.deepcopy(D)
         D.convert_density(unit)
         for new_den, orig_den in zip(D.edges, D_orig.edges):
-            np.testing.assert_allclose(new_den, orig_den)
+            assert_allclose(new_den, orig_den)
 
     @pytest.mark.parametrize("dxtype", ("float", "double", "int", "byte"))
     def test_export_types(self, D, dxtype, tmpdir, outfile="density.dx"):
@@ -267,7 +267,7 @@ class TestDensityAnalysis(DensityParameters):
             D.results.density.export(self.outfile)
 
             D2 = density.Density(self.outfile)
-            np.testing.assert_allclose(
+            assert_allclose(
                 D.results.density.grid,
                 D2.grid,
                 rtol=0,

--- a/testsuite/MDAnalysisTests/analysis/test_density.py
+++ b/testsuite/MDAnalysisTests/analysis/test_density.py
@@ -77,16 +77,12 @@ class TestDensity(object):
 
     def test_edges(self, bins, D):
         for dim, (edges, fixture) in enumerate(zip(D.edges, bins)):
-            assert_allclose(
-                edges, fixture, err_msg=f"edges[{dim}] mismatch"
-            )
+            assert_allclose(edges, fixture, err_msg=f"edges[{dim}] mismatch")
 
     def test_midpoints(self, bins, D):
         midpoints = [0.5 * (b[:-1] + b[1:]) for b in bins]
         for dim, (mp, fixture) in enumerate(zip(D.midpoints, midpoints)):
-            assert_allclose(
-                mp, fixture, err_msg=f"midpoints[{dim}] mismatch"
-            )
+            assert_allclose(mp, fixture, err_msg=f"midpoints[{dim}] mismatch")
 
     def test_delta(self, D):
         deltas = np.array([self.Lmax]) / np.array(self.nbins)


### PR DESCRIPTION
Contributes to #3743

### Changes made in this Pull Request:
- Modernized assertions in `testsuite/MDAnalysisTests/analysis/test_density.py`
- Replaced deprecated `assert_almost_equal` with `numpy.testing.assert_allclose`
- Replaced scalar float comparisons with `pytest.approx`
- Preserved precision behavior and error messages
- No behavioral changes introduced

## PR Checklist
 - [x] Issue raised/referenced? (Contributes to #3743)
 - [x] Tests updated/added? (Updated test assertions)
 - [ ] Documentation updated/added?
 - [ ] package/CHANGELOG file updated?
 - [x] Is your name in package/AUTHORS?

## Developers Certificate of Origin
I certify that I can submit this code contribution as described in the [**Developer Certificate of Origin**](https://developercertificate.org/), under the MDAnalysis [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE).

<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--5155.org.readthedocs.build/en/5155/

<!-- readthedocs-preview mdanalysis end -->