### PR TITLE
fixed _conclude() for msd.py for non_linear frames

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -20,6 +20,8 @@ The rules for this file:
  * 2.11.0
 
 Fixes
+ * Fixes msd for non-linear frames, when non_linear is not explicitly
+   provided (Issue #5100, PR #5254)
  * Drop/Replace lock file test in test_xdr (Issue #5236, PR #5237)
  * HydrogenBondAnalysis: Fixed `count_by_time()` when using `run(FrameIterator)` that
    results in `self.start` and `self.end` being None (Issue #5200, PR #5202)

--- a/package/MDAnalysis/analysis/msd.py
+++ b/package/MDAnalysis/analysis/msd.py
@@ -427,7 +427,12 @@ class EinsteinMSD(AnalysisBase):
         ]
 
     def _conclude(self):
-        if self.non_linear:
+        delta_time = np.diff(self.times)
+
+        if self.non_linear or (
+            len(delta_time) > 1
+            and not (np.allclose(delta_time, delta_time[0]))
+        ):
             self._conclude_non_linear()
         else:
             if self.fft:

--- a/testsuite/MDAnalysisTests/analysis/test_msd.py
+++ b/testsuite/MDAnalysisTests/analysis/test_msd.py
@@ -1849,12 +1849,12 @@ class TestMSDNonLinear:
             result_msd_per_particle, expected_msd_per_particle, rtol=1e-5
         )
 
-    def test_detect_non_linear_from_frames(self, u_nonlinear):
-        msd_auto = MSD(u_nonlinear, select="all", msd_type="xyz", fft=False)
+    def test_detect_non_linear_from_frames(self, step_traj):
+        msd_auto = MSD(step_traj, select="all", msd_type="xyz", fft=False)
         res1 = msd_auto.run(frames=[0, 1, 3, 6])
 
         msd_explicit = MSD(
-            u_nonlinear, select="all", msd_type="xyz", non_linear=True
+            step_traj, select="all", msd_type="xyz", non_linear=True
         )
         res2 = msd_explicit.run(frames=[0, 1, 3, 6])
 

--- a/testsuite/MDAnalysisTests/analysis/test_msd.py
+++ b/testsuite/MDAnalysisTests/analysis/test_msd.py
@@ -301,6 +301,21 @@ class TestMSDNonLinear:
             ("z", 1),
         ],
     )
+    def test_detect_non_linear_from_frames(self, u_nonlinear):
+        msd_auto = MSD(u_nonlinear, select="all", msd_type="xyz", fft=False)
+        res1 = msd_auto.run(frames=[0, 1, 3, 6])
+
+        msd_explicit = MSD(
+            u_nonlinear, select="all", msd_type="xyz", non_linear=True
+        )
+        res2 = msd_explicit.run(frames=[0, 1, 3, 6])
+
+        assert_allclose(
+            res1.results.msds_by_particle,
+            res2.results.msds_by_particle,
+            rtol=1e-5,
+        )
+
     def test_all_msd_types(self, u_nonlinear, dim, dim_factor):
         msd = MSD(u_nonlinear, select="all", msd_type=dim, non_linear=True)
         msd.run()

--- a/testsuite/MDAnalysisTests/analysis/test_msd.py
+++ b/testsuite/MDAnalysisTests/analysis/test_msd.py
@@ -301,7 +301,7 @@ class TestMSDNonLinear:
             ("z", 1),
         ],
     )
-    def test_detect_non_linear_from_frames(self, u_nonlinear):
+    def test_detect_non_linear_from_frames(self, u_nonlinear, dim, dim_factor):
         msd_auto = MSD(u_nonlinear, select="all", msd_type="xyz", fft=False)
         res1 = msd_auto.run(frames=[0, 1, 3, 6])
 

--- a/testsuite/MDAnalysisTests/analysis/test_msd.py
+++ b/testsuite/MDAnalysisTests/analysis/test_msd.py
@@ -301,21 +301,6 @@ class TestMSDNonLinear:
             ("z", 1),
         ],
     )
-    def test_detect_non_linear_from_frames(self, u_nonlinear, dim, dim_factor):
-        msd_auto = MSD(u_nonlinear, select="all", msd_type="xyz", fft=False)
-        res1 = msd_auto.run(frames=[0, 1, 3, 6])
-
-        msd_explicit = MSD(
-            u_nonlinear, select="all", msd_type="xyz", non_linear=True
-        )
-        res2 = msd_explicit.run(frames=[0, 1, 3, 6])
-
-        assert_allclose(
-            res1.results.msds_by_particle,
-            res2.results.msds_by_particle,
-            rtol=1e-5,
-        )
-
     def test_all_msd_types(self, u_nonlinear, dim, dim_factor):
         msd = MSD(u_nonlinear, select="all", msd_type=dim, non_linear=True)
         msd.run()
@@ -1862,4 +1847,19 @@ class TestMSDNonLinear:
         assert_allclose(result_delta_t, expected_delta_t, rtol=1e-5)
         assert_allclose(
             result_msd_per_particle, expected_msd_per_particle, rtol=1e-5
+        )
+
+    def test_detect_non_linear_from_frames(self, u_nonlinear):
+        msd_auto = MSD(u_nonlinear, select="all", msd_type="xyz", fft=False)
+        res1 = msd_auto.run(frames=[0, 1, 3, 6])
+
+        msd_explicit = MSD(
+            u_nonlinear, select="all", msd_type="xyz", non_linear=True
+        )
+        res2 = msd_explicit.run(frames=[0, 1, 3, 6])
+
+        assert_allclose(
+            res1.results.msds_by_particle,
+            res2.results.msds_by_particle,
+            rtol=1e-5,
         )


### PR DESCRIPTION
Fixes #5100

Changes made in this Pull Request:
- checked the difference between times of frames to detect whether that is linear or non_linear (obviously for length > 1) 
- updated test_msd.py to check non_linear is True, for uneven times (or frames)

**Could have also used self.frames instead of self.times as well**

## LLM / AI generated code disclosure
LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution: no

## PR Checklist
 - [x] Issue raised/referenced?
 - [x] Tests updated/added?
 - [ ] Documentation updated/added?
 - [x] `package/CHANGELOG` file updated?
 - [x] Is your name in `package/AUTHORS`? (If it is not, add it!)
 - [x] LLM/AI disclosure was updated.

## Developers Certificate of Origin

I certify that I can submit this code contribution as described in the [**Developer Certificate of Origin**](https://developercertificate.org/), under the MDAnalysis [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--5254.org.readthedocs.build/en/5254/

<!-- readthedocs-preview mdanalysis end -->