### PR TITLE
Drop/Replace lock file test in test_xdr

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -271,6 +271,7 @@ Chronological list of authors
   - Mohammad Ayaan
   - Khushi Phougat
   - Kushagar Garg
+  - Jeremy M. G. Leung
 
 External code
 -------------

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -20,6 +20,7 @@ The rules for this file:
  * 2.11.0
 
 Fixes
+ * Drop/Replace lock file test in test_xdr (Issue #5236, PR #5237)
  * HydrogenBondAnalysis: Fixed `count_by_time()` when using `run(FrameIterator)` that
    results in `self.start` and `self.end` being None (Issue #5200, PR #5202)
  * NoJump shows a more informative message and fails  when applied
@@ -35,7 +36,6 @@ Fixes
    to version 5.1.0 (Issue #5145, PR #5146)
  * Fixes incorrect assignment of secondary structure to proline residues in
    DSSP by porting upstream PyDSSP 0.9.1 fix (Issue #4913)
- * Drop/Replace lock file test in test_xdr (Issue #5236, PR #5237)
 
 Enhancements
  * Improved performance of `AtomGroup.wrap()` with compounds (PR #5220)

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -15,7 +15,7 @@ The rules for this file:
 
 -------------------------------------------------------------------------------
 ??/??/?? IAlibay, orbeckst, marinegor, tylerjereddy, ljwoods2, marinegor,
-         spyke7, talagayev, tanii1125, BradyAJohnston
+         spyke7, talagayev, tanii1125, BradyAJohnston, jeremyleung521
 
  * 2.11.0
 
@@ -35,6 +35,7 @@ Fixes
    to version 5.1.0 (Issue #5145, PR #5146)
  * Fixes incorrect assignment of secondary structure to proline residues in
    DSSP by porting upstream PyDSSP 0.9.1 fix (Issue #4913)
+ * Drop/Replace lock file test in test_xdr (Issue #5236, PR #5237)
 
 Enhancements
  * Adds support for parsing `.tpr` files produced by GROMACS 2026.0

--- a/testsuite/MDAnalysisTests/coordinates/test_xdr.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_xdr.py
@@ -27,6 +27,7 @@ import re
 import os
 import shutil
 import sys
+from filelock import FileLock
 from pathlib import Path
 
 import numpy as np
@@ -59,7 +60,6 @@ from MDAnalysisTests.coordinates.base import (
 import MDAnalysis as mda
 from MDAnalysis.coordinates import XDR
 from MDAnalysisTests.util import get_userid
-from filelock import FileLock
 
 
 @pytest.mark.parametrize(

--- a/testsuite/MDAnalysisTests/coordinates/test_xdr.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_xdr.py
@@ -25,10 +25,7 @@ from unittest.mock import patch
 
 import re
 import os
-import sys
 import shutil
-import subprocess
-import time
 from pathlib import Path
 
 import numpy as np
@@ -59,7 +56,6 @@ from MDAnalysisTests.coordinates.base import (
 )
 
 import MDAnalysis as mda
-from MDAnalysis.coordinates.base import Timestep
 from MDAnalysis.coordinates import XDR
 from MDAnalysisTests.util import get_userid
 from filelock import FileLock
@@ -320,7 +316,7 @@ class TestXTCReaderClass(object):
             with XTCReader(XTC) as trj:
                 N = trj.n_frames
                 frames = [ts.frame for ts in trj]
-        except:
+        except Exception:
             raise AssertionError("with_statement not working for XTCReader")
         assert_equal(
             N,
@@ -1050,6 +1046,19 @@ class _GromacsReader_offsets(object):
             os.path.exists(XDR.offsets_filename(filename, ending=".lock")),
             False,
         )
+
+    def test_offset_lock_created(self):
+        lock_file_path = XDR.offsets_filename(self.filename, ending="lock")
+
+        with FileLock(lock_file_path) as lock:
+            # Lock acquired in context manager, so lock file should exist
+            assert lock.is_locked
+            assert os.path.exists(lock_file_path)
+
+            # Explicitly release lock, file should be deleted
+            lock.release()
+            assert not lock.is_locked
+            assert not os.path.exists(lock_file_path)
 
 
 class TestXTCReader_offsets(_GromacsReader_offsets):

--- a/testsuite/MDAnalysisTests/coordinates/test_xdr.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_xdr.py
@@ -26,6 +26,7 @@ from unittest.mock import patch
 import re
 import os
 import shutil
+import sys
 from pathlib import Path
 
 import numpy as np
@@ -1047,6 +1048,7 @@ class _GromacsReader_offsets(object):
             False,
         )
 
+    
     def test_offset_lock_created(self):
         lock_file_path = XDR.offsets_filename(self.filename, ending="lock")
 
@@ -1055,10 +1057,11 @@ class _GromacsReader_offsets(object):
             assert lock.is_locked
             assert os.path.exists(lock_file_path)
 
-            # Explicitly release lock, file should be deleted
+            # Explicitly release lock, file should be deleted on UNIX
             lock.release()
             assert not lock.is_locked
-            assert not os.path.exists(lock_file_path)
+            if not sys.platform.startswith("win"):
+                assert not os.path.exists(lock_file_path)
 
 
 class TestXTCReader_offsets(_GromacsReader_offsets):

--- a/testsuite/MDAnalysisTests/coordinates/test_xdr.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_xdr.py
@@ -1048,7 +1048,6 @@ class _GromacsReader_offsets(object):
             False,
         )
 
-    
     def test_offset_lock_created(self):
         lock_file_path = XDR.offsets_filename(self.filename, ending="lock")
 

--- a/testsuite/MDAnalysisTests/coordinates/test_xdr.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_xdr.py
@@ -1051,13 +1051,6 @@ class _GromacsReader_offsets(object):
             False,
         )
 
-    @pytest.mark.skipif(
-        sys.platform.startswith("win"),
-        reason="The lock file only exists when it's locked in windows",
-    )
-    def test_offset_lock_created(self, traj):
-        assert os.path.exists(XDR.offsets_filename(traj, ending="lock"))
-
 
 class TestXTCReader_offsets(_GromacsReader_offsets):
     __test__ = True

--- a/testsuite/MDAnalysisTests/coordinates/test_xdr.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_xdr.py
@@ -1060,6 +1060,8 @@ class _GromacsReader_offsets(object):
             lock.release()
             assert not lock.is_locked
             if not sys.platform.startswith("win"):
+                # As of filelock>=3.21.0, filelock explicitly deletes lockfile
+                # upon release on UNIX. filelock does not do that on windows.
                 assert not os.path.exists(lock_file_path)
 
 

--- a/testsuite/MDAnalysisTests/coordinates/test_xdr.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_xdr.py
@@ -1044,7 +1044,7 @@ class _GromacsReader_offsets(object):
         assert_equal(os.path.exists(XDR.offsets_filename(filename)), False)
         # check the lock file is not created as well.
         assert_equal(
-            os.path.exists(XDR.offsets_filename(filename, ending=".lock")),
+            os.path.exists(XDR.offsets_filename(filename, ending="lock")),
             False,
         )
 


### PR DESCRIPTION
<!-- 
Insert issue number that this PR fixes (if any) just after 'Fixes #'.
If this PR does not fix an existing issue, consider opening one or remove 'Fixes #' from the PR description.
-->
Fixes #5236 

To be honest, the test (`test_offset_lock_created`) does not make sense to me since it was testing if we ever locked a file before and not actual current behavior of locking a file (and was apparently never tested in windows due to filelock's behavioral differences across OSes). <strike>Now that UNIX behavior is same as Windows (orphaned lock file automatically deleted after unlock)</strike>, it seems ok to remove the test.

First commit removes the test. Second commit implements a replacement test where  "open/acquire a lock --> check --> release it --> check it's gone."

I ran flake8 on the file and there were some unused imports which I removed.

(EDIT: The striked-out part apparently is no longer true from a commit five days ago... what a mess)

## Changes made in this Pull Request:
<!-- Describe the changes that this PR makes. If applicable, use the following bullet list. --> 
- Removed the relevant test (`test_offset_lock_created`) that involves checking for a lock file after the file lock had been released

## LLM / AI generated code disclosure
<!-- Please update this disclosure to reflect if you did or did not use LLMs / AI to generate code -->
LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution:  no

## PR Checklist
<!-- Please use the following checklist to ensure the PR is ready to be reviewed/merged. -->
 - [x] Issue raised/referenced?
 - [x] Tests updated/added?
 - [x] Documentation updated/added?
 - [x] `package/CHANGELOG` file updated?
 - [x] Is your name in `package/AUTHORS`? (If it is not, add it!)
 - [x] LLM/AI disclosure was updated.

## Developers Certificate of Origin
<!-- 
In order for this PR to be merged you **must certify that you are able to submit your code to be included in MDAnalysis**.
-->

I certify that I can submit this code contribution as described in the [**Developer Certificate of Origin**](https://developercertificate.org/), under the MDAnalysis [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--5237.org.readthedocs.build/en/5237/

<!-- readthedocs-preview mdanalysis end -->