### PR TITLE
ENH: Add min_distance and distance_statistics functions for atom groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ benchmarks/results
 .idea
 .vscode
 *.lock
+
+# virtual environments
+venv/

--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -270,6 +270,7 @@ Chronological list of authors
 2026
   - Mohammad Ayaan
   - Khushi Phougat
+  - Suriya Sureshkumar
   
 External code
 -------------

--- a/package/MDAnalysis/analysis/distances.py
+++ b/package/MDAnalysis/analysis/distances.py
@@ -44,6 +44,8 @@ __all__ = [
     "contact_matrix",
     "dist",
     "between",
+    "min_distance",
+    "distance_statistics",
 ]
 
 import numpy as np
@@ -218,3 +220,79 @@ def between(group, A, B, distance):
     resA = ns_group.search(A, distance)
     resB = ns_group.search(B, distance)
     return resB.intersection(resA)
+
+
+def min_distance(A, B, box=None):
+    """Calculate the minimum distance between two atom groups.
+
+    This function computes the shortest distance between any atom in group A
+    and any atom in group B. Useful for protein-ligand analysis, membrane-protein
+    distances, or identifying close contacts between molecular regions.
+
+    Parameters
+    ----------
+    A : AtomGroup
+        First atom group
+    B : AtomGroup
+        Second atom group
+    box : array_like, optional
+        Simulation cell dimensions for periodic boundary conditions in the form
+        ``[lx, ly, lz, alpha, beta, gamma]``. If provided, minimum image
+        convention is applied.
+
+    Returns
+    -------
+    float
+        Minimum distance between any atom in A and any atom in B (in Angstroms)
+
+    .. versionadded:: 2.8.0
+    """
+    distances = distance_array(A.positions, B.positions, box=box)
+    return np.min(distances)
+
+
+def distance_statistics(A, B, box=None):
+    """Calculate statistical measures of distances between two atom groups.
+
+    Computes minimum, maximum, mean, and standard deviation of all pairwise
+    distances between atoms in groups A and B. Useful for characterizing
+    the overall separation and distribution of distances between molecular regions.
+
+    Parameters
+    ----------
+    A : AtomGroup
+        First atom group
+    B : AtomGroup
+        Second atom group
+    box : array_like, optional
+        Simulation cell dimensions for periodic boundary conditions in the form
+        ``[lx, ly, lz, alpha, beta, gamma]``. If provided, minimum image
+        convention is applied.
+
+    Returns
+    -------
+    dict
+        Dictionary containing:
+        
+        - 'min' : float
+            Minimum distance
+        - 'max' : float
+            Maximum distance
+        - 'mean' : float
+            Mean of all pairwise distances
+        - 'std' : float
+            Standard deviation of distances
+        - 'n_distances' : int
+            Total number of pairwise distances calculated
+
+    .. versionadded:: 2.8.0
+    """
+    distances = distance_array(A.positions, B.positions, box=box)
+    
+    return {
+        'min': float(np.min(distances)),
+        'max': float(np.max(distances)),
+        'mean': float(np.mean(distances)),
+        'std': float(np.std(distances)),
+        'n_distances': distances.size
+    }

--- a/package/MDAnalysis/analysis/distances.py
+++ b/package/MDAnalysis/analysis/distances.py
@@ -273,7 +273,7 @@ def distance_statistics(A, B, box=None):
     -------
     dict
         Dictionary containing:
-        
+
         - 'min' : float
             Minimum distance
         - 'max' : float
@@ -288,11 +288,11 @@ def distance_statistics(A, B, box=None):
     .. versionadded:: 2.8.0
     """
     distances = distance_array(A.positions, B.positions, box=box)
-    
+
     return {
-        'min': float(np.min(distances)),
-        'max': float(np.max(distances)),
-        'mean': float(np.mean(distances)),
-        'std': float(np.std(distances)),
-        'n_distances': distances.size
+        "min": float(np.min(distances)),
+        "max": float(np.max(distances)),
+        "mean": float(np.mean(distances)),
+        "std": float(np.std(distances)),
+        "n_distances": distances.size,
     }

--- a/testsuite/MDAnalysisTests/analysis/test_distances.py
+++ b/testsuite/MDAnalysisTests/analysis/test_distances.py
@@ -247,3 +247,114 @@ class TestBetween(object):
         returns an AtomGroup even when the returned group is empty."""
         actual = MDAnalysis.analysis.distances.between(group, ag, ag2, dists)
         assert isinstance(actual, MDAnalysis.core.groups.AtomGroup)
+
+class TestMinDistance(object):
+    @staticmethod
+    @pytest.fixture()
+    def u():
+        return MDAnalysis.Universe(GRO)
+
+    @staticmethod
+    @pytest.fixture()
+    def ag(u):
+        return u.atoms[:10]
+
+    @staticmethod
+    @pytest.fixture()
+    def ag2(u):
+        return u.atoms[12:33]
+
+    @staticmethod
+    @pytest.fixture()
+    def box():
+        return np.array([8, 8, 8, 90, 90, 90], dtype=np.float32)
+
+    @pytest.fixture()
+    def expected(self, ag, ag2):
+        distance_matrix = scipy.spatial.distance.cdist(ag.positions, ag2.positions)
+        return np.min(distance_matrix)
+
+    def test_min_distance_simple_case(self, ag, ag2, expected):
+        """Test MDAnalysis.analysis.distances.min_distance() for
+        a simple input case. Checks returned minimum distance
+        against expected value."""
+        actual = MDAnalysis.analysis.distances.min_distance(ag, ag2)
+        assert_allclose(actual, expected)
+
+    def test_min_distance_return_type(self, ag, ag2):
+        """Test that MDAnalysis.analysis.distances.min_distance()
+        returns a float."""
+        actual = MDAnalysis.analysis.distances.min_distance(ag, ag2)
+        assert isinstance(actual, float)
+
+    def test_min_distance_box(self, ag, ag2, box):
+        """Test that MDAnalysis.analysis.distances.min_distance()
+        correctly accounts for periodic boundary conditions."""
+        actual = MDAnalysis.analysis.distances.min_distance(ag, ag2, box=box)
+        assert isinstance(actual, float)
+        assert actual >= 0.0
+
+    def test_min_distance_identical_groups(self, ag):
+        """Test that min_distance() returns 0 when the two AtomGroups are identical."""
+        actual = MDAnalysis.analysis.distances.min_distance(ag, ag)
+        assert_allclose(actual, 0.0)
+
+    def test_min_distance_single_atom_groups(self, u):
+        """Test that min_distance() returns the correct distance when both AtomGroups contain a single atom."""
+        ag1 = u.atoms[0:1]
+        ag2 = u.atoms[1:2]
+        expected = np.linalg.norm(ag1.positions - ag2.positions)
+        actual = MDAnalysis.analysis.distances.min_distance(ag1, ag2)
+        assert_allclose(actual, expected)
+
+class TestDistanceStatistics(object):
+    @staticmethod
+    @pytest.fixture()
+    def u():
+        return MDAnalysis.Universe(GRO)
+
+    @staticmethod
+    @pytest.fixture()
+    def ag(u):
+        return u.atoms[:10]
+
+    @staticmethod
+    @pytest.fixture()
+    def ag2(u):
+        return u.atoms[12:33]
+
+    @staticmethod
+    @pytest.fixture()
+    def box():
+        return np.array([8, 8, 8, 90, 90, 90], dtype=np.float32)
+
+    @pytest.fixture()
+    def expected(self, ag, ag2):
+        distance_matrix = scipy.spatial.distance.cdist(ag.positions, ag2.positions)
+        return {
+            'min': np.min(distance_matrix),
+            'max': np.max(distance_matrix),
+            'mean': np.mean(distance_matrix),
+            'std': np.std(distance_matrix)
+        }
+
+    def test_distance_statistics_simple_case(self, ag, ag2, expected):
+        """Test MDAnalysis.analysis.distances.distance_statistics() for
+        a simple input case. Checks returned distance statistics
+        against expected values."""
+        actual = MDAnalysis.analysis.distances.distance_statistics(ag, ag2)
+        for key in expected:
+            assert_allclose(actual[key], expected[key])
+
+    def test_distance_statistics_return_type(self, ag, ag2):
+        """Test that MDAnalysis.analysis.distances.distance_statistics()
+        returns a dictionary."""
+        actual = MDAnalysis.analysis.distances.distance_statistics(ag, ag2)
+        assert isinstance(actual, dict)
+
+    def test_distance_statistics_box(self, ag, ag2, box):
+        """Test that MDAnalysis.analysis.distances.distance_statistics()
+        works correctly when a box is provided."""
+        actual = MDAnalysis.analysis.distances.distance_statistics(ag, ag2, box=box)
+        assert isinstance(actual, dict)
+        assert all(key in actual for key in ['min', 'max', 'mean', 'std'])


### PR DESCRIPTION
## Distance analysis

Changes made in this Pull Request:
- Added `min_distance(A, B, box=None)` as a convenience function to compute the minimum pairwise distance between two AtomGroups using existing MDAnalysis distance utilities.
- Added `distance_statistics(A, B, box=None)` to compute basic summary statistics (min, max, mean, std, number of distances) over all pairwise distances between two AtomGroups.
- Reused `MDAnalysis.lib.distances.distance_array` to ensure consistency with existing distance calculations and periodic boundary condition handling.
- Added unit tests validating numerical correctness, return types, identical groups, single-atom groups, and basic PBC behavior.

## LLM / AI generated code disclosure
LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution: **yes**

## PR Checklist
- [ ] Issue raised/referenced?
- [x] Tests updated/added
- [x] Documentation updated/added
- [ ] `package/CHANGELOG` file updated
- [x] Is your name in `package/AUTHORS`? (If it is not, add it!)
- [x] LLM/AI disclosure was updated

## Developers Certificate of Origin

I certify that I can submit this code contribution as described in the
[**Developer Certificate of Origin**](https://developercertificate.org/),
under the MDAnalysis
[LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--5229.org.readthedocs.build/en/5229/

<!-- readthedocs-preview mdanalysis end -->