### PR TITLE
Add CC-BY-4.0 license to the AI policy

### DIFF
--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,7 +1,7 @@
 # 🤖 MDAnalysis AI-generated contributions policy 🤖
 
 ### Version: 1.0 (2026-02-03)
-### License: CC-BY-4.0
+### License: [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/)
 
 This document defines the [MDAnalysis organization's](https://github.com/MDAnalysis/) policy regarding AI-generated content. This policy applies to all aspects of the MDAnalysis project, including all the GitHub repositories under the organization.
 

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,6 +1,7 @@
 # 🤖 MDAnalysis AI-generated contributions policy 🤖
 
 ### Version: 1.0 (2026-02-03)
+### License: CC-BY-4.0
 
 This document defines the [MDAnalysis organization's](https://github.com/MDAnalysis/) policy regarding AI-generated content. This policy applies to all aspects of the MDAnalysis project, including all the GitHub repositories under the organization.
 


### PR DESCRIPTION
I would like to propose that the AI policy is placed under CC-BY-4.0. It would be useful for downstream projects.

### LLM/AI disclosure

No AI was used here.

## PR Checklist
<!-- Please use the following checklist to ensure the PR is ready to be reviewed/merged. -->
 - [ ] Issue raised/referenced?
 - [ ] Tests updated/added?
 - [ ] Documentation updated/added?
 - [ ] `package/CHANGELOG` file updated?
 - [ ] Is your name in `package/AUTHORS`? (If it is not, add it!)
 - [x] LLM/AI disclosure was updated.

## Developers Certificate of Origin
<!-- 
In order for this PR to be merged you **must certify that you are able to submit your code to be included in MDAnalysis**.
-->

I certify that I can submit this code contribution as described in the [**Developer Certificate of Origin**](https://developercertificate.org/), under the MDAnalysis [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--5232.org.readthedocs.build/en/5232/

<!-- readthedocs-preview mdanalysis end -->