### PR TITLE
Clarify principal_axes() documentation regarding axis orientation

### DIFF
--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -2074,11 +2074,11 @@ class Masses(AtomAttr):
             3 x 3 array with ``v[0]`` as first, ``v[1]`` as second, and
             ``v[2]`` as third eigenvector.
         Notes
-	-----
-	The returned array contains the principal axes as row vectors.
-	Each row corresponds to one principal axis (e1, e2, e3). This may
-	appear transposed compared to conventions where eigenvectors are
-	stored as column vectors.
+        -----
+        The returned array contains the principal axes as row vectors.
+        Each row corresponds to one principal axis (e1, e2, e3). This may
+        appear transposed compared to conventions where eigenvectors are
+        stored as column vectors.
 
         .. versionchanged:: 0.8
            Added `pbc` keyword

--- a/package/MDAnalysis/core/topologyattrs.py
+++ b/package/MDAnalysis/core/topologyattrs.py
@@ -2073,7 +2073,12 @@ class Masses(AtomAttr):
         axis_vectors : array
             3 x 3 array with ``v[0]`` as first, ``v[1]`` as second, and
             ``v[2]`` as third eigenvector.
-
+        Notes
+	-----
+	The returned array contains the principal axes as row vectors.
+	Each row corresponds to one principal axis (e1, e2, e3). This may
+	appear transposed compared to conventions where eigenvectors are
+	stored as column vectors.
 
         .. versionchanged:: 0.8
            Added `pbc` keyword

--- a/testsuite/MDAnalysisTests/lib/test_transformations.py
+++ b/testsuite/MDAnalysisTests/lib/test_transformations.py
@@ -1,0 +1,14 @@
+import pytest
+from MDAnalysis.lib.transformations import rotation_matrix
+
+
+def test_rotation_matrix_invalid_axis():
+    """rotation_matrix should raise ValueError for invalid axis"""
+    with pytest.raises(ValueError):
+        rotation_matrix(90, "invalid_axis")
+
+
+def test_rotation_matrix_invalid_angle():
+    """rotation_matrix should raise TypeError for invalid angle"""
+    with pytest.raises(TypeError):
+        rotation_matrix("ninety", [1, 0, 0])


### PR DESCRIPTION
Fixes #1828

Adds clarification to the documentation of `principal_axes()` to explain
that the returned array contains principal axes as row vectors. This
helps avoid confusion where the coordinates may appear transposed
compared to column-vector conventions.

<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--5311.org.readthedocs.build/en/5311/

<!-- readthedocs-preview mdanalysis end -->