### PR TITLE
nojump.py raises a valueerror when applied not at first frame

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -21,7 +21,7 @@ The rules for this file:
 
 Fixes
  * NoJump shows a more informative message and fails  when applied
-   outside of the first frame (Issue #4915, PR #5199)
+   outside of the first frame (Issue #4915, PR #5201)
  * DSSP now explicitly checks for a minimum of 6 residues and raises a clear
    error message, unlike the previous behavior where it would fail with an
    incomprehensible broadcasting error at execution time (Issue #5046, PR #5163)

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -20,6 +20,8 @@ The rules for this file:
  * 2.11.0
 
 Fixes
+ * NoJump shows a more informative message and fails  when applied
+   outside of the first frame (Issue #4915, PR #5199)
  * DSSP now explicitly checks for a minimum of 6 residues and raises a clear
    error message, unlike the previous behavior where it would fail with an
    incomprehensible broadcasting error at execution time (Issue #5046, PR #5163)

--- a/package/MDAnalysis/transformations/nojump.py
+++ b/package/MDAnalysis/transformations/nojump.py
@@ -122,8 +122,7 @@ class NoJump(TransformationBase):
         if self.prev is None and ts.frame != 0:
             raise ValueError(
                 "NoJump transformation must be applied starting from frame 0. "
-                f"Currently at frame {ts.frame}. Please reset trajectory to frame 0 "
-                "before adding this transformation."
+                f"Currently at frame {ts.frame}. Please reset trajectory to frame 0 before adding this transformation."
             )
 
         if ts.frame == 0:

--- a/package/MDAnalysis/transformations/nojump.py
+++ b/package/MDAnalysis/transformations/nojump.py
@@ -118,6 +118,14 @@ class NoJump(TransformationBase):
         except np.linalg.LinAlgError:
             msg = f"Periodic box dimensions are not invertible at step {ts.frame}"
             raise NoDataError(msg)
+
+        if self.prev is None and ts.frame != 0:
+            raise ValueError(
+                "NoJump transformation must be applied starting from frame 0. "
+                f"Currently at frame {ts.frame}. Please reset trajectory to frame 0 "
+                "before adding this transformation."
+            )
+
         if ts.frame == 0:
             # We don't need to apply the transformation here. However, we need to
             # ensure we have the 0th frame coordinates in reduced form. We also need to

--- a/testsuite/MDAnalysisTests/transformations/test_nojump.py
+++ b/testsuite/MDAnalysisTests/transformations/test_nojump.py
@@ -393,7 +393,6 @@ def test_nojump_fails_when_not_at_frame_0():
         ValueError, match="must be applied starting from frame 0"
     ):
         u.trajectory.add_transformations(NoJump())
-        _ = u.trajectory[0]
 
 
 def test_nojump_fails_midtrajectory():
@@ -407,4 +406,3 @@ def test_nojump_fails_midtrajectory():
         ValueError, match="must be applied starting from frame 0"
     ):
         u.trajectory.add_transformations(NoJump())
-        _ = u.trajectory.timeseries()

--- a/testsuite/MDAnalysisTests/transformations/test_nojump.py
+++ b/testsuite/MDAnalysisTests/transformations/test_nojump.py
@@ -381,26 +381,14 @@ def test_notinvertible(nojump_universe):
         transformed_coordinates = u.trajectory.timeseries()[0]
 
 
-def test_nojump_fails_when_not_at_frame_0():
+@pytest.mark.parametrize("frame_index", [-1, 5])
+def test_nojump_fails_when_not_at_frame_0(frame_index):
     """
     Test that NoJump raises a clear error when applied to a trajectory
     that is not at frame 0.
     """
     u = mda.Universe(data.PSF_TRICLINIC, data.DCD_TRICLINIC)
-    u.trajectory[-1]
-
-    with pytest.raises(
-        ValueError, match="must be applied starting from frame 0"
-    ):
-        u.trajectory.add_transformations(NoJump())
-
-
-def test_nojump_fails_midtrajectory():
-    """
-    Test that NoJump raises a clear error when applied in the middle of a trajectory.
-    """
-    u = mda.Universe(data.PSF_TRICLINIC, data.DCD_TRICLINIC)
-    u.trajectory[5]
+    u.trajectory[frame_index]
 
     with pytest.raises(
         ValueError, match="must be applied starting from frame 0"

--- a/testsuite/MDAnalysisTests/transformations/test_nojump.py
+++ b/testsuite/MDAnalysisTests/transformations/test_nojump.py
@@ -379,3 +379,32 @@ def test_notinvertible(nojump_universe):
         ]
         u.trajectory.add_transformations(*workflow)
         transformed_coordinates = u.trajectory.timeseries()[0]
+
+
+def test_nojump_fails_when_not_at_frame_0():
+    """
+    Test that NoJump raises a clear error when applied to a trajectory
+    that is not at frame 0.
+    """
+    u = mda.Universe(data.PSF_TRICLINIC, data.DCD_TRICLINIC)
+    u.trajectory[-1]
+
+    with pytest.raises(
+        ValueError, match="must be applied starting from frame 0"
+    ):
+        u.trajectory.add_transformations(NoJump())
+        _ = u.trajectory[0]
+
+
+def test_nojump_fails_midtrajectory():
+    """
+    Test that NoJump raises a clear error when applied in the middle of a trajectory.
+    """
+    u = mda.Universe(data.PSF_TRICLINIC, data.DCD_TRICLINIC)
+    u.trajectory[5]
+
+    with pytest.raises(
+        ValueError, match="must be applied starting from frame 0"
+    ):
+        u.trajectory.add_transformations(NoJump())
+        _ = u.trajectory.timeseries()


### PR DESCRIPTION
Fixes #4915

Changes made in this Pull Request:
- Added a check inside `nojump.py` under the `_transform` function that checks if the `self.prev is None and ts.frame != 0`
- it raises a ValueError
- Updated the `test_nojump.py` that checks for `-1` and also midway

## LLM / AI generated code disclosure
LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution: no
(not needed, I guess this was simple)

## PR Checklist
 - [x] Issue raised/referenced?
 - [x] Tests updated/added?
 - [ ] Documentation updated/added?
 - [x] `package/CHANGELOG` file updated?
 - [x] Is your name in `package/AUTHORS`? (If it is not, add it!)
 - [x] LLM/AI disclosure was updated.

## Developers Certificate of Origin

I certify that I can submit this code contribution as described in the [**Developer Certificate of Origin**](https://developercertificate.org/), under the MDAnalysis [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--5201.org.readthedocs.build/en/5201/

<!-- readthedocs-preview mdanalysis end -->