### PR TITLE
Fix mypy linter check

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -91,7 +91,7 @@ jobs:
         uses: ./.github/actions/setup-deps
         with:
           micromamba: true
-          full-deps: true
+          full-deps: false
           gsd: ''
           numpy: numpy=1.26.0
           rdkit: rdkit=2023.09.3

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -92,6 +92,7 @@ jobs:
         with:
           micromamba: true
           full-deps: true
+          gsd: ''
           numpy: numpy=1.26.0
           rdkit: rdkit=2023.09.3
 

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -92,7 +92,6 @@ jobs:
         with:
           micromamba: true
           full-deps: false
-          gsd: ''
           numpy: numpy=1.26.0
           rdkit: rdkit=2023.09.3
 

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -91,9 +91,7 @@ jobs:
         uses: ./.github/actions/setup-deps
         with:
           micromamba: true
-          full-deps: false
-          numpy: numpy=1.26.0
-          rdkit: rdkit=2023.09.3
+          full-deps: true
 
       - name: install
         run: |

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -92,6 +92,7 @@ jobs:
         with:
           micromamba: true
           full-deps: true
+          numpy: numpy=1.26.0
 
       - name: install
         run: |

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -202,7 +202,7 @@ import bz2
 import errno
 import functools
 import gzip
-import importlib
+import importlib.util
 import inspect
 import io
 import itertools


### PR DESCRIPTION
Fixes #5177, Fixes #4581

Changes made in this Pull Request:
<!-- Describe the changes that this PR makes. If applicable, use the following bullet list. --> 
- Fix the `mypy` error in `lib/util.py`
- Unpin rdkit
  - The original [openfe issue #844](https://github.com/OpenFreeEnergy/openfe/issues/844) that required this pinning is since fixed
- ~~Unpin numpy~~
  - ~~This seems to be a carry forward from the past as `mypy` (for the currently enabled files) seems to work with current version~~

The root cause of this issue seems to be the rdkit pinning. We use `full-deps: true` at other places in our tests and they all take a few seconds, where as the one for `mypy`, which has the rdkit pinned takes over 10 mins, leading to the timeout. Here is a run with the [pinned](https://github.com/MDAnalysis/mdanalysis/actions/runs/20485707138/job/58867630832) version that times out and an [unpinned](https://github.com/MDAnalysis/mdanalysis/actions/runs/20485652263/job/58867463911) run that takes only a few seconds (that is the only diff between these two runs). From earlier testing, it seems like `mypy` doesn't require `full-deps` to be true, but didn't change it for now as the install issue is now resolved.

I certify that I can submit this code contribution as described in the [**Developer Certificate of Origin**](https://developercertificate.org/), under the MDAnalysis [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--5185.org.readthedocs.build/en/5185/

<!-- readthedocs-preview mdanalysis end -->