### PR TITLE
tests: modernize assertions in test_persistencelength (ref #3743)

### DIFF
--- a/testsuite/MDAnalysisTests/analysis/test_persistencelength.py
+++ b/testsuite/MDAnalysisTests/analysis/test_persistencelength.py
@@ -31,7 +31,7 @@ import numpy as np
 import matplotlib
 import matplotlib.pyplot as plt
 
-from numpy.testing import assert_almost_equal, assert_equal
+from numpy.testing import assert_equal
 
 from MDAnalysisTests.datafiles import Plength, TRZ_psf, TRZ
 
@@ -73,10 +73,10 @@ class TestPersistenceLength(object):
         assert len(p_run.results.bond_autocorrelation) == 280
 
     def test_lb(self, p_run):
-        assert_almost_equal(p_run.results.lb, 1.485, 3)
+        assert p_run.results.lb == pytest.approx(1.485, abs=1e-3)
 
     def test_fit(self, p_run):
-        assert_almost_equal(p_run.results.lp, 6.504, 3)
+        assert p_run.results.lp == pytest.approx(6.504, abs=1e-3)
         assert len(p_run.results.fit) == len(
             p_run.results.bond_autocorrelation
         )
@@ -124,7 +124,7 @@ class TestFitExponential(object):
 
         a = polymer.fit_exponential_decay(self.x, y2)
 
-        assert_almost_equal(a, self.a_ref, decimal=3)
+        assert a == pytest.approx(self.a_ref, abs=1e-3)
         # assert np.rint(a) == self.a_ref
 
 


### PR DESCRIPTION
## Summary

This PR modernizes deprecated NumPy testing assertions in `testsuite/MDAnalysisTests/analysis/test_persistencelength.py` as part of issue #3743.

### Changes

* Replaced scalar uses of `assert_almost_equal()` with `pytest.approx()`
* Removed the deprecated `assert_almost_equal` import

### Verification

* Ran:

  `pytest testsuite/MDAnalysisTests/analysis/test_persistencelength.py`

* Result: all 30 tests passed successfully.
