### PR TITLE
changed btype, to btype as its causing error while running tests

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -280,6 +280,7 @@ Chronological list of authors
   - Amarendra Mohan
   - Shubham Mittal  
   - Charity Grey
+  - Sai Udayagiri
 
 External code
 -------------

--- a/testsuite/MDAnalysisTests/core/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/core/test_atomgroup.py
@@ -88,7 +88,7 @@ class TestAtomGroupToTopology(object):
         assert isinstance(imp, ImproperDihedral)
 
     @pytest.mark.parametrize(
-        "btype,", ["bond", "angle", "dihedral", "improper"]
+        "btype", ["bond", "angle", "dihedral", "improper"]
     )
     def test_VE(self, btype, u):
         ag = u.atoms[:10]


### PR DESCRIPTION
As this is a small change i have not raised any issue.

Changes made in this Pull Request:

* Fixed the parameter name in `pytest.mark.parametrize` for `test_VE` in `testsuite/MDAnalysisTests/core/test_atomgroup.py`.
* Removed the unintended trailing comma from `"btype,"`, changing it to `"btype"` so that the parametrized argument correctly matches the test function signature.

## LLM / AI generated code disclosure

LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution: No

## PR Checklist

* [ ] Issue raised/referenced?
* [x] Tests updated/added?
* [ ] Documentation updated/added?
* [ ] `package/CHANGELOG` file updated?
* [x] Is your name in `package/AUTHORS`? (If it is not, add it!)
* [ ] LLM/AI disclosure was updated.

## Developers Certificate of Origin

I certify that I can submit this code contribution as described in the [**[Developer Certificate of Origin](https://developercertificate.org/)**](https://developercertificate.org/), under the MDAnalysis [[LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE)](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE).