### PR TITLE
Add no selection option to RMSD analysis class

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -276,6 +276,7 @@ Chronological list of authors
   - Kunj Sinha
   - Ayush Agarwal
   - Parth Uppal
+  - Olivier Languin--Cattoën
 
 External code
 -------------

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -42,7 +42,8 @@ Fixes
    DSSP by porting upstream PyDSSP 0.9.1 fix (Issue #4913)
 
 Enhancements
- * Allow `select=None` in `MDAnalysis.analysis.rms.RMSD`
+ * Added `select=None` in `analysis.rms.RMSD` to perform no selection on
+   the input `atomgroup` and `reference` (Issue #5300, PR #5296)
  * Reduces duplication of code in _apply() function (Issue #5247, PR #5294)
  * Added new top-level `MDAnalysis.fetch` module (PR #4943)
  * Added new function `MDAnalysis.fetch.from_PDB` to download structure files from wwPDB

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -16,7 +16,7 @@ The rules for this file:
 -------------------------------------------------------------------------------
 ??/??/?? IAlibay, orbeckst, marinegor, tylerjereddy, ljwoods2, marinegor,
          spyke7, talagayev, tanii1125, BradyAJohnston, hejamu, jeremyleung521,
-         harshitgajjela-droid, kunjsinha, aygarwal, jauy123
+         harshitgajjela-droid, kunjsinha, aygarwal, jauy123, ollyfutur
 
  * 2.11.0
 
@@ -42,6 +42,7 @@ Fixes
    DSSP by porting upstream PyDSSP 0.9.1 fix (Issue #4913)
 
 Enhancements
+ * Allow `select=None` in `MDAnalysis.analysis.rms.RMSD`
  * Reduces duplication of code in _apply() function (Issue #5247, PR #5294)
  * Added new top-level `MDAnalysis.fetch` module (PR #4943)
  * Added new function `MDAnalysis.fetch.from_PDB` to download structure files from wwPDB

--- a/package/MDAnalysis/analysis/rms.py
+++ b/package/MDAnalysis/analysis/rms.py
@@ -298,7 +298,8 @@ def process_selection(select):
     -------
     dict
         selections for 'reference' and 'mobile'. Values are guarenteed to be
-        iterable (so that one can provide selections to retain order)
+        iterable (so that one can provide selections to retain order) or
+        ``None`` if no selection is to be performed.
 
     Notes
     -----
@@ -327,13 +328,15 @@ def process_selection(select):
                 "'mobile' and 'reference'."
             ) from None
     elif select is None:
-        return {"reference": None, "mobile": None}
+        select = {"reference": None, "mobile": None}
     else:
         raise TypeError(
             "'select' must be either a string, 2-tuple, dict or None"
         )
-    select["mobile"] = asiterable(select["mobile"])
-    select["reference"] = asiterable(select["reference"])
+    if select["mobile"] is not None:
+        select["mobile"] = asiterable(select["mobile"])
+    if select["reference"] is not None:
+        select["reference"] = asiterable(select["reference"])
     return select
 
 
@@ -410,7 +413,8 @@ class RMSD(AnalysisBase):
                and *sel2* are valid selection strings that are applied to
                `atomgroup` and `reference` respectively (the
                :func:`MDAnalysis.analysis.align.fasta2select` function returns such
-               a dictionary based on a ClustalW_ or STAMP_ sequence alignment); or
+               a dictionary based on a ClustalW_ or STAMP_ sequence alignment) or
+               ``None`` if no selection is to be performed; or
 
             3. a tuple ``(sel1, sel2)``
 
@@ -422,7 +426,7 @@ class RMSD(AnalysisBase):
             be a *list of selection strings* to generate a
             :class:`~MDAnalysis.core.groups.AtomGroup` with defined atom order as
             described under :ref:`ordered-selections-label`). When using ``None``
-            no selection is performed and all atoms from `atomgroup` and `reference`
+            no selection is performed and all atoms from `atomgroup` or `reference`
             are used in their original order.
 
         groupselections : list (optional)

--- a/package/MDAnalysis/analysis/rms.py
+++ b/package/MDAnalysis/analysis/rms.py
@@ -549,14 +549,14 @@ class RMSD(AnalysisBase):
         self.ref_frame = ref_frame
         self.weights_groupselections = weights_groupselections
         self.ref_atoms = (
-            self.reference
-            if select["reference"] is None
-            else self.reference.select_atoms(*select["reference"])
+            self.reference.select_atoms(*select["reference"])
+            if select["reference"] is not None
+            else self.reference
         )
         self.mobile_atoms = (
-            self.atomgroup
-            if select["mobile"] is None
-            else self.atomgroup.select_atoms(*select["mobile"])
+            self.atomgroup.select_atoms(*select["mobile"])
+            if select["mobile"] is not None
+            else self.atomgroup
         )
 
         if len(self.ref_atoms) != len(self.mobile_atoms):

--- a/package/MDAnalysis/analysis/rms.py
+++ b/package/MDAnalysis/analysis/rms.py
@@ -287,11 +287,12 @@ def process_selection(select):
 
     Parameters
     ----------
-    select : str or tuple or dict
+    select : str or tuple or dict or None
 
         - `str` -> Any valid string selection
         - `dict` -> ``{'mobile':sel1, 'reference':sel2}``
         - `tuple` -> ``(sel1, sel2)``
+        - ``None``
 
     Returns
     -------
@@ -325,8 +326,10 @@ def process_selection(select):
                 "select dictionary must contain entries for keys "
                 "'mobile' and 'reference'."
             ) from None
+    elif select is None:
+        select = {"reference": None, "mobile": None}
     else:
-        raise TypeError("'select' must be either a string, 2-tuple, or dict")
+        raise TypeError("'select' must be either a string, 2-tuple, dict or None")
     select["mobile"] = asiterable(select["mobile"])
     select["reference"] = asiterable(select["reference"])
     return select
@@ -394,7 +397,7 @@ class RMSD(AnalysisBase):
         reference : AtomGroup or Universe (optional)
             Group of reference atoms; if ``None`` then the current frame of
             `atomgroup` is used.
-        select : str or dict or tuple (optional)
+        select : str or dict or tuple or None (optional)
             The selection to operate on; can be one of:
 
             1. any valid selection string for
@@ -409,12 +412,16 @@ class RMSD(AnalysisBase):
 
             3. a tuple ``(sel1, sel2)``
 
+            4. ``None``
+
             When using 2. or 3. with *sel1* and *sel2* then these selection strings
             are applied to `atomgroup` and `reference` respectively and should
             generate *groups of equivalent atoms*.  *sel1* and *sel2* can each also
             be a *list of selection strings* to generate a
             :class:`~MDAnalysis.core.groups.AtomGroup` with defined atom order as
-            described under :ref:`ordered-selections-label`).
+            described under :ref:`ordered-selections-label`). When using ``None``
+            no selection is performed and all atoms from `atomgroup` and `reference`
+            are used in their original order.
 
         groupselections : list (optional)
             A list of selections as described for `select`, with the difference
@@ -539,8 +546,10 @@ class RMSD(AnalysisBase):
         self.tol_mass = tol_mass
         self.ref_frame = ref_frame
         self.weights_groupselections = weights_groupselections
-        self.ref_atoms = self.reference.select_atoms(*select["reference"])
-        self.mobile_atoms = self.atomgroup.select_atoms(*select["mobile"])
+        self.ref_atoms = (self.reference if select["reference"] is None
+                          else self.reference.select_atoms(*select["reference"]))
+        self.mobile_atoms = (self.atomgroup if select["mobile"] is None
+                             else self.atomgroup.select_atoms(*select["mobile"]))
 
         if len(self.ref_atoms) != len(self.mobile_atoms):
             err = (

--- a/package/MDAnalysis/analysis/rms.py
+++ b/package/MDAnalysis/analysis/rms.py
@@ -327,7 +327,7 @@ def process_selection(select):
                 "'mobile' and 'reference'."
             ) from None
     elif select is None:
-        select = {"reference": None, "mobile": None}
+        return {"reference": None, "mobile": None}
     else:
         raise TypeError("'select' must be either a string, 2-tuple, dict or None")
     select["mobile"] = asiterable(select["mobile"])

--- a/package/MDAnalysis/analysis/rms.py
+++ b/package/MDAnalysis/analysis/rms.py
@@ -329,7 +329,9 @@ def process_selection(select):
     elif select is None:
         return {"reference": None, "mobile": None}
     else:
-        raise TypeError("'select' must be either a string, 2-tuple, dict or None")
+        raise TypeError(
+            "'select' must be either a string, 2-tuple, dict or None"
+        )
     select["mobile"] = asiterable(select["mobile"])
     select["reference"] = asiterable(select["reference"])
     return select
@@ -546,10 +548,16 @@ class RMSD(AnalysisBase):
         self.tol_mass = tol_mass
         self.ref_frame = ref_frame
         self.weights_groupselections = weights_groupselections
-        self.ref_atoms = (self.reference if select["reference"] is None
-                          else self.reference.select_atoms(*select["reference"]))
-        self.mobile_atoms = (self.atomgroup if select["mobile"] is None
-                             else self.atomgroup.select_atoms(*select["mobile"]))
+        self.ref_atoms = (
+            self.reference
+            if select["reference"] is None
+            else self.reference.select_atoms(*select["reference"])
+        )
+        self.mobile_atoms = (
+            self.atomgroup
+            if select["mobile"] is None
+            else self.atomgroup.select_atoms(*select["mobile"])
+        )
 
         if len(self.ref_atoms) != len(self.mobile_atoms):
             err = (

--- a/testsuite/MDAnalysisTests/analysis/test_rms.py
+++ b/testsuite/MDAnalysisTests/analysis/test_rms.py
@@ -475,6 +475,28 @@ class TestRMSD(object):
         with pytest.warns(DeprecationWarning, match=wmsg):
             assert_equal(RMSD.rmsd, RMSD.results.rmsd)
 
+    def test_rmsd_no_selection(self, universe, correct_values, client_RMSD):
+        reference = MDAnalysis.Universe(PSF, DCD)
+        ref = reference.select_atoms("name CA")
+        ag = universe.select_atoms("name CA")
+        order = np.arange(len(ag))
+        order[0] = 2
+        order[2] = 0
+
+        # select=None will not sort the atomgroups
+        RMSD = MDAnalysis.analysis.rms.RMSD(ag[order], reference=ref, select=None)
+        RMSD.run(step=49, **client_RMSD)
+        assert not np.allclose(RMSD.results.rmsd, correct_values)
+
+        RMSD = MDAnalysis.analysis.rms.RMSD(ag[order], reference=ref[order], select=None)
+        RMSD.run(step=49, **client_RMSD)
+        assert_almost_equal(
+            RMSD.results.rmsd,
+            correct_values,
+            4,
+            err_msg="error: rmsd profile should match "
+            "between true values and calculated values",
+        )
 
 class TestRMSF(object):
     @pytest.fixture()

--- a/testsuite/MDAnalysisTests/analysis/test_rms.py
+++ b/testsuite/MDAnalysisTests/analysis/test_rms.py
@@ -484,11 +484,15 @@ class TestRMSD(object):
         order[2] = 0
 
         # select=None will not sort the atomgroups
-        RMSD = MDAnalysis.analysis.rms.RMSD(ag[order], reference=ref, select=None)
+        RMSD = MDAnalysis.analysis.rms.RMSD(
+            ag[order], reference=ref, select=None
+        )
         RMSD.run(step=49, **client_RMSD)
         assert not np.allclose(RMSD.results.rmsd, correct_values)
 
-        RMSD = MDAnalysis.analysis.rms.RMSD(ag[order], reference=ref[order], select=None)
+        RMSD = MDAnalysis.analysis.rms.RMSD(
+            ag[order], reference=ref[order], select=None
+        )
         RMSD.run(step=49, **client_RMSD)
         assert_almost_equal(
             RMSD.results.rmsd,
@@ -497,6 +501,7 @@ class TestRMSD(object):
             err_msg="error: rmsd profile should match "
             "between true values and calculated values",
         )
+
 
 class TestRMSF(object):
     @pytest.fixture()

--- a/testsuite/MDAnalysisTests/analysis/test_rms.py
+++ b/testsuite/MDAnalysisTests/analysis/test_rms.py
@@ -502,15 +502,12 @@ class TestRMSD(object):
             "between true values and calculated values",
         )
 
-    def test_rmsd_misuse_selec_raises_TypeError(
-        self, universe
-    ):
+    def test_rmsd_misuse_selec_raises_TypeError(self, universe):
         with pytest.raises(TypeError):
             RMSD = MDAnalysis.analysis.rms.RMSD(
                 universe,
                 select=42,
             )
-
 
 
 class TestRMSF(object):

--- a/testsuite/MDAnalysisTests/analysis/test_rms.py
+++ b/testsuite/MDAnalysisTests/analysis/test_rms.py
@@ -502,6 +502,16 @@ class TestRMSD(object):
             "between true values and calculated values",
         )
 
+    def test_rmsd_misuse_selec_raises_TypeError(
+        self, universe
+    ):
+        with pytest.raises(TypeError):
+            RMSD = MDAnalysis.analysis.rms.RMSD(
+                universe,
+                select=42,
+            )
+
+
 
 class TestRMSF(object):
     @pytest.fixture()


### PR DESCRIPTION
<!-- 
Insert issue number that this PR fixes (if any) just after 'Fixes #'.
If this PR does not fix an existing issue, consider opening one or remove 'Fixes #' from the PR description.
-->

Changes made in this Pull Request:
<!-- Describe the changes that this PR makes. If applicable, use the following bullet list. --> 
- `MDAnalysis.analysis.rms.RMSD` now accepts `select=None` to prevent any further selection on `atomgroup` and `reference`. This is useful e.g. to avoid reordering of the atomgroups.

## LLM / AI generated code disclosure
<!-- Please update this disclosure to reflect if you did or did not use LLMs / AI to generate code -->
LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution: no

## PR Checklist
<!-- Please use the following checklist to ensure the PR is ready to be reviewed/merged. -->
 - [x] Issue raised/referenced?
 - [x] Tests updated/added?
 - [x] Documentation updated/added?
 - [x] `package/CHANGELOG` file updated?
 - [x] Is your name in `package/AUTHORS`? (If it is not, add it!)
 - [x] LLM/AI disclosure was updated.

## Developers Certificate of Origin
<!-- 
In order for this PR to be merged you **must certify that you are able to submit your code to be included in MDAnalysis**.
-->

I certify that I can submit this code contribution as described in the [**Developer Certificate of Origin**](https://developercertificate.org/), under the MDAnalysis [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--5296.org.readthedocs.build/en/5296/

<!-- readthedocs-preview mdanalysis end -->