### PR TITLE
Add a current frame iterator for streamed trajectories

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -265,6 +265,7 @@ Chronological list of authors
   - Raúl Lois-Cuns  
   - Pranay Pelapkar
   - Shreejan Dolai
+  - Pardhav Maradani
 
 External code
 -------------

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -30,11 +30,11 @@ Fixes
    DSSP by porting upstream PyDSSP 0.9.1 fix (Issue #4913)
 
 Enhancements
- * Enables parallelization for analysis.diffusionmap.DistanceMatrix
-   (Issue #4679, PR #4745)
  * Added a current frame iterator `StreamFrameIteratorCurrent` for streamed
    trajectories to enable `AnalysisBase.run` on per-frame streamed data
    (Issue #5183, PR #5184)
+ * Enables parallelization for analysis.diffusionmap.DistanceMatrix
+   (Issue #4679, PR #4745)
 
 Changes
  * The msd.py inside analysis is changed, and ProgressBar is implemented inside

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -15,7 +15,7 @@ The rules for this file:
 
 -------------------------------------------------------------------------------
 ??/??/?? IAlibay, orbeckst, marinegor, tylerjereddy, ljwoods2, marinegor,
-         spyke7, talagayev
+         spyke7, talagayev, PardhavMaradani
 
  * 2.11.0
 
@@ -32,6 +32,9 @@ Fixes
 Enhancements
  * Enables parallelization for analysis.diffusionmap.DistanceMatrix
    (Issue #4679, PR #4745)
+ * Added a current frame iterator `StreamFrameIteratorCurrent` for streamed
+   trajectories to enable `AnalysisBase.run` on per-frame streamed data
+   (Issue #5183, PR #5184)
 
 Changes
  * The msd.py inside analysis is changed, and ProgressBar is implemented inside

--- a/package/MDAnalysis/coordinates/IMD.py
+++ b/package/MDAnalysis/coordinates/IMD.py
@@ -286,6 +286,9 @@ class IMDReader(StreamReaderBase):
             raise RuntimeError(f"IMDReader: Read error: {e}") from e
 
     def _read_frame(self, frame):
+        if frame == self._frame:
+            logger.debug("IMDReader: Using current frame %d", self._frame)
+            return self.ts
 
         imdf = self._imdclient.get_imdframe()
 

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -2008,7 +2008,9 @@ class StreamReaderBase(ReaderBase):
             raise RuntimeError(
                 "{}: Cannot reopen stream".format(self.__class__.__name__)
             )
-        self._frame = -1
+        if self._frame == 0:
+            # only reset when stream hasn't been iterated using next
+            self._frame = -1
         self._reopen_called = True
 
     def timeseries(self, **kwargs):

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -2065,7 +2065,14 @@ class StreamReaderBase(ReaderBase):
         StreamFrameIteratorSliced
         StreamFrameIteratorCurrent
         """
-        if isinstance(frame, slice):
+        if isinstance(frame, numbers.Integral):
+            if frame == self.trajectory.frame:
+                return self._read_frame_with_aux(frame)
+            else:
+                raise ValueError(
+                    "Streamed trajectories must specify current frame value"
+                )
+        elif isinstance(frame, slice):
             _, _, step = self.check_slice_indices(
                 frame.start, frame.stop, frame.step
             )

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -52,6 +52,8 @@ Iterator classes used by the by the :class:`ProtoReader`:
 
 .. autoclass:: StreamFrameIteratorSliced
 
+.. autoclass:: StreamFrameIteratorCurrent
+
 .. _ReadersBase:
 
 Readers
@@ -1882,10 +1884,11 @@ class StreamReaderBase(ReaderBase):
     See Also
     --------
     StreamFrameIteratorSliced : Iterator for stepped streaming access
+    StreamFrameIteratorCurrent : Iterator for current frame streaming access
     ReaderBase : Base class for standard trajectory readers
 
 
-    .. versionadded:: 2.10.0 
+    .. versionadded:: 2.10.0
     """
 
     def __init__(self, filename, convert_units=True, **kwargs):
@@ -2040,7 +2043,7 @@ class StreamReaderBase(ReaderBase):
 
         Returns
         -------
-        FrameIteratorAll or StreamFrameIteratorSliced
+        FrameIteratorAll or StreamFrameIteratorSliced or StreamFrameIteratorCurrent
             Iterator for the requested slice.
 
         Raises
@@ -2060,6 +2063,7 @@ class StreamReaderBase(ReaderBase):
         See Also
         --------
         StreamFrameIteratorSliced
+        StreamFrameIteratorCurrent
         """
         if isinstance(frame, slice):
             _, _, step = self.check_slice_indices(
@@ -2069,6 +2073,13 @@ class StreamReaderBase(ReaderBase):
                 return FrameIteratorAll(self)
             else:
                 return StreamFrameIteratorSliced(self, step)
+        elif isinstance(frame, (list, np.ndarray)):
+            if len(frame) == 1 and frame[0] == self.trajectory.frame:
+                return StreamFrameIteratorCurrent(self)
+            else:
+                raise ValueError(
+                    "Streamed trajectories must have single current frame value"
+                )
         else:
             raise TypeError(
                 "Streamed trajectories must be an indexed using a slice"
@@ -2311,3 +2322,38 @@ class StreamFrameIteratorSliced(FrameIteratorBase):
             
         """
         return self._step
+
+
+class StreamFrameIteratorCurrent(FrameIteratorBase):
+    """Iterator for current frame access in a streamed trajectory.
+
+    Created when an array with a single current frame value is passed.
+
+    Parameters
+    ----------
+    trajectory : StreamReaderBase
+        The streaming trajectory reader to iterate over. Must be a
+        stream-based reader that supports continuous data reading.
+
+    See Also
+    --------
+    StreamReaderBase
+    FrameIteratorBase
+
+    .. versionadded:: 2.11.0
+    """
+
+    def __init__(self, trajectory):
+        super(StreamFrameIteratorCurrent, self).__init__(trajectory)
+
+    def __len__(self):
+        return 1
+
+    def __iter__(self):
+        yield self.trajectory._read_frame_with_aux(self.trajectory.frame)
+
+    def __next__(self):
+        raise StopIteration from None
+
+    def __getitem__(self, frame):
+        raise RuntimeError("Current frame iterator does not support indexing")

--- a/package/MDAnalysis/coordinates/base.py
+++ b/package/MDAnalysis/coordinates/base.py
@@ -2067,7 +2067,7 @@ class StreamReaderBase(ReaderBase):
         """
         if isinstance(frame, numbers.Integral):
             if frame == self.trajectory.frame:
-                return self._read_frame_with_aux(frame)
+                return self._read_frame(frame)
             else:
                 raise ValueError(
                     "Streamed trajectories must specify current frame value"
@@ -2357,7 +2357,7 @@ class StreamFrameIteratorCurrent(FrameIteratorBase):
         return 1
 
     def __iter__(self):
-        yield self.trajectory._read_frame_with_aux(self.trajectory.frame)
+        yield self.trajectory._read_frame(self.trajectory.frame)
 
     def __next__(self):
         raise StopIteration from None

--- a/testsuite/MDAnalysisTests/coordinates/test_imd.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_imd.py
@@ -469,8 +469,12 @@ class TestStreamIteration:
                 pass
 
     def test_index_stream_raises_error(self, reader):
-        with pytest.raises(TypeError, match="Streamed trajectories must be"):
-            reader[0]
+        reader[0]
+        with pytest.raises(
+            ValueError,
+            match="Streamed trajectories must specify current frame value",
+        ):
+            reader[1]
 
     def test_iterate_backwards_raises_error(self, reader):
         with pytest.raises(ValueError, match="Cannot go backwards"):

--- a/testsuite/MDAnalysisTests/coordinates/test_imd.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_imd.py
@@ -528,10 +528,27 @@ class TestStreamIteration:
             ts[0]
 
     def test_iterate_current_frame(self, reader):
+        cts = reader.ts
+        # test iterator length
         assert len(reader[[reader.frame]]) == 1
+        # test list iterator
         for ts in reader[[reader.frame]]:
+            assert ts == cts
             assert ts.frame == reader.frame
+        # test np.ndarray iterator
         reader[np.array([reader.frame])]
+        # test same timestep
+        assert reader[reader.frame] == cts
+        assert reader[reader.frame] == reader[reader.frame]
+        # should be able to iterate all 5 frames in reader
+        # due to server.send_frames(1, 5) in reader setup
+        for i in range(5):
+            ts = reader[i]
+            if i < 4:
+                reader.next()
+            else:
+                with pytest.raises(StopIteration):
+                    reader.next()
 
 
 @pytest.mark.skipif(not HAS_IMDCLIENT, reason="IMDClient not installed")

--- a/testsuite/MDAnalysisTests/coordinates/test_imd.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_imd.py
@@ -527,35 +527,38 @@ class TestStreamIteration:
         ):
             ts[0]
 
-    def test_iterate_current_frame(self, reader):
+    @pytest.mark.parametrize("iter_type", [list, np.array])
+    def test_iterate_current_frame(self, reader, iter_type):
         cts = reader.ts
         # test iterator length
-        assert len(reader[[reader.frame]]) == 1
+        assert len(reader[iter_type([reader.frame])]) == 1
         # test list iterator
-        for ts in reader[[reader.frame]]:
+        for ts in reader[iter_type([reader.frame])]:
             assert ts == cts
             assert ts.frame == reader.frame
-        # test np.ndarray iterator
-        reader[np.array([reader.frame])]
+
+    def test_current_frame(self, reader):
+        cts = reader.ts
         # test same timestep
         assert reader[reader.frame] == cts
         assert reader[reader.frame] == reader[reader.frame]
         # should be able to iterate all 5 frames in reader
         # due to server.send_frames(1, 5) in reader setup
         for i in range(5):
-            ts = reader[i]
+            reader[i]
             if i < 4:
                 reader.next()
             else:
                 with pytest.raises(StopIteration):
                     reader.next()
 
-    def test_iterate_current_frame_no_transformations(self, reader):
+    def test_current_frame_transformations(self, reader):
         reader.add_transformations(
             translate([1, 1, 1]), translate([0, 0, 0.33])
         )
         p1 = reader[reader.frame].positions.copy()
         p2 = reader[reader.frame].positions
+        # test transformations not repeated
         assert_allclose(p1, p2)
 
     def test_iterate_continuity_1(self, reader):

--- a/testsuite/MDAnalysisTests/coordinates/test_imd.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_imd.py
@@ -644,6 +644,17 @@ class TestAnalysisClasses:
             frames=1,
         )
 
+    @pytest.fixture
+    def u4(self, create_imd_universe):
+        from MDAnalysisTests.datafiles import waterPSF, waterDCD
+
+        return create_imd_universe(
+            topo=waterPSF,
+            traj=waterDCD,
+            velocities=False,
+            forces=False,
+        )
+
     def test_atomicdistances(self, u1):
         from MDAnalysis.analysis.atomicdistances import AtomicDistances
 
@@ -792,21 +803,21 @@ class TestAnalysisClasses:
             dssp.run(frames=[u1.trajectory.frame])
             u1.trajectory.next()
 
-    def test_hba(self, u1):
+    def test_hba(self, u4):
         from MDAnalysis.analysis.hydrogenbonds import hbond_analysis
 
-        hba = hbond_analysis.HydrogenBondAnalysis(universe=u1)
-        for i in range(2):
-            hba.run(frames=[u1.trajectory.frame])
-            u1.trajectory.next()
+        hba = hbond_analysis.HydrogenBondAnalysis(universe=u4)
+        for i in range(3):
+            hba.run(frames=[u4.trajectory.frame])
+            u4.trajectory.next()
 
-    def test_wba(self, u1):
+    def test_wba(self, u4):
         from MDAnalysis.analysis.hydrogenbonds import WaterBridgeAnalysis
 
-        wba = WaterBridgeAnalysis(u1, "resname ARG", "resname ASP")
-        for i in range(2):
-            wba.run(frames=[u1.trajectory.frame])
-            u1.trajectory.next()
+        wba = WaterBridgeAnalysis(u4, "resid 1:10", "resid 10:20")
+        for i in range(3):
+            wba.run(frames=[u4.trajectory.frame])
+            u4.trajectory.next()
 
 
 @pytest.mark.skipif(not HAS_IMDCLIENT, reason="IMDClient not installed")

--- a/testsuite/MDAnalysisTests/coordinates/test_imd.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_imd.py
@@ -558,6 +558,27 @@ class TestStreamIteration:
         p2 = reader[reader.frame].positions
         assert_allclose(p1, p2)
 
+    def test_iterate_continuity_1(self, reader):
+        step = -1
+        for ts in reader:
+            step += 1
+            assert ts.data["step"] == step
+            if step == 4:
+                break
+
+    def test_iterate_continuity_2(self, reader):
+        ts = reader[0]
+        assert ts.data["step"] == 0
+        reader.next()
+        ts = reader[1]
+        assert ts.data["step"] == 1
+        step = 1
+        for ts in reader:
+            step += 1
+            assert ts.data["step"] == step
+            if step == 4:
+                break
+
 
 @pytest.mark.skipif(not HAS_IMDCLIENT, reason="IMDClient not installed")
 class TestAnalysisClasses:

--- a/testsuite/MDAnalysisTests/coordinates/test_imd.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_imd.py
@@ -531,6 +531,7 @@ class TestStreamIteration:
         assert len(reader[[reader.frame]]) == 1
         for ts in reader[[reader.frame]]:
             assert ts.frame == reader.frame
+        reader[np.array([reader.frame])]
 
 
 @pytest.mark.skipif(not HAS_IMDCLIENT, reason="IMDClient not installed")

--- a/testsuite/MDAnalysisTests/coordinates/test_imd.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_imd.py
@@ -507,6 +507,15 @@ class TestStreamIteration:
         sliced_reader_step5 = reader[::5]
         assert sliced_reader_step5.step == 5
 
+    def test_iterate_current_frame_raises_error(self, reader):
+        with pytest.raises(ValueError, match="must have single current frame value"):
+            for ts in reader[[1]]:
+                pass
+
+    def test_iterate_current_frame(self, reader):
+        for ts in reader[[reader.frame]]:
+            assert ts.frame == reader.frame
+
 
 @pytest.mark.skipif(not HAS_IMDCLIENT, reason="IMDClient not installed")
 def test_n_atoms_not_specified(universe, imdsinfo):

--- a/testsuite/MDAnalysisTests/coordinates/test_imd.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_imd.py
@@ -552,6 +552,256 @@ class TestStreamIteration:
 
 
 @pytest.mark.skipif(not HAS_IMDCLIENT, reason="IMDClient not installed")
+class TestAnalysisClasses:
+    """
+    Tests for AnalysisBase-based classes
+
+    Following classes currently do not work:
+        align.AlignTraj
+        align.AverageStructure
+        diffusionmap.DiffusionMap
+        gnm.GNMAnalysis
+        gnm.closeContactGNMAnalysis
+        pca.PCA
+        polymer.PersistenceLength
+        rms.RMSD
+        hydrogenbonds.HydrogenBondAutoCorrel
+
+    """
+
+    @pytest.fixture
+    def create_imd_universe(self):
+        server = None
+
+        def _create_imd_universe(
+            topo,
+            traj,
+            velocities=True,
+            forces=True,
+            box=True,
+            frames=5,
+        ):
+            nonlocal server
+            u = mda.Universe(topo, traj)
+            server = InThreadIMDServer(u.trajectory)
+            info = create_default_imdsinfo_v3()
+            info.velocities = velocities
+            info.forces = forces
+            info.box = box
+            server.set_imdsessioninfo(info)
+            server.handshake_sequence("localhost", first_frame=True)
+            u_imd = mda.Universe(
+                topo,
+                f"imd://localhost:{server.port}",
+                n_atoms=u.trajectory.n_atoms,
+            )
+            server.send_frames(1, frames)
+            return u_imd
+
+        yield _create_imd_universe
+        server.cleanup()
+
+    @pytest.fixture
+    def u1(self, create_imd_universe):
+        from MDAnalysisTests.datafiles import TPR, XTC
+
+        return create_imd_universe(
+            topo=TPR,
+            traj=XTC,
+            velocities=False,
+            forces=False,
+        )
+
+    @pytest.fixture
+    def u2(self, create_imd_universe):
+        from MDAnalysisTests.datafiles import PSF_TRICLINIC, DCD_TRICLINIC
+
+        return create_imd_universe(
+            topo=PSF_TRICLINIC,
+            traj=DCD_TRICLINIC,
+            velocities=False,
+            forces=False,
+        )
+
+    @pytest.fixture
+    def u3(self, create_imd_universe):
+        from MDAnalysisTests.datafiles import RNA_PSF, RNA_PDB
+
+        return create_imd_universe(
+            topo=RNA_PSF,
+            traj=RNA_PDB,
+            velocities=False,
+            forces=False,
+            box=False,
+            frames=1,
+        )
+
+    def test_atomicdistances(self, u1):
+        from MDAnalysis.analysis.atomicdistances import AtomicDistances
+
+        ag1 = u1.atoms[10:20]
+        ag2 = u1.atoms[70:80]
+        ad = AtomicDistances(ag1, ag2)
+        for i in range(3):
+            ad.run(frames=[u1.trajectory.frame])
+            u1.trajectory.next()
+
+    def test_bat(self, u1):
+        from MDAnalysis.analysis.bat import BAT
+
+        selected_residues = u1.select_atoms("resid 1:10")
+        bat = BAT(selected_residues)
+        for i in range(3):
+            bat.run(frames=[u1.trajectory.frame])
+            u1.trajectory.next()
+
+    def test_contacts(self, u1):
+        from MDAnalysis.analysis.contacts import Contacts
+
+        sel_basic = "(resname ARG LYS) and (name NH* NZ)"
+        sel_acidic = "(resname ASP GLU) and (name OE* OD*)"
+        acidic = u1.select_atoms(sel_acidic)
+        basic = u1.select_atoms(sel_basic)
+        ca1 = Contacts(
+            u1,
+            select=(sel_acidic, sel_basic),
+            refgroup=(acidic, basic),
+            radius=6.0,
+        )
+        for i in range(3):
+            ca1.run(frames=[u1.trajectory.frame])
+            u1.trajectory.next()
+
+    def test_density(self, u1):
+        from MDAnalysis.analysis.density import DensityAnalysis
+
+        ow = u1.select_atoms("protein")
+        da = DensityAnalysis(ow, delta=1.0)
+        for i in range(3):
+            da.run(frames=[u1.trajectory.frame])
+            u1.trajectory.next()
+
+    def test_dielectric(self, u2):
+        from MDAnalysis.analysis.dielectric import DielectricConstant
+
+        diel = DielectricConstant(u2.atoms)
+        for i in range(3):
+            diel.run(frames=[u2.trajectory.frame])
+            u2.trajectory.next()
+
+    def test_diffusionmap(self, u1):
+        import MDAnalysis.analysis.diffusionmap as diffusionmap
+
+        dm = diffusionmap.DistanceMatrix(u1, select="backbone")
+        for i in range(3):
+            dm.run(frames=[u1.trajectory.frame])
+            u1.trajectory.next()
+
+    def test_dihedrals(self, u1):
+        from MDAnalysis.analysis.dihedrals import Dihedral, Janin, Ramachandran
+
+        ags = [res.phi_selection() for res in u1.residues[4:9]]
+        d = Dihedral(ags)
+        rama = Ramachandran(u1.select_atoms("protein"))
+        janin = Janin(u1.select_atoms("protein"))
+        for i in range(3):
+            d.run(frames=[u1.trajectory.frame])
+            rama.run(frames=[u1.trajectory.frame])
+            janin.run(frames=[u1.trajectory.frame])
+            u1.trajectory.next()
+
+    def test_helix_analysis(self, u1):
+        from MDAnalysis.analysis import helix_analysis as hel
+
+        ha = hel.HELANAL(
+            u1.select_atoms("name CA"),
+            select="resnum 1-9",
+            flatten_single_helix=True,
+        )
+        for i in range(3):
+            ha.run(frames=[u1.trajectory.frame])
+            u1.trajectory.next()
+
+    def test_lineardensity(self, u1):
+        from MDAnalysis.analysis.lineardensity import LinearDensity
+
+        ld = LinearDensity(u1.select_atoms("all"), binsize=5)
+        for i in range(3):
+            ld.run(frames=[u1.trajectory.frame])
+            u1.trajectory.next()
+
+    def test_msd(self, u1):
+        from MDAnalysis.analysis import msd
+
+        m = msd.EinsteinMSD(u1, "all", non_linear=True)
+        for i in range(3):
+            m.run(frames=[u1.trajectory.frame])
+            u1.trajectory.next()
+
+    def test_nucleicacids(self, u3):
+        from MDAnalysis.analysis import nucleicacids
+        from MDAnalysis.core.groups import ResidueGroup
+
+        strand = u3.select_atoms("resid 1-100")
+        strand1 = ResidueGroup([strand.residues[0], strand.residues[21]])
+        strand2 = ResidueGroup([strand.residues[2], strand.residues[22]])
+        wcd = nucleicacids.WatsonCrickDist(strand1, strand2)
+        wcd.run(frames=[u3.trajectory.frame])
+        strand1 = ResidueGroup([strand.residues[2], strand.residues[19]])
+        strand2 = ResidueGroup([strand.residues[16], strand.residues[4]])
+        mi = nucleicacids.MinorPairDist(strand1, strand2)
+        mi.run(frames=[u3.trajectory.frame])
+        strand1 = ResidueGroup([strand.residues[1], strand.residues[4]])
+        strand2 = ResidueGroup([strand.residues[11], strand.residues[8]])
+        ma = nucleicacids.MajorPairDist(strand1, strand2)
+        ma.run(frames=[u3.trajectory.frame])
+
+    def test_rdf(self, u1):
+        from MDAnalysis.analysis import rdf
+
+        ag1 = u1.select_atoms("resid 1:10")
+        ag2 = u1.select_atoms("resid 30:40")
+        r = rdf.InterRDF(ag1, ag2)
+        r_s = rdf.InterRDF_s(u1, [[ag1, ag1], [ag2, ag2]])
+        for i in range(3):
+            r.run(frames=[u1.trajectory.frame])
+            r_s.run(frames=[u1.trajectory.frame])
+            u1.trajectory.next()
+
+    def test_rmsf(self, u1):
+        from MDAnalysis.analysis.rms import RMSF
+
+        rmsf = RMSF(u1.select_atoms("name CA"))
+        for i in range(3):
+            rmsf.run(frames=[u1.trajectory.frame])
+            u1.trajectory.next()
+
+    def test_dssp(self, u1):
+        from MDAnalysis.analysis.dssp import DSSP
+
+        dssp = DSSP(u1)
+        for i in range(3):
+            dssp.run(frames=[u1.trajectory.frame])
+            u1.trajectory.next()
+
+    def test_hba(self, u1):
+        from MDAnalysis.analysis.hydrogenbonds import hbond_analysis
+
+        hba = hbond_analysis.HydrogenBondAnalysis(universe=u1)
+        for i in range(2):
+            hba.run(frames=[u1.trajectory.frame])
+            u1.trajectory.next()
+
+    def test_wba(self, u1):
+        from MDAnalysis.analysis.hydrogenbonds import WaterBridgeAnalysis
+
+        wba = WaterBridgeAnalysis(u1, "resname ARG", "resname ASP")
+        for i in range(2):
+            wba.run(frames=[u1.trajectory.frame])
+            u1.trajectory.next()
+
+
+@pytest.mark.skipif(not HAS_IMDCLIENT, reason="IMDClient not installed")
 def test_n_atoms_not_specified(universe, imdsinfo):
     server = InThreadIMDServer(universe.trajectory)
     server.set_imdsessioninfo(imdsinfo)

--- a/testsuite/MDAnalysisTests/coordinates/test_imd.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_imd.py
@@ -514,8 +514,17 @@ class TestStreamIteration:
         ):
             for ts in reader[[1]]:
                 pass
+        ts = reader[[0]]
+        with pytest.raises(StopIteration):
+            next(ts)
+        with pytest.raises(
+            RuntimeError,
+            match="Current frame iterator does not support indexing",
+        ):
+            ts[0]
 
     def test_iterate_current_frame(self, reader):
+        assert len(reader[[reader.frame]]) == 1
         for ts in reader[[reader.frame]]:
             assert ts.frame == reader.frame
 

--- a/testsuite/MDAnalysisTests/coordinates/test_imd.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_imd.py
@@ -508,7 +508,10 @@ class TestStreamIteration:
         assert sliced_reader_step5.step == 5
 
     def test_iterate_current_frame_raises_error(self, reader):
-        with pytest.raises(ValueError, match="must have single current frame value"):
+        with pytest.raises(
+            ValueError,
+            match="must have single current frame value",
+        ):
             for ts in reader[[1]]:
                 pass
 

--- a/testsuite/MDAnalysisTests/coordinates/test_imd.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_imd.py
@@ -550,6 +550,14 @@ class TestStreamIteration:
                 with pytest.raises(StopIteration):
                     reader.next()
 
+    def test_iterate_current_frame_no_transformations(self, reader):
+        reader.add_transformations(
+            translate([1, 1, 1]), translate([0, 0, 0.33])
+        )
+        p1 = reader[reader.frame].positions.copy()
+        p2 = reader[reader.frame].positions
+        assert_allclose(p1, p2)
+
 
 @pytest.mark.skipif(not HAS_IMDCLIENT, reason="IMDClient not installed")
 class TestAnalysisClasses:


### PR DESCRIPTION
Fixes #5183 

Changes made in this Pull Request:
<!-- Describe the changes that this PR makes. If applicable, use the following bullet list. --> 
- Added a current frame iterator for streamed trajectories
  - The iterator is created when the frames array has a single value that is same as the current frame
  - This enables passing current frame to an analysis class `run` method as `.run(frames=[u.trajectory.frame])`
- Added a current frame access for streamed trajectories
  - This allows access like `u.trajectory[u.trajectory.frame]` to get current timestep
  - This enables analysis classes (like `RMSD`, `AverageStructure`) to use current frame as a `ref_frame` (in their `__init__` method)
-  Tests for all analysis classes that now work with streamed trajectories on a per-frame basis

This PR allows us to do something like the following:
```py
import MDAnalysis as mda
from MDAnalysis.analysis.dssp import DSSP

top = "/tmp/imd-workshop-2025/workshop/sample_simulation/GROMACS/input/start.gro"
u = mda.Universe(top, "imd://localhost:8889")
```
```py
dssp = DSSP(u)
```
```py
for i in range(5):
    ts = u.trajectory.ts
    print(ts.data, ts.frame)
    run = dssp.run(frames=[ts.frame])
    print("".join(run.results.dssp[0]))
    u.trajectory.next()
```

Here is a sample output of the per-frame analysis above:
```
{'time': 41.54, 'dt': 0.002, 'step': 20770} 0
-E--HHHHHHHHH-----------HHHHHHHHHHH---E---EEE-----EEE----EE-----E-------------E---------HHHHHHHHHH----------HHHHHH------HHHH-----
{'time': 41.56, 'dt': 0.002, 'step': 20780} 1
-E--HHHHHHHHH-----------HHHHHHHHHHH---E---EEE-----EEE----EE-----E-------------E---------HHHHHHHHHH----------HHHHHH-------HHH-----
{'time': 41.58, 'dt': 0.002, 'step': 20790} 2
-E--HHHHHHHHH-----------HHHHHHHHHHHH--E---EEE-----EEE----EE-----E-------------E---------HHHHHHHHHH----------HHHHHH-------HHH-----
{'time': 41.6, 'dt': 0.002, 'step': 20800} 3
-E--HHHHHHHHH------HHHE-HHHHHHHHHHHH--E---EEE-----EEE----EE-----E-------------E---------HHHHHHHHHHHHH-------HHHHHH-------HHH-----
{'time': 41.62, 'dt': 0.002, 'step': 20810} 4
-E--HHHHHHHHH------HHHE-HHHHHHHHHHHH--E---EEE-----EEE----EE-----E-------------E---------HHHHHHHHHH----------HHHHHH------HHHH-----
```
## LLM / AI generated code disclosure
<!-- Please update this disclosure to reflect if you did or did not use LLMs / AI to generate code -->
LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution: no

## PR Checklist
<!-- Please use the following checklist to ensure the PR is ready to be reviewed/merged. -->
 - [x] Issue raised/referenced?
 - [x] Tests updated/added?
 - [x] Documentation updated/added?
 - [x] `package/CHANGELOG` file updated?
 - [x] Is your name in `package/AUTHORS`? (If it is not, add it!)
 - [x] LLM/AI disclosure was updated.
 
## Developers Certificate of Origin
<!-- 
In order for this PR to be merged you **must certify that you are able to submit your code to be included in MDAnalysis**.
-->

I certify that I can submit this code contribution as described in the [**Developer Certificate of Origin**](https://developercertificate.org/), under the MDAnalysis [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--5184.org.readthedocs.build/en/5184/

<!-- readthedocs-preview mdanalysis end -->