### PR TITLE
Rotate velocities and forces besides positions during trajectory rotation

### DIFF
--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -23,6 +23,13 @@ The rules for this file:
  * 2.11.0
 
 Fixes
+ * Fixes
+ * `AtomGroup.rotate()` and the `rotateby` trajectory transformation now
+   also rotate velocities and forces besides positions. This also affects
+   `MDAnalysis.analysis.align.alignto()` and `AlignTraj`, since they
+   apply their fit via `AtomGroup.rotate()`. Note: this changes existing
+   behavior, as velocities/forces were previously left untouched by
+   rotation. (Issue #5421, PR #)
  * Fix FileLock tests for XTC and TRR: lock file is no longer removed (#5382)
  * InterRDF now correctly returns bins in parallel (PR #5344)
  * `Merge()` no longer raises a TypeError on Universes that have a `cmaps`

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -23,13 +23,12 @@ The rules for this file:
  * 2.11.0
 
 Fixes
- * Fixes
  * `AtomGroup.rotate()` and the `rotateby` trajectory transformation now
    also rotate velocities and forces besides positions. This also affects
    `MDAnalysis.analysis.align.alignto()` and `AlignTraj`, since they
    apply their fit via `AtomGroup.rotate()`. Note: this changes existing
    behavior, as velocities/forces were previously left untouched by
-   rotation. (Issue #5421, PR #)
+   rotation. (Issue #5421, PR #5452)
  * Fix FileLock tests for XTC and TRR: lock file is no longer removed (#5382)
  * InterRDF now correctly returns bins in parallel (PR #5344)
  * `Merge()` no longer raises a TypeError on Universes that have a `cmaps`

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -1601,7 +1601,7 @@ class GroupBase(_MutableBase):
         rotateby : rotate around given axis and angle
         MDAnalysis.lib.transformations : module of all coordinate transforms
 
-        
+
         .. versionchanged:: 2.11.0
            Also rotate velocities and forces if present in Timestep.
         """
@@ -1663,7 +1663,7 @@ class GroupBase(_MutableBase):
         MDAnalysis.lib.transformations.rotation_matrix :
             calculate :math:`\mathsf{R}`
 
-            
+
         .. versionchanged:: 2.11.0
            Also rotate velocities and forces if present in Timestep.
         """

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -1601,8 +1601,9 @@ class GroupBase(_MutableBase):
         rotateby : rotate around given axis and angle
         MDAnalysis.lib.transformations : module of all coordinate transforms
 
-        .. versionchanged: 2.11.0
-        Also rotate velocities and forces if present in Timestep.
+        
+        .. versionchanged:: 2.11.0
+           Also rotate velocities and forces if present in Timestep.
         """
         R = np.asarray(R)
         point = np.asarray(point)
@@ -1662,6 +1663,9 @@ class GroupBase(_MutableBase):
         MDAnalysis.lib.transformations.rotation_matrix :
             calculate :math:`\mathsf{R}`
 
+            
+        .. versionchanged:: 2.11.0
+           Also rotate velocities and forces if present in Timestep.
         """
         alpha = np.radians(angle)
         axis = np.asarray(axis)

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -1601,6 +1601,8 @@ class GroupBase(_MutableBase):
         rotateby : rotate around given axis and angle
         MDAnalysis.lib.transformations : module of all coordinate transforms
 
+        .. versionchanged: 2.11.0
+        Also rotate velocities and forces if present in Timestep.
         """
         R = np.asarray(R)
         point = np.asarray(point)
@@ -1611,17 +1613,18 @@ class GroupBase(_MutableBase):
         if require_translation:
             atomgroup.translate(-point)
         ts = atomgroup.universe.trajectory.ts
+        R_T = R.T
         x = ts.positions
         idx = atomgroup.indices
-        x[idx] = np.dot(x[idx], R.T)
+        x[idx] = np.dot(x[idx], R_T)
         if require_translation:
             atomgroup.translate(point)
         if ts.has_velocities:
             v = ts.velocities
-            v[idx] = np.dot(v[idx], R.T)
+            v[idx] = np.dot(v[idx], R_T)
         if ts.has_forces:
             f = ts.forces
-            f[idx] = np.dot(f[idx], R.T)
+            f[idx] = np.dot(f[idx], R_T)
 
         return self
 

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -1610,11 +1610,18 @@ class GroupBase(_MutableBase):
         require_translation = bool(np.count_nonzero(point))
         if require_translation:
             atomgroup.translate(-point)
-        x = atomgroup.universe.trajectory.ts.positions
+        ts = atomgroup.universe.trajectory.ts
+        x = ts.positions
         idx = atomgroup.indices
         x[idx] = np.dot(x[idx], R.T)
         if require_translation:
             atomgroup.translate(point)
+        if ts.has_velocities:
+            v = ts.velocities
+            v[idx] = np.dot(v[idx], R.T)
+        if ts.has_forces:
+            f = ts.forces
+            f[idx] = np.dot(f[idx], R.T)
 
         return self
 

--- a/package/MDAnalysis/transformations/rotate.py
+++ b/package/MDAnalysis/transformations/rotate.py
@@ -200,4 +200,8 @@ class rotateby(TransformationBase):
         translation = matrix[:3, 3]
         ts.positions = np.dot(ts.positions, rotation)
         ts.positions += translation
+        if ts.has_velocities:
+            ts.velocities = np.dot(ts.velocities, rotation)
+        if ts.has_forces:
+            ts.forces = np.dot(ts.forces, rotation)
         return ts

--- a/package/MDAnalysis/transformations/rotate.py
+++ b/package/MDAnalysis/transformations/rotate.py
@@ -121,6 +121,8 @@ class rotateby(TransformationBase):
     .. versionchanged:: 2.0.0
        The transformation was changed to inherit from the base class for
        limiting threads and checking if it can be used in parallel analysis.
+    .. versionchanged:: 2.11.0
+       Also rotate velocities and forces if present in Timestep.
     """
 
     def __init__(

--- a/testsuite/MDAnalysisTests/analysis/test_align.py
+++ b/testsuite/MDAnalysisTests/analysis/test_align.py
@@ -838,8 +838,10 @@ def test_alignto_rotates_velocities_and_forces():
     )
     reference.atoms.positions = ref_pos
 
-    angle = np.pi / 3
-    known_R = transformations.rotation_matrix(angle, [0, 0, 1])[:3, :3]
+    angle = 23
+    known_R = transformations.rotation_matrix(np.deg2rad(angle), [-1, 2, -3])[
+        :3, :3
+    ]
     mobile.atoms.positions = np.dot(ref_pos, known_R.T)
 
     rng = np.random.RandomState(0)

--- a/testsuite/MDAnalysisTests/analysis/test_align.py
+++ b/testsuite/MDAnalysisTests/analysis/test_align.py
@@ -31,6 +31,7 @@ import numpy as np
 import pytest
 from MDAnalysis import SelectionError, SelectionWarning
 from MDAnalysisTests import executable_not_found
+from MDAnalysis.lib import transformations
 from MDAnalysisTests.datafiles import (
     PSF,
     DCD,
@@ -821,3 +822,43 @@ def test_alignto_reorder_atomgroups():
     ref = u.atoms[[3, 2, 1, 0]]
     rmsd = align.alignto(mobile, ref, select="bynum 1-4")
     assert_allclose(rmsd, (0.0, 0.0))
+
+
+def test_alignto_rotates_velocities_and_forces():
+    mobile = mda.Universe.empty(
+        4, trajectory=True, velocities=True, forces=True
+    )
+    reference = mda.Universe.empty(4, trajectory=True)
+
+    mobile.add_TopologyAttr("masses", [1.0, 1.0, 1.0, 1.0])
+    reference.add_TopologyAttr("masses", [1.0, 1.0, 1.0, 1.0])
+
+    ref_pos = np.array(
+        [[1, 0, 0], [0, 1, 0], [-1, 0, 0], [0, -1, 0]], dtype=np.float64
+    )
+    reference.atoms.positions = ref_pos
+
+    angle = np.pi / 3
+    known_R = transformations.rotation_matrix(angle, [0, 0, 1])[:3, :3]
+    mobile.atoms.positions = np.dot(ref_pos, known_R.T)
+
+    rng = np.random.RandomState(0)
+    orig_v = rng.random((4, 3))
+    orig_f = rng.random((4, 3))
+    mobile.atoms.velocities = orig_v.copy()
+    mobile.atoms.forces = orig_f.copy()
+
+    mobile_centered = (
+        mobile.atoms.positions - mobile.atoms.center_of_geometry()
+    )
+    ref_centered = ref_pos - ref_pos.mean(axis=0)
+    expected_R, _ = align.rotation_matrix(mobile_centered, ref_centered)
+
+    align.alignto(mobile, reference)
+
+    assert_allclose(
+        mobile.atoms.velocities, np.dot(orig_v, expected_R.T), atol=1e-6
+    )
+    assert_allclose(
+        mobile.atoms.forces, np.dot(orig_f, expected_R.T), atol=1e-6
+    )

--- a/testsuite/MDAnalysisTests/core/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/core/test_atomgroup.py
@@ -437,14 +437,6 @@ class TestAtomGroupTransformations(object):
             assert_almost_equal(u.atoms.velocities, np.dot(orig_v, R.T))
             assert_almost_equal(u.atoms.forces, np.dot(orig_f, R.T))
 
-    def test_rotate_no_velocities_forces_does_not_raise(self):
-        u = mda.Universe.empty(2, trajectory=True)
-        orig_pos = np.array([[1, 0, 0], [-1, 0, 0]])
-        u.atoms.positions = orig_pos.copy()
-        R = transformations.rotation_matrix(1, [-1, 2, -3])[:3, :3]
-        u.atoms.rotate(R)
-        assert_almost_equal(u.atoms.positions, np.dot(orig_pos, R.T))
-
     def test_transform_rotation_only(self, u, coords):
         R = np.eye(3)
         u.atoms.rotate(R)

--- a/testsuite/MDAnalysisTests/core/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/core/test_atomgroup.py
@@ -417,6 +417,32 @@ class TestAtomGroupTransformations(object):
                 [-2 * np.cos(angle) + 1, -2 * np.sin(angle), 0],
             )
 
+    def test_rotate_velocities_forces(self):
+        u = mda.Universe.empty(
+            2, trajectory=True, velocities=True, forces=True
+        )
+        u.atoms.positions = np.array([[1, 0, 0], [-1, 0, 0]])
+        u.atoms.velocities = np.array([[1, 0, 0], [0, 1, 0]])
+        u.atoms.forces = np.array([[0, 0, 1], [1, 1, 0]])
+
+        orig_v = u.atoms.velocities.copy()
+        orig_f = u.atoms.forces.copy()
+
+        axis = np.array([0, 0, 1])
+        for angle in np.linspace(0, np.pi):
+            R = transformations.rotation_matrix(angle, axis)[:3, :3]
+            u.atoms.velocities = orig_v.copy()
+            u.atoms.forces = orig_f.copy()
+            u.atoms.rotate(R)
+            assert_almost_equal(u.atoms.velocities, np.dot(orig_v, R.T))
+            assert_almost_equal(u.atoms.forces, np.dot(orig_f, R.T))
+
+    def test_rotate_no_velocities_forces_does_not_raise(self):
+        u = mda.Universe.empty(2, trajectory=True)
+        u.atoms.positions = np.array([[1, 0, 0], [-1, 0, 0]])
+        R = transformations.rotation_matrix(1, [0, 0, 1])[:3, :3]
+        u.atoms.rotate(R)
+
     def test_transform_rotation_only(self, u, coords):
         R = np.eye(3)
         u.atoms.rotate(R)

--- a/testsuite/MDAnalysisTests/core/test_atomgroup.py
+++ b/testsuite/MDAnalysisTests/core/test_atomgroup.py
@@ -439,9 +439,11 @@ class TestAtomGroupTransformations(object):
 
     def test_rotate_no_velocities_forces_does_not_raise(self):
         u = mda.Universe.empty(2, trajectory=True)
-        u.atoms.positions = np.array([[1, 0, 0], [-1, 0, 0]])
-        R = transformations.rotation_matrix(1, [0, 0, 1])[:3, :3]
+        orig_pos = np.array([[1, 0, 0], [-1, 0, 0]])
+        u.atoms.positions = orig_pos.copy()
+        R = transformations.rotation_matrix(1, [-1, 2, -3])[:3, :3]
         u.atoms.rotate(R)
+        assert_almost_equal(u.atoms.positions, np.dot(orig_pos, R.T))
 
     def test_transform_rotation_only(self, u, coords):
         R = np.eye(3)

--- a/testsuite/MDAnalysisTests/transformations/test_rotate.py
+++ b/testsuite/MDAnalysisTests/transformations/test_rotate.py
@@ -192,9 +192,9 @@ def test_rotateby_velocities_forces():
     orig_v = ts.velocities.copy()
     orig_f = ts.forces.copy()
 
-    axis = [0, 0, 1]
+    axis = [-1, 2, -3]
     point = [0, 0, 0]
-    angle = 90
+    angle = 23
     matrix = rotation_matrix(np.deg2rad(angle), axis, point)
     rotation = matrix[:3, :3].T
 
@@ -210,9 +210,18 @@ def test_rotateby_velocities_forces():
 
 def test_rotateby_no_velocities_forces_does_not_raise():
     u = mda.Universe.empty(2, trajectory=True)
-    u.atoms.positions = np.array([[1, 0, 0], [-1, 0, 0]])
+    orig_pos = np.array([[1, 0, 0], [-1, 0, 0]])
+    u.atoms.positions = orig_pos.copy()
     ts = u.trajectory.ts
-    rotateby(90, [0, 0, 1], point=[0, 0, 0])(ts)
+    angle = 5
+    matrix = rotation_matrix(
+        np.deg2rad(angle), [-1, 2, -3], [0, 0, 0]
+    )
+    rotation = matrix[:3, :3].T
+    transformed_ts = rotateby(angle, [-1, 2, -3], point=[0, 0, 0])(ts)
+    assert_array_almost_equal(
+        transformed_ts.positions, np.dot(orig_pos, rotation), decimal=6
+    )
 
 
 @pytest.mark.parametrize(

--- a/testsuite/MDAnalysisTests/transformations/test_rotate.py
+++ b/testsuite/MDAnalysisTests/transformations/test_rotate.py
@@ -182,6 +182,39 @@ def test_rotateby_atomgroup_com_pbc(rotate_universes):
     assert_array_almost_equal(transformed.positions, ref.positions, decimal=6)
 
 
+def test_rotateby_velocities_forces():
+    u = mda.Universe.empty(2, trajectory=True, velocities=True, forces=True)
+    u.atoms.positions = np.array([[1, 0, 0], [-1, 0, 0]])
+    u.atoms.velocities = np.array([[1, 0, 0], [0, 1, 0]])
+    u.atoms.forces = np.array([[0, 0, 1], [1, 1, 0]])
+    ts = u.trajectory.ts
+
+    orig_v = ts.velocities.copy()
+    orig_f = ts.forces.copy()
+
+    axis = [0, 0, 1]
+    point = [0, 0, 0]
+    angle = 90
+    matrix = rotation_matrix(np.deg2rad(angle), axis, point)
+    rotation = matrix[:3, :3].T
+
+    transformed_ts = rotateby(angle, axis, point=point)(ts)
+
+    assert_array_almost_equal(
+        transformed_ts.velocities, np.dot(orig_v, rotation), decimal=6
+    )
+    assert_array_almost_equal(
+        transformed_ts.forces, np.dot(orig_f, rotation), decimal=6
+    )
+
+
+def test_rotateby_no_velocities_forces_does_not_raise():
+    u = mda.Universe.empty(2, trajectory=True)
+    u.atoms.positions = np.array([[1, 0, 0], [-1, 0, 0]])
+    ts = u.trajectory.ts
+    rotateby(90, [0, 0, 1], point=[0, 0, 0])(ts)
+
+
 @pytest.mark.parametrize(
     "ag",
     (

--- a/testsuite/MDAnalysisTests/transformations/test_rotate.py
+++ b/testsuite/MDAnalysisTests/transformations/test_rotate.py
@@ -208,20 +208,6 @@ def test_rotateby_velocities_forces():
     )
 
 
-def test_rotateby_no_velocities_forces_does_not_raise():
-    u = mda.Universe.empty(2, trajectory=True)
-    orig_pos = np.array([[1, 0, 0], [-1, 0, 0]])
-    u.atoms.positions = orig_pos.copy()
-    ts = u.trajectory.ts
-    angle = 5
-    matrix = rotation_matrix(np.deg2rad(angle), [-1, 2, -3], [0, 0, 0])
-    rotation = matrix[:3, :3].T
-    transformed_ts = rotateby(angle, [-1, 2, -3], point=[0, 0, 0])(ts)
-    assert_array_almost_equal(
-        transformed_ts.positions, np.dot(orig_pos, rotation), decimal=6
-    )
-
-
 @pytest.mark.parametrize(
     "ag",
     (

--- a/testsuite/MDAnalysisTests/transformations/test_rotate.py
+++ b/testsuite/MDAnalysisTests/transformations/test_rotate.py
@@ -214,9 +214,7 @@ def test_rotateby_no_velocities_forces_does_not_raise():
     u.atoms.positions = orig_pos.copy()
     ts = u.trajectory.ts
     angle = 5
-    matrix = rotation_matrix(
-        np.deg2rad(angle), [-1, 2, -3], [0, 0, 0]
-    )
+    matrix = rotation_matrix(np.deg2rad(angle), [-1, 2, -3], [0, 0, 0])
     rotation = matrix[:3, :3].T
     transformed_ts = rotateby(angle, [-1, 2, -3], point=[0, 0, 0])(ts)
     assert_array_almost_equal(


### PR DESCRIPTION
<!-- 
Insert issue number that this PR fixes (if any) just after 'Fixes #'.
If this PR does not fix an existing issue, consider opening one or remove 'Fixes #' from the PR description.
-->
Fixes #5421

Changes made in this Pull Request:
<!-- Describe the changes that this PR makes. If applicable, use the following bullet list. --> 
- **Modified `AtomGroup.rotate()`** in `package/MDAnalysis/core/groups.py` to automatically rotate velocities and forces in-place alongside positions when the data arrays are present in the trajectory (`ts.has_velocities` and `ts.has_forces`).
- This also affects `MDAnalysis.analysis.align.alignto()` and `AlignTraj`, since they
   apply their fit via `AtomGroup.rotate()`. 
- **Note:** this changes existing behavior, as velocities/forces were previously left untouched by
   rotation.
- **Added comprehensive test suites** across three test modules:
  * `MDAnalysisTests/core/test_atomgroup.py` (`test_rotate_velocities_forces` and `test_rotate_no_velocities_forces_does_not_raise`)
  * `MDAnalysisTests/analysis/test_align.py` (`test_alignto_rotates_velocities_and_forces`)
  * `MDAnalysisTests/transformations/test_rotate.py` (`test_rotateby_velocities_forces` and `test_rotateby_no_velocities_forces_does_not_raise`)

## LLM / AI generated code disclosure
<!-- Please update this disclosure to reflect if you did or did not use LLMs / AI to generate code -->
LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution: no

## PR Checklist
<!-- Please use the following checklist to ensure the PR is ready to be reviewed/merged. -->
 - [x] Issue raised/referenced?
 - [x] Tests updated/added?
 - [x] Documentation updated/added?
 - [x] `package/CHANGELOG` file updated?
 - [x] Is your name in `package/AUTHORS`? (If it is not, add it!)
 - [x] LLM/AI disclosure was updated.

## Developers Certificate of Origin
<!-- 
In order for this PR to be merged you **must certify that you are able to submit your code to be included in MDAnalysis**.
-->

I certify that I can submit this code contribution as described in the [**Developer Certificate of Origin**](https://developercertificate.org/), under the MDAnalysis [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE).
