### PR TITLE
Optimize inverse index mapping in groups.py (Fixes Issue #3387)

### DIFF
--- a/benchmarks/benchmarks/ag_methods.py
+++ b/benchmarks/benchmarks/ag_methods.py
@@ -195,6 +195,17 @@ class AtomGroupMethodsBench(object):
         """
         self.ag.wrap(compound="residues")
 
+    def time_asunique_no_sorted(self, num_atoms):
+        """Benchmark asunique() operation on
+        atomgroup without sorting"""
+        self.ag.asunique(sorted=False)
+
+    def time_asunique_sorted(self, num_atoms):
+        """Benchmark asunique() operation on
+        atomgroup with sorting"""
+        self.ag.asunique(sorted=True)
+
+
 class AtomGroupAttrsBench(object):
     """Benchmarks for the various MDAnalysis
     atomgroup attributes.

--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -271,8 +271,11 @@ Chronological list of authors
   - Mohammad Ayaan
   - Khushi Phougat
   - Kushagar Garg
-  - Ayush Agarwal
   - Jeremy M. G. Leung
+  - Harshit Gajjela
+  - Kunj Sinha
+  - Ayush Agarwal
+  - Parth Uppal
 
 External code
 -------------

--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -271,6 +271,7 @@ Chronological list of authors
   - Mohammad Ayaan
   - Khushi Phougat
   - Kushagar Garg
+  - Ayush Agarwal
 
 External code
 -------------

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -15,11 +15,18 @@ The rules for this file:
 
 -------------------------------------------------------------------------------
 ??/??/?? IAlibay, orbeckst, marinegor, tylerjereddy, ljwoods2, marinegor,
-         spyke7, talagayev, tanii1125, BradyAJohnston, hejamu, jeremyleung521
+         spyke7, talagayev, tanii1125, BradyAJohnston, hejamu, jeremyleung521,
+         harshitgajjela-droid, kunjsinha, aygarwal, jauy123
 
  * 2.11.0
 
 Fixes
+ * Improved performance of inverse index mapping in AtomGroup using an optimized 
+   Cython implementation in lib._cutils.inverse_int_index()
+   (Issue #3387, PR #5252)
+ * Fixes TypeError with np.int64 indexing in GSD Reader (Issue #5224)
+ * Fixed bug in add_transformations allowing non-callable transformations
+   (Issue #2558, PR #2558)
  * Drop/Replace lock file test in test_xdr (Issue #5236, PR #5237)
  * HydrogenBondAnalysis: Fixed `count_by_time()` when using `run(FrameIterator)` that
    results in `self.start` and `self.end` being None (Issue #5200, PR #5202)
@@ -38,13 +45,15 @@ Fixes
    DSSP by porting upstream PyDSSP 0.9.1 fix (Issue #4913)
 
 Enhancements
+ * Reduces duplication of code in _apply() function (Issue #5247, PR #5294)
+ * Added new top-level `MDAnalysis.fetch` module (PR #4943)
+ * Added new function `MDAnalysis.fetch.from_PDB` to download structure files from wwPDB
+   using `pooch` as optional dependency (Issue #4907, PR #4943) 
+ * Added benchmarks for package.MDAnalysis.analysis.msd.EinsteinMSD (PR #5277)
  * Improved performance of `AtomGroup.wrap()` with compounds (PR #5220)
  * Adds support for parsing `.tpr` files produced by GROMACS 2026.0
  * Enables parallelization for analysis.diffusionmap.DistanceMatrix
    (Issue #4679, PR #4745)
- * Improve performance of inverse index mapping in AtomGroup by
-   replacing O(n^2) logic with optimized Cython implementation.
-   (Issue #3387, PR #5252)
 
 Changes
  * The msd.py inside analysis is changed, and ProgressBar is implemented inside

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -41,6 +41,9 @@ Enhancements
  * Adds support for parsing `.tpr` files produced by GROMACS 2026.0
  * Enables parallelization for analysis.diffusionmap.DistanceMatrix
    (Issue #4679, PR #4745)
+ * Improve performance of inverse index mapping in AtomGroup by
+   replacing O(n^2) logic with optimized Cython implementation.
+   (Issue #3387, PR #5252)
 
 Changes
  * The msd.py inside analysis is changed, and ProgressBar is implemented inside

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -21,9 +21,6 @@ The rules for this file:
  * 2.11.0
 
 Fixes
- * Improved performance of inverse index mapping in AtomGroup using an optimized 
-   Cython implementation in lib._cutils.inverse_int_index()
-   (Issue #3387, PR #5252)
  * Fixes TypeError with np.int64 indexing in GSD Reader (Issue #5224)
  * Fixed bug in add_transformations allowing non-callable transformations
    (Issue #2558, PR #2558)
@@ -45,6 +42,9 @@ Fixes
    DSSP by porting upstream PyDSSP 0.9.1 fix (Issue #4913)
 
 Enhancements
+ * Improved performance of inverse index mapping in AtomGroup using an optimized 
+   Cython implementation in lib._cutils.inverse_int_index()
+   (Issue #3387, PR #5252)
  * Reduces duplication of code in _apply() function (Issue #5247, PR #5294)
  * Added new top-level `MDAnalysis.fetch` module (PR #4943)
  * Added new function `MDAnalysis.fetch.from_PDB` to download structure files from wwPDB

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -914,7 +914,7 @@ class GroupBase(_MutableBase):
         indices = unique_int_1d_unsorted(self.ix)
         if set_mask:
             mask = np.zeros_like(self.ix)
-            if len(indices) * 50 > len(self.ix) :
+            if len(indices) * 50 > len(self.ix) and len(indices) > 80:
                 mask = inverse_int_index(self.ix, indices)
             else :
                 for i, x in enumerate(indices):

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -913,12 +913,7 @@ class GroupBase(_MutableBase):
 
         indices = unique_int_1d_unsorted(self.ix)
         if set_mask:
-            mask = np.zeros_like(self.ix)
-            if len(indices) * 10 > len(self.ix):
-                mask = inverse_int_index(self.ix, indices)
-            else :
-                for i, x in enumerate(indices):
-                    mask[self.ix == x] = i
+            mask = inverse_int_index(self.ix, indices)
             self._unique_restore_mask = mask
 
         issorted = int_array_is_sorted(indices)

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -914,7 +914,7 @@ class GroupBase(_MutableBase):
         indices = unique_int_1d_unsorted(self.ix)
         if set_mask:
             mask = np.zeros_like(self.ix)
-            if len(indices) * 50 > len(self.ix):
+            if len(indices) * 10 > len(self.ix):
                 mask = inverse_int_index(self.ix, indices)
             else :
                 for i, x in enumerate(indices):

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -913,7 +913,13 @@ class GroupBase(_MutableBase):
 
         indices = unique_int_1d_unsorted(self.ix)
         if set_mask:
-            mask = inverse_int_index(self.ix, indices)
+            mask = np.zeros_like(self.ix)
+            if len(indices) * 50 > len(self.ix) :
+                mask = inverse_int_index(self.ix, indices)
+            else :
+                for i, x in enumerate(indices):
+                    values = np.where(self.ix == x)[0]
+                    mask[values] = i
             self._unique_restore_mask = mask
 
         issorted = int_array_is_sorted(indices)

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -918,8 +918,7 @@ class GroupBase(_MutableBase):
                 mask = inverse_int_index(self.ix, indices)
             else :
                 for i, x in enumerate(indices):
-                    values = np.where(self.ix == x)[0]
-                    mask[values] = i
+                    mask[self.ix == x] = i
             self._unique_restore_mask = mask
 
         issorted = int_array_is_sorted(indices)

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -914,7 +914,7 @@ class GroupBase(_MutableBase):
         indices = unique_int_1d_unsorted(self.ix)
         if set_mask:
             mask = np.zeros_like(self.ix)
-            if len(indices) * 50 > len(self.ix) and len(indices) > 80:
+            if len(indices) * 50 > len(self.ix):
                 mask = inverse_int_index(self.ix, indices)
             else :
                 for i, x in enumerate(indices):

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -122,6 +122,7 @@ from . import selection
 from ..exceptions import NoDataError
 from . import topologyobjects
 from ._get_readers import get_writer_for, get_converter_for
+from ..lib._cutil import inverse_int_index
 
 
 def _unpickle(u, ix):
@@ -912,10 +913,7 @@ class GroupBase(_MutableBase):
 
         indices = unique_int_1d_unsorted(self.ix)
         if set_mask:
-            mask = np.zeros_like(self.ix)
-            for i, x in enumerate(indices):
-                values = np.where(self.ix == x)[0]
-                mask[values] = i
+            mask = inverse_int_index(self.ix, indices)
             self._unique_restore_mask = mask
 
         issorted = int_array_is_sorted(indices)

--- a/package/MDAnalysis/lib/_cutil.pyx
+++ b/package/MDAnalysis/lib/_cutil.pyx
@@ -95,22 +95,45 @@ def unique_int_1d(cnp.intp_t[:] values):
 @cython.wraparound(False)
 def inverse_int_index(cnp.intp_t[:] values,
                       cnp.intp_t[:] unique_vals):
-    """
-    Construct inverse index map such that:
+    r"""Construct an inverse index array (mask) mapping values to unique_vals.
 
-        unique_vals[mask] == values
+    The returned mask contains the indices such that:
+    
+    .. math::
+        \text{unique\_vals}[\text{mask}] == \text{values}
 
     Parameters
     ----------
     values : numpy.ndarray
-        1D array of integers.
+        1D array of integers (can contain duplicates).
     unique_vals : numpy.ndarray
-        1D array of unique integers (unsorted).
+        1D array of unique integers corresponding to the elements in `values`.
 
     Returns
     -------
     numpy.ndarray
-        Integer mask mapping values -> index in unique_vals.
+        An integer array `mask` of the same length as `values`, where 
+        ``mask[i]`` is the index of ``values[i]`` in `unique_vals`.
+
+
+    Notes
+    -----
+
+
+    .. versionadded:: 2.11.0
+
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from MDAnalysis.lib._cutil import inverse_int_index
+    >>> vals = np.array([1, 5, 3, 3, 6], dtype=np.intp)
+    >>> uniq = np.array([1, 5, 3, 6], dtype=np.intp)
+    >>> mask = inverse_int_index(vals, uniq)
+    >>> mask
+    array([0, 1, 2, 2, 3])
+    >>> np.all(uniq[mask] == vals)
+    True
     """
 
     cdef Py_ssize_t n = values.shape[0]

--- a/package/MDAnalysis/lib/_cutil.pyx
+++ b/package/MDAnalysis/lib/_cutil.pyx
@@ -37,7 +37,7 @@ from cython.operator cimport dereference as deref
 
 cnp.import_array()
 
-__all__ = ['unique_int_1d', 'make_whole', 'find_fragments',
+__all__ = ['unique_int_1d', 'inverse_int_index', 'make_whole', 'find_fragments',
            '_sarrus_det_single', '_sarrus_det_multiple']
 
 cdef extern from "calc_distances.h":
@@ -91,6 +91,42 @@ def unique_int_1d(cnp.intp_t[:] values):
 
     return np.array(result)
 
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def inverse_int_index(cnp.intp_t[:] values,
+                      cnp.intp_t[:] unique_vals):
+    """
+    Construct inverse index map such that:
+
+        unique_vals[mask] == values
+
+    Parameters
+    ----------
+    values : numpy.ndarray
+        1D array of integers.
+    unique_vals : numpy.ndarray
+        1D array of unique integers (unsorted).
+
+    Returns
+    -------
+    numpy.ndarray
+        Integer mask mapping values -> index in unique_vals.
+    """
+
+    cdef Py_ssize_t n = values.shape[0]
+    cdef Py_ssize_t m = unique_vals.shape[0]
+    cdef Py_ssize_t i
+
+    cdef dict lookup = {}
+    cdef cnp.intp_t[:] mask = np.empty(n, dtype=np.intp)
+
+    for i in range(m):
+        lookup[unique_vals[i]] = i
+
+    for i in range(n):
+        mask[i] = lookup[values[i]]
+
+    return np.array(mask)
 
 @cython.boundscheck(False)
 def _in2d(cnp.intp_t[:, :] arr1, cnp.intp_t[:, :] arr2):

--- a/testsuite/MDAnalysisTests/lib/test_cutil.py
+++ b/testsuite/MDAnalysisTests/lib/test_cutil.py
@@ -28,6 +28,7 @@ from MDAnalysis.lib._cutil import (
     unique_int_1d,
     find_fragments,
     _in2d,
+    inverse_int_index,
 )
 
 
@@ -103,3 +104,52 @@ def test_in2d_VE(arr1, arr2):
         ValueError, match=r"Both arrays must be \(n, 2\) arrays"
     ):
         _in2d(arr1, arr2)
+
+
+def _python_reference_mask(ix, indices):
+    mask = np.zeros_like(ix)
+    for i, x in enumerate(indices):
+        values = np.where(ix == x)[0]
+        mask[values] = i
+    return mask
+
+
+@pytest.mark.parametrize(
+    "ix,indices",
+    [
+        # unsorted and not unique
+        (
+            np.array([1, 5, 3, 3, 6], dtype=np.intp),
+            np.array([1, 5, 3, 6], dtype=np.intp),
+        ),
+        # sorted and not unique
+        (
+            np.array([1, 3, 3, 5, 6], dtype=np.intp),
+            np.array([1, 3, 5, 6], dtype=np.intp),
+        ),
+        # unsorted and unique
+        (
+            np.array([1, 5, 3, 6], dtype=np.intp),
+            np.array([1, 5, 3, 6], dtype=np.intp),
+        ),
+        # sorted and unique
+        (
+            np.array([1, 3, 5, 6], dtype=np.intp),
+            np.array([1, 3, 5, 6], dtype=np.intp),
+        ),
+        # all elements identical
+        (
+            np.array([5, 5, 5], dtype=np.intp),
+            np.array([5], dtype=np.intp),
+        ),
+        # single element
+        (
+            np.array([7], dtype=np.intp),
+            np.array([7], dtype=np.intp),
+        ),
+    ],
+)
+def test_inverse_int_index(ix, indices):
+    pyref = _python_reference_mask(ix, indices)
+    cy = inverse_int_index(ix, indices)
+    assert_equal(pyref, cy)


### PR DESCRIPTION
<!-- 
Insert issue number that this PR fixes (if any) just after 'Fixes #'.
If this PR does not fix an existing issue, consider opening one or remove 'Fixes #' from the PR description.
-->
Fixes #3387

## Summary

This PR replaces the O(n²) inverse index reconstruction logic in groups.py with an O(n) implementation written in Cython.

The previous implementation used np.where inside a loop over unique indices, leading to quadratic complexity. The approach in this PR uses a dictionary-based lookup implemented in lib/_cutil.pyx, where the indices of the unique values in `indices` array are added to a map. Then `self.ix` array is iterated over only once and the map is consulted to get the index from the uniqe value array. 
This means that the `self.ix` array is traversed in a single pass, making it linear time complexity.

Changes made in this Pull Request:
<!-- Describe the changes that this PR makes. If applicable, use the following bullet list. --> 
- Implemented a new cython function inverse_int_index() in package/MDAnalysis/lib/_cutil.pyx
- Replaced the previous Python O(n²) logic in groups.py with a call to the new cython function
- Benchmarked performance improvement

## LLM / AI generated code disclosure
<!-- Please update this disclosure to reflect if you did or did not use LLMs / AI to generate code -->
LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution: no

## Benchmark
For an array of size 1,000,000 with ~5000 unique values, following speedup was observed :
Python: ~0.41s
Cython: ~0.11s
Speedup: ~3.64 times
(these values are from local testing)

## PR Checklist
<!-- Please use the following checklist to ensure the PR is ready to be reviewed/merged. -->
 - [x] Issue raised/referenced?
 - [x] Tests updated/added?
 - [x] Documentation updated/added?
 - [x] `package/CHANGELOG` file updated?
 - [x] Is your name in `package/AUTHORS`? (If it is not, add it!)
 - [x] LLM/AI disclosure was updated.

## Developers Certificate of Origin
<!-- 
In order for this PR to be merged you **must certify that you are able to submit your code to be included in MDAnalysis**.
-->

I certify that I can submit this code contribution as described in the [**Developer Certificate of Origin**](https://developercertificate.org/), under the MDAnalysis [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--5252.org.readthedocs.build/en/5252/

<!-- readthedocs-preview mdanalysis end -->