### PR TITLE
ENH: expose TPR box dimensions through timestep

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -280,6 +280,7 @@ Chronological list of authors
   - Amarendra Mohan
   - Shubham Mittal  
   - Charity Grey
+  - Tanmay Baranwal
 
 External code
 -------------

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -18,10 +18,13 @@ The rules for this file:
          spyke7, talagayev, tanii1125, BradyAJohnston, hejamu, jeremyleung521,
          harshitgajjela-droid, kunjsinha, aygarwal, jauy123, Dreamstick9,
          ollyfutur, Amarendra22, charity-g, ParthUppal523
-
+ 
  * 2.11.0
 
 Fixes
+ * TPRReader now exposes box dimensions when loading TPR files
+   as coordinates-only Universes, fixing missing `Universe.dimensions`
+   values. (Issue #5375, PR #27)
  * `MDAnalysis.analysis.nucleicacids.WatsonCrickDist`, `MinorPairDist`,
    and `MajorPairDist` now match residue names against the full resname
    instead of only the first character, fixing incorrect behaviour with

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -24,7 +24,7 @@ The rules for this file:
 Fixes
  * TPRReader now exposes box dimensions when loading TPR files
    as coordinates-only Universes, fixing missing `Universe.dimensions`
-   values. (Issue #5375, PR #27)
+   values. (Issue #5375, PR #5377)
  * `MDAnalysis.analysis.nucleicacids.WatsonCrickDist`, `MinorPairDist`,
    and `MajorPairDist` now match residue names against the full resname
    instead of only the first character, fixing incorrect behaviour with

--- a/package/MDAnalysis/coordinates/TPR.py
+++ b/package/MDAnalysis/coordinates/TPR.py
@@ -51,6 +51,7 @@ Classes
 
 """
 
+from ..lib.mdamath import triclinic_box
 from . import base
 from ..lib import util
 from .timestep import Timestep
@@ -110,7 +111,15 @@ class TPRReader(base.SingleFrameReaderBase):
 
         state_ngtc = th.ngtc  # done init_state() in src/gmxlib/tpxio.c
         if th.bBox:
-            tpr_utils.extract_box_info(data, th.fver)
+            box_info = tpr_utils.extract_box_info(data, th.fver)
+            # box vectors are stored in nm
+            box_angstrom = np.array(box_info.size) * 10.0
+
+            ts.dimensions = triclinic_box(
+                box_angstrom[0],
+                box_angstrom[1],
+                box_angstrom[2],
+            )
 
         if state_ngtc > 0:
             if th.fver < 69:  # redundancy due to  different versions

--- a/testsuite/MDAnalysisTests/coordinates/test_tpr.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_tpr.py
@@ -75,6 +75,7 @@ import MDAnalysis as mda
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
+from MDAnalysisTests.datafiles import TPR
 
 
 @pytest.mark.parametrize(
@@ -494,3 +495,16 @@ def test_different_versions():
     assert_allclose(u.atoms.velocities[-1, ...], exp_vel)
     assert_equal(u.atoms.positions.shape, exp_shape)
     assert_equal(u.atoms.velocities.shape, exp_shape)
+
+
+class TestTPRDimensions:
+    """Tests for TPR coordinate box dimensions."""
+
+    def test_tpr_dimensions_values(self):
+        u = mda.Universe(TPR)
+
+        assert_allclose(
+            u.dimensions,
+            [80.017006, 80.017006, 80.017006, 60.0, 60.0, 90.0],
+            rtol=1e-5,
+        )

--- a/testsuite/MDAnalysisTests/coordinates/test_tpr.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_tpr.py
@@ -500,11 +500,30 @@ def test_different_versions():
 class TestTPRDimensions:
     """Tests for TPR coordinate box dimensions."""
 
-    def test_tpr_dimensions_values(self):
-        u = mda.Universe(TPR)
-
-        assert_allclose(
-            u.dimensions,
-            [80.017006, 80.017006, 80.017006, 60.0, 60.0, 90.0],
-            rtol=1e-5,
-        )
+    @pytest.mark.parametrize(
+        "tpr_file, expected_dims",
+        [
+            # cubic box - adk oplsaa system (tpx 58)
+            (
+                TPR,
+                [80.017006, 80.017006, 80.017, 60.0, 60.0, 90.0],
+            ),
+            # cubic box - same system different gromacs versions
+            (
+                TPR2024_4,
+                [79.1, 79.1, 37.9, 90.0, 90.0, 90.0],
+            ),
+            (
+                TPR2016,
+                [79.1, 79.1, 37.9, 90.0, 90.0, 90.0],
+            ),
+            # different box shape
+            (
+                TPR455Double,
+                [43.7388, 43.7388, 107.9261, 90.0, 90.0, 90.0],
+            ),
+        ],
+    )
+    def test_tpr_dimensions_values(self, tpr_file, expected_dims):
+        u = mda.Universe(tpr_file)
+        assert_allclose(u.dimensions, expected_dims, rtol=1e-3)

--- a/testsuite/MDAnalysisTests/topology/test_tprparser.py
+++ b/testsuite/MDAnalysisTests/topology/test_tprparser.py
@@ -23,6 +23,7 @@
 import functools
 
 import MDAnalysis as mda
+from numpy.testing import assert_allclose
 import MDAnalysis.topology.TPRParser
 import numpy as np
 import pytest
@@ -438,23 +439,3 @@ def test_resids(resid_from_one, resid_addition):
         resids,
         err_msg="tpr_resid_from_one kwarg not switching resids",
     )
-
-
-class TestTPRBoxVectors:
-    """Tests for TPRParser box vector support."""
-
-    def test_tpr_only_dimensions_not_none(self):
-        import MDAnalysis as mda
-        from MDAnalysisTests.datafiles import TPR
-
-        u = mda.Universe(TPR)
-
-        assert u.dimensions is not None
-
-    def test_tpr_only_dimensions_shape(self):
-        import MDAnalysis as mda
-        from MDAnalysisTests.datafiles import TPR
-
-        u = mda.Universe(TPR)
-
-        assert u.dimensions.shape == (6,)

--- a/testsuite/MDAnalysisTests/topology/test_tprparser.py
+++ b/testsuite/MDAnalysisTests/topology/test_tprparser.py
@@ -439,6 +439,7 @@ def test_resids(resid_from_one, resid_addition):
         err_msg="tpr_resid_from_one kwarg not switching resids",
     )
 
+
 class TestTPRBoxVectors:
     """Tests for TPRParser box vector support."""
 

--- a/testsuite/MDAnalysisTests/topology/test_tprparser.py
+++ b/testsuite/MDAnalysisTests/topology/test_tprparser.py
@@ -438,3 +438,22 @@ def test_resids(resid_from_one, resid_addition):
         resids,
         err_msg="tpr_resid_from_one kwarg not switching resids",
     )
+
+class TestTPRBoxVectors:
+    """Tests for TPRParser box vector support."""
+
+    def test_tpr_only_dimensions_not_none(self):
+        import MDAnalysis as mda
+        from MDAnalysisTests.datafiles import TPR
+
+        u = mda.Universe(TPR)
+
+        assert u.dimensions is not None
+
+    def test_tpr_only_dimensions_shape(self):
+        import MDAnalysis as mda
+        from MDAnalysisTests.datafiles import TPR
+
+        u = mda.Universe(TPR)
+
+        assert u.dimensions.shape == (6,)


### PR DESCRIPTION
When a Universe is created directly from a TPR file, u.dimensions previously returned None because box information was extracted but discarded during TPR reading.

This change reads box vectors from the TPRReader, converts them from nanometres to Angstroms, converts triclinic vectors into MDAnalysis dimensions format, and stores them in ts.dimensions.

Tests were added to verify dimensions are populated correctly.

Closes #5375 

<!-- 
Insert issue number that this PR fixes (if any) just after 'Fixes #'.
If this PR does not fix an existing issue, consider opening one or remove 'Fixes #' from the PR description.
-->
Fixes #5375 

Changes made in this Pull Request:
<!-- Describe the changes that this PR makes. If applicable, use the following bullet list. --> 
- Read box vectors from TPR files in `TPRReader`.
- Convert triclinic box vectors into MDAnalysis dimensions format.
- Store dimensions in `ts.dimensions`.
- Add regression tests for TPR dimensions handling.
- Add changelog entry for the fix.


## LLM / AI generated code disclosure
<!-- Please update this disclosure to reflect if you did or did not use LLMs / AI to generate code -->
LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution: yes

## PR Checklist
<!-- Please use the following checklist to ensure the PR is ready to be reviewed/merged. -->
 - [x] Issue raised/referenced?
 - [x] Tests updated/added?
 - [ ] Documentation updated/added?
 - [x] `package/CHANGELOG` file updated?
 - [x] Is your name in `package/AUTHORS`? (If it is not, add it!)
 - [x] LLM/AI disclosure was updated.

## Developers Certificate of Origin
<!-- 
In order for this PR to be merged you **must certify that you are able to submit your code to be included in MDAnalysis**.
-->

I certify that I can submit this code contribution as described in the [**Developer Certificate of Origin**](https://developercertificate.org/), under the MDAnalysis [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--5377.org.readthedocs.build/en/5377/

<!-- readthedocs-preview mdanalysis end -->