### PR TITLE
Fix typo in benchmarks README (#5258)

### DIFF
--- a/benchmarks/README.rst
+++ b/benchmarks/README.rst
@@ -99,7 +99,7 @@ suitable reference. As a quick summary of guidelines:
 Advanced Notes
 --------------
 
-- the depedencies installed in the clean conda benchmarking environments,
+- the dependencies installed in the clean conda benchmarking environments,
   and indeed the decision to use conda over virtualenv, can be controlled
   in the ``asv.conf.json`` file, as can which versions of Python are probed
 


### PR DESCRIPTION
### Summary
This PR fixes a small typo in the benchmarks documentation.

The word "depedencies" has been corrected to "dependencies"
in `benchmarks/README.rst`.

### Details
This change improves documentation clarity and corrects
a spelling mistake in the benchmarking instructions.

No functional changes were made.

<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--5269.org.readthedocs.build/en/5269/

<!-- readthedocs-preview mdanalysis end -->