### PR TITLE
BEN: Add HydrogenBondAnalysis benchmark for performance tracking

### DIFF
--- a/benchmarks/benchmarks/analysis/hbond_analysis.py
+++ b/benchmarks/benchmarks/analysis/hbond_analysis.py
@@ -1,3 +1,7 @@
+"""
+Benchmark for HydrogenBondAnalysis
+"""
+
 try:
     from MDAnalysis.analysis.hydrogenbonds.hbond_analysis import HydrogenBondAnalysis as HBA
     from MDAnalysisTests.datafiles import waterPSF , waterDCD
@@ -7,6 +11,13 @@ except ImportError:
 import MDAnalysis
 
 class HydrogenBondAnalysisBenchmark:
+    """
+    It tests performance of hbond.run() across different
+    number of frames using waterPSF/waterDCD test files.
+    """
+
+    unit = "ms"
+    timeout = 60.0
     params = [2, 5, 10]
     param_names = ["n_frames"]
 

--- a/benchmarks/benchmarks/analysis/hbond_analysis.py
+++ b/benchmarks/benchmarks/analysis/hbond_analysis.py
@@ -1,0 +1,20 @@
+try:
+    from MDAnalysis.analysis.hydrogenbonds.hbond_analysis import HydrogenBondAnalysis as HBA
+    from MDAnalysisTests.datafiles import waterPSF , waterDCD
+except ImportError:
+    pass
+
+import MDAnalysis
+
+class HydrogenBondAnalysisBenchmark:
+    params = [2, 5, 10]
+    param_names = ["n_frames"]
+
+
+    def setup(self, n_frames):
+        u = MDAnalysis.Universe(waterPSF, waterDCD)
+        self.hbonds = HBA(universe= u)
+    
+    def time_run(self, n_frames):
+        self.hbonds.run(stop = n_frames)
+        

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -16,7 +16,7 @@ The rules for this file:
 -------------------------------------------------------------------------------
 ??/??/?? IAlibay, orbeckst, marinegor, tylerjereddy, ljwoods2, marinegor,
          spyke7, talagayev, tanii1125, BradyAJohnston, hejamu, jeremyleung521,
-         harshitgajjela-droid
+         harshitgajjela-droid, Dreamstick9
 
  * 2.11.0
 

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -16,7 +16,7 @@ The rules for this file:
 -------------------------------------------------------------------------------
 ??/??/?? IAlibay, orbeckst, marinegor, tylerjereddy, ljwoods2, marinegor,
          spyke7, talagayev, tanii1125, BradyAJohnston, hejamu, jeremyleung521,
-         harshitgajjela-droid, Dreamstick9
+         harshitgajjela-droid
 
  * 2.11.0
 
@@ -41,7 +41,7 @@ Fixes
    DSSP by porting upstream PyDSSP 0.9.1 fix (Issue #4913)
 
 Enhancements
- * Added HydrogenBondAnalysis benchmark for performance tracking (PR #)
+ * Added HydrogenBondAnalysis benchmark for performance tracking (PR #5309)
  * Improved performance of `AtomGroup.wrap()` with compounds (PR #5220)
  * Adds support for parsing `.tpr` files produced by GROMACS 2026.0
  * Enables parallelization for analysis.diffusionmap.DistanceMatrix

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -16,7 +16,7 @@ The rules for this file:
 -------------------------------------------------------------------------------
 ??/??/?? IAlibay, orbeckst, marinegor, tylerjereddy, ljwoods2, marinegor,
          spyke7, talagayev, tanii1125, BradyAJohnston, hejamu, jeremyleung521,
-         harshitgajjela-droid
+         harshitgajjela-droid, Dreamstick9
 
  * 2.11.0
 
@@ -41,6 +41,7 @@ Fixes
    DSSP by porting upstream PyDSSP 0.9.1 fix (Issue #4913)
 
 Enhancements
+ * Added HydrogenBondAnalysis benchmark for performance tracking (PR #)
  * Improved performance of `AtomGroup.wrap()` with compounds (PR #5220)
  * Adds support for parsing `.tpr` files produced by GROMACS 2026.0
  * Enables parallelization for analysis.diffusionmap.DistanceMatrix

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -16,7 +16,6 @@ The rules for this file:
 -------------------------------------------------------------------------------
 ??/??/?? IAlibay, orbeckst, marinegor, tylerjereddy, ljwoods2, marinegor,
          spyke7, talagayev, tanii1125, BradyAJohnston, hejamu, jeremyleung521,
-         harshitgajjela-droid, Dreamstick9
          harshitgajjela-droid, kunjsinha, aygarwal, jauy123, Dreamstick9
 
  * 2.11.0


### PR DESCRIPTION
<!-- 
Insert issue number that this PR fixes (if any) just after 'Fixes #'.
If this PR does not fix an existing issue, consider opening one or remove 'Fixes #' from the PR description.
-->

Changes made in this Pull Request:
<!-- Describe the changes that this PR makes. If applicable, use the following bullet list. --> 
- contributes to #1023 
- Added ASV benchmarks class "HydrogenBondAnalysisBenchmark" in mdanalysis/benchmarks/benchmarks/analysis/hbond_analysis.py
- it benchmarks hbond.run() across different number of frames([2,5,10]) using waterPSF/waterDCD test files

## LLM / AI generated code disclosure
<!-- Please update this disclosure to reflect if you did or did not use LLMs / AI to generate code -->
LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution: yes / no
no
## PR Checklist
<!-- Please use the following checklist to ensure the PR is ready to be reviewed/merged. -->
 - [x] Issue raised/referenced?
 - [ ] Tests updated/added?
 - [x] Documentation updated/added?
 - [x] `package/CHANGELOG` file updated?
 - [x] Is your name in `package/AUTHORS`? (If it is not, add it!)
 - [x] LLM/AI disclosure was updated.

## Developers Certificate of Origin
<!-- 
In order for this PR to be merged you **must certify that you are able to submit your code to be included in MDAnalysis**.
-->

I certify that I can submit this code contribution as described in the [**Developer Certificate of Origin**](https://developercertificate.org/), under the MDAnalysis [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--5309.org.readthedocs.build/en/5309/

<!-- readthedocs-preview mdanalysis end -->