### PR TITLE
Removed the always keyword for DeprecationWarning in hbonds_autocorrel.py

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -31,6 +31,21 @@ Changes
 Deprecations
 
 
+11/26/25 IAlibay, orbeckst, marinegor, tylerjereddy, ljwoods2, marinegor, spyke7
+
+ * 2.11.0
+
+Fixes
+ * Fixes the DeprecationWarning in hbonds_autocorrel.py so as the warning 
+   can be suppressed in mdacli which are not needed(Issue #5157, PR #5159)
+
+Changes
+ * In the hbonds\hbonds_autocorrel.py, removed the always keyword. And keeping
+   the message same (Issue #5157, PR #5159)
+
+Deprecations
+
+
 11/24/25 IAlibay, orbeckst, marinegor, tylerjereddy, ljwoods2, marinegor, spyke7
 
  * 2.11.0

--- a/package/MDAnalysis/analysis/hbonds/hbond_autocorrel.py
+++ b/package/MDAnalysis/analysis/hbonds/hbond_autocorrel.py
@@ -44,14 +44,12 @@ See Also
 """
 import warnings
 
-with warnings.catch_warnings():
-    warnings.simplefilter("always", DeprecationWarning)
-    wmsg = (
+wmsg = (
         "This module was moved to "
         "MDAnalysis.analysis.hydrogenbonds.hbond_autocorrel; "
         "hbonds.hbond_autocorrel will be removed in 3.0.0."
     )
-    warnings.warn(wmsg, category=DeprecationWarning)
+warnings.warn(wmsg, category=DeprecationWarning)    
 
 from MDAnalysis.lib.util import deprecate
 

--- a/package/MDAnalysis/analysis/hbonds/hbond_autocorrel.py
+++ b/package/MDAnalysis/analysis/hbonds/hbond_autocorrel.py
@@ -45,11 +45,11 @@ See Also
 import warnings
 
 wmsg = (
-        "This module was moved to "
-        "MDAnalysis.analysis.hydrogenbonds.hbond_autocorrel; "
-        "hbonds.hbond_autocorrel will be removed in 3.0.0."
-    )
-warnings.warn(wmsg, category=DeprecationWarning)    
+    "This module was moved to "
+    "MDAnalysis.analysis.hydrogenbonds.hbond_autocorrel; "
+    "hbonds.hbond_autocorrel will be removed in 3.0.0."
+)
+warnings.warn(wmsg, category=DeprecationWarning)
 
 from MDAnalysis.lib.util import deprecate
 


### PR DESCRIPTION
Fixes #5157 

Changes made in this Pull Request:
- Removed the "always" keyword for DeprecationWarning in hbonds_autocorrel.py
- Kept the message same

@marinegor @PicoCentauri  Updated the hbonds_autocorrel.py please check it!

## PR Checklist
<!-- Please use the following checklist to ensure the PR is ready to be reviewed/merged. -->
 - [x] Issue raised/referenced?
 - [ ] Tests updated/added?
 - [ ] Documentation updated/added?
 - [x] `package/CHANGELOG` file updated?
 - [x] Is your name in `package/AUTHORS`? (If it is not, add it!)

## Developers Certificate of Origin

I certify that I can submit this code contribution as described in the [**Developer Certificate of Origin**](https://developercertificate.org/), under the MDAnalysis [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--5159.org.readthedocs.build/en/5159/

<!-- readthedocs-preview mdanalysis end -->