### PR TITLE
DOC: fix doctests in universe.py for newer NumPy and optional rdkit

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -21,6 +21,8 @@ The rules for this file:
  * 2.11.0
 
 Fixes
+ * Fix doctests in universe.py for newer NumPy and optional rdkit
+    (Issue #3925, PR #5297)
  * Fixes TypeError with np.int64 indexing in GSD Reader (Issue #5224)
  * Fixed bug in add_transformations allowing non-callable transformations
    (Issue #2558, PR #2558)

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -1123,7 +1123,7 @@ class Universe(object):
         >>> u = mda.Universe(PSF, DCD)
         >>> u.add_TopologyAttr('tempfactors')
         >>> u.atoms.tempfactors
-        array([0., 0., 0., ..., 0., 0., 0.])
+        array([0., 0., 0., ..., 0., 0., 0.], shape=(3341,))
 
         .. versionchanged:: 0.17.0
            Can now also add TopologyAttrs with a string of the name of the
@@ -1775,18 +1775,18 @@ class Universe(object):
         --------
         To create a Universe with 10 conformers of ethanol:
 
-        >>> from rdkit.Chem import AllChem
-        >>> u = mda.Universe.from_smiles('CCO', numConfs=10)
-        >>> u
+        >>> from rdkit.Chem import AllChem # doctest: +SKIP
+        >>> u = mda.Universe.from_smiles('CCO', numConfs=10) # doctest: +SKIP
+        >>> u # doctest: +SKIP
         <Universe with 9 atoms>
-        >>> u.trajectory
+        >>> u.trajectory # doctest: +SKIP
         <RDKitReader with 10 frames of 9 atoms>
 
         To use a different conformer generation algorithm, like ETKDGv3:
 
-        >>> u = mda.Universe.from_smiles('CCO', rdkit_kwargs=dict(
-        ...      params=AllChem.ETKDGv3()))
-        >>> u.trajectory
+        >>> u = mda.Universe.from_smiles('CCO', rdkit_kwargs=dict( # doctest: +SKIP
+        ...      params=AllChem.ETKDGv3())) 
+        >>> u.trajectory # doctest: +SKIP
         <RDKitReader with 1 frames of 9 atoms>
 
 

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -1785,7 +1785,7 @@ class Universe(object):
         To use a different conformer generation algorithm, like ETKDGv3:
 
         >>> u = mda.Universe.from_smiles('CCO', rdkit_kwargs=dict( # doctest: +SKIP
-        ...      params=AllChem.ETKDGv3())) 
+        ...      params=AllChem.ETKDGv3()))
         >>> u.trajectory # doctest: +SKIP
         <RDKitReader with 1 frames of 9 atoms>
 


### PR DESCRIPTION
Fixes part of #3925

Changes made in this Pull Request:
- Updated expected doctest output for `u.atoms.tempfactors` in `universe.py` — newer NumPy returns `array([..., shape=(3341,))` instead of `array([...])`
- Added `# doctest: +SKIP` to all `from_smiles()` examples that require optional `rdkit` library

## LLM / AI generated code disclosure
LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution: yes
(Claude by Anthropic was used to help identify and understand the fixes. Actual code changes were made manually.)

## PR Checklist
 - [x] Issue raised/referenced?
 - [ ] Tests updated/added? (documentation-only change, no new tests needed)
 - [x] Documentation updated/added?
 - [ ] `package/CHANGELOG` file updated?
 - [x] Is your name in `package/AUTHORS`?
 - [x] LLM/AI disclosure was updated.

## Developers Certificate of Origin
I certify that I can submit this code contribution as described in the [**Developer Certificate of Origin**](https://developercertificate.org/), under the MDAnalysis [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE).

<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--5297.org.readthedocs.build/en/5297/

<!-- readthedocs-preview mdanalysis end -->