### PR TITLE
Fix bond guessing with mixed-case atomtypes

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -22,6 +22,7 @@ The rules for this file:
  * 2.11.0
 
 Fixes
+ * Fix mixed-case atom types in guess_bonds (Issue #5342, PR #5343)
  * Fixes msd for non-linear frames, when non_linear is not explicitly
    provided (Issue #5100, PR #5254)
  * Fixes TypeError with np.int64 indexing in GSD Reader (Issue #5224)

--- a/package/MDAnalysis/guesser/default_guesser.py
+++ b/package/MDAnalysis/guesser/default_guesser.py
@@ -429,7 +429,7 @@ class DefaultGuesser(GuesserBase):
 
         # Try using types, then elements
         if hasattr(atoms, "types"):
-            atomtypes = atoms.types
+            atomtypes = np.char.upper(atoms.types.astype(str))
         else:
             atomtypes = self.guess_types(atom_types=atoms.names)
 

--- a/package/MDAnalysis/guesser/default_guesser.py
+++ b/package/MDAnalysis/guesser/default_guesser.py
@@ -429,9 +429,12 @@ class DefaultGuesser(GuesserBase):
 
         # Try using types, then elements
         if hasattr(atoms, "types"):
-            atomtypes = np.char.upper(atoms.types.astype(str))
+            atomtypes = atoms.types
         else:
             atomtypes = self.guess_types(atom_types=atoms.names)
+
+        # vdwradii keys are uppercase, so normalize atomtypes to match
+        atomtypes = np.char.upper(np.asarray(atomtypes, dtype=str))
 
         # check that all types have a defined vdw
         if not all(val in vdwradii for val in set(atomtypes)):

--- a/testsuite/MDAnalysisTests/guesser/test_default_guesser.py
+++ b/testsuite/MDAnalysisTests/guesser/test_default_guesser.py
@@ -280,6 +280,19 @@ def test_guess_bonds_peptide():
     assert_equal(np.sort(u.bonds.indices, axis=0), np.sort(bonds, axis=0))
 
 
+def test_guess_bonds_mixed_case_types():
+    """Test that the guesser can handle mixed-case types"""
+    n_atoms = 2
+    # Actual positions don't matter for this test
+    positions = np.array([[0.0, 0.0, 0.0], [2.5, 0.0, 0.0]])
+    # Use mixed-case types
+    topology = Topology(n_atoms, attrs=[Atomtypes(["Au", "h"])])
+    u = mda.Universe(topology)
+    guesser = DefaultGuesser(None)
+    # This should not raise an error due to the mixed-case types
+    bonds = guesser.guess_bonds(u.atoms, positions)
+
+
 @pytest.mark.parametrize(
     "smi",
     [


### PR DESCRIPTION
Fixes #5342 

Changes made in this Pull Request:
- Atomtypes are converted to uppercase for comparison with the vdwradii table (which is all uppercase)

## LLM / AI generated code disclosure
LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution: no

## PR Checklist
 - [x] Issue raised/referenced?
 - [x] Tests updated/added?
 - [ ] Documentation updated/added?
 - [x] `package/CHANGELOG` file updated?
 - [x] Is your name in `package/AUTHORS`? (If it is not, add it!)
 - [x] LLM/AI disclosure was updated.

## Developers Certificate of Origin

I certify that I can submit this code contribution as described in the [**Developer Certificate of Origin**](https://developercertificate.org/), under the MDAnalysis [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--5343.org.readthedocs.build/en/5343/

<!-- readthedocs-preview mdanalysis end -->