### PR TITLE
Add ASV benchmark for trajectory iteration performance

### DIFF
--- a/benchmarks/benchmarks/trajectory_iteration.py
+++ b/benchmarks/benchmarks/trajectory_iteration.py
@@ -1,0 +1,11 @@
+import MDAnalysis as mda
+from MDAnalysis.tests.datafiles import PSF, DCD
+
+
+class TimeTrajectoryIteration:
+    def setup(self):
+        self.u = mda.Universe(PSF, DCD)
+
+    def time_iterate_trajectory(self):
+        for ts in self.u.trajectory:
+            pass


### PR DESCRIPTION
Fixes #

Changes made in this Pull Request:

* Added an **ASV benchmark** to measure performance of trajectory iteration in MDAnalysis.
* The benchmark measures the time required to iterate through all frames of a trajectory using `Universe.trajectory`.
* Implemented a new benchmark file: `benchmarks/benchmarks/trajectory_iteration.py`.
* This helps monitor performance regressions or improvements in trajectory iteration across future commits.

## LLM / AI generated code disclosure

LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution: yes

## PR Checklist

* [ ] Issue raised/referenced?
* [ ] Tests updated/added?
* [x] Documentation updated/added?
* [ ] `package/CHANGELOG` file updated?
* [ ] Is your name in `package/AUTHORS`? (If it is not, add it!)
* [x] LLM/AI disclosure was updated.

## Developers Certificate of Origin

I certify that I can submit this code contribution as described in the **Developer Certificate of Origin**, under the MDAnalysis LICENSE.


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--5314.org.readthedocs.build/en/5314/

<!-- readthedocs-preview mdanalysis end -->