### PR TITLE
Enable Pylint check for LF line endings

### DIFF
--- a/package/.pylintrc
+++ b/package/.pylintrc
@@ -177,6 +177,7 @@ enable=abstract-class-instantiated,
        too-many-star-expressions,
        truncated-format-string,
        unexpected-keyword-arg,
+       unexpected-line-ending-format,
        unichr-builtin,
        unicode-builtin,
        unnecessary-pass,
@@ -398,7 +399,7 @@ indent-string='    '
 indent-after-paren=4
 
 # Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
-expected-line-ending-format=
+expected-line-ending-format=LF
 
 
 [BASIC]

--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -284,6 +284,7 @@ Chronological list of authors
   - Sai Udayagiri
   - Apoorva Verma
   - Aryaman Chaudhri
+  - Urvi Tyagi
 
 External code
 -------------


### PR DESCRIPTION
Fixes #5315

Changes made in this Pull Request:
- Updated `package/.pylintrc` to set `expected-line-ending-format=LF` under `[FORMAT]`.
- Added `unexpected-line-ending-format` to `enable=` under `[MESSAGES CONTROL]`.
- Verified that Pylint reports `unexpected-line-ending-format` for files containing CRLF line endings.

## LLM / AI generated code disclosure

LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution: **yes**

AI assistance was used to understand the repository structure, evaluate implementation options, review the relevant Pylint configuration and documentation, and assist in drafting explanations and the pull request description.

I reviewed the proposed approach, implemented the configuration changes, verified the behavior locally, committed the changes, and submitted this pull request.

## PR Checklist

- [x] Issue raised/referenced?
- [ ] Tests updated/added?
- [ ] Documentation updated/added?
- [ ] `package/CHANGELOG` file updated?
- [x] Is your name in `package/AUTHORS`? (If it is not, add it!)
- [x] LLM/AI disclosure was updated.

## Developers Certificate of Origin

I certify that I can submit this code contribution as described in the [Developer Certificate of Origin](https://developercertificate.org/), under the MDAnalysis LICENSE.