### PR TITLE
FIX: Use mean aggregation for InterRDF bins

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -17,11 +17,12 @@ The rules for this file:
 ??/??/?? IAlibay, orbeckst, marinegor, tylerjereddy, ljwoods2, marinegor,
          spyke7, talagayev, tanii1125, BradyAJohnston, hejamu, jeremyleung521,
          harshitgajjela-droid, kunjsinha, aygarwal, jauy123, Dreamstick9,
-         ollyfutur, Amarendra22, charity-g, ParthUppal523
+         ollyfutur, Amarendra22, charity-g, ParthUppal523, raulloiscuns
 
  * 2.11.0
 
 Fixes
+ * InterRDF now correctly returns bins in parallel (PR #5344)
  * The `principal_axes` method in :class:`Masses` now uses
    `np.linalg.eigh` instead of `np.linalg.eig`, improving numerical
    stability. This may lead to slightly different results from previous
@@ -65,7 +66,7 @@ Fixes
 
 Enhancements
  * Added ASV benchmark for PDB trajectory reading (PR #5394)
- * Read Linear Angle bonded interaction entries from GROMACS TPR files and 
+ * Read Linear Angle bonded interaction entries from GROMACS TPR files and
    add the angles to the topology (Issue #5361, PR #5372)
  * Enables parallelization for analysis.atomicdistances.AtomicDistances
    (Issue #4662, PR #4822)

--- a/package/MDAnalysis/analysis/rdf.py
+++ b/package/MDAnalysis/analysis/rdf.py
@@ -369,7 +369,7 @@ class InterRDF(AnalysisBase):
             lookup={
                 "count": ResultsGroup.ndarray_sum,
                 "volume_cum": ResultsGroup.ndarray_sum,
-                "bins": ResultsGroup.ndarray_sum,
+                "bins": ResultsGroup.ndarray_mean,
                 "edges": ResultsGroup.ndarray_mean,
             }
         )

--- a/testsuite/MDAnalysisTests/analysis/test_rdf.py
+++ b/testsuite/MDAnalysisTests/analysis/test_rdf.py
@@ -31,7 +31,8 @@ from MDAnalysisTests.datafiles import two_water_gro
 import numpy as np
 from numpy.testing import assert_allclose
 
-NFRAMES=5
+NFRAMES = 5
+
 
 @pytest.fixture()
 def u():
@@ -46,10 +47,10 @@ def sels(u):
     # (NOTE: requires in-memory coordinates to make them permanent)
     for at, (x, y) in zip(u.atoms, zip([1] * 3 + [2] * 3, [2, 1, 3] * 2)):
         at.position = x, y, 0.0
-    #Create a fake trajectory with the same frame for testing parallel backends
+    # Create a fake trajectory with the same frame for testing parallel backends
     trajectory_data = np.tile(u.atoms.positions, (NFRAMES, 1, 1))
     dimensions_data = np.tile(u.dimensions, (NFRAMES, 1))
-    u.load_new(trajectory_data, format="Memory", dimensions=dimensions_data)
+    u.load_new(trajectory_data, format="MEMORY", dimensions=dimensions_data)
     s1 = u.select_atoms("name OW")
     s2 = u.select_atoms("name HW1 HW2")
     return s1, s2
@@ -90,7 +91,7 @@ def test_count(sels, client_InterRDF):
 
 def test_double_run(sels):
     # running rdf twice should give the same result
-    # Note: this only make sense for serial backend as results aggregator can not handle 
+    # Note: this only make sense for serial backend as results aggregator can not handle
     # rdf flag if rdf.results object is not restarted when parallel backend is used
     s1, s2 = sels
     rdf = InterRDF(s1, s2).run()

--- a/testsuite/MDAnalysisTests/analysis/test_rdf.py
+++ b/testsuite/MDAnalysisTests/analysis/test_rdf.py
@@ -28,8 +28,10 @@ from MDAnalysisTests.util import distopia_conditional_backend
 
 from MDAnalysisTests.datafiles import two_water_gro
 
+import numpy as np
 from numpy.testing import assert_allclose
 
+NFRAMES=5
 
 @pytest.fixture()
 def u():
@@ -44,6 +46,10 @@ def sels(u):
     # (NOTE: requires in-memory coordinates to make them permanent)
     for at, (x, y) in zip(u.atoms, zip([1] * 3 + [2] * 3, [2, 1, 3] * 2)):
         at.position = x, y, 0.0
+    #Create a fake trajectory with the same frame for testing parallel backends
+    trajectory_data = np.tile(u.atoms.positions, (NFRAMES, 1, 1))
+    dimensions_data = np.tile(u.dimensions, (NFRAMES, 1))
+    u.load_new(trajectory_data, format="Memory", dimensions=dimensions_data)
     s1 = u.select_atoms("name OW")
     s2 = u.select_atoms("name HW1 HW2")
     return s1, s2
@@ -72,29 +78,31 @@ def test_count_sum(sels, client_InterRDF):
     # should see 8 comparisons in count
     s1, s2 = sels
     rdf = InterRDF(s1, s2).run(**client_InterRDF)
-    assert rdf.results.count.sum() == 8
+    assert rdf.results.count.sum() == 8 * NFRAMES
 
 
 def test_count(sels, client_InterRDF):
     # should see two distances with 4 counts each
     s1, s2 = sels
     rdf = InterRDF(s1, s2).run(**client_InterRDF)
-    assert len(rdf.results.count[rdf.results.count == 4]) == 2
+    assert len(rdf.results.count[rdf.results.count == 4 * NFRAMES]) == 2
 
 
-def test_double_run(sels, client_InterRDF):
+def test_double_run(sels):
     # running rdf twice should give the same result
+    # Note: this only make sense for serial backend as results aggregator can not handle 
+    # rdf flag if rdf.results object is not restarted when parallel backend is used
     s1, s2 = sels
-    rdf = InterRDF(s1, s2).run(**client_InterRDF)
-    rdf.run(**client_InterRDF)
-    assert len(rdf.results.count[rdf.results.count == 4]) == 2
+    rdf = InterRDF(s1, s2).run()
+    rdf.run()
+    assert len(rdf.results.count[rdf.results.count == 4 * NFRAMES]) == 2
 
 
 def test_exclusion(sels, client_InterRDF):
     # should see two distances with 4 counts each
     s1, s2 = sels
     rdf = InterRDF(s1, s2, exclusion_block=(1, 2)).run(**client_InterRDF)
-    assert rdf.results.count.sum() == 4
+    assert rdf.results.count.sum() == 4 * NFRAMES
 
 
 @pytest.mark.parametrize(
@@ -105,7 +113,7 @@ def test_ignore_same_residues(sels, attr, count, client_InterRDF):
     s1, s2 = sels
     rdf = InterRDF(s2, s2, exclude_same=attr).run(**client_InterRDF)
     assert rdf.rdf[0] == 0
-    assert rdf.results.count.sum() == count
+    assert rdf.results.count.sum() == count * NFRAMES
 
 
 def test_ignore_same_residues_fails(sels, client_InterRDF):
@@ -158,7 +166,7 @@ def test_unknown_norm(sels):
 
 
 @pytest.mark.parametrize("backend", distopia_conditional_backend())
-def test_norm(sels, backend):
+def test_backend(sels, backend):
     s1, s2 = sels
     rdf = InterRDF(s1, s2, norm="none", backend=backend).run()
     assert_allclose(max(rdf.results.rdf), 4)


### PR DESCRIPTION
FIX: update bin calculation to use ndarray_mean in aggregator of InterRDF and correct InterRDF tests to correctly support multiple frames


Changes made in this Pull Request:
<!-- Describe the changes that this PR makes. If applicable, use the following bullet list. --> 
- **Fixed parallel aggregation for bins:** Updated the `ResultsGroup` aggregator in `InterRDF` to use `ndarray_mean` instead of `ndarray_sum` for `bins`.
- **Added multi-frame support to tests:** Modified the `sels` fixture in `test_rdf.py` to generate a mock trajectory with multiple frames.
- **Adjusted `test_double_run`:** Removed the parallel backend parametrization for `test_double_run`, restricting it to the serial backend.
- **Renamed duplicated `test_norm`**

## LLM / AI generated code disclosure
<!-- Please update this disclosure to reflect if you did or did not use LLMs / AI to generate code -->
LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution: no

## PR Checklist
<!-- Please use the following checklist to ensure the PR is ready to be reviewed/merged. -->
 - [ ] Issue raised/referenced?
 - [X] Tests updated/added?
 - [X] Documentation updated/added?
 - [x] `package/CHANGELOG` file updated?
 - [X] Is your name in `package/AUTHORS`? (If it is not, add it!)
 - [X] LLM/AI disclosure was updated.

## Developers Certificate of Origin
<!-- 
In order for this PR to be merged you **must certify that you are able to submit your code to be included in MDAnalysis**.
-->

I certify that I can submit this code contribution as described in the [**Developer Certificate of Origin**](https://developercertificate.org/), under the MDAnalysis [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--5344.org.readthedocs.build/en/5344/

<!-- readthedocs-preview mdanalysis end -->