### PR TITLE
Add test to cover unit conversion path in DMSReader

### DIFF
--- a/testsuite/MDAnalysisTests/coordinates/test_dms.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_dms.py
@@ -105,4 +105,3 @@ class TestDMSReader(object):
             u_conv.atoms.positions,
             u_native.atoms.positions,
         )
-        

--- a/testsuite/MDAnalysisTests/coordinates/test_dms.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_dms.py
@@ -95,8 +95,11 @@ class TestDMSReader(object):
             universe.trajectory[1]
 
     def test_convert_pos_from_native(self):
-        u = mda.Universe(DMS, convert_units=True)
+        u_native = mda.Universe(DMS, convert_units=False)
+        u_conv = mda.Universe(DMS, convert_units=True)
 
-        coords = u.atoms.positions
-
-        assert coords.shape[0] == len(u.atoms)
+        np.testing.assert_allclose(
+            u_conv.atoms.positions,
+            u_native.atoms.positions,
+            rtol=1e-6,
+        )

--- a/testsuite/MDAnalysisTests/coordinates/test_dms.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_dms.py
@@ -98,8 +98,11 @@ class TestDMSReader(object):
         u_native = mda.Universe(DMS, convert_units=False)
         u_conv = mda.Universe(DMS, convert_units=True)
 
+        # DMS native coordinates are already in Angstroms, which matches
+        # MDAnalysis base length units, so enabling unit conversion should
+        # not change the coordinate values.
         np.testing.assert_allclose(
             u_conv.atoms.positions,
             u_native.atoms.positions,
-            rtol=1e-6,
         )
+        

--- a/testsuite/MDAnalysisTests/coordinates/test_dms.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_dms.py
@@ -93,3 +93,10 @@ class TestDMSReader(object):
     def test_frame_index_1_raises_IndexError(self, universe):
         with pytest.raises(IndexError):
             universe.trajectory[1]
+    
+    def test_convert_pos_from_native(self):
+        u= mda.Universe(DMS,convert_units=True)
+        
+        coords= u.atoms.positions
+        
+        assert coords.shape[0] == len(u.atoms)

--- a/testsuite/MDAnalysisTests/coordinates/test_dms.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_dms.py
@@ -93,10 +93,10 @@ class TestDMSReader(object):
     def test_frame_index_1_raises_IndexError(self, universe):
         with pytest.raises(IndexError):
             universe.trajectory[1]
-    
+
     def test_convert_pos_from_native(self):
-        u= mda.Universe(DMS,convert_units=True)
-        
-        coords= u.atoms.positions
-        
+        u = mda.Universe(DMS, convert_units=True)
+
+        coords = u.atoms.positions
+
         assert coords.shape[0] == len(u.atoms)


### PR DESCRIPTION
### Summary
Fixes : #3304
This PR adds a small test for `DMSReader` that exercises the unit-conversion code path when `convert_units=True`.

### Details
*  Adds coverage for `convert_pos_from_native` by triggering position access
* Does not alter reader behavior or logic
* No changes to existing tests

**Test verified locally with:**
```text
pytest testsuite/MDAnalysisTests/coordinates/test_dms.py::TestDMSReader::test_convert_pos_from_native
```


### Notes
`ts.dimensions` is intentionally `None` for DMS files, so this test does not attempt to assert or modify box dimensions.

<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--5180.org.readthedocs.build/en/5180/

<!-- readthedocs-preview mdanalysis end -->