### PR TITLE
BUG: combine cmaps when merging Universes (Issue #3672)

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -281,6 +281,7 @@ Chronological list of authors
   - Shubham Mittal  
   - Charity Grey
   - Sai Udayagiri
+  - Apoorva Verma
 
 External code
 -------------

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -17,11 +17,14 @@ The rules for this file:
 ??/??/?? IAlibay, orbeckst, marinegor, tylerjereddy, ljwoods2, marinegor,
          spyke7, talagayev, tanii1125, BradyAJohnston, hejamu, jeremyleung521,
          harshitgajjela-droid, kunjsinha, aygarwal, jauy123, Dreamstick9,
-         ollyfutur, Amarendra22, charity-g, ParthUppal523
+         ollyfutur, Amarendra22, charity-g, ParthUppal523, apoorva-01
 
  * 2.11.0
 
 Fixes
+ * `Merge()` no longer raises a TypeError on Universes that have a `cmaps`
+   attribute; cmaps are now combined like the other connection attributes
+   (bonds, angles, dihedrals, impropers) (Issue #3672).
  * The `principal_axes` method in :class:`Masses` now uses
    `np.linalg.eigh` instead of `np.linalg.eig`, improving numerical
    stability. This may lead to slightly different results from previous

--- a/package/MDAnalysis/core/universe.py
+++ b/package/MDAnalysis/core/universe.py
@@ -2162,7 +2162,7 @@ def Merge(*args):
     common_attrs = set.intersection(
         *[set(dir(ag.universe._topology)) for ag in args]
     )
-    tops = set(["bonds", "angles", "dihedrals", "impropers"])
+    tops = set(["bonds", "angles", "dihedrals", "impropers", "cmaps"])
 
     attrs = []
 

--- a/testsuite/MDAnalysisTests/utils/test_modelling.py
+++ b/testsuite/MDAnalysisTests/utils/test_modelling.py
@@ -329,3 +329,24 @@ class TestMergeTopology(object):
         assert len(u_merge.atoms.angles) == 0
         assert len(u_merge.atoms.dihedrals) == 0
         assert len(u_merge.atoms.impropers) == 0
+
+    def test_merge_with_cmaps(self, u):
+        # cmaps are a connection attribute like bonds/angles, so Merge() must
+        # route them through the connection path rather than treating them as a
+        # plain array (Issue #3672).
+        u.add_TopologyAttr(
+            "cmaps", [[0, 1, 2, 3, 4], [100, 101, 102, 103, 104]]
+        )
+
+        ag1 = u.atoms[:20]
+        ag2 = u.atoms[100:110]
+        u_merge = MDAnalysis.Merge(ag1, ag2)
+
+        # Both cmaps lie entirely within their atomgroup, so both survive and
+        # are renumbered against the merged universe (ag2 is offset by len(ag1)).
+        assert hasattr(u_merge.atoms, "cmaps")
+        assert len(u_merge.atoms.cmaps) == 2
+        merged = sorted(
+            tuple(int(i) for i in c.indices) for c in u_merge.atoms.cmaps
+        )
+        assert merged == [(0, 1, 2, 3, 4), (20, 21, 22, 23, 24)]


### PR DESCRIPTION
Fixes #3672

Changes made in this Pull Request:
`Merge()` remaps the connection attributes (bonds, angles, dihedrals, impropers) onto the merged Universe and concatenates everything else as a plain array. `cmaps` is a connection attribute too, but it wasn't in that set, so merging a Universe that carries cmaps raised `TypeError: Encountered unexpected topology attribute of type ...TopologyGroup`. This adds `cmaps` to the set so it's combined the same way as the others, with a regression test that fails without the change.

`UreyBradleys` is another `_Connection` missing from that set, so it has the same latent bug. I kept this PR to just `cmaps`, but I'm happy to generalise it (derive the set from the `_Connection` subclasses) or do a follow-up if you'd rather.

## LLM / AI generated code disclosure
LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution: no

## PR Checklist
 - [x] Issue raised/referenced?
 - [x] Tests updated/added?
 - [ ] Documentation updated/added? (bug fix, no API change)
 - [x] `package/CHANGELOG` file updated?
 - [x] Is your name in `package/AUTHORS`?
 - [x] LLM/AI disclosure was updated.

## Developers Certificate of Origin
I certify that I can submit this code contribution as described in the [**Developer Certificate of Origin**](https://developercertificate.org/), under the MDAnalysis [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE).
