### PR TITLE
Ensure IMDServer sends EOF to client DURING test

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -247,6 +247,8 @@ Changes
  * 2.8.0
 
 Fixes
+ * Fix `test_imd.py` test failures after imdclient 0.2.4
+   increased default timeout by ensuring EOF sent (Issue #5442, PR #5443)
  * Allows bond/angle/dihedral connectivity to be guessed additively with
    `to_guess`, and as a replacement of existing values with `force_guess`.
    Also updates cached bond attributes when updating bonds. (Issue #4759, PR #4761)

--- a/testsuite/MDAnalysisTests/coordinates/test_imd.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_imd.py
@@ -544,12 +544,12 @@ def test_imd_stream_empty(universe, imdsinfo):
             n_atoms=universe.trajectory.n_atoms,
             # we have no opportunity to send an EOF here
             # since IMDReader creation both establishes a connection
-            # and attempts to read the first frame, and the EOF 
+            # and attempts to read the first frame, and the EOF
             # would have to arrive between these two.
             # rather than creating a special IMDServer method that
             # immediately sends EOF after handshake,
             # just use a 1s timeout passed to IMDClient
-            timeout=1
+            timeout=1,
         )
     server.cleanup()
 

--- a/testsuite/MDAnalysisTests/coordinates/test_imd.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_imd.py
@@ -217,6 +217,8 @@ class TestIMDReaderBaseAPI(MultiframeReaderTest):
         )
         # Send the rest of the frames- small enough to all fit in socket itself
         ref.server.send_frames(1, 5)
+        # Send EOF so the client does not rely on timeout to mark the end of the stream
+        ref.server.disconnect()
 
         reader.add_auxiliary(
             "lowf",
@@ -249,6 +251,8 @@ class TestIMDReaderBaseAPI(MultiframeReaderTest):
         )
         # Send the rest of the frames- small enough to all fit in socket itself
         ref.server.send_frames(1, 5)
+        # Send EOF so the client does not rely on timeout to mark the end of the stream
+        ref.server.disconnect()
         transformed.add_transformations(
             translate([1, 1, 1]), translate([0, 0, 0.33])
         )
@@ -436,6 +440,8 @@ class TestStreamIteration:
             buffer_size=1 * 1024 * 1024,
         )
         server.send_frames(1, 5)
+        # Send EOF so the client does not rely on timeout to mark the end of the stream
+        server.disconnect()
 
         yield reader
         server.cleanup()

--- a/testsuite/MDAnalysisTests/coordinates/test_imd.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_imd.py
@@ -519,6 +519,8 @@ def test_n_atoms_not_specified(universe, imdsinfo):
     server = InThreadIMDServer(universe.trajectory)
     server.set_imdsessioninfo(imdsinfo)
     server.handshake_sequence("localhost", first_frame=True)
