### PR TITLE
Fix typo in benchmark documentation

### DIFF
--- a/benchmarks/README.rst
+++ b/benchmarks/README.rst
@@ -99,7 +99,7 @@ suitable reference. As a quick summary of guidelines:
 Advanced Notes
 --------------
 
-- the depedencies installed in the clean conda benchmarking environments,
+- the dependencies installed in the clean conda benchmarking environments,
   and indeed the decision to use conda over virtualenv, can be controlled
   in the ``asv.conf.json`` file, as can which versions of Python are probed
 


### PR DESCRIPTION
This PR fixes a minor typo in the benchmark documentation (" depedencies-> dependencies") to improve clarity and correctness.

<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--5258.org.readthedocs.build/en/5258/

<!-- readthedocs-preview mdanalysis end -->