### PR TITLE
FIX: Mismatch in groupselections for RMSD between target and reference 

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -280,6 +280,7 @@ Chronological list of authors
   - Amarendra Mohan
   - Shubham Mittal  
   - Charity Grey
+  - Dhanushka Weerakoon
 
 External code
 -------------

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -17,11 +17,13 @@ The rules for this file:
 ??/??/?? IAlibay, orbeckst, marinegor, tylerjereddy, ljwoods2, marinegor,
          spyke7, talagayev, tanii1125, BradyAJohnston, hejamu, jeremyleung521,
          harshitgajjela-droid, kunjsinha, aygarwal, jauy123, Dreamstick9,
-         ollyfutur, Amarendra22, charity-g, ParthUppal523
+         ollyfutur, Amarendra22, charity-g, ParthUppal523, DhanushkaWeerakoon
 
  * 2.11.0
 
 Fixes
+* Fix mismatch in target and reference groupselection coordinates which
+   can occur during RMSD calculations (Issue #2797) 
  * `MDAnalysis.analysis.nucleicacids.WatsonCrickDist`, `MinorPairDist`,
    and `MajorPairDist` now match residue names against the full resname
    instead of only the first character, fixing incorrect behaviour with

--- a/package/MDAnalysis/analysis/rms.py
+++ b/package/MDAnalysis/analysis/rms.py
@@ -733,7 +733,7 @@ class RMSD(AnalysisBase):
             if self._groupselections_atoms:
                 self._groupselections_ref_coords64 = [
                     (
-                        self.reference.select_atoms(
+                        self.reference.universe.select_atoms(
                             *s["reference"]
                         ).positions.astype(np.float64)
                     )

--- a/testsuite/MDAnalysisTests/analysis/test_rms.py
+++ b/testsuite/MDAnalysisTests/analysis/test_rms.py
@@ -194,6 +194,10 @@ class TestRMSD(object):
     def correct_values_backbone_group(self):
         return [[0, 1, 0, 0, 0], [49, 50, 4.6997, 1.9154, 2.7139]]
 
+    @pytest.fixture()
+    def correct_values_alphacarbons_group(self):
+        return [[0, 1, 0, 0], [49, 50, 1.6521, 1.6371]]
+
     def test_rmsd(self, universe, correct_values, client_RMSD):
         # client_RMSD is defined in testsuite/analysis/conftest.py
         # among with other testing fixtures. During testing, it will

--- a/testsuite/MDAnalysisTests/analysis/test_rms.py
+++ b/testsuite/MDAnalysisTests/analysis/test_rms.py
@@ -513,12 +513,7 @@ class TestRMSD(object):
                 select=42,
             )
 
-    def test_group_selections_outside_atomgroup(
-            self,
-            universe,
-            correct_values_alphacarbons_group,
-            client_RMSD
-            ):
+    def test_group_selections_outside_atomgroup(self, universe, correct_values_alphacarbons_group, client_RMSD):
         ca = universe.select_atoms('name CA')
         CORE = 'backbone and (resid 1-29 or resid 60-121 or resid 160-214)'
         RMSD = MDAnalysis.analysis.rms.RMSD(

--- a/testsuite/MDAnalysisTests/analysis/test_rms.py
+++ b/testsuite/MDAnalysisTests/analysis/test_rms.py
@@ -513,9 +513,11 @@ class TestRMSD(object):
                 select=42,
             )
 
-    def test_group_selections_outside_atomgroup(self, universe, correct_values_alphacarbons_group, client_RMSD):
-        ca = universe.select_atoms('name CA')
-        CORE = 'backbone and (resid 1-29 or resid 60-121 or resid 160-214)'
+    def test_group_selections_outside_atomgroup(
+        self, universe, correct_values_alphacarbons_group, client_RMSD
+    ):
+        ca = universe.select_atoms("name CA")
+        CORE = "backbone and (resid 1-29 or resid 60-121 or resid 160-214)"
         RMSD = MDAnalysis.analysis.rms.RMSD(
             ca,
             ca,
@@ -529,7 +531,7 @@ class TestRMSD(object):
             correct_values_alphacarbons_group,
             4,
             err_msg="error: rmsd profile should match"
-            "between true values and calculated values"
+            "between true values and calculated values",
         )
 
 

--- a/testsuite/MDAnalysisTests/analysis/test_rms.py
+++ b/testsuite/MDAnalysisTests/analysis/test_rms.py
@@ -509,6 +509,30 @@ class TestRMSD(object):
                 select=42,
             )
 
+    def test_group_selections_outside_atomgroup(
+            self,
+            universe,
+            correct_values_alphacarbons_group,
+            client_RMSD
+            ):
+        ca = universe.select_atoms('name CA')
+        CORE = 'backbone and (resid 1-29 or resid 60-121 or resid 160-214)'
+        RMSD = MDAnalysis.analysis.rms.RMSD(
+            ca,
+            ca,
+            select=CORE,
+            groupselections=[CORE],
+        )
+        RMSD.run(step=49, **client_RMSD)
+
+        assert_almost_equal(
+            RMSD.results.rmsd,
+            correct_values_alphacarbons_group,
+            4,
+            err_msg="error: rmsd profile should match"
+            "between true values and calculated values"
+        )
+
 
 class TestRMSF(object):
     @pytest.fixture()


### PR DESCRIPTION
<!-- 
Insert issue number that this PR fixes (if any) just after 'Fixes #'.
If this PR does not fix an existing issue, consider opening one or remove 'Fixes #' from the PR description.
-->
Fixes #2797 

Changes made in this Pull Request:
<!-- Describe the changes that this PR makes. If applicable, use the following bullet list. --> 
- Fixed mismatch between groupselection mobile and reference coordinates: changed atom selection for reference groupselection to be from self.reference.universe instead of self.reference (line 736)
- Added test_group_selections_outside_atomgroup: recreates test case in Issue #2797 for a single frame

## LLM / AI generated code disclosure
<!-- Please update this disclosure to reflect if you did or did not use LLMs / AI to generate code -->
LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution: no

## PR Checklist
<!-- Please use the following checklist to ensure the PR is ready to be reviewed/merged. -->
 - [x] Issue raised/referenced?
 - [x] Tests updated/added?
 - [ ] Documentation updated/added?
 - [x] `package/CHANGELOG` file updated?
 - [x] Is your name in `package/AUTHORS`? (If it is not, add it!)
 - [x] LLM/AI disclosure was updated.

## Developers Certificate of Origin
<!-- 
In order for this PR to be merged you **must certify that you are able to submit your code to be included in MDAnalysis**.
-->

I certify that I can submit this code contribution as described in the [**Developer Certificate of Origin**](https://developercertificate.org/), under the MDAnalysis [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE).


<!-- readthedocs-preview mdanalysis start -->
----
📚 Documentation preview 📚: https://mdanalysis--5379.org.readthedocs.build/en/5379/

<!-- readthedocs-preview mdanalysis end -->