### PR TITLE
Fix for First argument to super() is not enclosing class

### DIFF
--- a/package/MDAnalysis/analysis/dihedrals.py
+++ b/package/MDAnalysis/analysis/dihedrals.py
@@ -637,7 +637,7 @@ class Janin(Ramachandran):
            :attr:`angles` results are now stored in a
            :class:`MDAnalysis.analysis.base.Results` instance.
         """
-        super(Ramachandran, self).__init__(
+        super(Janin, self).__init__(
             atomgroup.universe.trajectory, **kwargs
         )
         self.atomgroup = atomgroup


### PR DESCRIPTION
Fixes #

Changes made in this Pull Request:

Fixes incorrect call of super in the Janin analysis class. 

This error was detected when doing a trial run of CodeQL, see https://github.com/MDAnalysis/mdanalysis/security/quality and in particular https://github.com/MDAnalysis/mdanalysis/security/quality/rules/py%2Fsuper-not-enclosing-class

The "generate fix" disregards our standard PR template and adds the text below. For compliance, I manually inserted the PR text from 


## LLM / AI generated code disclosure
<!-- Please update this disclosure to reflect if you did or did not use LLMs / AI to generate code -->
LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution: yes 

The fix was auto-generated, i.e., full AI use. However, that was simply faster than me making the equivalent edit.


## PR Checklist
<!-- Please use the following checklist to ensure the PR is ready to be reviewed/merged. -->
 - [ ] Issue raised/referenced?
 - [ ] Tests updated/added?
 - [ ] Documentation updated/added?
 - [ ] `package/CHANGELOG` file updated?
 - [x] Is your name in `package/AUTHORS`? (If it is not, add it!)
 - [x] LLM/AI disclosure was updated.

## Developers Certificate of Origin
<!-- 
In order for this PR to be merged you **must certify that you are able to submit your code to be included in MDAnalysis**.
-->

I certify that I can submit this code contribution as described in the [**Developer Certificate of Origin**](https://developercertificate.org/), under the MDAnalysis [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE).



---- 

## Autofix-generated text

The fix is to make the `super()` call reference the enclosing class (`Janin`) so object initialization follows the correct MRO and calls the intended base-class constructor.

Best minimal fix (no behavior change beyond correcting initialization): in `package/MDAnalysis/analysis/dihedrals.py`, replace:

- `super(Ramachandran, self).__init__(...)`

with:

- `super(Janin, self).__init__(...)`

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._