### PR TITLE
Remove nose references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,6 @@ examples/output.txt
 # ignore coverage files
 .coverage*
 !.coveragerc
-.noseids
 htmlcov
 # ignore trajectory offset caches
 .adk_oplsaa.trr_offsets.pkl

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -33,7 +33,6 @@
         "scipy": [],
 	    "six": [],
 	    "pytest": [],
-	    "nose": [],
 	    "mock": [],
         "MDAnalysisTests": [],
     },

--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -270,6 +270,7 @@ Chronological list of authors
 2026
   - Mohammad Ayaan
   - Khushi Phougat
+  
 External code
 -------------
 

--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -265,7 +265,9 @@ Chronological list of authors
   - Raúl Lois-Cuns  
   - Pranay Pelapkar
   - Shreejan Dolai
-
+2026
+  - Khushi Phougat
+  
 External code
 -------------
 

--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -269,7 +269,7 @@ Chronological list of authors
   - Brady Johnston
 2026
   - Mohammad Ayaan
-
+  - Khushi Phougat
 External code
 -------------
 

--- a/testsuite/MDAnalysisTests/utils/test_streamio.py
+++ b/testsuite/MDAnalysisTests/utils/test_streamio.py
@@ -214,8 +214,6 @@ class TestNamedStream_filename_behavior(object):
 
     def test_join(self, tmpdir, funcname="join"):
         # join not included because of different call signature
-        # but added first argument for the sake of it showing up in the verbose
-        # nose output
         ns = self.create_NamedStream()
         fn = self.textname
         reference = str(tmpdir.join(fn))


### PR DESCRIPTION
Fixes #5085

Changes made in this Pull Request:
 
- Removed "nose" configuration from asv.conf.json
- Removed .noseids from .gitignore
- Removed comments referencing nose output in testsuite/MDAnalysisTests/utils/test_streamio.py

## LLM / AI generated code disclosure
LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution: no

## PR Checklist
<!-- Please use the following checklist to ensure the PR is ready to be reviewed/merged. -->
 - [x] Issue raised/referenced?
 - [x] Tests updated/added?
 - [ ] Documentation updated/added?
 - [ ] `package/CHANGELOG` file updated?
 - [x] Is your name in `package/AUTHORS`? (If it is not, add it!)
 - [x] LLM/AI disclosure was updated.

## Developers Certificate of Origin

I certify that I can submit this code contribution as described in the [**Developer Certificate of Origin**](https://developercertificate.org/), under the MDAnalysis [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--5212.org.readthedocs.build/en/5212/

<!-- readthedocs-preview mdanalysis end -->