### PR TITLE
Docs: Fix doctest failure in rms.py

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -267,6 +267,8 @@ Chronological list of authors
   - Shreejan Dolai
   - Tanisha Dubey
   - Brady Johnston
+2026
+  - Mohammad Ayaan
 
 External code
 -------------

--- a/package/MDAnalysis/analysis/rms.py
+++ b/package/MDAnalysis/analysis/rms.py
@@ -243,8 +243,8 @@ def rmsd(a, b, weights=None, center=False, superposition=False):
     >>> A = bb.positions.copy()  # coordinates of first frame
     >>> _ = u.trajectory[-1]  # forward to last frame
     >>> B = bb.positions.copy()  # coordinates of last frame
-    >>> float(rmsd(A, B, center=True))
-    6.838544558398293
+    >>> rmsd(A, B, center=True)
+    np.float64(6.838544558398293)
 
 
     .. versionchanged:: 0.8.1

--- a/package/MDAnalysis/analysis/rms.py
+++ b/package/MDAnalysis/analysis/rms.py
@@ -243,7 +243,7 @@ def rmsd(a, b, weights=None, center=False, superposition=False):
     >>> A = bb.positions.copy()  # coordinates of first frame
     >>> _ = u.trajectory[-1]  # forward to last frame
     >>> B = bb.positions.copy()  # coordinates of last frame
-    >>> rmsd(A, B, center=True)
+    >>> float(rmsd(A, B, center=True))
     6.838544558398293
 
 


### PR DESCRIPTION
Contributes to #3925

**Changes made in this Pull Request:**
- Fixed `rms.py` doctest failure by updated the expected output to np.float64(6.838544558398293) so it lines up with what NumPy actually returns
- Verified that the doctest passes using `pytest --doctest-modules`.

## LLM / AI generated code disclosure
- No

## PR Checklist
- [x] Issue raised/referenced?
- [x] Tests updated/added?
- [x] Documentation updated/added?

<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--5205.org.readthedocs.build/en/5205/

<!-- readthedocs-preview mdanalysis end -->