### PR TITLE
Add RMSFResidue analysis class for per-residue RMSF computation

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -265,6 +265,8 @@ Chronological list of authors
   - Raúl Lois-Cuns  
   - Pranay Pelapkar
   - Shreejan Dolai
+  - Nitin Pratap Singh
+
 
 External code
 -------------

--- a/package/MDAnalysis/analysis/rmsf_residue.py
+++ b/package/MDAnalysis/analysis/rmsf_residue.py
@@ -1,6 +1,7 @@
 from MDAnalysis.analysis.base import AnalysisBase
 import numpy as np
 
+
 class RMSFResidue(AnalysisBase):
     """
     Compute RMSF (Root Mean Square Fluctuation) per residue.
@@ -26,7 +27,9 @@ class RMSFResidue(AnalysisBase):
 
         # Residue metadata
         self.resids = np.array([res.resid for res in self.universe.residues])
-        self.resnames = np.array([res.resname for res in self.universe.residues])
+        self.resnames = np.array(
+            [res.resname for res in self.universe.residues]
+        )
 
         # Running statistics
         self._sum = np.zeros((self.n_residues, 3))
@@ -39,7 +42,7 @@ class RMSFResidue(AnalysisBase):
             if len(group) > 0:
                 mean_pos = group.positions.mean(axis=0)
                 self._sum[i] += mean_pos
-                self._sum_sq[i] += mean_pos ** 2
+                self._sum_sq[i] += mean_pos**2
 
         self._counts += 1
 

--- a/package/MDAnalysis/analysis/rmsf_residue.py
+++ b/package/MDAnalysis/analysis/rmsf_residue.py
@@ -1,0 +1,55 @@
+from MDAnalysis.analysis.base import AnalysisBase
+import numpy as np
+
+class RMSFResidue(AnalysisBase):
+    """
+    Compute RMSF (Root Mean Square Fluctuation) per residue.
+    """
+
+    def __init__(self, universe, select="all", **kwargs):
+        self.universe = universe
+        self.select = select
+
+        # Select atoms
+        self.ag = universe.select_atoms(select)
+
+        # Build residue -> atomgroup mapping manually (safe & correct)
+        self.residue_groups = []
+        for res in universe.residues:
+            self.residue_groups.append(self.ag[self.ag.resids == res.resid])
+
+        super().__init__(self.universe.trajectory, **kwargs)
+
+    def _prepare(self):
+        # Number of residues
+        self.n_residues = len(self.residue_groups)
+
+        # Residue metadata
+        self.resids = np.array([res.resid for res in self.universe.residues])
+        self.resnames = np.array([res.resname for res in self.universe.residues])
+
+        # Running statistics
+        self._sum = np.zeros((self.n_residues, 3))
+        self._sum_sq = np.zeros((self.n_residues, 3))
+        self._counts = 0
+
+    def _single_frame(self):
+        # For each residue compute mean atomic position
+        for i, group in enumerate(self.residue_groups):
+            if len(group) > 0:
+                mean_pos = group.positions.mean(axis=0)
+                self._sum[i] += mean_pos
+                self._sum_sq[i] += mean_pos ** 2
+
+        self._counts += 1
+
+    def _conclude(self):
+        # Compute RMSF
+        mean = self._sum / self._counts
+        mean_sq = self._sum_sq / self._counts
+        self.rmsf = np.sqrt((mean_sq - mean**2).sum(axis=1))
+
+        # Store results
+        self.results.resids = self.resids
+        self.results.resnames = self.resnames
+        self.results.residue_rmsf = self.rmsf

--- a/testsuite/MDAnalysisTests/analysis/test_rmsf_residue.py
+++ b/testsuite/MDAnalysisTests/analysis/test_rmsf_residue.py
@@ -1,0 +1,25 @@
+import numpy as np
+import MDAnalysis as mda
+from MDAnalysis.analysis.rmsf_residue import RMSFResidue
+from MDAnalysisTests.datafiles import PSF, DCD
+
+
+def test_rmsf_residue_runs():
+    # Load tiny test system included in MDAnalysis
+    u = mda.Universe(PSF, DCD)
+
+    # Create the analysis
+    rmsf = RMSFResidue(u, select="all")
+
+    # Should run without errors
+    rmsf.run()
+
+    # Check that results exist
+    assert hasattr(rmsf.results, "residue_rmsf")
+
+    # Number of residues should match universe
+    n_res = len(u.residues)
+    assert rmsf.results.residue_rmsf.shape[0] == n_res
+
+    # RMSF values must be >= 0
+    assert np.all(rmsf.results.residue_rmsf >= 0)


### PR DESCRIPTION
This PR adds a new analysis module `RMSFResidue` that computes
Root Mean Square Fluctuations (RMSF) on a per-residue basis.

### Motivation
MDAnalysis currently provides atom-level RMSF via `RMSF`. This PR adds a
small convenience analysis that aggregates RMSF values at the residue
level, following the existing RMSF API. This does not introduce a new
method, but provides a commonly requested way to summarize RMSF results
at the residue level.

### Implementation
- Introduces `RMSFResidue` in `MDAnalysis.analysis.rmsf_residue`.
- Computes residue-level mean positions frame-by-frame.
- Accumulates statistics and final RMSF in `_conclude()`.
- Stores results in `results.residue_rmsf`.

### Tests
Added:
- `testsuite/MDAnalysisTests/analysis/test_rmsf_residue.py`
Ensures:
- Analysis runs without error
- Output length matches number of residues
- RMSF values are non-negative

### Notes
The implementation avoids `groupby("residues")` due to current API limitations, and instead manually groups atoms by `resid`.

### Status
All tests pass locally.


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--5176.org.readthedocs.build/en/5176/

<!-- readthedocs-preview mdanalysis end -->