+    # send EOF after handshake and first frame
+    server.disconnect()
     with pytest.raises(
         ValueError,
         match="IMDReader: n_atoms must be specified",
@@ -534,6 +536,8 @@ def test_imd_stream_empty(universe, imdsinfo):
     server = InThreadIMDServer(universe.trajectory)
     server.set_imdsessioninfo(imdsinfo)
     server.handshake_sequence("localhost", first_frame=False)
+    # send EOF after handshake
+    server.disconnect()
     with pytest.raises(
         RuntimeError,
         match="IMDReader: Read error",
@@ -550,6 +554,8 @@ def test_create_imd_universe(universe, imdsinfo):
     server = InThreadIMDServer(universe.trajectory)
     server.set_imdsessioninfo(imdsinfo)
     server.handshake_sequence("localhost", first_frame=True)
+    # send EOF after handshake and first frame
+    server.disconnect()
     u_imd = mda.Universe(
         COORDINATES_TOPOLOGY,
         f"imd://localhost:{server.port}",
@@ -582,7 +588,8 @@ def test_wrong_imd_protocol_version(universe, imdsinfo):
     server = InThreadIMDServer(universe.trajectory)
     server.set_imdsessioninfo(imdsinfo)
     server.handshake_sequence("localhost", first_frame=True)
-
+    # send EOF after handshake
+    server.disconnect()
     with pytest.raises(
         ValueError,
         match=rf"IMDReader: Detected IMD version v{imdsinfo.version}, "

--- a/testsuite/MDAnalysisTests/coordinates/test_imd.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_imd.py
@@ -519,8 +519,7 @@ def test_n_atoms_not_specified(universe, imdsinfo):
     server = InThreadIMDServer(universe.trajectory)
     server.set_imdsessioninfo(imdsinfo)
     server.handshake_sequence("localhost", first_frame=True)
-    # send EOF after handshake and first frame
-    server.disconnect()
+    # no EOF needed- client should fail before parsing frames
     with pytest.raises(
         ValueError,
         match="IMDReader: n_atoms must be specified",
@@ -536,8 +535,6 @@ def test_imd_stream_empty(universe, imdsinfo):
     server = InThreadIMDServer(universe.trajectory)
     server.set_imdsessioninfo(imdsinfo)
     server.handshake_sequence("localhost", first_frame=False)
-    # send EOF after handshake
-    server.disconnect()
     with pytest.raises(
         RuntimeError,
         match="IMDReader: Read error",
@@ -545,6 +542,14 @@ def test_imd_stream_empty(universe, imdsinfo):
         IMDReader(
             f"imd://localhost:{server.port}",
             n_atoms=universe.trajectory.n_atoms,
+            # we have no opportunity to send an EOF here
+            # since IMDReader creation both establishes a connection
+            # and attempts to read the first frame, and the EOF 
+            # would have to arrive between these two.
+            # rather than creating a special IMDServer method that
+            # immediately sends EOF after handshake,
+            # just use a 1s timeout passed to IMDClient
+            timeout=1
         )
     server.cleanup()
 
@@ -554,13 +559,13 @@ def test_create_imd_universe(universe, imdsinfo):
     server = InThreadIMDServer(universe.trajectory)
     server.set_imdsessioninfo(imdsinfo)
     server.handshake_sequence("localhost", first_frame=True)
-    # send EOF after handshake and first frame
-    server.disconnect()
     u_imd = mda.Universe(
         COORDINATES_TOPOLOGY,
         f"imd://localhost:{server.port}",
         n_atoms=universe.trajectory.n_atoms,
     )
+    # send EOF after handshake and first frame
+    server.disconnect()
     assert type(u_imd.trajectory).__name__ == "IMDReader"
     with pytest.raises(ValueError, match="IMDReader: Invalid IMD URL"):
         u_imd = mda.Universe(
@@ -588,8 +593,7 @@ def test_wrong_imd_protocol_version(universe, imdsinfo):
     server = InThreadIMDServer(universe.trajectory)
     server.set_imdsessioninfo(imdsinfo)
     server.handshake_sequence("localhost", first_frame=True)
-    # send EOF after handshake
-    server.disconnect()
+    # no EOF needed- client should fail before parsing frames
     with pytest.raises(
         ValueError,
         match=rf"IMDReader: Detected IMD version v{imdsinfo.version}, "


### PR DESCRIPTION
<!-- 
Insert issue number that this PR fixes (if any) just after 'Fixes #'.
If this PR does not fix an existing issue, consider opening one or remove 'Fixes #' from the PR description.
-->
Fixes #5442 

Changes made in this Pull Request:
<!-- Describe the changes that this PR makes. If applicable, use the following bullet list. --> 
- IMDServer now calls disconnect after sending frames so that the client does not rely on the (now 600s) timeout to see the end of the stream

## LLM / AI generated code disclosure
<!-- Please update this disclosure to reflect if you did or did not use LLMs / AI to generate code -->
LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution: no

## PR Checklist
<!-- Please use the following checklist to ensure the PR is ready to be reviewed/merged. -->
 - [x] Issue raised/referenced?
 - [x] Tests updated/added?
 - [ ] Documentation updated/added?
 - [x] `package/CHANGELOG` file updated?
 - [x] Is your name in `package/AUTHORS`? (If it is not, add it!)
 - [x] LLM/AI disclosure was updated.

## Developers Certificate of Origin
<!-- 
In order for this PR to be merged you **must certify that you are able to submit your code to be included in MDAnalysis**.
-->

I certify that I can submit this code contribution as described in the [**Developer Certificate of Origin**](https://developercertificate.org/), under the MDAnalysis [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE).
