### PR TITLE
ENH: support reading box vectors from TPR files

### DIFF
--- a/package/AUTHORS
+++ b/package/AUTHORS
@@ -285,6 +285,8 @@ Chronological list of authors
   - Apoorva Verma
   - Aryaman Chaudhri
   - Francesco Siciliani
+  - Akshit Boora
+
 
 External code
 -------------

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -108,6 +108,10 @@ Enhancements
  * Adds support for parsing `.tpr` files produced by GROMACS 2026.0
  * Enables parallelization for analysis.diffusionmap.DistanceMatrix
    (Issue #4679, PR #4745)
+ * TPRReader now reads box vectors from TPR files and exposes them as
+   ``Universe.dimensions``. Previously, ``u.dimensions`` returned ``None``
+   when a TPR file was used as the sole coordinate source
+   (``mda.Universe(tpr)`` or ``mda.Universe(tpr, tpr)``). (Issue #5375)
 
 Changes
  * The msd.py inside analysis is changed, and ProgressBar is implemented inside

--- a/package/MDAnalysis/coordinates/TPR.py
+++ b/package/MDAnalysis/coordinates/TPR.py
@@ -53,6 +53,7 @@ Classes
 
 from . import base
 from ..lib import util
+from ..lib.mdamath import triclinic_box
 from .timestep import Timestep
 import MDAnalysis.topology.tpr.utils as tpr_utils
 import MDAnalysis.topology.tpr.setting as S
@@ -110,7 +111,10 @@ class TPRReader(base.SingleFrameReaderBase):
 
         state_ngtc = th.ngtc  # done init_state() in src/gmxlib/tpxio.c
         if th.bBox:
-            tpr_utils.extract_box_info(data, th.fver)
+            box_info = tpr_utils.extract_box_info(data, th.fver)
+            ts.dimensions = triclinic_box(*box_info.size)
+            if self.convert_units and ts.dimensions is not None:
+                self.convert_pos_from_native(ts.dimensions[:3])
 
         if state_ngtc > 0:
             if th.fver < 69:  # redundancy due to  different versions

--- a/testsuite/MDAnalysisTests/coordinates/test_tpr.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_tpr.py
@@ -514,7 +514,10 @@ def test_different_versions():
     assert_equal(u.atoms.velocities.shape, exp_shape)
 
 
-@pytest.mark.parametrize("convert_units", [True, False])
+@pytest.mark.parametrize(
+    "convert_units",
+    [True, False],
+)
 def test_unit_swapping(convert_units):
     reader = TPRReader(TPR_xvf_2024_4, convert_units=convert_units)
     ts = reader.ts
@@ -538,3 +541,141 @@ def test_unit_swapping(convert_units):
     assert_allclose(actual_positions[-1, ...], expected_last_pos * factor)
     assert_allclose(actual_velocities[0, ...], expected_first_vel * factor)
     assert_allclose(actual_velocities[-1, ...], expected_last_vel * factor)
+
+
+# ----- Tests for issue #5375: box vectors from TPR files -----
+
+
+@pytest.mark.parametrize(
+    "tpr_file, expected_dimensions",
+    [
+        # adk_oplsaa.tpr: rhombic dodecahedron box
+        # expected values verified against mda.Universe(TPR, XTC).dimensions
+        # see issue #5375
+        (
+            TPR_xvf_2024_4,
+            [52.763, 52.763, 52.763, 90.0, 90.0, 90.0],
+        ),
+        (
+            TPR2024_4,
+            [79.1, 79.1, 37.9, 90.0, 90.0, 90.0],
+        ),
+        (
+            TPR2020,
+            [79.1, 79.1, 37.9, 90.0, 90.0, 90.0],
+        ),
+        (
+            TPR455Double,
+            [43.7388, 43.7388, 107.9261, 90.0, 90.0, 90.0],
+        ),
+    ],
+)
+@pytest.mark.parametrize("double_incantation", [True, False])
+def test_tpr_box_vectors(tpr_file, expected_dimensions, double_incantation):
+    """TPR coordinate reader should expose box dimensions (issue #5375).
+
+    When a TPR file is used as the sole coordinate source (either
+    ``mda.Universe(tpr)`` or ``mda.Universe(tpr, tpr)``), the resulting
+    Universe should have non-None ``dimensions`` that match the box stored
+    inside the TPR file.
+    """
+    if double_incantation:
+        u = mda.Universe(tpr_file, tpr_file)
+    else:
+        u = mda.Universe(tpr_file)
+    assert u.dimensions is not None, (
+        "u.dimensions should not be None when using a TPR file as the "
+        "coordinate source (issue #5375)"
+    )
+    assert_allclose(u.dimensions, expected_dimensions, atol=1e-3)
+
+
+def test_tpr_box_vectors_unit_conversion():
+    """Box lengths from TPR reader should respect the convert_units flag.
+
+    With ``convert_units=True`` (default) lengths are in Angstroms; with
+    ``convert_units=False`` they remain in GROMACS native nanometres.
+    Angles are dimensionless and must be identical in both cases.
+    """
+    reader_angstrom = TPRReader(TPR2024_4, convert_units=True)
+    reader_nm = TPRReader(TPR2024_4, convert_units=False)
+
+    dims_ang = reader_angstrom.ts.dimensions
+    dims_nm = reader_nm.ts.dimensions
+
+    assert dims_ang is not None
+    assert dims_nm is not None
+
+    # lengths scale by factor 10 (nm -> Å)
+    assert_allclose(dims_ang[:3], dims_nm[:3] * 10, rtol=1e-5)
+    # angles are unchanged
+    assert_allclose(dims_ang[3:], dims_nm[3:], rtol=1e-5)
+
+
+# ----- Tests for issue #5375: box vectors from TPR files -----
+
+
+@pytest.mark.parametrize(
+    "tpr_file, expected_dimensions",
+    [
+        # adk_oplsaa.tpr: rhombic dodecahedron box
+        # expected values verified against mda.Universe(TPR, XTC).dimensions
+        # see issue #5375
+        (
+            TPR_xvf_2024_4,
+            [52.763, 52.763, 52.763, 90.0, 90.0, 90.0],
+        ),
+        (
+            TPR2024_4,
+            [79.1, 79.1, 37.9, 90.0, 90.0, 90.0],
+        ),
+        (
+            TPR2020,
+            [79.1, 79.1, 37.9, 90.0, 90.0, 90.0],
+        ),
+        (
+            TPR455Double,
+            [43.7388, 43.7388, 107.9261, 90.0, 90.0, 90.0],
+        ),
+    ],
+)
+@pytest.mark.parametrize("double_incantation", [True, False])
+def test_tpr_box_vectors(tpr_file, expected_dimensions, double_incantation):
+    """TPR coordinate reader should expose box dimensions (issue #5375).
+
+    When a TPR file is used as the sole coordinate source (either
+    ``mda.Universe(tpr)`` or ``mda.Universe(tpr, tpr)``), the resulting
+    Universe should have non-None ``dimensions`` that match the box stored
+    inside the TPR file.
+    """
+    if double_incantation:
+        u = mda.Universe(tpr_file, tpr_file)
+    else:
+        u = mda.Universe(tpr_file)
+    assert u.dimensions is not None, (
+        "u.dimensions should not be None when using a TPR file as the "
+        "coordinate source (issue #5375)"
+    )
+    assert_allclose(u.dimensions, expected_dimensions, atol=1e-3)
+
+
+def test_tpr_box_vectors_unit_conversion():
+    """Box lengths from TPR reader should respect the convert_units flag.
+
+    With ``convert_units=True`` (default) lengths are in Angstroms; with
+    ``convert_units=False`` they remain in GROMACS native nanometres.
+    Angles are dimensionless and must be identical in both cases.
+    """
+    reader_angstrom = TPRReader(TPR2024_4, convert_units=True)
+    reader_nm = TPRReader(TPR2024_4, convert_units=False)
+
+    dims_ang = reader_angstrom.ts.dimensions
+    dims_nm = reader_nm.ts.dimensions
+
+    assert dims_ang is not None
+    assert dims_nm is not None
+
+    # lengths scale by factor 10 (nm -> Å)
+    assert_allclose(dims_ang[:3], dims_nm[:3] * 10, rtol=1e-5)
+    # angles are unchanged
+    assert_allclose(dims_ang[3:], dims_nm[3:], rtol=1e-5)


### PR DESCRIPTION
Fixes #5375

Changes made in this Pull Request:
- Modified `TPRReader._read_first_frame()` in `package/MDAnalysis/coordinates/TPR.py` to capture the `Box` tuple from `extract_box_info()` and set `ts.dimensions = triclinic_box(*box_info.size)`.
- Added unit conversion (`convert_units=True` converts nm to Å; `convert_units=False` preserves nm) following MDAnalysis coordinate reader standards.
- Added comprehensive unit tests in `testsuite/MDAnalysisTests/coordinates/test_tpr.py` for single (`mda.Universe(tpr)`) and double (`mda.Universe(tpr, tpr)`) TPR universes across different GROMACS TPR versions.
- Updated `package/CHANGELOG`.

## LLM / AI generated code disclosure
LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution: No

## PR Checklist
 - [x] Issue raised/referenced?
 - [x] Tests updated/added?
 - [x] Documentation updated/added?
 - [x] `package/CHANGELOG` file updated?
 - [x] Is your name in `package/AUTHORS`? (If it is not, add it!)
 - [x] I have read and understand the current [AI Policy](https://github.com/MDAnalysis/mdanalysis/blob/develop/AI_POLICY.md)
 - [x] LLM/AI disclosure was updated.

## Developers Certificate of Origin

I certify that I can submit this code contribution as described in the [**Developer Certificate of Origin**](https://developercertificate.org/), under the MDAnalysis [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE).
