### PR TITLE
Add mass to MDAnalysis base units

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -284,6 +284,7 @@ Chronological list of authors
   - Sai Udayagiri
   - Apoorva Verma
   - Aryaman Chaudhri
+  - Francesco Siciliani
 
 External code
 -------------

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -18,7 +18,7 @@ The rules for this file:
          spyke7, talagayev, tanii1125, BradyAJohnston, hejamu, jeremyleung521,
          harshitgajjela-droid, kunjsinha, aygarwal, jauy123, Dreamstick9,
          ollyfutur, Amarendra22, charity-g, ParthUppal523, apoorva-01, RMeli,
-         raulloiscuns, Aryaman-Chaudhri
+         raulloiscuns, Aryaman-Chaudhri, sici17
 
  * 2.11.0
 
@@ -76,6 +76,9 @@ Fixes
    to version 5.1.0 (Issue #5145, PR #5146)
  * Fixes incorrect assignment of secondary structure to proline residues in
    DSSP by porting upstream PyDSSP 0.9.1 fix (Issue #4913)
+ * Mass (u) has been added to MDAnalysis base units and
+   clarified that physical constants use CODATA 2010 values
+   (Issue #3944, PR #5439)
 
 Enhancements
  * Added ASV benchmark for PDB trajectory reading (PR #5394)

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -23,6 +23,9 @@ The rules for this file:
  * 2.11.0
 
 Fixes
+ * Mass (u) has been added to MDAnalysis base units and
+   clarified that physical constants use CODATA 2010 values
+   (Issue #3944, PR #5439)
  * Added `.gitattributes` to enforce LF (\n) as line endings and renormalized
    existing files to conform (Issue #5315, PR #5446)
  * `AtomGroup.rotate()` and the `rotateby` trajectory transformation now
@@ -76,9 +79,6 @@ Fixes
    to version 5.1.0 (Issue #5145, PR #5146)
  * Fixes incorrect assignment of secondary structure to proline residues in
    DSSP by porting upstream PyDSSP 0.9.1 fix (Issue #4913)
- * Mass (u) has been added to MDAnalysis base units and
-   clarified that physical constants use CODATA 2010 values
-   (Issue #3944, PR #5439)
 
 Enhancements
  * Added ASV benchmark for PDB trajectory reading (PR #5394)

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -23,9 +23,8 @@ The rules for this file:
  * 2.11.0
 
 Fixes
- * Mass (u) has been added to MDAnalysis base units and
-   clarified that physical constants use CODATA 2010 values
-   (Issue #3944, PR #5439)
+ * Mass (u) has been added to MDAnalysis base units and clarified that physical
+   constants use CODATA 2010 values (Issue #3944, PR #5439)
  * Added `.gitattributes` to enforce LF (\n) as line endings and renormalized
    existing files to conform (Issue #5315, PR #5446)
  * `AtomGroup.rotate()` and the `rotateby` trajectory transformation now

--- a/package/MDAnalysis/units.py
+++ b/package/MDAnalysis/units.py
@@ -56,12 +56,6 @@ MDAnalysis currently uses the NIST `CODATA 2010`_ values for physical constants.
    https://physics.nist.gov/cuu/Constants/ArchiveASCII/allascii_2010.txt
 
 
-MDAnalysis currently uses the NIST `CODATA 2010`_ values for physical constants.
-
-.. _`CODATA 2010`:
-   https://physics.nist.gov/cuu/Constants/ArchiveASCII/allascii_2010.txt
-
-
 Implementation notes
 --------------------
 

--- a/package/MDAnalysis/units.py
+++ b/package/MDAnalysis/units.py
@@ -50,6 +50,13 @@ table on :ref:`table-baseunits`.
    mass         u              :math:`1.66053892103219 \times 10^{-27}` kg
    =========== ============== ===============================================
 
+
+MDAnalysis currently uses the NIST `CODATA 2010`_ values for physical constants.
+
+.. _`CODATA 2010`:
+   https://physics.nist.gov/cuu/Constants/ArchiveASCII/allascii_2010.txt
+
+
 Implementation notes
 --------------------
 

--- a/package/MDAnalysis/units.py
+++ b/package/MDAnalysis/units.py
@@ -47,6 +47,7 @@ table on :ref:`table-baseunits`.
    charge       :math:`e`      :math:`1.602176565 \times 10^{-19}` As
    force        kJ/(mol·Å)     :math:`1.66053892103219 \times 10^{-11}` J/m
    speed        Å/ps           :math:`100` m/s
+   mass         u              :math:`1.66053892103219 \times 10^{-27}` kg
    =========== ============== ===============================================
 
 Implementation notes
@@ -407,6 +408,7 @@ MDANALYSIS_BASE_UNITS = {
     "charge": "e",
     "force": "kJ/(mol*A)",
     "speed": "A/ps",
+    "mass": "u",
 }
 
 

--- a/package/MDAnalysis/units.py
+++ b/package/MDAnalysis/units.py
@@ -50,6 +50,11 @@ table on :ref:`table-baseunits`.
    mass         u              :math:`1.66053892103219 \times 10^{-27}` kg
    =========== ============== ===============================================
 
+MDAnalysis currently uses the NIST `CODATA 2010`_ values for physical constants.
+
+.. _`CODATA 2010`: 
+   https://physics.nist.gov/cuu/Constants/ArchiveASCII/allascii_2010.txt
+
 
 MDAnalysis currently uses the NIST `CODATA 2010`_ values for physical constants.
 

--- a/testsuite/MDAnalysisTests/utils/test_units.py
+++ b/testsuite/MDAnalysisTests/utils/test_units.py
@@ -181,6 +181,7 @@ class TestBaseUnits:
             "charge": "e",
             "force": "kJ/(mol*A)",
             "speed": "A/ps",
+            "mass": "u",
         }
         return ref
 


### PR DESCRIPTION
Fixes #3944

Changes made in this Pull Request:
- Added `mass` to the `MDAnalysis.units` base-units documentation table.
- Added `"mass": "u"` to `MDANALYSIS_BASE_UNITS`.
- Updated the corresponding base-units test.

I did not update `package/CHANGELOG` because this is a small documentation/base-units table fix.

The SI value used for `u` is `1.66053892103219 × 10^-27 kg`, which is consistent with the CODATA 2010 constants already used in `MDAnalysis.units`.

Note that the User Guide currently lists a newer value for `u` (`1.66053906660(50) × 10^-27 kg`). This PR intentionally keeps the `MDAnalysis.units` API documentation consistent with the existing CODATA 2010 values used by the module, following the maintainer guidance in the issue.

## LLM / AI generated code disclosure

LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution: yes

## PR Checklist
 - [x] Issue raised/referenced?
 - [x] Tests updated/added?
 - [x] Documentation updated/added?
 - [ ] `package/CHANGELOG` file updated?
 - [x] Is your name in `package/AUTHORS`? (If it is not, add it!)
 - [x] LLM/AI disclosure was updated.

## Developers Certificate of Origin

I certify that I can submit this code contribution as described in the [**Developer Certificate of Origin**](https://developercertificate.org/), under the MDAnalysis [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE).