### PR TITLE
Docs: Fix doctest failures in align.py

### DIFF
--- a/package/MDAnalysis/analysis/align.py
+++ b/package/MDAnalysis/analysis/align.py
@@ -76,14 +76,14 @@ two structures, using :func:`rmsd`::
    >>> ref = mda.Universe(PDB_small)
    >>> mobile = mda.Universe(PSF, DCD)
    >>> rmsd(mobile.select_atoms('name CA').positions, ref.select_atoms('name CA').positions)
-   28.20178579474479
+   np.float64(28.20178579474479)
 
 Note that in this example translations have not been removed. In order
 to look at the pure rotation one needs to superimpose the centres of
 mass (or geometry) first::
 
    >>> rmsd(mobile.select_atoms('name CA').positions, ref.select_atoms('name CA').positions, center=True)
-   21.892591663632704
+   np.float64(21.892591663632704)
 
 This has only done a translational superposition. If you want to also do a
 rotational superposition use the superposition keyword. This will calculate a
@@ -126,7 +126,7 @@ To **fit a single structure** with :func:`alignto`::
    >>> ref = mda.Universe(PSF, PDB_small)
    >>> mobile = mda.Universe(PSF, DCD)     # we use the first frame
    >>> align.alignto(mobile, ref, select="protein and name CA", weights="mass")
-   (21.892591663632704, 6.809396586471809)
+   (np.float64(21.892591663632704), 6.809396586471809)
 
 This will change *all* coordinates in *mobile* so that the protein
 C-alpha atoms are optimally superimposed (translation and rotation).
@@ -137,8 +137,8 @@ To **fit a whole trajectory** to a reference structure with the
    >>> ref = mda.Universe(PSF, PDB_small)   # reference structure 1AKE
    >>> trj = mda.Universe(PSF, DCD)         # trajectory of change 1AKE->4AKE
    >>> alignment = align.AlignTraj(trj, ref, filename='rmsfit.dcd')
-   >>> alignment.run()
-   <MDAnalysis.analysis.align.AlignTraj object at ...> 
+   >>> _ = alignment.run()
+
 
 It is also possible to align two arbitrary structures by providing a
 mapping between atoms based on a sequence alignment. This allows


### PR DESCRIPTION
Docs: Fix failing doctests in MDAnalysis.analysis.align

Fixed failing doctests in `package/MDAnalysis/analysis/align.py` caused by NumPy scalar types and non-deterministic memory addresses.

**Details:**

1) **NumPy Scalars & Mixed Types:**
   Functions like `rmsd()` and `alignto()` are now returning `np.float64` (or a mixed tuple of `np.float64` and `float`) instead of just plain floats. I updated the docstrings to match the actual output.

   *Before (Failing):*
   ```text
   Expected:
       (21.892591663632704, 6.809396586471809)
   Got:
       (np.float64(21.892591663632704), 6.809396586471809)

2) Memory Address (RAM) Issue: The AlignTraj example was failing because the object print includes a memory address (e.g., 0x00...), which changes on every run. The standard ellipsis ... wasn't catching it properly on my environment.

Before (Failing):

 Expected:
    <MDAnalysis.analysis.align.AlignTraj object at ...>
Got:
    <MDAnalysis.analysis.align.AlignTraj object at 0x000001D789C0F770>

After: Suppressed the output using _ = ... to make the test deterministic.

Verification: Ran tests locally: `pytest --doctest-modules package/MDAnalysis/analysis/align.py` Result: 2 passed (All warnings unrelated to changes).

LLM / AI generated code disclosure
LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution: no

PR Checklist

* [x] Issue raised/referenced?
* [x] Tests updated/added?
* [ ] Documentation updated/added?
* [ ] package/CHANGELOG file updated?
* [x] Is your name in package/AUTHORS?
* [x] LLM/AI disclosure was updated.

Developers Certificate of Origin
I certify that I can submit this code contribution as described in the [Developer Certificate of Origin](https://developercertificate.org/), under the MDAnalysis [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--5207.org.readthedocs.build/en/5207/

<!-- readthedocs-preview mdanalysis end -->