### PR TITLE
Raised meaningful error for short peptide stretch

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -20,8 +20,9 @@ The rules for this file:
  * 2.11.0
 
 Fixes
- * Fixes the error message for short peptide stretches inside dssp.py, 
-   and showing minimum value is 6 (Issue #5046, PR #5163)
+ * DSSP now explicitly checks for a minimum of 6 residues and raises a clear
+   error message, unlike the previous behavior where it would fail with an
+   incomprehensible broadcasting error at execution time (Issue #5046, PR #5163)
  * Fixes the verbose=False in EinsteinMSD, and only shows progress bar when
    verbose=True (Issue #5144, PR #5153)
  * Fix incorrect assignment of topology_format to format (and vice versa)
@@ -36,8 +37,6 @@ Enhancements
    (Issue #4679, PR #4745)
 
 Changes
- * Inside the DSSP class of dssp.py file, a value error is raised for 
-   value less than 6 (Issue #5046, PR #5163)
  * The msd.py inside analysis is changed, and ProgressBar is implemented inside
    _conclude_simple and _conclude_fft functions instead of tqdm (Issue #5144, PR #5153)
 

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -20,6 +20,8 @@ The rules for this file:
  * 2.11.0
 
 Fixes
+ * Fixes the error message for short peptide stretches inside dssp.py, 
+   and showing minimum value is 6 (Issue #5046, PR #5163)
  * Fixes the verbose=False in EinsteinMSD, and only shows progress bar when
    verbose=True (Issue #5144, PR #5153)
  * Fix incorrect assignment of topology_format to format (and vice versa)
@@ -34,6 +36,8 @@ Enhancements
    (Issue #4679, PR #4745)
 
 Changes
+ * Inside the DSSP class of dssp.py file, a value error is raised for 
+   value less than 6 (Issue #5046, PR #5163)
  * The msd.py inside analysis is changed, and ProgressBar is implemented inside
    _conclude_simple and _conclude_fft functions instead of tqdm (Issue #5144, PR #5153)
 

--- a/package/MDAnalysis/analysis/dssp/dssp.py
+++ b/package/MDAnalysis/analysis/dssp/dssp.py
@@ -312,6 +312,13 @@ class DSSP(AnalysisBase):
         ag: AtomGroup = atoms.select_atoms("protein")
         super().__init__(ag.universe.trajectory)
 
+        n_residues = len(ag.residues)
+        min_residues = 5
+        if n_residues < min_residues:
+            raise ValueError(
+                f"DSSP requires at least {min_residues} residues for secondary structure analysis, but only {n_residues} residue(s) were provided in the selection."
+            )
+
         # define necessary selections
         self._heavy_atoms: dict[str, "AtomGroup"] = {
             t: ag.atoms[

--- a/package/MDAnalysis/analysis/dssp/dssp.py
+++ b/package/MDAnalysis/analysis/dssp/dssp.py
@@ -210,7 +210,7 @@ class DSSP(AnalysisBase):
     Parameters
     ----------
     atoms : Union[Universe, AtomGroup]
-        input at least 6 Universe or AtomGroup. In both cases, only protein residues will
+        input Universe or AtomGroup with at least 6 protein residues. In both cases, only protein residues will
         be chosen prior to the analysis via `select_atoms('protein')`.
         Heavy atoms of the protein are then selected by name
         `heavyatom_names`, and hydrogens are selected by name

--- a/package/MDAnalysis/analysis/dssp/dssp.py
+++ b/package/MDAnalysis/analysis/dssp/dssp.py
@@ -210,7 +210,7 @@ class DSSP(AnalysisBase):
     Parameters
     ----------
     atoms : Union[Universe, AtomGroup]
-        input Universe or AtomGroup. In both cases, only protein residues will
+        input at least 6 Universe or AtomGroup. In both cases, only protein residues will
         be chosen prior to the analysis via `select_atoms('protein')`.
         Heavy atoms of the protein are then selected by name
         `heavyatom_names`, and hydrogens are selected by name

--- a/package/MDAnalysis/analysis/dssp/dssp.py
+++ b/package/MDAnalysis/analysis/dssp/dssp.py
@@ -312,13 +312,6 @@ class DSSP(AnalysisBase):
         ag: AtomGroup = atoms.select_atoms("protein")
         super().__init__(ag.universe.trajectory)
 
-        n_residues = len(ag.residues)
-        min_residues = 5
-        if n_residues < min_residues:
-            raise ValueError(
-                f"DSSP requires at least {min_residues} residues for secondary structure analysis, but only {n_residues} residue(s) were provided in the selection."
-            )
-
         # define necessary selections
         self._heavy_atoms: dict[str, "AtomGroup"] = {
             t: ag.atoms[
@@ -362,6 +355,13 @@ class DSSP(AnalysisBase):
                     "Universe contains unequal numbers of (N,CA,C,O) atoms ('name' field)."
                     " Please select appropriate AtomGroup manually."
                 )
+            )
+
+        n_residues = len(ag.residues)
+        MIN_RESIDUES = 5
+        if n_residues < MIN_RESIDUES:
+            raise ValueError(
+                f"DSSP requires at least {MIN_RESIDUES} residues for secondary structure analysis, but only {n_residues} residue(s) were provided in the selection."
             )
 
     def _prepare(self):

--- a/package/MDAnalysis/analysis/dssp/dssp.py
+++ b/package/MDAnalysis/analysis/dssp/dssp.py
@@ -240,6 +240,8 @@ class DSSP(AnalysisBase):
     Raises
     ------
     ValueError
+        If fewer than 6 residues are provided in the selection.
+    ValueError
         if ``guess_hydrogens`` is True but some non-PRO hydrogens are missing.
 
     Examples
@@ -357,11 +359,10 @@ class DSSP(AnalysisBase):
                 )
             )
 
-        n_residues = len(ag.residues)
-        MIN_RESIDUES = 5
-        if n_residues < MIN_RESIDUES:
+        if len(ag.residues) < 6:
             raise ValueError(
-                f"DSSP requires at least {MIN_RESIDUES} residues for secondary structure analysis, but only {n_residues} residue(s) were provided in the selection."
+                "DSSP requires at least 6 residues for secondary structure analysis, "
+                f"but only {len(ag.residues)} residue(s) were provided in the selection."
             )
 
     def _prepare(self):

--- a/testsuite/MDAnalysisTests/analysis/test_dssp.py
+++ b/testsuite/MDAnalysisTests/analysis/test_dssp.py
@@ -96,7 +96,6 @@ def test_insufficient_residues_raises_error(client_DSSP):
     u = mda.Universe(TPR, XTC)
 
     protein = u.select_atoms("protein")
-    resids = protein.residues.resids
 
     with pytest.raises(ValueError, match="DSSP requires at least 6 residues"):
         res2 = protein.residues[:2].atoms

--- a/testsuite/MDAnalysisTests/analysis/test_dssp.py
+++ b/testsuite/MDAnalysisTests/analysis/test_dssp.py
@@ -99,14 +99,14 @@ def test_insufficient_residues_raises_error(client_DSSP):
     resids = protein.residues.resids
 
     with pytest.raises(ValueError, match="DSSP requires at least 6 residues"):
-        res2 = u.select_atoms(f"protein and resid {resids[0]}-{resids[1]}")
+        res2 = protein.residues[:2].atoms
         DSSP(res2)
 
     with pytest.raises(ValueError, match="DSSP requires at least 6 residues"):
-        res4 = u.select_atoms(f"protein and resid {resids[0]}-{resids[3]}")
+        res4 = protein.residues[:4].atoms
         DSSP(res4)
 
-    res6 = u.select_atoms(f"protein and resid {resids[0]}-{resids[5]}")
+    res6 = protein.residues[:6].atoms
     dssp = DSSP(res6)
     result = dssp.run(**client_DSSP, stop=1)
     assert result.results.dssp.shape[1] == 6

--- a/testsuite/MDAnalysisTests/analysis/test_dssp.py
+++ b/testsuite/MDAnalysisTests/analysis/test_dssp.py
@@ -89,3 +89,24 @@ def test_exception_raises_with_atom_index(pdb_filename, client_DSSP):
         match="Residue <Residue SER, 298> contains*",
     ):
         DSSP(u, guess_hydrogens=False).run(**client_DSSP)
+
+
+def test_insufficient_residues_raises_error(client_DSSP):
+    """Test that DSSP raises clear error for insufficient residues."""
+    u = mda.Universe(TPR, XTC)
+
+    protein = u.select_atoms("protein")
+    resids = protein.residues.resids
+
+    with pytest.raises(ValueError, match="DSSP requires at least 6 residues"):
+        res2 = u.select_atoms(f"protein and resid {resids[0]}-{resids[1]}")
+        DSSP(res2)
+
+    with pytest.raises(ValueError, match="DSSP requires at least 6 residues"):
+        res4 = u.select_atoms(f"protein and resid {resids[0]}-{resids[3]}")
+        DSSP(res4)
+
+    res6 = u.select_atoms(f"protein and resid {resids[0]}-{resids[5]}")
+    dssp = DSSP(res6)
+    result = dssp.run(**client_DSSP, stop=1)
+    assert result.results.dssp.shape[1] == 6


### PR DESCRIPTION
Fixes #5046 

Changes made in this Pull Request:
- Added a block for raising value error inside __init__ in dssp.py
- Checked the length of `ag.residues`, and just raised a simple value error message showing the minimum required residues

## PR Checklist
 - [x] Issue raised/referenced?
 - [x] Tests updated/added?
 - [x] Documentation updated/added?
 - [x] `package/CHANGELOG` file updated?
 - [x] Is your name in `package/AUTHORS`? (If it is not, add it!)

## Developers Certificate of Origin

I certify that I can submit this code contribution as described in the [**Developer Certificate of Origin**](https://developercertificate.org/), under the MDAnalysis [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--5163.org.readthedocs.build/en/5163/

<!-- readthedocs-preview mdanalysis end -->