### PR TITLE
Add LLM/AI code disclosure section to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,10 @@ Changes made in this Pull Request:
 <!-- Describe the changes that this PR makes. If applicable, use the following bullet list. --> 
 -
 
+## LLM / AI generated code disclosure
+<!-- Please update this disclosure to reflect if you did or did not use LLMs / AI to generate code -->
+LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution: yes / no
+
 ## PR Checklist
 <!-- Please use the following checklist to ensure the PR is ready to be reviewed/merged. -->
  - [ ] Issue raised/referenced?
@@ -15,6 +19,7 @@ Changes made in this Pull Request:
  - [ ] Documentation updated/added?
  - [ ] `package/CHANGELOG` file updated?
  - [ ] Is your name in `package/AUTHORS`? (If it is not, add it!)
+ - [ ] LLM/AI disclosure was updated.
 
 ## Developers Certificate of Origin
 <!-- 


### PR DESCRIPTION
Added a section for LLM/AI generated code disclosure in the PR template.

Please note that I'm not adding a tickbox but rather a yes/no, to avoid the case where someone doesn't tick it and we don't know if they forgot or if they just aren't using an LLM.

## PR Checklist
<!-- Please use the following checklist to ensure the PR is ready to be reviewed/merged. -->
 - [ ] Issue raised/referenced?
 - [ ] Tests updated/added?
 - [ ] Documentation updated/added?
 - [ ] `package/CHANGELOG` file updated?
 - [ ] Is your name in `package/AUTHORS`? (If it is not, add it!)

## Developers Certificate of Origin
<!-- 
In order for this PR to be merged you **must certify that you are able to submit your code to be included in MDAnalysis**.
-->

I certify that I can submit this code contribution as described in the [**Developer Certificate of Origin**](https://developercertificate.org/), under the MDAnalysis [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--5196.org.readthedocs.build/en/5196/

<!-- readthedocs-preview mdanalysis end -->