### PR TITLE
Add ASV benchmark for guess_bonds

### DIFF
--- a/benchmarks/time_guess_bonds.py
+++ b/benchmarks/time_guess_bonds.py
@@ -1,0 +1,12 @@
+class TimeGuessBonds:
+    def setup(self):
+        import MDAnalysis as mda
+        from MDAnalysis.tests.datafiles import PSF, DCD
+        
+        self.u = mda.Universe(PSF, DCD)
+
+        # Provide simple vdW radii (dummy but valid)
+        self.vdwradii = {atom.type: 1.5 + (i % 3)*0.1 for i, atom in enumerate(self.u.atoms)}
+
+    def time_guess_bonds(self):
+        self.u.atoms.guess_bonds(vdwradii=self.vdwradii)


### PR DESCRIPTION
Fixes #4577

Changes made in this Pull Request:

* Added an ASV benchmark `TimeGuessBonds` for `AtomGroup.guess_bonds`
* Measures execution time using MDAnalysis test datasets (PSF, DCD)
* Provided vdW radii explicitly to ensure stable execution and avoid runtime errors
* Contributes to improving benchmark coverage and detecting performance regressions

## LLM / AI generated code disclosure

LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution: yes

## PR Checklist

* [x] Issue raised/referenced?
* [x] Tests updated/added?
* [ ] Documentation updated/added?
* [ ] `package/CHANGELOG` file updated?
* [ ] Is your name in `package/AUTHORS`? (If it is not, add it!)
* [x] LLM/AI disclosure was updated.

## Developers Certificate of Origin

I certify that I can submit this code contribution as described in the [**[Developer Certificate of Origin](https://developercertificate.org/)**](https://developercertificate.org/), under the MDAnalysis [[LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE)](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE).

## Additional Notes

This is my first contribution to MDAnalysis. I would appreciate any feedback or suggestions for improvement.

<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--5321.org.readthedocs.build/en/5321/

<!-- readthedocs-preview mdanalysis end -->