### PR TITLE
Exclude bad rdkit version for mypy check

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -94,6 +94,7 @@ jobs:
           micromamba: true
           full-deps: true
           numpy: numpy=1.26.0
+          rdkit: rdkit!=2026.03.3
 
       - name: install
         run: |


### PR DESCRIPTION
There's an issue with rdkit 2026.03.3 when it comes to type checking - I believe it's being addressed upstream.

## LLM / AI generated code disclosure
<!-- Please update this disclosure to reflect if you did or did not use LLMs / AI to generate code -->
LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution: no

## PR Checklist
<!-- Please use the following checklist to ensure the PR is ready to be reviewed/merged. -->
 - [-] Issue raised/referenced?
 - [-] Tests updated/added?
 - [-] Documentation updated/added?
 - [-] `package/CHANGELOG` file updated?
 - [-] Is your name in `package/AUTHORS`? (If it is not, add it!)
 - [-] LLM/AI disclosure was updated.

## Developers Certificate of Origin
<!-- 
In order for this PR to be merged you **must certify that you are able to submit your code to be included in MDAnalysis**.
-->

I certify that I can submit this code contribution as described in the [**Developer Certificate of Origin**](https://developercertificate.org/), under the MDAnalysis [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE).
