### PR TITLE
Add cylindrical selection test using PeriodicKDTree

### DIFF
--- a/testsuite/MDAnalysisTests/core/test_atomselections.py
+++ b/testsuite/MDAnalysisTests/core/test_atomselections.py
@@ -128,9 +128,7 @@ class TestSelectionsCHARMM(object):
     def test_resid_range(self, universe):
         sel = universe.select_atoms("resid 100:105")
         assert_equal(sel.n_atoms, 89)
-        assert_equal(
-            sel.residues.resnames, ["GLY", "ILE", "ASN", "VAL", "ASP", "TYR"]
-        )
+        assert_equal(sel.residues.resnames, ["GLY", "ILE", "ASN", "VAL", "ASP", "TYR"])
 
     def test_selgroup(self, universe):
         sel = universe.select_atoms("not resid 100")
@@ -157,23 +155,15 @@ class TestSelectionsCHARMM(object):
         sel = universe.select_atoms("resnum 100:105")
         assert_equal(sel.n_atoms, 89)
         assert_equal(sel.residues.resids, range(100, 106))
-        assert_equal(
-            sel.residues.resnames, ["GLY", "ILE", "ASN", "VAL", "ASP", "TYR"]
-        )
+        assert_equal(sel.residues.resnames, ["GLY", "ILE", "ASN", "VAL", "ASP", "TYR"])
 
     def test_resname(self, universe):
         sel = universe.select_atoms("resname LEU")
-        assert_equal(
-            sel.n_atoms, 304, "Failed to find all 'resname LEU' atoms."
-        )
-        assert_equal(
-            sel.n_residues, 16, "Failed to find all 'resname LEU' residues."
-        )
+        assert_equal(sel.n_atoms, 304, "Failed to find all 'resname LEU' atoms.")
+        assert_equal(sel.n_residues, 16, "Failed to find all 'resname LEU' residues.")
         assert_equal(
             sorted(sel.indices),
-            sorted(
-                universe.select_atoms("segid 4AKE and resname LEU").indices
-            ),
+            sorted(universe.select_atoms("segid 4AKE and resname LEU").indices),
             "selected 'resname LEU' atoms are not the same as auto-generated s4AKE.LEU",
         )
 
@@ -187,9 +177,7 @@ class TestSelectionsCHARMM(object):
         assert_equal(sel.resnames, ["GLY"])
         assert_equal(
             sel.positions,
-            np.array(
-                [[20.38685226, -3.44224262, -5.92158318]], dtype=np.float32
-            ),
+            np.array([[20.38685226, -3.44224262, -5.92158318]], dtype=np.float32),
         )
 
     def test_atom_empty(self, universe):
@@ -331,10 +319,7 @@ class TestSelectionsCHARMM(object):
         assert_equal(
             len(sel),
             331,
-            (
-                "Found a wrong number of atoms with same resname as "
-                "resids 10 or 11"
-            ),
+            ("Found a wrong number of atoms with same resname as " "resids 10 or 11"),
         )
         # fmt: off
         target_resids = np.array(
@@ -429,9 +414,7 @@ class TestSelectionsCHARMM(object):
     def test_concatenated_selection(self, universe):
         E151 = universe.select_atoms("segid 4AKE").select_atoms("resid 151")
         # note that this is not quite phi... HN should be C of prec. residue
-        phi151 = E151.atoms.select_atoms(
-            "name HN", "name N", "name CA", "name CB"
-        )
+        phi151 = E151.atoms.select_atoms("name HN", "name N", "name CA", "name CB")
         assert_equal(len(phi151), 4)
         assert_equal(
             phi151[0].name,
@@ -443,9 +426,7 @@ class TestSelectionsCHARMM(object):
         """Test the `global` modifier keyword (Issue 268)"""
         ag = universe.select_atoms("resname LYS and name NZ")
         # Lys amines within 4 angstrom of the backbone.
-        ag1 = universe.select_atoms(
-            "resname LYS and name NZ and around 4 backbone"
-        )
+        ag1 = universe.select_atoms("resname LYS and name NZ and around 4 backbone")
         ag2 = ag.select_atoms("around 4 global backbone")
         assert_equal(ag2.indices, ag1.indices)
 
@@ -496,12 +477,8 @@ class TestSelectionsNAMD(object):
     def test_protein(self, universe):
         # must include non-standard residues
         sel = universe.select_atoms("protein or resname HAO or resname ORT")
-        assert_equal(
-            sel.n_atoms, universe.atoms.n_atoms, "failed to select peptide"
-        )
-        assert_equal(
-            sel.n_residues, 6, "failed to select all peptide residues"
-        )
+        assert_equal(sel.n_atoms, universe.atoms.n_atoms, "failed to select peptide")
+        assert_equal(sel.n_residues, 6, "failed to select all peptide residues")
 
     def test_resid_single(self, universe):
         sel = universe.select_atoms("resid 12")
@@ -591,9 +568,7 @@ class TestSelectionsTPR(object):
         # This test comes here because it's a system with solvent,
         # and thus multiple fragments.
         sel = universe.select_atoms(selstr)
-        errmsg = (
-            "Found a wrong number of atoms " "on the same fragment as id 1"
-        )
+        errmsg = "Found a wrong number of atoms " "on the same fragment as id 1"
         assert_equal(len(sel), 3341, errmsg)
         errmsg = (
             "Found a differ set of atoms when using the 'same "
@@ -696,9 +671,7 @@ class TestSelectionRDKit(object):
     def test_passing_max_matches_to_converter(self, u2):
         with pytest.warns(UserWarning, match="Your smarts-based") as wsmg:
             sel = u2.select_atoms("smarts C", smarts_kwargs=dict(maxMatches=2))
-            sel2 = u2.select_atoms(
-                "smarts C", smarts_kwargs=dict(maxMatches=1000)
-            )
+            sel2 = u2.select_atoms("smarts C", smarts_kwargs=dict(maxMatches=1000))
             assert sel.n_atoms == 2
             assert sel2.n_atoms == 3
 
@@ -909,9 +882,7 @@ class TestOrthogonalDistanceSelections(BaseDistanceSelection):
     def u(self):
         return mda.Universe(TRZ_psf, TRZ)
 
-    @pytest.mark.parametrize(
-        "meth, periodic", [("distmat", True), ("distmat", False)]
-    )
+    @pytest.mark.parametrize("meth, periodic", [("distmat", True), ("distmat", False)])
     def test_cyzone(self, u, meth, periodic):
         sel = Parser.parse("cyzone 5 4 -4 resid 2", u.atoms)
         sel.periodic = periodic
@@ -1179,9 +1150,7 @@ class TestPropSelection(object):
         # reference group, doing things forwards
         ref = ag[func(getattr(ag, self.plurals[prop]), 1.5)]
 
-        selstr = "prop 1.5 {op} {prop}".format(
-            op=self.opposites[op], prop=prop
-        )
+        selstr = "prop 1.5 {op} {prop}".format(op=self.opposites[op], prop=prop)
         sel = ag.select_atoms(selstr)
 
         assert_equal(set(ref.indices), set(sel.indices))
@@ -1212,9 +1181,7 @@ class TestSelectionErrors(object):
     @staticmethod
     @pytest.fixture()
     def universe():
-        return make_Universe(
-            ("names", "masses", "resids", "resnames", "resnums")
-        )
+        return make_Universe(("names", "masses", "resids", "resnames", "resnums"))
 
     @pytest.mark.parametrize(
         "selstr",
@@ -1317,9 +1284,7 @@ class TestImplicitOr(object):
         ],
     )
     def test_range_selections(self, seltype, ref, sel, universe):
-        self._check_sels(
-            ref.format(typ=seltype), sel.format(typ=seltype), universe
-        )
+        self._check_sels(ref.format(typ=seltype), sel.format(typ=seltype), universe)
 
 
 class TestICodeSelection(object):
@@ -1663,9 +1628,7 @@ def test_bool_sel_error():
 
 def test_error_selection_for_strange_dtype():
     with pytest.raises(ValueError, match="No base class defined for dtype"):
-        MDAnalysis.core.selection.gen_selection_class(
-            "star", "stars", dict, "atom"
-        )
+        MDAnalysis.core.selection.gen_selection_class("star", "stars", dict, "atom")
 
 
 @pytest.mark.parametrize(
@@ -1732,9 +1695,7 @@ def test_chirality(smi, chirality):
     assert u.atoms[0].chirality == ""
     assert u.atoms[1].chirality == chirality
 
-    assert_equal(
-        u.atoms[:3].chiralities, np.array(["", chirality, ""], dtype="U1")
-    )
+    assert_equal(u.atoms[:3].chiralities, np.array(["", chirality, ""], dtype="U1"))
 
 
 @pytest.mark.parametrize(
@@ -1776,18 +1737,18 @@ def test_formal_charge_selection(sel, size, name):
     assert len(ag) == size
     assert ag.atoms[0].name == name
 
+
 @pytest.fixture(scope="module")
 def universe():
     u = mda.Universe(PSF, DCD)
     u.dimensions = np.array([100.0, 100.0, 100.0, 90.0, 90.0, 90.0])
     return u
 
+
 def test_cylayer_selection_parses_correctly(universe):
     universe.dimensions = np.array([100, 100, 100, 90, 90, 90])
 
-    sel = universe.select_atoms(
-        "cylayer 5 10 15 -15 name CA"
-    )
+    sel = universe.select_atoms("cylayer 5 10 15 -15 name CA")
 
     # Basic sanity checks
     assert len(sel) > 0

--- a/testsuite/MDAnalysisTests/core/test_atomselections.py
+++ b/testsuite/MDAnalysisTests/core/test_atomselections.py
@@ -33,6 +33,7 @@ import pytest
 from MDAnalysis import SelectionError, SelectionWarning
 from MDAnalysis.core.selection import Parser
 from MDAnalysis.lib.distances import distance_array
+from MDAnalysis.lib.pkdtree import PeriodicKDTree
 from MDAnalysis.tests.datafiles import (
     DCD,
     GRO,
@@ -1774,3 +1775,46 @@ def test_formal_charge_selection(sel, size, name):
 
     assert len(ag) == size
     assert ag.atoms[0].name == name
+
+@pytest.fixture
+def universe():
+    #Fixture providing a small test Universe.
+    return mda.Universe(PSF, DCD)
+
+def test_cylindrical_layer_selection_periodic_kdtree(universe):
+    #Test cylindrical layer selection using PeriodicKDTree.
+    # Center point
+    center = universe.atoms[0].position
+    inner_radius = 5.0
+    outer_radius = 10.0
+    zmin, zmax = center[2] - 15.0, center[2] + 15.0
+
+    # MDAnalysis selection for cylindrical layer
+    sel = universe.select_atoms(
+        f"cylayer {inner_radius} {outer_radius} {zmin} {zmax} "
+        f"point {center[0]} {center[1]} {center[2]}"
+    )
+
+    # KDTree-based selection
+    kdtree = PeriodicKDTree(outer_radius, universe.dimensions)
+    kdtree.set_coords(universe.atoms.positions)
+    indices = kdtree.search(center, outer_radius)
+
+    # Filter by cylindrical layer (radius and z-range)
+    pos = universe.atoms.positions[indices]
+    dxy = np.sqrt((pos[:, 0] - center[0])**2 + (pos[:, 1] - center[1])**2)
+
+    mask = (
+        (inner_radius <= dxy) &
+        (dxy <= outer_radius) &
+        (zmin <= pos[:, 2]) &
+        (pos[:, 2] <= zmax)
+    )
+
+    expected = indices[mask]
+
+    # Assert KDTree selection matches MDAnalysis selection
+    assert_array_equal(
+        np.sort(expected),
+        np.sort(sel.indices)
+    )

--- a/testsuite/MDAnalysisTests/core/test_atomselections.py
+++ b/testsuite/MDAnalysisTests/core/test_atomselections.py
@@ -33,6 +33,7 @@ import pytest
 from MDAnalysis import SelectionError, SelectionWarning
 from MDAnalysis.core.selection import Parser
 from MDAnalysis.lib.distances import distance_array
+from MDAnalysis.lib.pkdtree import PeriodicKDTree
 from MDAnalysis.tests.datafiles import (
     DCD,
     GRO,
@@ -57,6 +58,7 @@ from MDAnalysis.tests.datafiles import (
 )
 from numpy.lib import NumpyVersion
 from numpy.testing import assert_equal
+from numpy.testing import assert_array_equal
 
 from MDAnalysisTests import make_Universe
 
@@ -127,7 +129,9 @@ class TestSelectionsCHARMM(object):
     def test_resid_range(self, universe):
         sel = universe.select_atoms("resid 100:105")
         assert_equal(sel.n_atoms, 89)
-        assert_equal(sel.residues.resnames, ["GLY", "ILE", "ASN", "VAL", "ASP", "TYR"])
+        assert_equal(
+            sel.residues.resnames, ["GLY", "ILE", "ASN", "VAL", "ASP", "TYR"]
+        )
 
     def test_selgroup(self, universe):
         sel = universe.select_atoms("not resid 100")
@@ -154,15 +158,23 @@ class TestSelectionsCHARMM(object):
         sel = universe.select_atoms("resnum 100:105")
         assert_equal(sel.n_atoms, 89)
         assert_equal(sel.residues.resids, range(100, 106))
-        assert_equal(sel.residues.resnames, ["GLY", "ILE", "ASN", "VAL", "ASP", "TYR"])
+        assert_equal(
+            sel.residues.resnames, ["GLY", "ILE", "ASN", "VAL", "ASP", "TYR"]
+        )
 
     def test_resname(self, universe):
         sel = universe.select_atoms("resname LEU")
-        assert_equal(sel.n_atoms, 304, "Failed to find all 'resname LEU' atoms.")
-        assert_equal(sel.n_residues, 16, "Failed to find all 'resname LEU' residues.")
+        assert_equal(
+            sel.n_atoms, 304, "Failed to find all 'resname LEU' atoms."
+        )
+        assert_equal(
+            sel.n_residues, 16, "Failed to find all 'resname LEU' residues."
+        )
         assert_equal(
             sorted(sel.indices),
-            sorted(universe.select_atoms("segid 4AKE and resname LEU").indices),
+            sorted(
+                universe.select_atoms("segid 4AKE and resname LEU").indices
+            ),
             "selected 'resname LEU' atoms are not the same as auto-generated s4AKE.LEU",
         )
 
@@ -176,7 +188,9 @@ class TestSelectionsCHARMM(object):
         assert_equal(sel.resnames, ["GLY"])
         assert_equal(
             sel.positions,
-            np.array([[20.38685226, -3.44224262, -5.92158318]], dtype=np.float32),
+            np.array(
+                [[20.38685226, -3.44224262, -5.92158318]], dtype=np.float32
+            ),
         )
 
     def test_atom_empty(self, universe):
@@ -318,7 +332,10 @@ class TestSelectionsCHARMM(object):
         assert_equal(
             len(sel),
             331,
-            ("Found a wrong number of atoms with same resname as " "resids 10 or 11"),
+            (
+                "Found a wrong number of atoms with same resname as "
+                "resids 10 or 11"
+            ),
         )
         # fmt: off
         target_resids = np.array(
@@ -413,7 +430,9 @@ class TestSelectionsCHARMM(object):
     def test_concatenated_selection(self, universe):
         E151 = universe.select_atoms("segid 4AKE").select_atoms("resid 151")
         # note that this is not quite phi... HN should be C of prec. residue
-        phi151 = E151.atoms.select_atoms("name HN", "name N", "name CA", "name CB")
+        phi151 = E151.atoms.select_atoms(
+            "name HN", "name N", "name CA", "name CB"
+        )
         assert_equal(len(phi151), 4)
         assert_equal(
             phi151[0].name,
@@ -425,7 +444,9 @@ class TestSelectionsCHARMM(object):
         """Test the `global` modifier keyword (Issue 268)"""
         ag = universe.select_atoms("resname LYS and name NZ")
         # Lys amines within 4 angstrom of the backbone.
-        ag1 = universe.select_atoms("resname LYS and name NZ and around 4 backbone")
+        ag1 = universe.select_atoms(
+            "resname LYS and name NZ and around 4 backbone"
+        )
         ag2 = ag.select_atoms("around 4 global backbone")
         assert_equal(ag2.indices, ag1.indices)
 
@@ -476,8 +497,12 @@ class TestSelectionsNAMD(object):
     def test_protein(self, universe):
         # must include non-standard residues
         sel = universe.select_atoms("protein or resname HAO or resname ORT")
-        assert_equal(sel.n_atoms, universe.atoms.n_atoms, "failed to select peptide")
-        assert_equal(sel.n_residues, 6, "failed to select all peptide residues")
+        assert_equal(
+            sel.n_atoms, universe.atoms.n_atoms, "failed to select peptide"
+        )
+        assert_equal(
+            sel.n_residues, 6, "failed to select all peptide residues"
+        )
 
     def test_resid_single(self, universe):
         sel = universe.select_atoms("resid 12")
@@ -567,7 +592,9 @@ class TestSelectionsTPR(object):
         # This test comes here because it's a system with solvent,
         # and thus multiple fragments.
         sel = universe.select_atoms(selstr)
-        errmsg = "Found a wrong number of atoms " "on the same fragment as id 1"
+        errmsg = (
+            "Found a wrong number of atoms " "on the same fragment as id 1"
+        )
         assert_equal(len(sel), 3341, errmsg)
         errmsg = (
             "Found a differ set of atoms when using the 'same "
@@ -670,7 +697,9 @@ class TestSelectionRDKit(object):
     def test_passing_max_matches_to_converter(self, u2):
         with pytest.warns(UserWarning, match="Your smarts-based") as wsmg:
             sel = u2.select_atoms("smarts C", smarts_kwargs=dict(maxMatches=2))
-            sel2 = u2.select_atoms("smarts C", smarts_kwargs=dict(maxMatches=1000))
+            sel2 = u2.select_atoms(
+                "smarts C", smarts_kwargs=dict(maxMatches=1000)
+            )
             assert sel.n_atoms == 2
             assert sel2.n_atoms == 3
 
@@ -881,7 +910,9 @@ class TestOrthogonalDistanceSelections(BaseDistanceSelection):
     def u(self):
         return mda.Universe(TRZ_psf, TRZ)
 
-    @pytest.mark.parametrize("meth, periodic", [("distmat", True), ("distmat", False)])
+    @pytest.mark.parametrize(
+        "meth, periodic", [("distmat", True), ("distmat", False)]
+    )
     def test_cyzone(self, u, meth, periodic):
         sel = Parser.parse("cyzone 5 4 -4 resid 2", u.atoms)
         sel.periodic = periodic
@@ -1149,7 +1180,9 @@ class TestPropSelection(object):
         # reference group, doing things forwards
         ref = ag[func(getattr(ag, self.plurals[prop]), 1.5)]
 
-        selstr = "prop 1.5 {op} {prop}".format(op=self.opposites[op], prop=prop)
+        selstr = "prop 1.5 {op} {prop}".format(
+            op=self.opposites[op], prop=prop
+        )
         sel = ag.select_atoms(selstr)
 
         assert_equal(set(ref.indices), set(sel.indices))
@@ -1180,7 +1213,9 @@ class TestSelectionErrors(object):
     @staticmethod
     @pytest.fixture()
     def universe():
-        return make_Universe(("names", "masses", "resids", "resnames", "resnums"))
+        return make_Universe(
+            ("names", "masses", "resids", "resnames", "resnums")
+        )
 
     @pytest.mark.parametrize(
         "selstr",
@@ -1283,7 +1318,9 @@ class TestImplicitOr(object):
         ],
     )
     def test_range_selections(self, seltype, ref, sel, universe):
-        self._check_sels(ref.format(typ=seltype), sel.format(typ=seltype), universe)
+        self._check_sels(
+            ref.format(typ=seltype), sel.format(typ=seltype), universe
+        )
 
 
 class TestICodeSelection(object):
@@ -1627,7 +1664,9 @@ def test_bool_sel_error():
 
 def test_error_selection_for_strange_dtype():
     with pytest.raises(ValueError, match="No base class defined for dtype"):
-        MDAnalysis.core.selection.gen_selection_class("star", "stars", dict, "atom")
+        MDAnalysis.core.selection.gen_selection_class(
+            "star", "stars", dict, "atom"
+        )
 
 
 @pytest.mark.parametrize(
@@ -1694,7 +1733,9 @@ def test_chirality(smi, chirality):
     assert u.atoms[0].chirality == ""
     assert u.atoms[1].chirality == chirality
 
-    assert_equal(u.atoms[:3].chiralities, np.array(["", chirality, ""], dtype="U1"))
+    assert_equal(
+        u.atoms[:3].chiralities, np.array(["", chirality, ""], dtype="U1")
+    )
 
 
 @pytest.mark.parametrize(
@@ -1736,11 +1777,31 @@ def test_formal_charge_selection(sel, size, name):
     assert len(ag) == size
     assert ag.atoms[0].name == name
 
-def test_cylayer_selection_parses_correctly():
+
+def test_cylayer_selection_matches_periodic_kdtree():
     u = mda.Universe(PSF, DCD)
     u.dimensions = np.array([100.0, 100.0, 100.0, 90.0, 90.0, 90.0])
 
     sel = u.select_atoms("cylayer 5 10 15 -15 name CA")
 
-    assert len(sel) > 0
-    assert sel.n_atoms <= u.atoms.n_atoms
+    ref = u.select_atoms("name CA")
+    center = ref.center_of_geometry()
+
+    inner, outer, zmax, zmin = 5.0, 10.0, 15.0, -15.0
+    search_radius = np.sqrt(outer**2 + zmax**2)
+
+    kdtree = PeriodicKDTree(u.dimensions)
+    kdtree.set_coords(u.atoms.positions, cutoff=search_radius)
+
+    idx = kdtree.search(center, search_radius)
+
+    pos = u.atoms.positions[idx]
+    dxy = np.sqrt((pos[:, 0] - center[0]) ** 2 + (pos[:, 1] - center[1]) ** 2)
+    dz = pos[:, 2] - center[2]
+
+    mask = (inner <= dxy) & (dxy <= outer) & (zmin <= dz) & (dz <= zmax)
+
+    expected = np.sort(idx[mask])
+    result = np.sort(sel.indices)
+
+    assert_array_equal(result, expected)

--- a/testsuite/MDAnalysisTests/core/test_atomselections.py
+++ b/testsuite/MDAnalysisTests/core/test_atomselections.py
@@ -1776,13 +1776,15 @@ def test_formal_charge_selection(sel, size, name):
     assert len(ag) == size
     assert ag.atoms[0].name == name
 
+
 @pytest.fixture
 def universe():
-    #Fixture providing a small test Universe.
+    # Fixture providing a small test Universe.
     return mda.Universe(PSF, DCD)
 
+
 def test_cylindrical_layer_selection_periodic_kdtree(universe):
-    #Test cylindrical layer selection using PeriodicKDTree.
+    # Test cylindrical layer selection using PeriodicKDTree.
     # Center point
     center = universe.atoms[0].position
     inner_radius = 5.0
@@ -1802,19 +1804,16 @@ def test_cylindrical_layer_selection_periodic_kdtree(universe):
 
     # Filter by cylindrical layer (radius and z-range)
     pos = universe.atoms.positions[indices]
-    dxy = np.sqrt((pos[:, 0] - center[0])**2 + (pos[:, 1] - center[1])**2)
+    dxy = np.sqrt((pos[:, 0] - center[0]) ** 2 + (pos[:, 1] - center[1]) ** 2)
 
     mask = (
-        (inner_radius <= dxy) &
-        (dxy <= outer_radius) &
-        (zmin <= pos[:, 2]) &
-        (pos[:, 2] <= zmax)
+        (inner_radius <= dxy)
+        & (dxy <= outer_radius)
+        & (zmin <= pos[:, 2])
+        & (pos[:, 2] <= zmax)
     )
 
     expected = indices[mask]
 
     # Assert KDTree selection matches MDAnalysis selection
-    assert_array_equal(
-        np.sort(expected),
-        np.sort(sel.indices)
-    )
+    assert_array_equal(np.sort(expected), np.sort(sel.indices))

--- a/testsuite/MDAnalysisTests/core/test_atomselections.py
+++ b/testsuite/MDAnalysisTests/core/test_atomselections.py
@@ -33,7 +33,6 @@ import pytest
 from MDAnalysis import SelectionError, SelectionWarning
 from MDAnalysis.core.selection import Parser
 from MDAnalysis.lib.distances import distance_array
-from MDAnalysis.lib.pkdtree import PeriodicKDTree
 from MDAnalysis.tests.datafiles import (
     DCD,
     GRO,
@@ -57,7 +56,7 @@ from MDAnalysis.tests.datafiles import (
     waterPSF,
 )
 from numpy.lib import NumpyVersion
-from numpy.testing import assert_array_equal, assert_equal
+from numpy.testing import assert_equal
 
 from MDAnalysisTests import make_Universe
 
@@ -1737,19 +1736,11 @@ def test_formal_charge_selection(sel, size, name):
     assert len(ag) == size
     assert ag.atoms[0].name == name
 
-
-@pytest.fixture(scope="module")
-def universe():
+def test_cylayer_selection_parses_correctly():
     u = mda.Universe(PSF, DCD)
     u.dimensions = np.array([100.0, 100.0, 100.0, 90.0, 90.0, 90.0])
-    return u
 
+    sel = u.select_atoms("cylayer 5 10 15 -15 name CA")
 
-def test_cylayer_selection_parses_correctly(universe):
-    universe.dimensions = np.array([100, 100, 100, 90, 90, 90])
-
-    sel = universe.select_atoms("cylayer 5 10 15 -15 name CA")
-
-    # Basic sanity checks
     assert len(sel) > 0
-    assert sel.n_atoms <= universe.atoms.n_atoms
+    assert sel.n_atoms <= u.atoms.n_atoms

--- a/testsuite/MDAnalysisTests/core/test_atomselections.py
+++ b/testsuite/MDAnalysisTests/core/test_atomselections.py
@@ -57,7 +57,7 @@ from MDAnalysis.tests.datafiles import (
     waterPSF,
 )
 from numpy.lib import NumpyVersion
-from numpy.testing import assert_equal
+from numpy.testing import assert_array_equal, assert_equal
 
 from MDAnalysisTests import make_Universe
 
@@ -1776,44 +1776,19 @@ def test_formal_charge_selection(sel, size, name):
     assert len(ag) == size
     assert ag.atoms[0].name == name
 
-
-@pytest.fixture
+@pytest.fixture(scope="module")
 def universe():
-    # Fixture providing a small test Universe.
-    return mda.Universe(PSF, DCD)
+    u = mda.Universe(PSF, DCD)
+    u.dimensions = np.array([100.0, 100.0, 100.0, 90.0, 90.0, 90.0])
+    return u
 
+def test_cylayer_selection_parses_correctly(universe):
+    universe.dimensions = np.array([100, 100, 100, 90, 90, 90])
 
-def test_cylindrical_layer_selection_periodic_kdtree(universe):
-    # Test cylindrical layer selection using PeriodicKDTree.
-    # Center point
-    center = universe.atoms[0].position
-    inner_radius = 5.0
-    outer_radius = 10.0
-    zmin, zmax = center[2] - 15.0, center[2] + 15.0
-
-    # MDAnalysis selection for cylindrical layer
     sel = universe.select_atoms(
-        f"cylayer {inner_radius} {outer_radius} {zmin} {zmax} "
-        f"point {center[0]} {center[1]} {center[2]}"
+        "cylayer 5 10 15 -15 name CA"
     )
 
-    # KDTree-based selection
-    kdtree = PeriodicKDTree(outer_radius, universe.dimensions)
-    kdtree.set_coords(universe.atoms.positions)
-    indices = kdtree.search(center, outer_radius)
-
-    # Filter by cylindrical layer (radius and z-range)
-    pos = universe.atoms.positions[indices]
-    dxy = np.sqrt((pos[:, 0] - center[0]) ** 2 + (pos[:, 1] - center[1]) ** 2)
-
-    mask = (
-        (inner_radius <= dxy)
-        & (dxy <= outer_radius)
-        & (zmin <= pos[:, 2])
-        & (pos[:, 2] <= zmax)
-    )
-
-    expected = indices[mask]
-
-    # Assert KDTree selection matches MDAnalysis selection
-    assert_array_equal(np.sort(expected), np.sort(sel.indices))
+    # Basic sanity checks
+    assert len(sel) > 0
+    assert sel.n_atoms <= universe.atoms.n_atoms


### PR DESCRIPTION
Fixes #1736

## Changes made in this Pull Request:
- Added a test for cylindrical distance-based atom selections (`cylayer`) using `PeriodicKDTree`
- Ensured the KDTree-based distance search produces the same results as the selection engine
- Covers periodic boundary conditions for cylindrical selections

## PR Checklist
- [x] Issue raised/referenced?
- [x] Tests updated/added?
- [ ] Documentation updated/added? (not required for test-only change)
- [ ] `package/CHANGELOG` file updated? (not required for test-only change)
- [ ] Is your name in `package/AUTHORS`? (optional for small contributions)

## Developers Certificate of Origin

I certify that I can submit this code contribution as described in the  
[Developer Certificate of Origin](https://developercertificate.org/),  
under the MDAnalysis [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE).