### PR TITLE
Add backends support for minimize_vectors

### DIFF
--- a/benchmarks/benchmarks/lib/distances.py
+++ b/benchmarks/benchmarks/lib/distances.py
@@ -39,5 +39,5 @@ class DistancesMinimizeVectorsBench(object):
         vectors = self.coords_1 - self.coords_2
         try:
             distances.minimize_vectors(vectors, self.box, backend=backend)
-        except TypeError:
+        except (TypeError, ValueError):
             raise SkipNotImplemented("minimize_vectors is skipped")

--- a/benchmarks/benchmarks/lib/distances.py
+++ b/benchmarks/benchmarks/lib/distances.py
@@ -1,0 +1,43 @@
+from asv_runner.benchmarks.mark import SkipNotImplemented
+import numpy as np
+
+try:
+    from MDAnalysis.lib import distances, mdamath
+except ImportError:
+    pass
+
+
+class DistancesMinimizeVectorsBench(object):
+    """Benchmarks for MDAnalysis.lib.distances.minimize_vectors
+    function.
+    """
+
+    params = (
+        [10, 100, 1000, 10000, 100000, 1000000],
+        ["ortho", "triclinic"],
+        ["serial", "openmp", "distopia"],
+    )
+    param_names = ["num_atoms", "box", "backend"]
+
+    def setup(self, num_atoms, box, backend):
+        np.random.seed(17809)
+        self.coords_1 = np.random.random_sample((num_atoms, 3)).astype(np.float32)
+        np.random.seed(9008716)
+        self.coords_2 = np.random.random_sample((num_atoms, 3)).astype(np.float32)
+        if box == "ortho":
+            box = np.eye(3) * 10
+        elif box == "triclinic":
+            box = np.array([[10, 0, 0], [2, 10, 0], [2, 2, 10]])
+        else:
+            raise ValueError(f"box needs to be ortho or triclinic, passed {box}")
+        self.box = mdamath.triclinic_box(*box)
+
+    def time_minimize_vectors(self, num_atoms, box, backend):
+        """Benchmark calculation of minimized vectors
+        based on the unitcell dimensions box.
+        """
+        vectors = self.coords_1 - self.coords_2
+        try:
+            distances.minimize_vectors(vectors, self.box, backend=backend)
+        except TypeError:
+            raise SkipNotImplemented("minimize_vectors is skipped")

--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -271,6 +271,7 @@ Chronological list of authors
   - Mohammad Ayaan
   - Khushi Phougat
   - Kushagar Garg
+  - Pardhav Maradani
 
 External code
 -------------

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -15,7 +15,7 @@ The rules for this file:
 
 -------------------------------------------------------------------------------
 ??/??/?? IAlibay, orbeckst, marinegor, tylerjereddy, ljwoods2, marinegor,
-         spyke7, talagayev, tanii1125, BradyAJohnston
+         spyke7, talagayev, tanii1125, BradyAJohnston, PardhavMaradani
 
  * 2.11.0
 
@@ -37,6 +37,7 @@ Fixes
    DSSP by porting upstream PyDSSP 0.9.1 fix (Issue #4913)
 
 Enhancements
+ * Adds support for backend options in `minimize_vectors` (Issue #5234, PR #5235)
  * Adds support for parsing `.tpr` files produced by GROMACS 2026.0
  * Enables parallelization for analysis.diffusionmap.DistanceMatrix
    (Issue #4679, PR #4745)

--- a/package/MANIFEST.in
+++ b/package/MANIFEST.in
@@ -2,6 +2,7 @@ global-include *.pyx
 global-include *.pxd
 global-include *.c
 global-include *.h
+global-include *.hpp
 global-include *.cpp
 include MDAnalysis/lib/src/transformations/*
 recursive-include doc * 

--- a/package/MDAnalysis/lib/_distopia.py
+++ b/package/MDAnalysis/lib/_distopia.py
@@ -190,3 +190,15 @@ def calc_self_distance_array_triclinic(
     coords: np.ndarray, box: np.ndarray, results: np.ndarray
 ) -> None:
     distopia.self_distance_array_triclinic(coords, box, results=results)
+
+
+def calc_minimize_vectors_ortho(
+    vectors: np.ndarray, box: np.ndarray, output: np.ndarray
+) -> None:
+    distopia.minimize_vectors_ortho(vectors, box[:3], output)
+
+
+def calc_minimize_vectors_triclinic(
+    vectors: np.ndarray, box: np.ndarray, output: np.ndarray
+) -> None:
+    distopia.minimize_vectors_triclinic(vectors, box, output)

--- a/package/MDAnalysis/lib/c_distances.pxd
+++ b/package/MDAnalysis/lib/c_distances.pxd
@@ -1,4 +1,3 @@
-# distutils: language = c++
 from libc.stdint cimport uint64_t, UINT64_MAX
 
 

--- a/package/MDAnalysis/lib/c_distances.pxd
+++ b/package/MDAnalysis/lib/c_distances.pxd
@@ -1,3 +1,4 @@
+# distutils: language = c++
 from libc.stdint cimport uint64_t, UINT64_MAX
 
 
@@ -27,3 +28,7 @@ cdef extern from "calc_distances.h":
     void _triclinic_pbc(coordinate* coords, uint64_t numcoords, float* box)
     void minimum_image(double* x, float* box, float* inverse_box)
     void minimum_image_triclinic(float* x, float* box, float* inverse_box)
+
+cdef extern from "calc_distances.hpp":
+    void _calc_minimize_vectors_ortho[T](T* vectors, uint64_t numvectors, T* box, T* output)
+    void _calc_minimize_vectors_triclinic[T](T* vectors, uint64_t numvectors, T* box, T* output)

--- a/package/MDAnalysis/lib/c_distances.pyx
+++ b/package/MDAnalysis/lib/c_distances.pyx
@@ -33,6 +33,7 @@ cimport cython
 from libc.stdint cimport uint64_t, UINT64_MAX
 import numpy
 cimport numpy
+from cython cimport floating
 numpy.import_array()
 
 from libc.math cimport round as cround
@@ -272,143 +273,19 @@ def contact_matrix_pbc(coord, sparse_contacts, box, cutoff):
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef inline void _minimum_image_orthogonal(cython.floating[:] dx,
-                                           cython.floating[:] box,
-                                           cython.floating[:] inverse_box) nogil:
-    """Minimize dx to be the shortest vector
-
-    Parameters
-    ----------
-    dx : numpy.array, shape (3,)
-      vector to minimize
-    box : numpy.array, shape (3,)
-      box length in each dimension
-    inverse_box : numpy.array, shape (3,)
-      inverse of box
-
-    Operates in-place on dx!
-    """
-    cdef int i
-    cdef cython.floating s
-
-    for i in range(3):
-        if box[i] > 0:
-            s = inverse_box[i] * dx[i]
-            dx[i] = box[i] * (s - cround(s))
+def calc_minimize_vectors_ortho(
+    floating[:, ::1] vectors,
+    floating[::1] box,
+    floating[:, ::1] output) -> None:
+    cdef uint64_t numvectors = vectors.shape[0]
+    _calc_minimize_vectors_ortho(&vectors[0, 0], numvectors, &box[0], &output[0, 0])
 
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef inline void _minimum_image_triclinic(cython.floating[:] dx,
-                                          cython.floating[:] box,
-                                          cython.floating[:] inverse_box) nogil:
-    """Minimise dx to be the shortest vector
-
-    Parameters
-    ----------
-    dx : numpy.array, shape (3,)
-      the vector to apply minimum image convention to
-    box : numpy.array, shape (9,)
-      flattened 3x3 representation of the unit cell
-    inverse_box : numpy.array, shape (3,)
-      inverse of the **diagonal** of the 3x3 representation
-
-    This version is near identical to the version in calc_distances.h, with the
-    difference being that this version does not assume that coordinates are at
-    most a single box length apart.
-
-    Operates in-place on dx!
-    """
-    cdef cython.floating dx_min[3]
-    cdef cython.floating s, dsq, dsq_min, rx
-    cdef cython.floating ry[2]
-    cdef cython.floating rz[3]
-    cdef int ix, iy, iz
-
-    # first make shift only 1 cell in any direction
-    s = cround(inverse_box[2] * dx[2])
-    dx[0] -= s * box[6]
-    dx[1] -= s * box[7]
-    dx[2] -= s * box[8]
-    s = cround(inverse_box[1] * dx[1])
-    dx[0] -= s * box[3]
-    dx[1] -= s * box[4]
-    s = cround(inverse_box[0] * dx[0])
-    dx[0] -= s * box[0]
-
-    if cython.floating is float:
-        dsq_min = FLT_MAX
-    else:
-        dsq_min = DBL_MAX
-    dx_min[0] = 0.0
-    dx_min[1] = 0.0
-    dx_min[2] = 0.0
-
-    # then check all images to see which combination of 1 cell shifts gives the best shift
-    for ix in range(-1, 2):
-        rx = dx[0] + box[0] * ix
-        for iy in range(-1, 2):
-            ry[0] = rx + box[3] * iy
-            ry[1] = dx[1] + box[4] * iy
-            for iz in range(-1, 2):
-                rz[0] = ry[0] + box[6] * iz
-                rz[1] = ry[1] + box[7] * iz
-                rz[2] = dx[2] + box[8] * iz
-                dsq = rz[0] * rz[0] + rz[1] * rz[1] + rz[2] * rz[2]
-                if (dsq < dsq_min):
-                    dsq_min = dsq
-                    dx_min[0] = rz[0]
-                    dx_min[1] = rz[1]
-                    dx_min[2] = rz[2]
-
-    dx[0] = dx_min[0]
-    dx[1] = dx_min[1]
-    dx[2] = dx_min[2]
-
-
-@cython.boundscheck(False)
-@cython.wraparound(False)
-@cython.cdivision(True)
-def _minimize_vectors_ortho(cython.floating[:, :] vectors not None, cython.floating[:] box not None,
-                            cython.floating[:, :] output not None):
-    cdef int i, n
-    cdef cython.floating box_inverse[3]
-    cdef cython.floating[:] box_inverse_view
-
-    box_inverse[0] = 1.0 / box[0]
-    box_inverse[1] = 1.0 / box[1]
-    box_inverse[2] = 1.0 / box[2]
-
-    box_inverse_view = box_inverse
-
-    n = len(vectors)
-    with nogil:
-        for i in range(n):
-            output[i, 0] = vectors[i, 0]
-            output[i, 1] = vectors[i, 1]
-            output[i, 2] = vectors[i, 2]
-            _minimum_image_orthogonal(output[i, :], box, box_inverse_view)
-
-
-@cython.boundscheck(False)
-@cython.wraparound(False)
-def _minimize_vectors_triclinic(cython.floating[:, :] vectors not None, cython.floating[:] box not None,
-                                cython.floating[:, :] output not None):
-    cdef int i, n
-    cdef cython.floating box_inverse[3]
-    cdef cython.floating[:] box_inverse_view
-
-    # this is only inverse of diagonal, used for initial shift to ensure vector is within a single shift away
-    box_inverse[0] = 1.0 / box[0]
-    box_inverse[1] = 1.0 / box[4]
-    box_inverse[2] = 1.0 / box[8]
-
-    box_inverse_view = box_inverse
-
-    n = len(vectors)
-    with nogil:
-        for i in range(n):
-            output[i, 0] = vectors[i, 0]
-            output[i, 1] = vectors[i, 1]
-            output[i, 2] = vectors[i, 2]
-            _minimum_image_triclinic(output[i, :], box, box_inverse_view)
+def calc_minimize_vectors_triclinic(
+    floating[:, ::1] vectors,
+    floating[:, ::1] box,
+    floating[:, ::1] output) -> None:
+    cdef uint64_t numvectors = vectors.shape[0]
+    _calc_minimize_vectors_triclinic(&vectors[0, 0], numvectors, &box[0][0], &output[0, 0])

--- a/package/MDAnalysis/lib/c_distances_openmp.pyx
+++ b/package/MDAnalysis/lib/c_distances_openmp.pyx
@@ -21,7 +21,6 @@
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
 #
-# distutils: language = c++
 
 """
 Parallel distance calculation library --- :mod:`MDAnalysis.lib.c_distances_openmp`

--- a/package/MDAnalysis/lib/c_distances_openmp.pyx
+++ b/package/MDAnalysis/lib/c_distances_openmp.pyx
@@ -21,6 +21,7 @@
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
 #
+# distutils: language = c++
 
 """
 Parallel distance calculation library --- :mod:`MDAnalysis.lib.c_distances_openmp`
@@ -30,9 +31,11 @@ Parallel distance calculation library --- :mod:`MDAnalysis.lib.c_distances_openm
 Contains OpenMP versions of the contents of "calc_distances.h"
 """
 
+cimport cython
 from libc.stdint cimport uint64_t
 import numpy
 cimport numpy
+from cython cimport floating
 numpy.import_array()
 
 cdef extern from "string.h":
@@ -59,6 +62,10 @@ cdef extern from "calc_distances.h":
     void _calc_dihedral_triclinic(coordinate* atom1, coordinate* atom2, coordinate* atom3, coordinate* atom4, uint64_t numatom, float* box, double* angles)
     void _ortho_pbc(coordinate* coords, uint64_t numcoords, float* box)
     void _triclinic_pbc(coordinate* coords, uint64_t numcoords, float* box)
+
+cdef extern from "calc_distances.hpp":
+    void _calc_minimize_vectors_ortho[T](T* vectors, uint64_t numvectors, T* box, T* output)
+    void _calc_minimize_vectors_triclinic[T](T* vectors, uint64_t numvectors, T* box, T* output)
 
 
 OPENMP_ENABLED = True if USED_OPENMP else False
@@ -241,3 +248,23 @@ def triclinic_pbc(numpy.ndarray coords, numpy.ndarray box):
     numcoords = coords.shape[0]
 
     _triclinic_pbc(<coordinate*> coords.data, numcoords, <float*> box.data)
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def calc_minimize_vectors_ortho(
+    floating[:, ::1] vectors,
+    floating[::1] box,
+    floating[:, ::1] output):
+    cdef uint64_t numvectors = vectors.shape[0]
+    _calc_minimize_vectors_ortho(&vectors[0, 0], numvectors, &box[0], &output[0, 0])
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def calc_minimize_vectors_triclinic(
+    floating[:, ::1] vectors,
+    floating[:, ::1] box,
+    floating[:, ::1] output):
+    cdef uint64_t numvectors = vectors.shape[0]
+    _calc_minimize_vectors_triclinic(&vectors[0, 0], numvectors, &box[0][0], &output[0, 0])

--- a/package/MDAnalysis/lib/distances.py
+++ b/package/MDAnalysis/lib/distances.py
@@ -151,7 +151,10 @@ from .util import check_coords, check_box
 from .mdamath import triclinic_vectors
 from ._augment import augment_coordinates, undo_augment
 from .nsgrid import FastNS
-from .c_distances import _minimize_vectors_ortho, _minimize_vectors_triclinic
+from .c_distances import (
+    calc_minimize_vectors_ortho,
+    calc_minimize_vectors_triclinic,
+)
 from ._distopia import HAS_DISTOPIA
 
 
@@ -2103,7 +2106,11 @@ def apply_PBC(
 
 
 @check_coords("vectors", enforce_copy=False, enforce_dtype=False)
-def minimize_vectors(vectors: npt.NDArray, box: npt.NDArray) -> npt.NDArray:
+def minimize_vectors(
+    vectors: npt.NDArray,
+    box: npt.NDArray,
+    backend: str = "serial",
+) -> npt.NDArray:
     """Apply minimum image convention to an array of vectors
 
     This function is required for calculating the correct vectors between two
@@ -2121,6 +2128,8 @@ def minimize_vectors(vectors: npt.NDArray, box: npt.NDArray) -> npt.NDArray:
         triclinic and must be provided in the same format as returned by
         :attr:`MDAnalysis.coordinates.timestep.Timestep.dimensions`:
         ``[lx, ly, lz, alpha, beta, gamma]``.
+    backend : {'serial', 'OpenMP'}, optional
+        Keyword selecting the type of acceleration.
 
     Returns
     -------
@@ -2130,6 +2139,8 @@ def minimize_vectors(vectors: npt.NDArray, box: npt.NDArray) -> npt.NDArray:
 
 
     .. versionadded:: 2.1.0
+    .. versionchanged:: 2.11.0
+       Added *backend* keyword.
     """
     boxtype, box = check_box(box)
     output = np.empty_like(vectors)
@@ -2138,8 +2149,16 @@ def minimize_vectors(vectors: npt.NDArray, box: npt.NDArray) -> npt.NDArray:
     box = box.astype(vectors.dtype)
 
     if boxtype == "ortho":
-        _minimize_vectors_ortho(vectors, box, output)
+        _run(
+            "calc_minimize_vectors_ortho",
+            args=(vectors, box, output),
+            backend=backend,
+        )
     else:
-        _minimize_vectors_triclinic(vectors, box.ravel(), output)
+        _run(
+            "calc_minimize_vectors_triclinic",
+            args=(vectors, box, output),
+            backend=backend,
+        )
 
     return output

--- a/package/MDAnalysis/lib/include/calc_distances.hpp
+++ b/package/MDAnalysis/lib/include/calc_distances.hpp
@@ -1,0 +1,149 @@
+/*
+ MDAnalysis --- https://www.mdanalysis.org
+ Copyright (c) 2006-2017 The MDAnalysis Development Team and contributors
+ (see the file AUTHORS for the full list of names)
+
+ Released under the Lesser GNU Public Licence, v2.1 or any higher version
+
+ Please cite your use of MDAnalysis in published work:
+
+ R. J. Gowers, M. Linke, J. Barnoud, T. J. E. Reddy, M. N. Melo, S. L. Seyler,
+ D. L. Dotson, J. Domanski, S. Buchoux, I. M. Kenney, and O. Beckstein.
+ MDAnalysis: A Python package for the rapid analysis of molecular dynamics
+ simulations. In S. Benthall and S. Rostrup editors, Proceedings of the 15th
+ Python in Science Conference, pages 102-109, Austin, TX, 2016. SciPy.
+ doi: 10.25080/majora-629e541a-00e
+
+ N. Michaud-Agrawal, E. J. Denning, T. B. Woolf, and O. Beckstein.
+ MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
+ J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
+*/
+
+#ifndef __DISTANCES_HPP__
+#define __DISTANCES_HPP__
+
+#include <limits>
+
+template <typename T>
+void _minimize_vectors_ortho(T* dx, T* box, T* inverse_box)
+{
+  /*
+    Minimise dx to be the shortest vector
+    Operates in-place on dx!
+
+    This version is near identical to minimum_image, with the
+    difference being that this version uses templatized types.
+  */
+  int i;
+  T s;
+  T eps = std::numeric_limits<T>::epsilon();
+  for (i=0; i<3; i++) {
+    if (box[i] > eps) {
+      s = inverse_box[i] * dx[i];
+      dx[i] = box[i] * (s - round(s));
+    }
+  }
+}
+
+template <typename T>
+static void _calc_minimize_vectors_ortho(T* vectors, uint64_t numvectors, T* box, T* output)
+{
+  T inverse_box[3];
+  inverse_box[0] = 1.0 / box[0];
+  inverse_box[1] = 1.0 / box[1];
+  inverse_box[2] = 1.0 / box[2];
+
+#ifdef PARALLEL
+#pragma omp parallel for shared(vectors)
+#endif
+  for (uint64_t i = 0; i < numvectors; i++) {
+    T dx[3];
+    dx[0] = vectors[i * 3];
+    dx[1] = vectors[i * 3 + 1];
+    dx[2] = vectors[i * 3 + 2];
+    _minimize_vectors_ortho(dx, box, inverse_box);
+    output[i * 3] = dx[0];
+    output[i * 3 + 1] = dx[1];
+    output[i * 3 + 2] = dx[2];
+  }
+}
+
+template <typename T>
+void _minimize_vectors_triclinic(T* dx, T* box, T* inverse_box)
+{
+  /*
+    Minimise dx to be the shortest vector
+    Operates in-place on dx!
+
+    This version is near identical to minimum_image_triclinic, with the
+    difference being that this version does not assume that coordinates are at
+    most a single box length apart and uses templatized types.
+  */
+  T dx_min[3] = {0.0, 0.0, 0.0};
+  T s;
+  T dsq;
+  T dsq_min = DBL_MAX;
+  T rx;
+  T ry[2];
+  T rz[3];
+  int ix, iy, iz;
+
+  // Shift into primary unit cell
+  s = round(inverse_box[2] * dx[2]);
+  dx[0] -= s * box[6];
+  dx[1] -= s * box[7];
+  dx[2] -= s * box[8];
+  s = round(inverse_box[1] * dx[1]);
+  dx[0] -= s * box[3];
+  dx[1] -= s * box[4];
+  s = round(inverse_box[0] * dx[0]);
+  dx[0] -= s * box[0];
+
+  for (ix = -1; ix < 2; ++ix) {
+    rx = dx[0] + box[0] * ix;
+    for (iy = -1; iy < 2; ++iy) {
+      ry[0] = rx + box[3] * iy;
+      ry[1] = dx[1] + box[4] * iy;
+      for (iz = -1; iz < 2; ++iz) {
+        rz[0] = ry[0] + box[6] * iz;
+        rz[1] = ry[1] + box[7] * iz;
+        rz[2] = dx[2] + box[8] * iz;
+        dsq = rz[0] * rz[0] + rz[1] * rz[1] + rz[2] * rz[2];
+        if (dsq < dsq_min) {
+            dsq_min = dsq;
+            dx_min[0] = rz[0];
+            dx_min[1] = rz[1];
+            dx_min[2] = rz[2];
+        }
+      }
+    }
+  }
+  dx[0] = dx_min[0];
+  dx[1] = dx_min[1];
+  dx[2] = dx_min[2];
+}
+
+template <typename T>
+static void _calc_minimize_vectors_triclinic(T* vectors, uint64_t numvectors, T* box, T* output)
+{
+  T inverse_box[3];
+  inverse_box[0] = 1.0 / box[0];
+  inverse_box[1] = 1.0 / box[4];
+  inverse_box[2] = 1.0 / box[8];
+
+#ifdef PARALLEL
+#pragma omp parallel for shared(vectors)
+#endif
+  for (uint64_t i = 0; i < numvectors; i++) {
+    T dx[3];
+    dx[0] = vectors[i * 3];
+    dx[1] = vectors[i * 3 + 1];
+    dx[2] = vectors[i * 3 + 2];
+    _minimize_vectors_triclinic(dx, box, inverse_box);
+    output[i * 3] = dx[0];
+    output[i * 3 + 1] = dx[1];
+    output[i * 3 + 2] = dx[2];
+  }
+}
+
+#endif

--- a/package/setup.py
+++ b/package/setup.py
@@ -366,10 +366,12 @@ def extensions(config):
     distances = MDAExtension(
         "MDAnalysis.lib.c_distances",
         ["MDAnalysis/lib/c_distances" + source_suffix],
+        language="c++",
         include_dirs=include_dirs + ["MDAnalysis/lib/include"],
         libraries=mathlib,
         define_macros=define_macros,
-        extra_compile_args=extra_compile_args,
+        extra_compile_args=cpp_extra_compile_args,
+        extra_link_args=cpp_extra_link_args,
     )
     distances_omp = MDAExtension(
         "MDAnalysis.lib.c_distances_openmp",

--- a/package/setup.py
+++ b/package/setup.py
@@ -365,7 +365,7 @@ def extensions(config):
     )
     distances = MDAExtension(
         "MDAnalysis.lib.c_distances",
-        ["MDAnalysis/lib/c_distances" + source_suffix],
+        ["MDAnalysis/lib/c_distances" + cpp_source_suffix],
         language="c++",
         include_dirs=include_dirs + ["MDAnalysis/lib/include"],
         libraries=mathlib,
@@ -375,7 +375,7 @@ def extensions(config):
     )
     distances_omp = MDAExtension(
         "MDAnalysis.lib.c_distances_openmp",
-        ["MDAnalysis/lib/c_distances_openmp" + source_suffix],
+        ["MDAnalysis/lib/c_distances_openmp" + cpp_source_suffix],
         language="c++",
         include_dirs=include_dirs + ["MDAnalysis/lib/include"],
         libraries=mathlib + parallel_libraries,

--- a/package/setup.py
+++ b/package/setup.py
@@ -376,11 +376,12 @@ def extensions(config):
     distances_omp = MDAExtension(
         "MDAnalysis.lib.c_distances_openmp",
         ["MDAnalysis/lib/c_distances_openmp" + source_suffix],
+        language="c++",
         include_dirs=include_dirs + ["MDAnalysis/lib/include"],
         libraries=mathlib + parallel_libraries,
         define_macros=define_macros + parallel_macros,
-        extra_compile_args=parallel_args + extra_compile_args,
-        extra_link_args=parallel_args,
+        extra_compile_args=parallel_args + cpp_extra_compile_args,
+        extra_link_args=parallel_args + cpp_extra_link_args,
     )
     qcprot = MDAExtension(
         "MDAnalysis.lib.qcprot",

--- a/testsuite/MDAnalysisTests/lib/test_distances.py
+++ b/testsuite/MDAnalysisTests/lib/test_distances.py
@@ -2486,7 +2486,7 @@ def test_minimize_vectors(box, shift, dtype, backend):
 
     box2 = mdamath.triclinic_box(*box).astype(dtype)
 
-    res = distances.minimize_vectors(shifted_vec, box2)
+    res = distances.minimize_vectors(shifted_vec, box2, backend=backend)
 
     assert_allclose(res, vec, atol=0.00001)
     assert res.dtype == dtype

--- a/testsuite/MDAnalysisTests/lib/test_distances.py
+++ b/testsuite/MDAnalysisTests/lib/test_distances.py
@@ -2468,7 +2468,9 @@ def test_used_openmpflag():
     "shift", itertools.product(range(-2, 3), range(-2, 3), range(-2, 3))
 )
 @pytest.mark.parametrize("dtype", (np.float32, np.float64))
-def test_minimize_vectors(box, shift, dtype):
+@pytest.mark.parametrize("backend", ("serial", "openmp"))
+# @pytest.mark.parametrize("backend", distopia_conditional_backend())
+def test_minimize_vectors(box, shift, dtype, backend):
     # test vectors pointing in all directions
     # these currently all obey minimum convention as they're much smaller than the box
     vec = np.array(


### PR DESCRIPTION
<!-- 
Insert issue number that this PR fixes (if any) just after 'Fixes #'.
If this PR does not fix an existing issue, consider opening one or remove 'Fixes #' from the PR description.
-->
This is one of two PRs needed for #5234

Changes made in this Pull Request:
<!-- Describe the changes that this PR makes. If applicable, use the following bullet list. --> 

This PR moves the current `cython` implementation to `c++` to support `openmp` (and have template support). Support for invoking the corresponding `distopia` methods (when supported in `distopia`) is also added.

There is already a considerable speedup moving away from `cython` (for default `serial`) and this gets better with `openmp` and `distopia` backends.

The [YiiP equilibrium dataset](https://www.mdanalysis.org/MDAnalysisData/yiip_equilibrium.html) is used for these performance tests. This trajectory has around 111k atoms/coordinates. The coordinates are duplicated by a multiple (1 - 10, using `np.tile`) to calculate times.

Here is an example of the `timeit` call:

```py
import MDAnalysis as mda
from MDAnalysisData import yiip_equilibrium
from MDAnalysis.lib.distances import check_box, minimize_vectors
import timeit

data = yiip_equilibrium.fetch_yiip_equilibrium_short()

u = mda.Universe(data["topology"], data["trajectory"])

ts = u.trajectory[0]
box = ts.dimensions
coords = ts.positions
boxtype, tric_vecs = check_box(box)
center = tric_vecs.sum(axis=0) * 0.5

backend = "serial"
secs = timeit.timeit(lambda: minimize_vectors(coords - center, box, backend=backend) + center, number=100)
```

Here are the results with current `cython` version and with the new backends support as part of this PR:

<img width="1137" height="703" alt="minimize_vectors" src="https://github.com/user-attachments/assets/e4327f65-8133-43a0-bb01-0ed5bbf2a2da" />

`minimize_vectors` can also be used to achieve `compact` wrapping support for visualization. Here are two methods as on-the-fly transformations for this.

The first is from PR #2982, with minor modifications to make it a transformation that can be applied at runtime:

<details>
<summary>Compact wrapping with distance_array</summary>

```py
# Compact PBC wrapping transformation
# From: https://github.com/MDAnalysis/mdanalysis/pull/2982
def compact_w_distance_array(ts):
    backend = "serial"
    box = ts.dimensions
    coords = ts.positions
    boxtype, tric_vecs = check_box(box)
    pbc_img_coeffs = np.array(list(itertools.product([0, -1, 1], repeat=3)))
    pbc_img_vecs = np.matmul(pbc_img_coeffs, tric_vecs)
    min_compact_norm = np.linalg.norm(pbc_img_vecs[1:], axis=1).min() * 0.5
    center = tric_vecs.sum(axis=0) * 0.5
    pbc_imgs = pbc_img_vecs + center
    # Also improvable as distance^2
    center_dists = distance_array(center, coords)[0]
    outside_ats = np.where(center_dists > min_compact_norm)[0]
    # Let's make sure we're dealing with everyone in the primary cell
    outside_pos = coords[outside_ats] = apply_PBC(
        coords[outside_ats], box
    )
    # Potentially save cycles by re-filtering after PBC. It makes sense for
    # GROMACS trajectories, that are saved as the rectangular cell.
    center_dists = distance_array(center, outside_pos)[0]
    outside_ats = outside_ats[center_dists > min_compact_norm]
    outside_pos = coords[outside_ats]
    # This works for the general case by checking the distance to all 27
    # unit cell centers (primary + 1st neighbors). Will break for extremely
    # skewed cases where the closest center is in a 2nd neighbor unit cell.
    # The distance check to all 26 1st neighbors can also probably be
    # optimized, both in general and with boxtype-specific shortcuts.
    # Also improvable as distance^2
    closest_img_ndx = distance_array(outside_pos, pbc_imgs, backend=backend).argmin(axis=1)
    to_move = closest_img_ndx.nonzero()[0]
    closest_img_ndx = closest_img_ndx[to_move]
    outside_ats = outside_ats[to_move]
    outside_pos = coords[outside_ats] - pbc_img_vecs[closest_img_ndx]
    coords[outside_ats] = outside_pos
    return ts
```

</details>

Here is a version using `minimize_vectors`:

<details>
<summary>Compact wrapping with minimize_vectors</summary>

```py
def compact_w_minimize_vectors(ts):
    backend = "serial"
    box = ts.dimensions
    coords = ts.positions
    boxtype, tric_vecs = check_box(box)
    pbc_img_coeffs = np.array(list(itertools.product([0, -1, 1], repeat=3)))
    pbc_img_vecs = np.matmul(pbc_img_coeffs, tric_vecs)
    min_compact_norm = np.linalg.norm(pbc_img_vecs[1:], axis=1).min() * 0.5
    center = tric_vecs.sum(axis=0) * 0.5
    center_dists = distance_array(center, coords)[0]
    outside_ats = np.where(center_dists > min_compact_norm)[0]
    coords[outside_ats] = minimize_vectors(coords[outside_ats] - center, box, backend=backend) + center
    return ts
```

</details>

Here is a performance comparison of the above transformations (with slight changes to allow different backends and a multiple of the coordinates):

<img width="1137" height="703" alt="compact - distance_array (da) vs minimize_vectors (mv)" src="https://github.com/user-attachments/assets/bcb4c18a-d389-4cf6-81c5-c76ec8122d65" />

The tests currently use only the `serial` and `openmp` backends as `distopia` support doesn't exist yet. The above performance tests used a modified version of `distopia` that has this support (I will create a separate PR in [distopia](https://github.com/MDAnalysis/distopia) for that).


## LLM / AI generated code disclosure
<!-- Please update this disclosure to reflect if you did or did not use LLMs / AI to generate code -->
LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution: no

## PR Checklist
<!-- Please use the following checklist to ensure the PR is ready to be reviewed/merged. -->
 - [x] Issue raised/referenced?
 - [x] Tests updated/added?
 - [x] Documentation updated/added?
 - [x] `package/CHANGELOG` file updated?
 - [x] Is your name in `package/AUTHORS`? (If it is not, add it!)
 - [x] LLM/AI disclosure was updated.

## Developers Certificate of Origin
<!-- 
In order for this PR to be merged you **must certify that you are able to submit your code to be included in MDAnalysis**.
-->

I certify that I can submit this code contribution as described in the [**Developer Certificate of Origin**](https://developercertificate.org/), under the MDAnalysis [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--5235.org.readthedocs.build/en/5235/

<!-- readthedocs-preview mdanalysis end -->