### PR TITLE
Add benchmarks for MDAnalysis.analysis.align

### DIFF
--- a/benchmarks/benchmarks/analysis/bench_align.py
+++ b/benchmarks/benchmarks/analysis/bench_align.py
@@ -1,0 +1,68 @@
+# bench_align.py
+# Benchmarks for MDAnalysis.analysis.align
+# No benchmarks existed for this module before this file
+
+import MDAnalysis as mda
+from MDAnalysis.analysis import align
+from MDAnalysis.tests.datafiles import PSF, DCD, PDB_small
+
+
+class AlignBenchmark:
+    """
+    Benchmarks for MDAnalysis.analysis.align module.
+    Tests alignto() and AlignTraj() which are the two
+    most commonly used functions in this module.
+    """
+
+    def setup(self):
+        # setup() runs ONCE before any timing starts
+        # load data here — never in time_ methods
+        # PSF = protein structure file (topology)
+        # DCD = trajectory file (coordinates over time)
+        # PDB_small = single reference structure
+        self.mobile = mda.Universe(PSF, DCD)
+        self.reference = mda.Universe(PSF, PDB_small)
+
+    def time_alignto_all_atoms(self):
+        """Time aligning all atoms of a single frame"""
+        align.alignto(
+            self.mobile,
+            self.reference,
+            select="all"
+        )
+
+    def time_alignto_backbone(self):
+        """Time aligning backbone atoms only (common in research)"""
+        align.alignto(
+            self.mobile,
+            self.reference,
+            select="backbone"
+        )
+
+    def time_alignto_mass_weighted(self):
+        """Time aligning with mass weighting"""
+        align.alignto(
+            self.mobile,
+            self.reference,
+            select="backbone",
+            weights="mass"
+        )
+
+    def time_aligntraj_all_frames(self):
+        """Time aligning entire trajectory — most expensive operation"""
+        alignment = align.AlignTraj(
+            self.mobile,
+            self.reference,
+            select="backbone",
+            in_memory=True  # avoids writing to disk during benchmark
+        )
+        alignment.run()
+
+    def time_average_structure(self):
+        """Time computing average structure across trajectory"""
+        avg = align.AverageStructure(
+            self.mobile,
+            self.reference,
+            select="backbone"
+        )
+        avg.run()

--- a/benchmarks/benchmarks/analysis/bench_align.py
+++ b/benchmarks/benchmarks/analysis/bench_align.py
@@ -1,25 +1,13 @@
-# bench_align.py
-# Benchmarks for MDAnalysis.analysis.align
-# No benchmarks existed for this module before this file
-
 import MDAnalysis as mda
 from MDAnalysis.analysis import align
 from MDAnalysis.tests.datafiles import PSF, DCD, PDB_small
 
 
 class AlignBenchmark:
-    """
-    Benchmarks for MDAnalysis.analysis.align module.
-    Tests alignto() and AlignTraj() which are the two
-    most commonly used functions in this module.
-    """
 
     def setup(self):
         # setup() runs ONCE before any timing starts
         # load data here — never in time_ methods
-        # PSF = protein structure file (topology)
-        # DCD = trajectory file (coordinates over time)
-        # PDB_small = single reference structure
         self.mobile = mda.Universe(PSF, DCD)
         self.reference = mda.Universe(PSF, PDB_small)
 


### PR DESCRIPTION
Contributes to #1023

Changes made in this Pull Request:
- Adds new file benchmarks/benchmarks/analysis/bench_align.py
- time_alignto_all_atoms: single frame alignment on all atoms
- time_alignto_backbone: alignment on backbone selection only
- time_alignto_mass_weighted: mass weighted alignment
- time_aligntraj_all_frames: full trajectory alignment across all frames
- time_average_structure: average structure calculation

No benchmarks previously existed for the MDAnalysis.analysis.align
module. This is part of increasing benchmark coverage as outlined
in GSoC 2026 Project 3: Benchmarking and Performance Optimization.

## LLM / AI generated code disclosure
LLMs or other AI-powered tools (beyond simple IDE use cases) 
were used in this contribution: yes

AI was used to help structure the benchmark class and suggest 
which functions to benchmark. All code was reviewed, tested 
and verified locally by the contributor.

## PR Checklist
 - [x] Issue raised/referenced?
 - [ ] Tests updated/added?
 - [ ] Documentation updated/added?
 - [ ] `package/CHANGELOG` file updated?
 - [ ] Is your name in `package/AUTHORS`?
 - [x] LLM/AI disclosure was updated.

## Developers Certificate of Origin
I certify that I can submit this code contribution as described in the
Developer Certificate of Origin, under the MDAnalysis LICENSE.

<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--5298.org.readthedocs.build/en/5298/

<!-- readthedocs-preview mdanalysis end -->