### PR TITLE
Fix documentation for geometric selections with PBC (#2166)

### DIFF
--- a/package/doc/sphinx/source/documentation_pages/selections.rst
+++ b/package/doc/sphinx/source/documentation_pages/selections.rst
@@ -302,12 +302,10 @@ prop [abs] *property*  *operator*  *value*
 
 
 .. note::
-   By default periodicity **is** taken into account with geometric
-   selections, i.e. selections will find atoms that are in different
-   periodic images.
-   To control this behaviour, use the boolean ``"periodic"`` keyword
-   argument of :meth:`~MDAnalysis.core.groups.AtomGroup.select_atoms`.
-
+   Geometric selections internally use capped distance searches together
+   with periodic KD-trees to correctly handle periodic boundary conditions
+   (PBC). This ensures that atom selections follow the minimum image
+   convention when computing distances across periodic boundaries.
 
 Similarity and connectivity
 ---------------------------


### PR DESCRIPTION
Fixes #2166

Updates the documentation for geometric selections to correctly describe
how periodic boundary conditions (PBC) are handled.

Changes:
- Clarified that geometric selections use capped distance searches
- Mentioned the use of periodic KD-trees for handling PBC
- Removed outdated explanation about periodic behaviour

This improves the accuracy of the documentation and aligns it with the
current implementation in MDAnalysis.

<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--5305.org.readthedocs.build/en/5305/

<!-- readthedocs-preview mdanalysis end -->