### PR TITLE
SEL: add sugar atom selection based on GLYCAM residue names

### DIFF
--- a/package/MDAnalysis/core/selection.py
+++ b/package/MDAnalysis/core/selection.py
@@ -1501,7 +1501,6 @@ class SugarSelection(Selection):
         # GLYCAM06 Hexoses (D-Glc, D-Gal, D-Man)
         # Linkage indicators: 0 (terminal), 2, 3, 4, 6
         # Isomers: A (alpha), B (beta)
-
         # Glucose (G)
         "0GA",
         "0GB",

--- a/package/MDAnalysis/core/selection.py
+++ b/package/MDAnalysis/core/selection.py
@@ -1489,6 +1489,65 @@ class NucleicSugarSelection(NucleicSelection):
         return group.unique
 
 
+class SugarSelection(Selection):
+    """Select atoms in carbohydrate residues with recognized GLYCAM names.
+
+    Recognized residue names in :attr:`SugarSelection.sugar_res`.
+    """
+
+    token = "sugar"
+
+    sugar_res = {
+        # GLYCAM06 Hexoses (D-Glc, D-Gal, D-Man)
+        # Linkage indicators: 0 (terminal), 2, 3, 4, 6
+        # Isomers: A (alpha), B (beta)
+
+        # Glucose (G)
+        "0GA",
+        "0GB",
+        "2GA",
+        "2GB",
+        "3GA",
+        "3GB",
+        "4GA",
+        "4GB",
+        "6GA",
+        "6GB",
+        # Galactose (L)
+        "0LA",
+        "0LB",
+        "2LA",
+        "2LB",
+        "3LA",
+        "3LB",
+        "4LA",
+        "4LB",
+        "6LA",
+        "6LB",
+        # Mannose (M)
+        "0MA",
+        "0MB",
+        "2MA",
+        "2MB",
+        "3MA",
+        "3MB",
+        "4MA",
+        "4MB",
+        "6MA",
+        "6MB",
+    }
+
+    def _apply(self, group):
+        resname_attr = group.universe._topology.resnames
+        matches = [
+            ix
+            for (nm, ix) in resname_attr.namedict.items()
+            if nm in self.sugar_res
+        ]
+        nmidx = resname_attr.nmidx[group.resindices]
+        return group[np.isin(nmidx, matches)]
+
+
 class PropertySelection(Selection):
     """Some of the possible properties:
     x, y, z, radius, mass,

--- a/testsuite/MDAnalysisTests/core/test_sugar_selection.py
+++ b/testsuite/MDAnalysisTests/core/test_sugar_selection.py
@@ -1,0 +1,70 @@
+# -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 fileencoding=utf-8
+#
+# MDAnalysis --- https://www.mdanalysis.org
+# Copyright (c) 2006-2017 The MDAnalysis Development Team and contributors
+# (see the file AUTHORS for the full list of names)
+#
+# Released under the GNU Public Licence, v2 or any higher version
+#
+# Please cite your use of MDAnalysis in published work:
+#
+# R. J. Gowers, M. Linke, J. Barnoud, T. J. E. Reddy, M. N. Melo, S. L. Seyler,
+# D. L. Dotson, J. Domanski, S. Buchoux, I. M. Kenney, and O. Beckstein.
+# MDAnalysis: A Python package for the rapid analysis of molecular dynamics
+# simulations. In S. Benthall and S. Rostrup editors, Proceedings of the 15th
+# Python in Science Conference, pages 102-109, Austin, TX, 2016. SciPy.
+#
+# N. Michaud-Agrawal, E. J. Denning, T. B. Woolf, and O. Beckstein.
+# MDAnalysis of BioMolecular Simulations. J. Comput. Chem. 32 (2011), 2319-2327,
+# doi:10.1002/jcc.21787
+#
+
+import pytest
+import numpy as np
+import MDAnalysis as mda
+
+
+def test_sugar_selection():
+    # 0GA = Glucose, ALA = Protein, 4LB = Galactose
+    resnames = np.array(["0GA", "ALA", "4LB"])
+    # 3 atoms per residue
+    resindices = np.repeat([0, 1, 2], 3)
+    # 1 segment
+    segindices = np.repeat([0], 3)
+
+    u = mda.Universe.empty(
+        n_atoms=9,
+        n_residues=3,
+        n_segments=1,
+        atom_resindex=resindices,
+        residue_segindex=segindices,
+        trajectory=True,
+    )
+    u.add_TopologyAttr("resname", resnames)
+
+    sugar = u.select_atoms("sugar")
+
+    assert len(sugar) == 6
+    assert np.all(np.isin(sugar.resnames, ["0GA", "4LB"]))
+    assert "ALA" not in sugar.resnames
+
+
+def test_sugar_selection_empty():
+    resnames = np.array(["ALA", "VAL"])
+    resindices = np.repeat([0, 1], 3)
+    segindices = np.repeat([0], 2)
+
+    u = mda.Universe.empty(
+        n_atoms=6,
+        n_residues=2,
+        n_segments=1,
+        atom_resindex=resindices,
+        residue_segindex=segindices,
+        trajectory=True,
+    )
+    u.add_TopologyAttr("resname", resnames)
+
+    sugar = u.select_atoms("sugar")
+
+    assert len(sugar) == 0


### PR DESCRIPTION
**What**:
Add a _sugar atom selection_ based on common GLYCAM residue names.

**Why**:
MDAnalysis currently provides residue-based selectors such as _protein_ but lacks an equivalent selector for carbohydrates. This change adds a minimal, explicit sugar selector using well-documented GLYCAM06 residue names, without relying on heuristics or pattern matching.

**Notes**:
- The initial residue list is intentionally limited to common GLYCAM hexoses (Glc, Gal, Man) to establish the selector pattern.
- The implementation mirrors existing selector logic in this module, including use of topology-backed residue name lookups.
- Additional sugars, aliases, or broader coverage are intentionally deferred for follow-up discussion.

**PR Checklist**:
- [x] Tests added for positive and negative selection cases
- [x] No public API changes
- [x] No behavior changes outside selection logic
- [ ] Docs (intentionally deferred)
- [ ] Changelog (not required for this change)
- [x] Issue referenced (Closes #4790)


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--5209.org.readthedocs.build/en/5209/

<!-- readthedocs-preview mdanalysis end -->