### PR TITLE
DOC: fix doctest in util.py for greedy_splitext on Windows

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -22,6 +22,7 @@ The rules for this file:
  * 2.11.0
 
 Fixes
+<<<<<<< HEAD
  * `MDAnalysis.analysis.nucleicacids.WatsonCrickDist`, `MinorPairDist`,
    and `MajorPairDist` now match residue names against the full resname
    instead of only the first character, fixing incorrect behaviour with
@@ -39,6 +40,10 @@ Fixes
  * Fix mixed-case atom types in guess_bonds (Issue #5342, PR #5343)
  * Fixes msd for non-linear frames, when non_linear is not explicitly
    provided (Issue #5100, PR #5254)
+=======
+ * Fix doctest in util.py for platform-dependent path output
+   (Issue #3925, PR #5285)
+>>>>>>> 530afe184 (DOC: update CHANGELOG for PR #5285)
  * Fixes TypeError with np.int64 indexing in GSD Reader (Issue #5224)
  * Fixed bug in add_transformations allowing non-callable transformations
    (Issue #2558, PR #2558)

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -505,7 +505,7 @@ def greedy_splitext(p):
     -------
 
     >>> from MDAnalysis.lib.util import greedy_splitext
-    >>> greedy_splitext("/home/joe/protein.pdb.bz2")
+    >>> greedy_splitext("/home/joe/protein.pdb.bz2") # doctest: +SKIP
     ('/home/joe/protein', '.pdb.bz2')
 
     """


### PR DESCRIPTION
Fixes part of #3925

Changes made in this Pull Request:
- Fix doctest in `greedy_splitext()` in `util.py`
- Added `# doctest: +SKIP` for platform-dependent path example that behaves differently on Windows vs Linux

## LLM / AI generated code disclosure
LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution: yes
(Claude by Anthropic was used to help identify and understand the fix. Actual code changes were made manually.)

## PR Checklist
 - [x] Issue raised/referenced?
 - [ ] Tests updated/added? (documentation-only change, no new tests needed)
 - [x] Documentation updated/added?
 - [x] `package/CHANGELOG` file updated?
 - [x] Is your name in `package/AUTHORS`?
 - [x] LLM/AI disclosure was updated.

## Developers Certificate of Origin
I certify that I can submit this code contribution as described in the [**Developer Certificate of Origin**](https://developercertificate.org/), under the MDAnalysis [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE).