### PR TITLE
Maint: Disable build isolation in pip cron tests

### DIFF
--- a/.github/workflows/gh-ci-cron.yaml
+++ b/.github/workflows/gh-ci-cron.yaml
@@ -203,11 +203,11 @@ jobs:
 
     - name: pip install mdanalysis
       run: |
-        cd package && pip install .
+        cd package && pip install . --no-build-isolation
 
     - name: pip install mdanalysistests
       run: |
-        cd testsuite && pip install .
+        cd testsuite && pip install . --no-build-isolation
 
     - name: install_pip_extras
       run: |


### PR DESCRIPTION
Fixes #5125 

Changes made in this Pull Request:
- Updated `.github/workflows/gh-ci-cron.yaml` to include the `--no-build-isolation` flag in pip install commands.
- This ensures that the nightly cron tests run against the actual environment dependencies (like nightly NumPy builds) rather than installing isolated stable versions.

## PR Checklist
 - [x] Issue raised/referenced?
 - [ ] Tests updated/added? (N/A - CI workflow update)
 - [ ] Documentation updated/added? (N/A)
 - [ ] `package/CHANGELOG` file updated? (N/A - Maintenance fix)
 - [ ] Is your name in `package/AUTHORS`? (Note: My name is added to AUTHORS in my pending PR #5156)

## Developers Certificate of Origin
I certify that I can submit this code contribution as described in the [**Developer Certificate of Origin**](https://developercertificate.org/), under the MDAnalysis [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE).

<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--5181.org.readthedocs.build/en/5181/

<!-- readthedocs-preview mdanalysis end -->