### PR TITLE
FIX: Handle a non-linear FrameIterator in HydrogenBondAnalysis

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -266,6 +266,7 @@ Chronological list of authors
   - Pranay Pelapkar
   - Shreejan Dolai
   - Tanisha Dubey
+  - Brady Johnston
 
 External code
 -------------

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -15,11 +15,13 @@ The rules for this file:
 
 -------------------------------------------------------------------------------
 ??/??/?? IAlibay, orbeckst, marinegor, tylerjereddy, ljwoods2, marinegor,
-         spyke7, talagayev, tanii1125
+         spyke7, talagayev
 
  * 2.11.0
 
 Fixes
+ * HydrogenBondAnalysis: Fixed `count_by_time()` when using `run(FrameIterator)` that
+   results in `self.start` and `self.end` being None (Issue #5200, PR #****)
  * DSSP now explicitly checks for a minimum of 6 residues and raises a clear
    error message, unlike the previous behavior where it would fail with an
    incomprehensible broadcasting error at execution time (Issue #5046, PR #5163)

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -21,7 +21,7 @@ The rules for this file:
 
 Fixes
  * HydrogenBondAnalysis: Fixed `count_by_time()` when using `run(FrameIterator)` that
-   results in `self.start` and `self.end` being None (Issue #5200, PR #****)
+   results in `self.start` and `self.end` being None (Issue #5200, PR #5202)
  * DSSP now explicitly checks for a minimum of 6 residues and raises a clear
    error message, unlike the previous behavior where it would fail with an
    incomprehensible broadcasting error at execution time (Issue #5046, PR #5163)

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -15,7 +15,7 @@ The rules for this file:
 
 -------------------------------------------------------------------------------
 ??/??/?? IAlibay, orbeckst, marinegor, tylerjereddy, ljwoods2, marinegor,
-         spyke7, talagayev
+         spyke7, talagayev, tanii1125, BradyAJohnston
 
  * 2.11.0
 

--- a/package/MDAnalysis/analysis/hydrogenbonds/hbond_analysis.py
+++ b/package/MDAnalysis/analysis/hydrogenbonds/hbond_analysis.py
@@ -913,10 +913,11 @@ class HydrogenBondAnalysis(AnalysisBase):
         """
         hbond_frames = self.results.hbonds[:, 0].astype(int)
         frame_unique, frame_counts = np.unique(hbond_frames, return_counts=True)
+        frame_min, frame_max = self.frames.min(), self.frames.max()
 
-        counts = np.zeros(max(self.frames) + 1, dtype=int)
-        counts[frame_unique] = frame_counts
-        return counts[self.frames]
+        counts = np.zeros(frame_max - frame_min + 1, dtype=int)
+        counts[frame_unique - frame_min] = frame_counts
+        return counts[self.frames - frame_min]
 
     def count_by_type(self):
         """Counts the total number of each unique type of hydrogen bond.

--- a/package/MDAnalysis/analysis/hydrogenbonds/hbond_analysis.py
+++ b/package/MDAnalysis/analysis/hydrogenbonds/hbond_analysis.py
@@ -920,7 +920,7 @@ class HydrogenBondAnalysis(AnalysisBase):
         # so we do a manual lookup and return instead. some frames might be zero
         # so they would be missing from the np.unique return
         if self.start is None:
-            count_lookup = {idx: count for idx, count in zip(indices, tmp_counts)}
+            count_lookup = dict(zip(indices, tmp_counts))
             return np.array([count_lookup.get(i, 0) for i in range(len(self.frames))])
 
         indices -= self.start

--- a/package/MDAnalysis/analysis/hydrogenbonds/hbond_analysis.py
+++ b/package/MDAnalysis/analysis/hydrogenbonds/hbond_analysis.py
@@ -911,25 +911,12 @@ class HydrogenBondAnalysis(AnalysisBase):
              Can be used along with :attr:`HydrogenBondAnalysis.times` to plot
              the number of hydrogen bonds over time.
         """
+        hbond_frames = self.results.hbonds[:, 0].astype(int)
+        frame_unique, frame_counts = np.unique(hbond_frames, return_counts=True)
 
-        indices, tmp_counts = np.unique(
-            self.results.hbonds[:, 0], axis=0, return_counts=True
-        )
-
-        # if we pass a specific subset of frames there won't be a start / end frame
-        # so we do a manual lookup and return instead. some frames might be zero
-        # so they would be missing from the np.unique return
-        if self.start is None:
-            count_lookup = dict(zip(indices, tmp_counts))
-            return np.array([count_lookup.get(i, 0) for i in range(len(self.frames))])
-
-        indices -= self.start
-        indices /= self.step
-
-        counts = np.zeros_like(self.frames)
-        counts[indices.astype(np.intp)] = tmp_counts
-
-        return counts
+        counts = np.zeros(max(self.frames) + 1, dtype=int)
+        counts[frame_unique] = frame_counts
+        return counts[self.frames]
 
     def count_by_type(self):
         """Counts the total number of each unique type of hydrogen bond.

--- a/package/MDAnalysis/analysis/hydrogenbonds/hbond_analysis.py
+++ b/package/MDAnalysis/analysis/hydrogenbonds/hbond_analysis.py
@@ -912,8 +912,16 @@ class HydrogenBondAnalysis(AnalysisBase):
              the number of hydrogen bonds over time.
         """
 
-        indices, tmp_counts = np.unique(self.results.hbonds[:, 0], axis=0,
-                                        return_counts=True)
+        indices, tmp_counts = np.unique(
+            self.results.hbonds[:, 0], axis=0, return_counts=True
+        )
+
+        # if we pass a specific subset of frames there won't be a start / end frame
+        # so we do a manual lookup and return instead. some frames might be zero
+        # so they would be missing from the np.unique return
+        if self.start is None:
+            count_lookup = {idx: count for idx, count in zip(indices, tmp_counts)}
+            return np.array([count_lookup.get(i, 0) for i in range(len(self.frames))])
 
         indices -= self.start
         indices /= self.step

--- a/testsuite/MDAnalysisTests/analysis/test_hydrogenbonds_analysis.py
+++ b/testsuite/MDAnalysisTests/analysis/test_hydrogenbonds_analysis.py
@@ -778,5 +778,5 @@ class TestHydrogenBondAnalysisFrameIterator:
         )
         hbonds.run(frames=frames)
         assert np.array_equal(
-            hbonds.count_by_time(), np.array([2, 1, 4, 0, 0, 3, 3])
+            hbonds.count_by_time(), np.array([2, 1, 4, 3, 3, 2, 2])
         )

--- a/testsuite/MDAnalysisTests/analysis/test_hydrogenbonds_analysis.py
+++ b/testsuite/MDAnalysisTests/analysis/test_hydrogenbonds_analysis.py
@@ -760,3 +760,23 @@ class TestHydrogenBondAnalysisEmptySelections:
         assert h.hydrogens_sel == ""
         assert h.acceptors_sel == ""
         assert h.results.hbonds.size == 0
+
+
+class TestHydrogenBondAnalysisFrameIterator:
+    @staticmethod
+    @pytest.fixture(scope="class")
+    def universe():
+        return MDAnalysis.Universe(waterPSF, waterDCD)
+
+    def test_frame_iterator(self, universe):
+        frames = np.array([0, 1, 2, 5, 6, 7, 8])
+        hbonds = HydrogenBondAnalysis(
+            universe=universe,
+            hydrogens_sel="name H1 H2",
+            acceptors_sel="name OH2",
+            update_selections=False,
+        )
+        hbonds.run(frames=frames)
+        assert np.array_equal(
+            hbonds.count_by_time(), np.array([2, 1, 4, 0, 0, 3, 3])
+        )


### PR DESCRIPTION
Fixes #5200 

Changes made in this Pull Request:
<!-- Describe the changes that this PR makes. If applicable, use the following bullet list. --> 
- Refactor `count_by_time()` to handle returning values on a non-linear FrameIterator

## LLM / AI generated code disclosure
<!-- Please update this disclosure to reflect if you did or did not use LLMs / AI to generate code -->
LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution:  no

## PR Checklist
<!-- Please use the following checklist to ensure the PR is ready to be reviewed/merged. -->
 - [x] Issue raised/referenced?
 - [x] Tests updated/added?
 - [x] Documentation updated/added?
 - [x] `package/CHANGELOG` file updated?
 - [x] Is your name in `package/AUTHORS`? (If it is not, add it!)
 - [x] LLM/AI disclosure was updated.

## Developers Certificate of Origin
<!-- 
In order for this PR to be merged you **must certify that you are able to submit your code to be included in MDAnalysis**.
-->

I certify that I can submit this code contribution as described in the [**Developer Certificate of Origin**](https://developercertificate.org/), under the MDAnalysis [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--5202.org.readthedocs.build/en/5202/

<!-- readthedocs-preview mdanalysis end -->